### PR TITLE
Add STYLE.md for code style

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,6 +32,7 @@ This repository implements methods from two key research papers on parameter dec
 - Useful reading for understanding the implementation details, though may be outdated.
 
 **Attribution-based Parameter Decomposition (APD)** - [`papers/Attribution_based_Parameter_Decomposition/apd_paper.md`](papers/Attribution_based_Parameter_Decomposition/apd_paper.md)
+- This paper was the first to introduce the concept of linear parameter decomposition. It's the precursor to SPD.
 - Contains **high-level conceptual insights** of parameter decompositions
 - Provides theoretical foundations and broader context for parameter decomposition approaches
 - Useful for understanding the conceptual framework and motivation behind SPD
@@ -202,4 +203,4 @@ spd-run --no-create_report                   # Skip W&B report creation
 - Use branch names `refactor/X` or `feature/Y` or `fix/Z`.
 
 ## Coding Guidelines
-- Always use the PEP 604 typing format of unions everywhere and no "Optional".
+- see [STYLE.md](./STYLE.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,5 +27,5 @@ Before making an issue or PR, search for existing issues or PRs in the repositor
 
 ## Code Quality
 - Run `make check` before committing to ensure your code passes all quality checks
-- Follow the existing code style and conventions in the repository
+- See [STYLE.md](./STYLE.md) for our coding style guide.
 - Write clear commit messages that explain what changes were made and why

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,15 +1,21 @@
 # Code Style Guide
 
 TLDR:
-- simple, straightforward code
-- fail fast - no defensive programming
-- use einops, jaxtyping, and shape assertions for tensor shape clarity
+- prioritise simple, straightforward code. Our users are researchers, often with little coding experience.
+- safety: use types, einops, jaxtyping, and liberal assertions.
+- fail fast - if something is wrong, the code should fail, not recover silently.
 
 
-## Core Principles
+## Design / Architecture
+
+We want to decouple metrics and analysis from the core codebase as much as possible, so that users can easily define their own and we don't need to make PRs to the codebase. See how this is done for core_metrics_and_figs.py.
 
 ### Fail Fast (Negative Space Programming)
 Code should fail immediately when assumptions are violated, preventing bugs from propagating.
+
+If there's an assumption you're making while writing code, assert it.
+- If you were right, then it won't matter
+- If you were wrong, then the code **should** fail.
 
 ```python
 # BAD - silently handles unexpected state
@@ -23,16 +29,11 @@ def process_activations(acts):
     assert acts.dim() == 3, f"Expected 3D tensor, got {acts.dim()}D"
 ```
 
-In practice:
-- Use assertions liberally
-- Use tensor shape assertions liberally
-- Define types as tightly as possible
-- Log warnings for edge cases
-- Don't add soft failovers unless they're very much expected
-
 ## Type Annotations
-- Don't add type annotations when they're redundant or obvious
 - Use jaxtyping for tensor shapes (though for now we don't do runtime checking)
+- Always use the PEP 604 typing format of `|` for unions and `type | None` over `Optional`.
+- Use `dict`, `list` and `tuple` not `Dict`, `List` and `Tuple`
+- Don't add type annotations when they're redundant. (i.e. `my_thing: Thing = Thing()` or `name: str = "John Doe"`)
 
 ## Tensor Operations
 - Try to use einops by default for clarity.
@@ -41,26 +42,29 @@ In practice:
 
 ## Comments
 
-Your first instinct should be: "How can I write this code so it's clear without comments?"
+Your first instinct should be: "If I couldn't write any comments, how would I write this code?"
 
-### Don't Write Obvious Comments
+**Don't**: Write Obvious Comments
+**Do**: Write comments for complex logic
 
 ```python
 # BAD
 # get dataloader
 dataloader = get_dataloader(config)
-
-# make a tensor of all zeros
-mask = torch.zeros(...)
 ```
 
-### Do Comment Complex Logic
-
-```python
+```
 # GOOD
 # We need to mask out future positions for causal attention
 # Upper triangular matrix excludes the diagonal (hence k=1)
 causal_mask = torch.triu(torch.ones(seq_len, seq_len), diagonal=1)
 ```
 
-Watch: [Don't Write Comments (YouTube)](https://www.youtube.com/watch?v=Bf7vDBBOBUA)
+(See: [Don't Write Comments (YouTube)](https://www.youtube.com/watch?v=Bf7vDBBOBUA))
+
+
+### Testing
+
+The point of tests in this codebase is to ensure that the code is working as expected, not to prevent production outages - there's no deployment here.
+Therefore, don't worry about lots of larger integration/end-to-end tests. These often require too much overhead for what it's worth in our case, and
+this codebase is interactively run so often that issues will likely be caught by the user at very little cost.

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,0 +1,66 @@
+# Code Style Guide
+
+TLDR:
+- simple, straightforward code
+- fail fast - no defensive programming
+- use einops, jaxtyping, and shape assertions for tensor shape clarity
+
+
+## Core Principles
+
+### Fail Fast (Negative Space Programming)
+Code should fail immediately when assumptions are violated, preventing bugs from propagating.
+
+```python
+# BAD - silently handles unexpected state
+def process_activations(acts):
+    if acts is None:
+        return torch.zeros(hidden_size)  # Hides the problem
+    
+# GOOD - fail immediately with clear error
+def process_activations(acts):
+    assert acts is not None, "Activations cannot be None"
+    assert acts.dim() == 3, f"Expected 3D tensor, got {acts.dim()}D"
+```
+
+In practice:
+- Use assertions liberally
+- Use tensor shape assertions liberally
+- Define types as tightly as possible
+- Log warnings for edge cases
+- Don't add soft failovers unless they're very much expected
+
+## Type Annotations
+- Don't add type annotations when they're redundant or obvious
+- Use jaxtyping for tensor shapes (though for now we don't do runtime checking)
+
+## Tensor Operations
+- Try to use einops by default for clarity.
+- Assert shapes liberally
+- Document complex tensor manipulations
+
+## Comments
+
+Your first instinct should be: "How can I write this code so it's clear without comments?"
+
+### Don't Write Obvious Comments
+
+```python
+# BAD
+# get dataloader
+dataloader = get_dataloader(config)
+
+# make a tensor of all zeros
+mask = torch.zeros(...)
+```
+
+### Do Comment Complex Logic
+
+```python
+# GOOD
+# We need to mask out future positions for causal attention
+# Upper triangular matrix excludes the diagonal (hence k=1)
+causal_mask = torch.triu(torch.ones(seq_len, seq_len), diagonal=1)
+```
+
+Watch: [Don't Write Comments (YouTube)](https://www.youtube.com/watch?v=Bf7vDBBOBUA)

--- a/STYLE.md
+++ b/STYLE.md
@@ -17,18 +17,6 @@ If there's an assumption you're making while writing code, assert it.
 - If you were right, then it won't matter
 - If you were wrong, then the code **should** fail.
 
-```python
-# BAD - silently handles unexpected state
-def process_activations(acts):
-    if acts is None:
-        return torch.zeros(hidden_size)  # Hides the problem
-    
-# GOOD - fail immediately with clear error
-def process_activations(acts):
-    assert acts is not None, "Activations cannot be None"
-    assert acts.dim() == 3, f"Expected 3D tensor, got {acts.dim()}D"
-```
-
 ## Type Annotations
 - Use jaxtyping for tensor shapes (though for now we don't do runtime checking)
 - Always use the PEP 604 typing format of `|` for unions and `type | None` over `Optional`.
@@ -47,14 +35,14 @@ Your first instinct should be: "If I couldn't write any comments, how would I wr
 **Don't**: Write Obvious Comments
 **Do**: Write comments for complex logic
 
+**Bad:**
 ```python
-# BAD
 # get dataloader
 dataloader = get_dataloader(config)
 ```
 
-```
-# GOOD
+**Good:**
+```python
 # We need to mask out future positions for causal attention
 # Upper triangular matrix excludes the diagonal (hence k=1)
 causal_mask = torch.triu(torch.ones(seq_len, seq_len), diagonal=1)


### PR DESCRIPTION
straighforward - adds a code style guide. My justification for this being useful is that it prevents back and forth about style which is somewhat subjective. In general, agreeing on and obeying a consistent coding style is much more beneficial than picking "the right" coding style.

Very open to suggestions here