### PR TITLE
Refactor component alive tracking with configurable AliveComponentsTracker

### DIFF
--- a/spd/configs.py
+++ b/spd/configs.py
@@ -294,7 +294,7 @@ class Config(BaseModel):
     )
     n_examples_until_dead: PositiveInt = Field(
         ...,
-        description="Number of examples without firing before a component is considered dead",
+        description="Number of examples without firing before a component is considered dead. an example is whatever a ",
     )
 
     # --- Pretrained model info ---

--- a/spd/configs.py
+++ b/spd/configs.py
@@ -287,6 +287,16 @@ class Config(BaseModel):
         description="List of local names of functions to use for creating figures. These functions must be defined in the `spd.metrics_and_figs` module.",
     )
 
+    # --- Component Tracking ---
+    ci_alive_threshold: Probability = Field(
+        default=0.1,
+        description="Causal importance threshold above which a component is considered 'firing'",
+    )
+    n_examples_until_dead: PositiveInt = Field(
+        ...,
+        description="Number of examples without firing before a component is considered dead",
+    )
+
     # --- Pretrained model info ---
     pretrained_model_class: str = Field(
         ...,

--- a/spd/configs.py
+++ b/spd/configs.py
@@ -294,7 +294,7 @@ class Config(BaseModel):
     )
     n_examples_until_dead: PositiveInt = Field(
         ...,
-        description="Number of examples without firing before a component is considered dead. an example is whatever a ",
+        description="Number of examples without firing before a component is considered dead. Note that in LMs, an example is a token, not a sequence.",
     )
 
     # --- Pretrained model info ---

--- a/spd/experiments/lm/component_viz.py
+++ b/spd/experiments/lm/component_viz.py
@@ -48,6 +48,7 @@ def main(path: ModelPath) -> None:
             dataloader=dataloader,
             n_steps=100,
             device=device,
+            threshold=config.ci_alive_threshold,
         )
     )
     logger.info(f"n_components: {ss_model.C}")

