### PR TITLE
Feat/graph causal estimator

### DIFF
--- a/spd/models/component_model.py
+++ b/spd/models/component_model.py
@@ -68,10 +68,13 @@ class ComponentModel(nn.Module):
         components: nn.ModuleDict, gate_type: GateType, gate_hidden_dims: list[int], C: int
     ) -> nn.ModuleDict:
         if gate_type == "star_graph":
-            gates = nn.ModuleDict({"star_graph": StarGraphGate(
-                components=components, C=C, node_dims=gate_hidden_dims
+            gates = nn.ModuleDict(
+                {
+                    "star_graph": StarGraphGate(
+                        components=components, C=C, node_dims=gate_hidden_dims
+                    )
+                }
             )
-            })
         else:
             gates = nn.ModuleDict()
             for component_name, component in components.items():

--- a/spd/run_spd.py
+++ b/spd/run_spd.py
@@ -18,7 +18,13 @@ from spd.core_metrics_and_figs import create_figures, create_metrics
 from spd.log import logger
 from spd.losses import calculate_losses
 from spd.models.component_model import ComponentModel, init_Vs_and_Us_
-from spd.models.components import EmbeddingComponent, GateMLP, LinearComponent, StarGraphGate, VectorGateMLP
+from spd.models.components import (
+    EmbeddingComponent,
+    GateMLP,
+    LinearComponent,
+    StarGraphGate,
+    VectorGateMLP,
+)
 from spd.utils.component_utils import calc_causal_importances
 from spd.utils.general_utils import (
     extract_batch_data,
@@ -85,7 +91,7 @@ def optimize(
         for k, v in model.gates.items()
     }
     components: dict[str, LinearComponent | EmbeddingComponent] = {
-        k.removeprefix("components.").replace("-", "."): cast(  
+        k.removeprefix("components.").replace("-", "."): cast(
             LinearComponent | EmbeddingComponent, v
         )
         for k, v in model.components.items()

--- a/spd/utils/component_utils.py
+++ b/spd/utils/component_utils.py
@@ -8,7 +8,13 @@ from torch import Tensor
 from torch.utils.data import DataLoader
 
 from spd.models.component_model import ComponentModel
-from spd.models.components import EmbeddingComponent, GateMLP, LinearComponent, StarGraphGate, VectorGateMLP
+from spd.models.components import (
+    EmbeddingComponent,
+    GateMLP,
+    LinearComponent,
+    StarGraphGate,
+    VectorGateMLP,
+)
 from spd.models.sigmoids import SIGMOID_TYPES, SigmoidTypes
 from spd.utils.general_utils import extract_batch_data
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
This PR introduces a causal estimator based on a star-shaped graph neural network.

Star-shaped GNNs are ones where central nodes have in-degree C but are connected to C nodes with out-degree 1. This layout means we can implement them with just broadcasting and einops operations, so we technically do not have to resort to using a GNN library at all.

## Related Issue
<!--- Use the keywords 'Close', 'Closes', 'Fix', or 'Fixes' followed by the issue number(s) to close the related issue(s) -->
Closes #15 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In certain contexts causal importance of a subcomponent requires knowledge of another subcomponent. For instance, in attention mechanisms, certain query tokens of the same identity should perhaps only have a subcomponent active if a corresponding key token exists. Without global knowledge, these distinctions cannot be made.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
This can been tested locally on toy models, but I have not run the big eval suite.

## Does this PR introduce a breaking change?
<!--- If this PR introduces a breaking change, please describe the impact and migration path for existing applications below. -->