### PR TITLE
makefile improvements

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,26 +9,17 @@ repos:
   #         - commit
   - repo: local
     hooks:
-      - id: basedpyright
-        name: BasedPyright
-        entry: basedpyright
+      - id: format
+        name: Ruff lint and format
+        entry: make format
         language: system
         types: [python]
         stages:
           - pre-commit
 
-      - id: ruff-lint
-        name: Ruff lint
-        entry: ruff check
-        args: ["--fix-only"]
-        language: system
-        types: [python]
-        stages:
-          - pre-commit
-
-      - id: ruff-format
-        name: Ruff format
-        entry: ruff format
+      - id: type
+        name: "Type check with BasedPyright"
+        entry: make type
         language: system
         types: [python]
         stages:

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+RUN = uv run
+
 .PHONY: install
 install:
 	uv sync --no-dev
@@ -13,7 +15,7 @@ install:
 .PHONY: install-dev
 install-dev:
 	uv sync
-	pre-commit install
+	$(RUN) pre-commit install
 	@if [ ! -f spd/user_metrics_and_figs.py ]; then \
 		cp spd/user_metrics_and_figs.py.example spd/user_metrics_and_figs.py; \
 		echo "Created spd/user_metrics_and_figs.py from template"; \
@@ -25,22 +27,22 @@ install-dev:
 
 .PHONY: type
 type:
-	SKIP=no-commit-to-branch pre-commit run -a basedpyright
+	SKIP=no-commit-to-branch $(RUN) pre-commit run -a basedpyright
 
 .PHONY: format
 format:
 	# Fix all autofixable problems (which sorts imports) then format errors
-	SKIP=no-commit-to-branch pre-commit run -a ruff-lint
-	SKIP=no-commit-to-branch pre-commit run -a ruff-format
+	SKIP=no-commit-to-branch $(RUN) pre-commit run -a ruff-lint
+	SKIP=no-commit-to-branch $(RUN) pre-commit run -a ruff-format
 
 .PHONY: check
 check:
-	SKIP=no-commit-to-branch pre-commit run -a --hook-stage commit
+	SKIP=no-commit-to-branch $(RUN) pre-commit run -a --hook-stage commit
 
 .PHONY: test
 test:
-	uv run pytest tests/
+	$(RUN) pytest tests/
 
 .PHONY: test-all
 test-all:
-	uv run pytest tests/ --runslow
+	$(RUN) pytest tests/ --runslow

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,21 @@ install-dev: copy-templates
 	uv sync
 	$(RUN) pre-commit install
 
+# If the file "spd/user_metrics_and_figs.py" does not exist,
+# copy it from the example file and print a confirmation message.
 spd/user_metrics_and_figs.py:
 	@cp spd/user_metrics_and_figs.py.example spd/user_metrics_and_figs.py
 	@echo "Created spd/user_metrics_and_figs.py from template"
 
+# Same logic as above: create the sweep_params.yaml file from its template
+# only if it doesn't already exist.
 spd/scripts/sweep_params.yaml:
 	@cp spd/scripts/sweep_params.yaml.example spd/scripts/sweep_params.yaml
 	@echo "Created spd/scripts/sweep_params.yaml from template"
 
+# Declare "copy-templates" as a phony target (not a file on disk)
+# This rule depends on two file targets. If either file doesn't exist,
+# its associated recipe will be executed to create it.
 .PHONY: copy-templates
 copy-templates: spd/user_metrics_and_figs.py spd/scripts/sweep_params.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -7,25 +7,18 @@ install: copy-templates
 .PHONY: install-dev
 install-dev: copy-templates
 	uv sync
-	$(RUN) pre-commit install
+	pre-commit install
 
-# If the file "spd/user_metrics_and_figs.py" does not exist,
-# copy it from the example file and print a confirmation message.
-spd/user_metrics_and_figs.py:
-	@cp spd/user_metrics_and_figs.py.example spd/user_metrics_and_figs.py
-	@echo "Created spd/user_metrics_and_figs.py from template"
-
-# Same logic as above: create the sweep_params.yaml file from its template
-# only if it doesn't already exist.
-spd/scripts/sweep_params.yaml:
-	@cp spd/scripts/sweep_params.yaml.example spd/scripts/sweep_params.yaml
-	@echo "Created spd/scripts/sweep_params.yaml from template"
-
-# Declare "copy-templates" as a phony target (not a file on disk)
-# This rule depends on two file targets. If either file doesn't exist,
-# its associated recipe will be executed to create it.
 .PHONY: copy-templates