--- a/spd/experiments/lm/plot_embedding_components.py
+++ b/spd/experiments/lm/plot_embedding_components.py
@@ -74,12 +74,15 @@ def permute_to_identity(
     return new_mask, perm_indices
 
 
-def plot_embedding_mask_heatmap(masks: Float[Tensor, "vocab C"], out_dir: Path) -> None:
+def plot_embedding_mask_heatmap(
+    masks: Float[Tensor, "vocab C"], out_dir: Path, ci_alive_threshold: float
+) -> None:
     """Plot heatmap of embedding masks.
 
     Args:
         masks: Tensor of shape (vocab_size, C) containing masks
         out_dir: Directory to save the plots
+        ci_alive_threshold: Threshold for considering a component alive
     """
     plt.figure(figsize=(20, 10))
     plt.imshow(
@@ -125,8 +128,8 @@ def plot_embedding_mask_heatmap(masks: Float[Tensor, "vocab C"], out_dir: Path) 
     print(f"Saved first token histogram to {out_dir / 'first_token_histogram.png'} and .svg")
     plt.close()
 
-    n_alive_components = ((masks > 0.1).any(dim=0)).sum().item()
-    print(f"Number of components that have any value > 0.1: {n_alive_components}")
+    n_alive_components = ((masks > ci_alive_threshold).any(dim=0)).sum().item()
+    print(f"Number of components that have any value > {ci_alive_threshold}: {n_alive_components}")
     ...
 
 
@@ -137,14 +140,14 @@ def main(model_path: str | Path) -> None:
         model_path: Path to the model checkpoint
     """
     # Load model
-    model, _config, out_dir = ComponentModel.from_pretrained(model_path)
+    model, config, out_dir = ComponentModel.from_pretrained(model_path)
     device = "cuda" if torch.cuda.is_available() else "cpu"
     model.to(device)
 
     # Collect masks
     masks = collect_embedding_masks(model, device)
     permuted_masks, _perm_indices = permute_to_identity(masks)
-    plot_embedding_mask_heatmap(permuted_masks, out_dir)
+    plot_embedding_mask_heatmap(permuted_masks, out_dir, config.ci_alive_threshold)
 
 
 if __name__ == "__main__":

--- a/spd/experiments/lm/ss_emb_config.yaml
+++ b/spd/experiments/lm/ss_emb_config.yaml
@@ -40,6 +40,7 @@ image_freq: 2000
 image_on_first_step: true
 print_freq: 1000
 save_freq: null
+n_examples_until_dead: 2_048_000  # print_freq * batch_size * max_seq_len = 1000 * 4 * 512
 figures_fns:
   - name: "ci_histograms"
   - name: "mean_component_activation_counts"

--- a/spd/experiments/lm/ts_config.yaml
+++ b/spd/experiments/lm/ts_config.yaml
@@ -43,6 +43,7 @@ image_freq: 2000
 image_on_first_step: true
 print_freq: 1000
 save_freq: null
+n_examples_until_dead: 8_192_000  # print_freq * batch_size * max_seq_len = 1000 * 4 * 2048
 figures_fns:
   - name: "ci_histograms"
   - name: "mean_component_activation_counts"

--- a/spd/experiments/resid_mlp/resid_mlp1_config.yaml
+++ b/spd/experiments/resid_mlp/resid_mlp1_config.yaml
@@ -39,6 +39,7 @@ image_freq: 5_000
 image_on_first_step: true
 print_freq: 100
 save_freq: null
+n_examples_until_dead: 204_800  # print_freq * batch_size = 100 * 2048
 figures_fns:
   - name: "ci_histograms"
   - name: "mean_component_activation_counts"

--- a/spd/experiments/resid_mlp/resid_mlp2_config.yaml
+++ b/spd/experiments/resid_mlp/resid_mlp2_config.yaml
@@ -39,6 +39,7 @@ image_freq: 5_000
 image_on_first_step: true
 print_freq: 500
 save_freq: null
+n_examples_until_dead: 1_024_000  # print_freq * batch_size = 500 * 2048
 figures_fns:
   - name: "ci_histograms"
   - name: "mean_component_activation_counts"

--- a/spd/experiments/resid_mlp/resid_mlp3_config.yaml
+++ b/spd/experiments/resid_mlp/resid_mlp3_config.yaml
@@ -39,6 +39,7 @@ image_freq: 5_000
 image_on_first_step: true
 print_freq: 500
 save_freq: null
+n_examples_until_dead: 1_024_000  # print_freq * batch_size = 500 * 2048
 figures_fns:
   - name: "ci_histograms"
   - name: "mean_component_activation_counts"

--- a/spd/experiments/tms/tms_40-10-id_config.yaml
+++ b/spd/experiments/tms/tms_40-10-id_config.yaml
@@ -35,6 +35,7 @@ n_eval_steps: 100
 image_freq: 5_000
 print_freq: 1000
 save_freq: null
+n_examples_until_dead: 4_096_000  # print_freq * batch_size = 1000 * 4096
 figures_fns:
   - name: "ci_histograms"
   - name: "mean_component_activation_counts"

--- a/spd/experiments/tms/tms_40-10_config.yaml
+++ b/spd/experiments/tms/tms_40-10_config.yaml
@@ -35,6 +35,7 @@ n_eval_steps: 100
 image_freq: 5_000
 print_freq: 1000
 save_freq: null
+n_examples_until_dead: 4_096_000  # print_freq * batch_size = 1000 * 4096
 figures_fns:
   - name: "ci_histograms"
   - name: "mean_component_activation_counts"

--- a/spd/experiments/tms/tms_5-2-id_config.yaml
+++ b/spd/experiments/tms/tms_5-2-id_config.yaml
@@ -35,6 +35,7 @@ n_eval_steps: 100
 image_freq: 5_000
 print_freq: 1000
 save_freq: null
+n_examples_until_dead: 4_096_000  # print_freq * batch_size = 1000 * 4096
 figures_fns:
   - name: "ci_histograms"
   - name: "mean_component_activation_counts"

--- a/spd/experiments/tms/tms_5-2_config.yaml
+++ b/spd/experiments/tms/tms_5-2_config.yaml
@@ -35,6 +35,7 @@ n_eval_steps: 100
 image_freq: 5_000
 print_freq: 1000
 save_freq: null
+n_examples_until_dead: 4_096_000  # print_freq * batch_size = 1000 * 4096
 figures_fns:
   - name: "ci_histograms"
   - name: "mean_component_activation_counts"

--- a/spd/figures.py
+++ b/spd/figures.py
@@ -60,6 +60,7 @@ def mean_component_activation_counts(inputs: CreateFiguresInputs) -> Mapping[str
         dataloader=inputs.eval_loader,
         n_steps=inputs.n_eval_steps,
         device=str(inputs.device),
+        threshold=inputs.config.ci_alive_threshold,
     )[1]
     return {
         "mean_component_activation_counts": plot_mean_component_activation_counts(

--- a/spd/metrics.py
+++ b/spd/metrics.py
@@ -71,7 +71,9 @@ def lm_ce_losses(inputs: CreateMetricsInputs) -> Mapping[str, float | int | wand
 def lm_embed(inputs: CreateMetricsInputs) -> Mapping[str, float | int | wandb.Table]:
     for key in ["transformer.wte", "model.embed_tokens"]:
         if key in inputs.causal_importances:
-            embed_ci_table = create_embed_ci_sample_table(inputs.causal_importances, key)
+            embed_ci_table = create_embed_ci_sample_table(
+                inputs.causal_importances, key, threshold=inputs.config.ci_alive_threshold
+            )
             return {"misc/embed_ci_sample": embed_ci_table}
     raise ValueError("No embedding components found in causal importances")
 

--- a/spd/plotting.py
+++ b/spd/plotting.py
@@ -338,7 +338,7 @@ def plot_UV_matrices(
 
 
 def create_embed_ci_sample_table(
-    causal_importances: dict[str, Float[Tensor, "... C"]], key: str
+    causal_importances: dict[str, Float[Tensor, "... C"]], key: str, threshold: float
 ) -> wandb.Table:
     """Create a wandb table visualizing embedding mask values.
 
@@ -354,7 +354,7 @@ def create_embed_ci_sample_table(
     component_names = ["TokenSample"] + ["CompVal" for _ in range(10)]
 
     for i, ci in enumerate(causal_importances[key][0, :20]):
-        active_values = ci[ci > 0.1].tolist()
+        active_values = ci[ci > threshold].tolist()
         # Cap at 10 components
         active_values = active_values[:10]
         formatted_values = [f"{val:.2f}" for val in active_values]

--- a/spd/run_spd.py
+++ b/spd/run_spd.py
@@ -156,7 +156,7 @@ def optimize(
                 if step > 0:
                     n_alive = alive_tracker.n_alive()
                     for layer_name, n_alive_count in n_alive.items():
-                        log_data[f"{layer_name}/n_alive_01"] = n_alive_count
+                        log_data[f"{layer_name}/n_alive_{config.ci_alive_threshold}"] = n_alive_count
 
                 metrics = create_metrics(
                     model=model,

--- a/spd/run_spd.py
+++ b/spd/run_spd.py
@@ -156,7 +156,9 @@ def optimize(
                 if step > 0:
                     n_alive = alive_tracker.n_alive()
                     for layer_name, n_alive_count in n_alive.items():
-                        log_data[f"{layer_name}/n_alive_{config.ci_alive_threshold}"] = n_alive_count
+                        log_data[f"{layer_name}/n_alive_{config.ci_alive_threshold}"] = (
+                            n_alive_count
+                        )
 
                 metrics = create_metrics(
                     model=model,

--- a/spd/utils/alive_components_tracker.py
+++ b/spd/utils/alive_components_tracker.py
@@ -1,0 +1,87 @@
+"""Track which components are alive based on their firing frequency."""
+
+import torch
+from einops import reduce
+from jaxtyping import Bool, Float
+from torch import Tensor
+
+
+class AliveComponentsTracker:
+    """Track which components are considered alive based on their firing frequency.
+
+    A component is considered alive if it has fired (importance > threshold) within
+    the last n_examples_until_dead examples.
+    """
+
+    def __init__(
+        self,
+        module_names: list[str],
+        C: int,
+        n_examples_until_dead: int,
+        device: torch.device,
+        ci_alive_threshold: float,
+    ):
+        """Initialize the tracker.
+
+        Args:
+            module_names: Names of modules to track
+            C: Number of components per module
+            n_examples_until_dead: Number of examples without firing before component is considered dead
+            device: Device to store tensors on
+            ci_alive_threshold: Causal importance threshold above which a component is considered 'firing'
+        """
+        self.module_names = module_names
+        self.examples_since_fired_C = {
+            module_name: torch.zeros(C, dtype=torch.int64, device=device)
+            for module_name in module_names
+        }
+        self.n_examples_until_dead = n_examples_until_dead
+        self.ci_alive_threshold = ci_alive_threshold
+
+    def watch_batch(self, importance_vals_dict_BxC: dict[str, Float[Tensor, "... C"]]) -> None:
+        """Update tracking based on importance values from a batch.
+
+        Args:
+            importance_vals_dict_BxC: Dict mapping module names to importance tensors
+                                     with shape (..., C) where ... represents batch dimensions
+        """
+        assert set(importance_vals_dict_BxC.keys()) == set(self.module_names), (
+            "importance_vals_BxC must have the same keys as module_names"
+        )
+        for module_name, importance_vals_BxC in importance_vals_dict_BxC.items():
+            firing_C: Bool[Tensor, " C"] = reduce(
+                importance_vals_BxC > self.ci_alive_threshold, "... C -> C", "any"
+            )
+            self.examples_since_fired_C[module_name][firing_C] = 0
+
+            n_examples = importance_vals_BxC.shape[:-1].numel()
+            self.examples_since_fired_C[module_name][~firing_C] += n_examples
+
+    def n_alive(self) -> dict[str, int]:
+        """Get the number of alive components per module.
+
+        Returns:
+            Dict mapping module names to number of alive components
+        """
+        return {
+            module_name: int(
+                (self.examples_since_fired_C[module_name] < self.n_examples_until_dead).sum().item()
+            )
+            for module_name in self.module_names
+        }
+
+    def is_alive(self) -> dict[str, Bool[Tensor, " C"]]:
+        """Get boolean mask of which components are alive per module.
+
+        Returns:
+            Dict mapping module names to boolean tensors indicating alive components
+        """
+        return {
+            module_name: self.examples_since_fired_C[module_name] < self.n_examples_until_dead
+            for module_name in self.module_names
+        }
+
+    def reset(self) -> None:
+        """Reset all tracking (all components start as not having fired)."""
+        for module_name in self.module_names:
+            self.examples_since_fired_C[module_name].zero_()

--- a/spd/utils/alive_components_tracker.py
+++ b/spd/utils/alive_components_tracker.py
@@ -2,7 +2,7 @@
 
 import torch
 from einops import reduce
-from jaxtyping import Bool, Float
+from jaxtyping import Bool, Float, Int
 from torch import Tensor
 
 
@@ -31,31 +31,35 @@ class AliveComponentsTracker:
             ci_alive_threshold: Causal importance threshold above which a component is considered 'firing'
         """
         self.module_names = module_names
-        self.examples_since_fired_C = {
+        self.examples_since_fired: dict[str, Int[Tensor, " C"]] = {
             module_name: torch.zeros(C, dtype=torch.int64, device=device)
             for module_name in module_names
         }
         self.n_examples_until_dead = n_examples_until_dead
         self.ci_alive_threshold = ci_alive_threshold
 
-    def watch_batch(self, importance_vals_dict_BxC: dict[str, Float[Tensor, "... C"]]) -> None:
+    def watch_batch(self, importance_vals_dict: dict[str, Float[Tensor, "... C"]]) -> None:
         """Update tracking based on importance values from a batch.
 
         Args:
-            importance_vals_dict_BxC: Dict mapping module names to importance tensors
-                                     with shape (..., C) where ... represents batch dimensions
+            importance_vals_dict: Dict mapping module names to importance tensors
+                                  with shape (..., C) where ... represents batch dimensions
         """
-        assert set(importance_vals_dict_BxC.keys()) == set(self.module_names), (
-            "importance_vals_BxC must have the same keys as module_names"
+        assert set(importance_vals_dict.keys()) == set(self.module_names), (
+            "importance_vals_dict must have the same keys as module_names"
         )
-        for module_name, importance_vals_BxC in importance_vals_dict_BxC.items():
-            firing_C: Bool[Tensor, " C"] = reduce(
-                importance_vals_BxC > self.ci_alive_threshold, "... C -> C", "any"
+        for module_name, importance_vals in importance_vals_dict.items():
+            firing: Bool[Tensor, " C"] = reduce(
+                importance_vals > self.ci_alive_threshold, "... C -> C", torch.any
             )
-            self.examples_since_fired_C[module_name][firing_C] = 0
 
-            n_examples = importance_vals_BxC.shape[:-1].numel()
-            self.examples_since_fired_C[module_name][~firing_C] += n_examples
+            n_examples = importance_vals.shape[:-1].numel()
+
+            self.examples_since_fired[module_name] = torch.where(
+                firing,
+                0,
+                self.examples_since_fired[module_name] + n_examples,
+            )
 
     def n_alive(self) -> dict[str, int]:
         """Get the number of alive components per module.
@@ -65,7 +69,7 @@ class AliveComponentsTracker:
         """
         return {
             module_name: int(
-                (self.examples_since_fired_C[module_name] < self.n_examples_until_dead).sum().item()
+                (self.examples_since_fired[module_name] < self.n_examples_until_dead).sum().item()
             )
             for module_name in self.module_names
         }

--- a/spd/utils/alive_components_tracker.py
+++ b/spd/utils/alive_components_tracker.py
@@ -69,14 +69,3 @@ class AliveComponentsTracker:
             )
             for module_name in self.module_names
         }
-
-    def is_alive(self) -> dict[str, Bool[Tensor, " C"]]:
-        """Get boolean mask of which components are alive per module.
-
-        Returns:
-            Dict mapping module names to boolean tensors indicating alive components
-        """
-        return {
-            module_name: self.examples_since_fired_C[module_name] < self.n_examples_until_dead
-            for module_name in self.module_names
-        }

--- a/spd/utils/alive_components_tracker.py
+++ b/spd/utils/alive_components_tracker.py
@@ -80,8 +80,3 @@ class AliveComponentsTracker:
             module_name: self.examples_since_fired_C[module_name] < self.n_examples_until_dead
             for module_name in self.module_names
         }
-
-    def reset(self) -> None:
-        """Reset all tracking (all components start as not having fired)."""
-        for module_name in self.module_names:
-            self.examples_since_fired_C[module_name].zero_()

--- a/spd/utils/component_utils.py
+++ b/spd/utils/component_utils.py
@@ -46,7 +46,7 @@ def component_activation_statistics(
     | DataLoader[tuple[Float[Tensor, "..."], Float[Tensor, "..."]]],
     n_steps: int,
     device: str,
-    threshold: float = 0.1,
+    threshold: float,
 ) -> tuple[dict[str, float], dict[str, Float[Tensor, " C"]]]:
     """Get the number and strength of the masks over the full dataset."""
     n_tokens = {module_name: 0 for module_name in model.components}

--- a/tests/test_alive_components_tracker.py
+++ b/tests/test_alive_components_tracker.py
@@ -116,31 +116,6 @@ def test_n_alive():
     assert n_alive["layer2"] == 3
 
 
-def test_is_alive():
-    """Test getting alive boolean masks."""
-    module_names = ["layer1"]
-    C = 4
-    n_examples_until_dead = 5
-    device = torch.device("cpu")
-    ci_alive_threshold = 0.1
-
-    tracker = AliveComponentsTracker(
-        module_names=module_names,
-        C=C,
-        n_examples_until_dead=n_examples_until_dead,
-        device=device,
-        ci_alive_threshold=ci_alive_threshold,
-    )
-
-    # Manually set examples since fired
-    tracker.examples_since_fired_C["layer1"] = torch.tensor([0, 3, 5, 10], device=device)
-
-    is_alive = tracker.is_alive()
-
-    expected = torch.tensor([True, True, False, False], device=device)
-    assert torch.equal(is_alive["layer1"], expected)
-
-
 def test_sequence_dimensions():
     """Test with sequence dimensions (e.g., for language models)."""
     module_names = ["embedding"]

--- a/tests/test_alive_components_tracker.py
+++ b/tests/test_alive_components_tracker.py
@@ -1,0 +1,228 @@
+"""Tests for AliveComponentsTracker."""
+
+import torch
+
+from spd.utils.alive_components_tracker import AliveComponentsTracker
+
+
+def test_watch_batch_single_example():
+    """Test watching a single example batch."""
+    module_names = ["layer1", "layer2"]
+    C = 5
+    n_examples_until_dead = 10
+    device = torch.device("cpu")
+    ci_alive_threshold = 0.1
+
+    tracker = AliveComponentsTracker(
+        module_names=module_names,
+        C=C,
+        n_examples_until_dead=n_examples_until_dead,
+        device=device,
+        ci_alive_threshold=ci_alive_threshold,
+    )
+
+    # Create importance values where some components fire (> threshold)
+    # layer1: components 0, 2 fire; 1, 3, 4 don't
+    # layer2: components 1, 3, 4 fire; 0, 2 don't
+    importance_vals = {
+        "layer1": torch.tensor([0.2, 0.05, 0.15, 0.0, 0.08], device=device),
+        "layer2": torch.tensor([0.05, 0.12, 0.08, 0.2, 0.11], device=device),
+    }
+
+    tracker.watch_batch(importance_vals)
+
+    # Check that firing components reset to 0
+    assert tracker.examples_since_fired_C["layer1"][0] == 0
+    assert tracker.examples_since_fired_C["layer1"][2] == 0
+    assert tracker.examples_since_fired_C["layer2"][1] == 0
+    assert tracker.examples_since_fired_C["layer2"][3] == 0
+    assert tracker.examples_since_fired_C["layer2"][4] == 0
+
+    # Check that non-firing components increment by 1
+    assert tracker.examples_since_fired_C["layer1"][1] == 1
+    assert tracker.examples_since_fired_C["layer1"][3] == 1
+    assert tracker.examples_since_fired_C["layer1"][4] == 1
+    assert tracker.examples_since_fired_C["layer2"][0] == 1
+    assert tracker.examples_since_fired_C["layer2"][2] == 1
+
+
+def test_watch_batch_multiple_examples():
+    """Test watching a batch with multiple examples."""
+    module_names = ["layer1"]
+    C = 3
+    n_examples_until_dead = 10
+    device = torch.device("cpu")
+    ci_alive_threshold = 0.1
+
+    tracker = AliveComponentsTracker(
+        module_names=module_names,
+        C=C,
+        n_examples_until_dead=n_examples_until_dead,
+        device=device,
+        ci_alive_threshold=ci_alive_threshold,
+    )
+
+    # Batch of 4 examples, shape (4, 3)
+    # Component 0: fires in examples 0 and 2
+    # Component 1: never fires
+    # Component 2: fires in example 3
+    importance_vals = {
+        "layer1": torch.tensor(
+            [
+                [0.2, 0.05, 0.08],  # Example 0: component 0 fires
+                [0.05, 0.08, 0.09],  # Example 1: no components fire
+                [0.15, 0.0, 0.05],  # Example 2: component 0 fires
+                [0.08, 0.09, 0.12],  # Example 3: component 2 fires
+            ],
+            device=device,
+        )
+    }
+
+    tracker.watch_batch(importance_vals)
+
+    # Component 0 fired, so should be 0
+    assert tracker.examples_since_fired_C["layer1"][0] == 0
+    # Component 1 never fired, so should be 4 (batch size)
+    assert tracker.examples_since_fired_C["layer1"][1] == 4
+    # Component 2 fired, so should be 0
+    assert tracker.examples_since_fired_C["layer1"][2] == 0
+
+
+def test_n_alive():
+    """Test counting alive components."""
+    module_names = ["layer1", "layer2"]
+    C = 4
+    n_examples_until_dead = 5
+    device = torch.device("cpu")
+    ci_alive_threshold = 0.1
+
+    tracker = AliveComponentsTracker(
+        module_names=module_names,
+        C=C,
+        n_examples_until_dead=n_examples_until_dead,
+        device=device,
+        ci_alive_threshold=ci_alive_threshold,
+    )
+
+    # Manually set examples since fired
+    tracker.examples_since_fired_C["layer1"] = torch.tensor([0, 3, 5, 10], device=device)
+    tracker.examples_since_fired_C["layer2"] = torch.tensor([4, 4, 6, 0], device=device)
+
+    n_alive = tracker.n_alive()
+
+    # layer1: components 0 (0 < 5) and 1 (3 < 5) are alive
+    assert n_alive["layer1"] == 2
+    # layer2: components 0 (4 < 5), 1 (4 < 5), and 3 (0 < 5) are alive
+    assert n_alive["layer2"] == 3
+
+
+def test_is_alive():
+    """Test getting alive boolean masks."""
+    module_names = ["layer1"]
+    C = 4
+    n_examples_until_dead = 5
+    device = torch.device("cpu")
+    ci_alive_threshold = 0.1
+
+    tracker = AliveComponentsTracker(
+        module_names=module_names,
+        C=C,
+        n_examples_until_dead=n_examples_until_dead,
+        device=device,
+        ci_alive_threshold=ci_alive_threshold,
+    )
+
+    # Manually set examples since fired
+    tracker.examples_since_fired_C["layer1"] = torch.tensor([0, 3, 5, 10], device=device)
+
+    is_alive = tracker.is_alive()
+
+    expected = torch.tensor([True, True, False, False], device=device)
+    assert torch.equal(is_alive["layer1"], expected)
+
+
+def test_sequence_dimensions():
+    """Test with sequence dimensions (e.g., for language models)."""
+    module_names = ["embedding"]
+    C = 3
+    n_examples_until_dead = 100
+    device = torch.device("cpu")
+    ci_alive_threshold = 0.1
+
+    tracker = AliveComponentsTracker(
+        module_names=module_names,
+        C=C,
+        n_examples_until_dead=n_examples_until_dead,
+        device=device,
+        ci_alive_threshold=ci_alive_threshold,
+    )
+
+    # Batch size 2, sequence length 5, components 3
+    # Shape: (2, 5, 3)
+    importance_vals = {
+        "embedding": torch.tensor(
+            [
+                # Batch item 0
+                [
+                    [0.2, 0.05, 0.08],  # Token 0: component 0 fires
+                    [0.05, 0.08, 0.09],  # Token 1: no components fire
+                    [0.05, 0.12, 0.08],  # Token 2: component 1 fires
+                    [0.08, 0.09, 0.05],  # Token 3: no components fire
+                    [0.08, 0.09, 0.15],  # Token 4: component 2 fires
+                ],
+                # Batch item 1
+                [
+                    [0.05, 0.08, 0.09],  # Token 0: no components fire
+                    [0.15, 0.05, 0.08],  # Token 1: component 0 fires
+                    [0.05, 0.08, 0.09],  # Token 2: no components fire
+                    [0.08, 0.12, 0.05],  # Token 3: component 1 fires
+                    [0.08, 0.09, 0.05],  # Token 4: no components fire
+                ],
+            ],
+            device=device,
+        )
+    }
+
+    tracker.watch_batch(importance_vals)
+
+    # Component 0 fired in both batch items, so should be 0
+    assert tracker.examples_since_fired_C["embedding"][0] == 0
+    # Component 1 fired in both batch items, so should be 0
+    assert tracker.examples_since_fired_C["embedding"][1] == 0
+    # Component 2 fired only in batch item 0, so should be 0
+    assert tracker.examples_since_fired_C["embedding"][2] == 0
+
+    # Make a new batch where components 1 and 2 fire, but not 0
+    # - c0: doesn't fire in either batch
+    # - c1: fires only in batch item 1
+    # - c2: fires in both batch items
+    importance_vals = {
+        "embedding": torch.tensor(
+            [
+                # Batch item 0
+                [
+                    [0.0, 0.0, 0.0],  # Token 0: component 0 fires
+                    [0.0, 0.0, 0.0],  # Token 1: no components fire
+                    [0.0, 0.0, 0.0],  # Token 2: component 1 fires
+                    [0.0, 0.0, 0.0],  # Token 3: no components fire
+                    [0.0, 0.0, 0.2],  # Token 4: component 2 fires
+                ],
+                # Batch item 1
+                [
+                    [0.0, 0.0, 0.0],  # Token 0: no components fire
+                    [0.0, 0.0, 0.0],  # Token 1: component 0 fires
+                    [0.0, 0.0, 0.0],  # Token 2: no components fire
+                    [0.0, 0.0, 0.0],  # Token 3: component 1 fires
+                    [0.0, 0.2, 0.2],  # Token 4: no components fire
+                ],
+            ],
+            device=device,
+        )
+    }
+
+    tracker.watch_batch(importance_vals)
+
+    # All components should increment by batch_size * seq_len = 2 * 5 = 10
+    assert tracker.examples_since_fired_C["embedding"][0] == 10
+    assert tracker.examples_since_fired_C["embedding"][1] == 0
+    assert tracker.examples_since_fired_C["embedding"][2] == 0

--- a/tests/test_alive_components_tracker.py
+++ b/tests/test_alive_components_tracker.py
@@ -32,18 +32,18 @@ def test_watch_batch_single_example():
     tracker.watch_batch(importance_vals)
 
     # Check that firing components reset to 0
-    assert tracker.examples_since_fired_C["layer1"][0] == 0
-    assert tracker.examples_since_fired_C["layer1"][2] == 0
-    assert tracker.examples_since_fired_C["layer2"][1] == 0
-    assert tracker.examples_since_fired_C["layer2"][3] == 0
-    assert tracker.examples_since_fired_C["layer2"][4] == 0
+    assert tracker.examples_since_fired["layer1"][0] == 0
+    assert tracker.examples_since_fired["layer1"][2] == 0
+    assert tracker.examples_since_fired["layer2"][1] == 0
+    assert tracker.examples_since_fired["layer2"][3] == 0
+    assert tracker.examples_since_fired["layer2"][4] == 0
 
     # Check that non-firing components increment by 1
-    assert tracker.examples_since_fired_C["layer1"][1] == 1
-    assert tracker.examples_since_fired_C["layer1"][3] == 1
-    assert tracker.examples_since_fired_C["layer1"][4] == 1
-    assert tracker.examples_since_fired_C["layer2"][0] == 1
-    assert tracker.examples_since_fired_C["layer2"][2] == 1
+    assert tracker.examples_since_fired["layer1"][1] == 1
+    assert tracker.examples_since_fired["layer1"][3] == 1
+    assert tracker.examples_since_fired["layer1"][4] == 1
+    assert tracker.examples_since_fired["layer2"][0] == 1
+    assert tracker.examples_since_fired["layer2"][2] == 1
 
 
 def test_watch_batch_multiple_examples():
@@ -81,11 +81,11 @@ def test_watch_batch_multiple_examples():
     tracker.watch_batch(importance_vals)
 
     # Component 0 fired, so should be 0
-    assert tracker.examples_since_fired_C["layer1"][0] == 0
+    assert tracker.examples_since_fired["layer1"][0] == 0
     # Component 1 never fired, so should be 4 (batch size)
-    assert tracker.examples_since_fired_C["layer1"][1] == 4
+    assert tracker.examples_since_fired["layer1"][1] == 4
     # Component 2 fired, so should be 0
-    assert tracker.examples_since_fired_C["layer1"][2] == 0
+    assert tracker.examples_since_fired["layer1"][2] == 0
 
 
 def test_n_alive():
@@ -105,8 +105,8 @@ def test_n_alive():
     )
 
     # Manually set examples since fired
-    tracker.examples_since_fired_C["layer1"] = torch.tensor([0, 3, 5, 10], device=device)
-    tracker.examples_since_fired_C["layer2"] = torch.tensor([4, 4, 6, 0], device=device)
+    tracker.examples_since_fired["layer1"] = torch.tensor([0, 3, 5, 10], device=device)
+    tracker.examples_since_fired["layer2"] = torch.tensor([4, 4, 6, 0], device=device)
 
     n_alive = tracker.n_alive()
 
@@ -161,11 +161,11 @@ def test_sequence_dimensions():
     tracker.watch_batch(importance_vals)
 
     # Component 0 fired in both batch items, so should be 0
-    assert tracker.examples_since_fired_C["embedding"][0] == 0
+    assert tracker.examples_since_fired["embedding"][0] == 0
     # Component 1 fired in both batch items, so should be 0
-    assert tracker.examples_since_fired_C["embedding"][1] == 0
+    assert tracker.examples_since_fired["embedding"][1] == 0
     # Component 2 fired only in batch item 0, so should be 0
-    assert tracker.examples_since_fired_C["embedding"][2] == 0
+    assert tracker.examples_since_fired["embedding"][2] == 0
 
     # Make a new batch where components 1 and 2 fire, but not 0
     # - c0: doesn't fire in either batch
@@ -198,6 +198,6 @@ def test_sequence_dimensions():
     tracker.watch_batch(importance_vals)
 
     # All components should increment by batch_size * seq_len = 2 * 5 = 10
-    assert tracker.examples_since_fired_C["embedding"][0] == 10
-    assert tracker.examples_since_fired_C["embedding"][1] == 0
-    assert tracker.examples_since_fired_C["embedding"][2] == 0
+    assert tracker.examples_since_fired["embedding"][0] == 10
+    assert tracker.examples_since_fired["embedding"][1] == 0
+    assert tracker.examples_since_fired["embedding"][2] == 0

--- a/tests/test_component_model.py
+++ b/tests/test_component_model.py
@@ -211,6 +211,7 @@ def test_from_pretrained_model_works():
             n_eval_steps=1,
             importance_minimality_coeff=1.0,
             pnorm=1.0,
+            n_examples_until_dead=1,
             output_loss_type="mse",
             print_freq=1,
             n_mask_samples=1,

--- a/tests/test_component_model.py
+++ b/tests/test_component_model.py
@@ -195,7 +195,6 @@ def test_from_pretrained_model_works():
 
         base_model_path = base_model_dir / "model.pth"
         save_file(target_model.state_dict(), base_model_path)
-        # save_file(target_model.state_dict(), base_model_path)
 
         config = Config(
             pretrained_model_class="tests.test_component_model.SimpleTestModel",

--- a/tests/test_grid_search.py
+++ b/tests/test_grid_search.py
@@ -160,6 +160,8 @@ class TestConfigIntegration:
             "batch_size": 32,
             "n_eval_steps": 100,
             "print_freq": 100,
+            "ci_alive_threshold": 0.1,
+            "n_examples_until_dead": 3200,  # print_freq * batch_size = 100 * 32
             "pretrained_model_class": "spd.experiments.tms.models.TMSModel",
             "task_config": {
                 "task_name": "tms",
@@ -193,6 +195,8 @@ class TestConfigIntegration:
             "batch_size": 32,
             "n_eval_steps": 100,
             "print_freq": 100,
+            "ci_alive_threshold": 0.1,
+            "n_examples_until_dead": 1638400,  # print_freq * batch_size * max_seq_len = 100 * 32 * 512
             "pretrained_model_class": "transformers.LlamaForCausalLM",
             "task_config": {
                 "task_name": "lm",
@@ -234,6 +238,8 @@ class TestConfigIntegration:
             "batch_size": 32,
             "n_eval_steps": 100,
             "print_freq": 100,
+            "ci_alive_threshold": 0.1,
+            "n_examples_until_dead": 3200,  # print_freq * batch_size = 100 * 32
             "pretrained_model_class": "spd.experiments.tms.models.TMSModel",
             "task_config": {"task_name": "tms", "feature_probability": 0.1},
         }
@@ -267,6 +273,8 @@ class TestConfigIntegration:
             "batch_size": 32,
             "n_eval_steps": 100,
             "print_freq": 100,
+            "ci_alive_threshold": 0.1,
+            "n_examples_until_dead": 3200,  # print_freq * batch_size = 100 * 32
             "pretrained_model_class": "spd.experiments.tms.models.TMSModel",
             "task_config": {
                 "task_name": "tms",

--- a/tests/test_resid_mlp.py
+++ b/tests/test_resid_mlp.py
@@ -63,6 +63,8 @@ def test_resid_mlp_decomposition_happy_path() -> None:
         image_on_first_step=True,
         print_freq=50,  # Print at step 0, 50, and 100
         save_freq=None,
+        ci_alive_threshold=0.1,
+        n_examples_until_dead=200,  # print_freq * batch_size = 50 * 4
         figures_fns=[
             FiguresFnConfig(name="ci_histograms"),
             FiguresFnConfig(name="mean_component_activation_counts"),

--- a/tests/test_tms.py
+++ b/tests/test_tms.py
@@ -64,6 +64,8 @@ def test_tms_decomposition_happy_path() -> None:
         image_on_first_step=True,
         print_freq=2,
         save_freq=None,
+        ci_alive_threshold=0.1,
+        n_examples_until_dead=8,  # print_freq * batch_size = 2 * 4
         figures_fns=[
             FiguresFnConfig(name="ci_histograms"),
             FiguresFnConfig(name="mean_component_activation_counts"),


### PR DESCRIPTION
## Description

[run here](https://wandb.ai/goodfire/spd/runs/ald6jc8x?nw=nwuserolicggf)

### Summary
- Refactored component alive tracking to use a dedicated `AliveComponentsTracker` class
- Made component tracking parameters fully configurable via YAML configs
- Removed implicit defaults to ensure explicit configuration

### Changes
1. **Created `AliveComponentsTracker` class** (`spd/utils/alive_components_tracker.py`)
   - Tracks which components are "alive" based on firing frequency over a sliding window
   - Components are considered dead if they haven't fired in `n_examples_until_dead` examples
   - Cleaner, more maintainable implementation

2. **Made tracking parameters configurable**:
   - `ci_alive_threshold` (default: 0.1) - threshold for considering a component as "firing"
   - `n_examples_until_dead` - number of examples without firing before component is dead
   - Removed computed defaults to make configuration explicit

3. **Updated all YAML configs** with explicit `n_examples_until_dead` values:
This was a little tricky:
   - The existing implementation depended on print_freq (it would zero out the tracker every time we printed). 
   - But I don't think this is a great idea - we should have an independent idea of what "alive" means
   - So - to keep behaviour close to what we're currently doing, I've baked in the current behaviour by setting `n_examples_until_dead` to `print_freq * batch_size (* seq_len)`
   - BUT I do suggest we standardise this moving forward, which I can do in this PR if people think that'd be good.

5. **Removed soft defaults** of `threshold=0.1` throughout codebase:
   - All functions now require explicit threshold parameters
   - Updated all usages of hardcoded 0.1 threshold to use config value

## Related Issue
N/A

## Motivation and Context
The current implementation, relied on print-freq to set what is considered dead. Also AFAICT it was broken. will comment inline for this.

## How Has This Been Tested?
Doing some runs now

## Does this PR introduce a breaking change?
We'll have to recalibrate our idea of "dead" but I think that this is good, actually


🤖 Generated with [Claude Code](https://claude.ai/code)