### PR TITLE
fix usage of deprecated ruff settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,12 +49,12 @@ include = ["spd*"]
 [tool.ruff]
 line-length = 100
 fix = true
+
+[tool.ruff.lint]
 ignore = [
     "F722", # Incompatible with jaxtyping
     "E731" # I think lambda functions are fine in several places
 ]
-
-[tool.ruff.lint]
 select = [
     # pycodestyle
     "E",
@@ -74,7 +74,7 @@ select = [
 # Enable reformatting of code snippets in docstrings.
 docstring-code-format = true
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-third-party = ["wandb"]
 
 [tool.pyright]


### PR DESCRIPTION
## Description
update the pyproject.toml to use correct ruff settings

## Related Issue
N/A, this is a tiny change

## Motivation and Context
ruff complains about the pyproject.toml:

```
warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section. Please update the following options in `pyproject.toml`:
  - 'ignore' -> 'lint.ignore'
  - 'isort' -> 'lint.isort'
```

## How Has This Been Tested?
manual testing of `make format`

## Does this PR introduce a breaking change?
no