-copy-templates: spd/user_metrics_and_figs.py spd/scripts/sweep_params.yaml
+copy-templates:
+	@if [ ! -f spd/user_metrics_and_figs.py ]; then \
+		cp spd/user_metrics_and_figs.py.example spd/user_metrics_and_figs.py; \
+		echo "Created spd/user_metrics_and_figs.py from template"; \
+	fi
+	@if [ ! -f spd/scripts/sweep_params.yaml ]; then \
+		cp spd/scripts/sweep_params.yaml.example spd/scripts/sweep_params.yaml; \
+		echo "Created spd/scripts/sweep_params.yaml from template"; \
+	fi
 
 .PHONY: type
 type:

--- a/Makefile
+++ b/Makefile
@@ -1,29 +1,24 @@
 RUN = uv run
 
 .PHONY: install
-install:
+install: copy-templates
 	uv sync --no-dev
-	@if [ ! -f spd/user_metrics_and_figs.py ]; then \
-		cp spd/user_metrics_and_figs.py.example spd/user_metrics_and_figs.py; \
-		echo "Created spd/user_metrics_and_figs.py from template"; \
-	fi
-	@if [ ! -f spd/scripts/sweep_params.yaml ]; then \
-		cp spd/scripts/sweep_params.yaml.example spd/scripts/sweep_params.yaml; \
-		echo "Created spd/scripts/sweep_params.yaml from template"; \
-	fi
 
 .PHONY: install-dev
-install-dev:
+install-dev: copy-templates
 	uv sync
 	$(RUN) pre-commit install
-	@if [ ! -f spd/user_metrics_and_figs.py ]; then \
-		cp spd/user_metrics_and_figs.py.example spd/user_metrics_and_figs.py; \
-		echo "Created spd/user_metrics_and_figs.py from template"; \
-	fi
-	@if [ ! -f spd/scripts/sweep_params.yaml ]; then \
-		cp spd/scripts/sweep_params.yaml.example spd/scripts/sweep_params.yaml; \
-		echo "Created spd/scripts/sweep_params.yaml from template"; \
-	fi
+
+spd/user_metrics_and_figs.py:
+	@cp spd/user_metrics_and_figs.py.example spd/user_metrics_and_figs.py
+	@echo "Created spd/user_metrics_and_figs.py from template"
+
+spd/scripts/sweep_params.yaml:
+	@cp spd/scripts/sweep_params.yaml.example spd/scripts/sweep_params.yaml
+	@echo "Created spd/scripts/sweep_params.yaml from template"
+
+.PHONY: copy-templates
+copy-templates: spd/user_metrics_and_figs.py spd/scripts/sweep_params.yaml
 
 .PHONY: type
 type:

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
-RUN = uv run
-
+# setup
 .PHONY: install
 install: copy-templates
 	uv sync --no-dev
@@ -20,24 +19,30 @@ copy-templates:
 		echo "Created spd/scripts/sweep_params.yaml from template"; \
 	fi
 
+
+# checks
 .PHONY: type
 type:
-	SKIP=no-commit-to-branch $(RUN) pre-commit run -a basedpyright
+	basedpyright
 
 .PHONY: format
 format:
 	# Fix all autofixable problems (which sorts imports) then format errors
-	SKIP=no-commit-to-branch $(RUN) pre-commit run -a ruff-lint
-	SKIP=no-commit-to-branch $(RUN) pre-commit run -a ruff-format
+	ruff check --fix
+	ruff format
 
 .PHONY: check
-check:
-	SKIP=no-commit-to-branch $(RUN) pre-commit run -a --hook-stage commit
+check: format type
 
+.PHONY: check-pre-commit
+check-pre-commit:
+	SKIP=no-commit-to-branch pre-commit run -a --hook-stage commit
+
+# tests
 .PHONY: test
 test:
-	$(RUN) pytest tests/
+	pytest tests/
 
 .PHONY: test-all
 test-all:
