### PR TITLE
Add configurable sampling strategies for stochastic reconstruction

### DIFF
--- a/spd/configs.py
+++ b/spd/configs.py
@@ -146,6 +146,57 @@ class LMTaskConfig(BaseModel):
     )
 
 
+class SampleConfig(BaseModel):
+    sample_type: Literal["uniform", "bernoulli"] = Field(
+        default="uniform",
+        description="Type of sample to use for stochastic reconstruction",
+    )
+
+
+class UniformSampleConfig(BaseModel):
+    sample_type: Literal["uniform"] = Field(
+        default="uniform",
+        description="Type of sample to use for stochastic reconstruction",
+    )
+
+
+class BernoulliSampleConfig(BaseModel):
+    sample_type: Literal["bernoulli"] = Field(
+        default="bernoulli",
+        description="Type of sample to use for stochastic reconstruction",
+    )
+    min: float = Field(
+        default=0.0,
+        description="Minimum value for stochastic reconstruction",
+    )
+
+
+class ConcreteSampleConfig(BaseModel):
+    sample_type: Literal["concrete"] = Field(
+        default="concrete",
+        description="Type of sample to use for stochastic reconstruction",
+    )
+    temperature: float = Field(
+        default=0.3,
+        description="Temperature parameter for concrete distribution",
+    )
+
+
+class HardConcreteSampleConfig(BaseModel):
+    sample_type: Literal["hard_concrete"] = Field(
+        default="hard_concrete",
+        description="Type of sample to use for stochastic reconstruction",
+    )
+    temperature: float = Field(
+        default=0.3,
+        description="Temperature parameter for hard concrete distribution",
+    )
+    stretch: float = Field(
+        default=1.1,
+        description="Stretch parameter for hard concrete distribution",
+    )
+
+
 class Config(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", frozen=True)
     # --- WandB
@@ -167,6 +218,16 @@ class Config(BaseModel):
     C: PositiveInt = Field(
         ...,
         description="The number of subcomponents per layer",
+    )
+    sample_config: (
+        UniformSampleConfig
+        | BernoulliSampleConfig
+        | ConcreteSampleConfig
+        | HardConcreteSampleConfig
+    ) = Field(
+        default_factory=UniformSampleConfig,
+        discriminator="sample_type",
+        description="Configuration for the sample function used for stochastic reconstruction",
     )
     n_mask_samples: PositiveInt = Field(
         ...,

--- a/spd/utils/component_utils.py
+++ b/spd/utils/component_utils.py
@@ -102,12 +102,11 @@ def get_sample_fn(sample_config: SampleConfig) -> Callable[[Tensor], Tensor]:
         return partial(bernoulli_ste, min=sample_config.min)
     elif sample_config.sample_type == "concrete":
         return partial(concrete_gate, temperature=sample_config.temperature)
-    elif sample_config.sample_type == "hard_concrete":
+    else:
+        assert sample_config.sample_type == "hard_concrete"
         return partial(
             hard_concrete_gate, temperature=sample_config.temperature, stretch=sample_config.stretch
         )
-    else:
-        raise ValueError(f"Unknown sample type: {sample_config.sample_type}")
 
 
 def calc_stochastic_masks(


### PR DESCRIPTION
## Summary
This PR adds configurable sampling strategies for stochastic reconstruction in SPD, building on top of #73.

## Changes
- Add sample configuration classes to support different sampling strategies:
  - `UniformSampleConfig`: Uniform sampling between CI and 1
  - `BernoulliSampleConfig`: Bernoulli sampling with straight-through estimator
  - `ConcreteSampleConfig`: Gumbel-Softmax (concrete) distribution sampling
  - `HardConcreteSampleConfig`: Hard concrete with stretch parameter
- Implement sampling functions for each strategy in `component_utils.py`
- Add unified `get_sample_fn` to select appropriate sampling function
- Update `calc_stochastic_masks` to use the new configurable sampling

## Sampling Strategies
1. **Uniform**: `ci + (1 - ci) * rand_unif(0,1)` - Original SPD approach
2. **Bernoulli**: Samples from Bernoulli distribution with straight-through gradient estimator
3. **Concrete**: Continuous relaxation of discrete distributions using Gumbel-Softmax
4. **Hard Concrete**: Extends concrete with stretch parameter for better control over sparsity

## Example Config
```yaml
sample_config:
  sample_type: bernoulli
  min: 0.0
```

## Test plan
- [x] Type checking passes
- [x] All sampling functions tested manually
- [ ] Run SPD with each sampling strategy
- [ ] Verify gradients flow correctly through all sampling methods

🤖 Generated with [Claude Code](https://claude.ai/code)