-	$(RUN) pytest tests/ --runslow
+	pytest tests/ --runslow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,8 @@ fix = true
 [tool.ruff.lint]
 ignore = [
     "F722", # Incompatible with jaxtyping
-    "E731" # I think lambda functions are fine in several places
+    "E731", # I think lambda functions are fine in several places
+    "E501", # there are a lot of long lines in the codebase
 ]
 select = [
     # pycodestyle

--- a/spd/experiments/tms/plotting.py
+++ b/spd/experiments/tms/plotting.py
@@ -742,10 +742,7 @@ class HiddenLayerPlotter:
         # Ensure axs is iterable even for single subplot
         from matplotlib.axes import Axes as AxesType
 
-        if isinstance(axs, AxesType):
-            axs_list = [axs]
-        else:
-            axs_list = list(axs)
+        axs_list: list[AxesType] = [axs] if isinstance(axs, AxesType) else list(axs)
 
         # Plot heatmaps
         self._plot_heatmaps(fig, axs_list, all_weights, subnets_order, n_subnets)

--- a/spd/utils/data_utils.py
+++ b/spd/utils/data_utils.py
@@ -1,15 +1,13 @@
 from collections.abc import Iterator
-from typing import Generic, Literal, TypeVar, override
+from typing import Literal, override
 
 import torch
 from jaxtyping import Float
 from torch import Tensor
 from torch.utils.data import DataLoader, Dataset
 
-Q = TypeVar("Q")
 
-
-class DatasetGeneratedDataLoader(DataLoader[Q], Generic[Q]):
+class DatasetGeneratedDataLoader[Q](DataLoader[Q]):
     """DataLoader that generates batches by calling the dataset's `generate_batch` method."""
 
     def __init__(
@@ -31,7 +29,7 @@ class DatasetGeneratedDataLoader(DataLoader[Q], Generic[Q]):
             yield self.dataset.generate_batch(self.batch_size)  # pyright: ignore[reportAttributeAccessIssue]
 
 
-class BatchedDataLoader(DataLoader[Q], Generic[Q]):
+class BatchedDataLoader[Q](DataLoader[Q]):
     """DataLoader that unpacks the batch in __getitem__.
 
     This is used for datasets which generate a whole batch in one call to __getitem__.

--- a/spd/utils/general_utils.py
+++ b/spd/utils/general_utils.py
@@ -95,10 +95,9 @@ def load_config(config_path_or_obj: Path | str | dict[str, Any] | T, config_mode
     return config_model(**config_dict)
 
 
-BaseModelType = TypeVar("BaseModelType", bound=BaseModel)
-
-
-def replace_pydantic_model(model: BaseModelType, *updates: dict[str, Any]) -> BaseModelType:
+def replace_pydantic_model[BaseModelType: BaseModel](
+    model: BaseModelType, *updates: dict[str, Any]
+) -> BaseModelType:
     """Create a new model with (potentially nested) updates in the form of dictionaries.
 
     Args:

--- a/spd/utils/wandb_utils.py
+++ b/spd/utils/wandb_utils.py
@@ -10,7 +10,7 @@ from wandb.apis.public import File, Run
 from spd.settings import REPO_ROOT
 from spd.utils.general_utils import replace_pydantic_model
 
-T = TypeVar("T", bound=BaseModel)
+T_config = TypeVar("T_config", bound=BaseModel)
 
 
 def fetch_latest_wandb_checkpoint(run: Run, prefix: str | None = None) -> File:
@@ -80,9 +80,9 @@ def download_wandb_file(run: Run, wandb_run_dir: Path, file_name: str) -> Path:
     return path
 
 
-def init_wandb(
-    config: T, project: str, name: str | None = None, tags: list[str] | None = None
-) -> T:
+def init_wandb[T_config: BaseModel](
+    config: T_config, project: str, name: str | None = None, tags: list[str] | None = None
+) -> T_config:
     """Initialize Weights & Biases and return a config updated with sweep hyperparameters.
 
     Args:


### PR DESCRIPTION
## Description
We want a single source of truth for common repo tasks, and having it be the makefile is nice. `make` is installed by default pretty much everywhere, and using it instead of `pre-commit` as the source of truth means running tasks does not depend on having the virtual environment set up properly.

## Related Issue
Closes #5 

Specifically, see https://github.com/goodfire-ai/spd/issues/5#issuecomment-3079215722

## Motivation and Context
- `make` recipes are now the source of truth for themselves and for `pre-commit`
- template copying is cleaner
