### PR TITLE
Feature/memorization experiments

### DIFF
--- a/spd/configs.py
+++ b/spd/configs.py
@@ -146,6 +146,14 @@ class LMTaskConfig(BaseModel):
     )
 
 
+class MemorizationTaskConfig(BaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", frozen=True)
+    task_name: Literal["memorization"] = Field(
+        default="memorization",
+        description="Identifier for the memorization decomposition task",
+    )
+
+
 class Config(BaseModel):
     model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", frozen=True)
     # --- WandB
@@ -338,10 +346,12 @@ class Config(BaseModel):
     )
 
     # --- Task Specific ---
-    task_config: TMSTaskConfig | ResidualMLPTaskConfig | LMTaskConfig = Field(
-        ...,
-        discriminator="task_name",
-        description="Nested task-specific configuration selected by the `task_name` discriminator",
+    task_config: TMSTaskConfig | ResidualMLPTaskConfig | LMTaskConfig | MemorizationTaskConfig = (
+        Field(
+            ...,
+            discriminator="task_name",
+            description="Nested task-specific configuration selected by the `task_name` discriminator",
+        )
     )
 
     DEPRECATED_CONFIG_KEYS: ClassVar[list[str]] = []

--- a/spd/experiments/memorization/__init__.py
+++ b/spd/experiments/memorization/__init__.py
@@ -1,0 +1,1 @@
+"""Memorization toy model experiments."""

--- a/spd/experiments/memorization/decomp_config_32-128-1p4x.yaml
+++ b/spd/experiments/memorization/decomp_config_32-128-1p4x.yaml
@@ -1,0 +1,56 @@
+# Single Layer Memorization Model
+# --- WandB ---
+wandb_project: nathu-memorization-spd
+wandb_run_name: null
+wandb_run_name_prefix: ""
+
+# --- General ---
+seed: 0
+C: 350
+n_mask_samples: 1
+gate_type: "mlp"
+gate_hidden_dims: [128]
+sigmoid_type: "leaky_hard"
+target_module_patterns:
+  - "linear"
+  - "output"
+
+# --- Loss Coefficients ---
+faithfulness_coeff: 100
+out_recon_coeff: 0.0
+recon_coeff: null
+stochastic_recon_coeff: 1.0
+recon_layerwise_coeff: null
+stochastic_recon_layerwise_coeff: 1.0
+importance_minimality_coeff: 1e-3
+pnorm: 2
+output_loss_type: mse
+
+# --- Training ---
+batch_size: 2048
+steps: 200_000
+lr: 3e-4
+lr_schedule: cosine
+lr_warmup_pct: 0.1
+n_eval_steps: 100
+n_examples_until_dead: 10000
+
+# --- Logging & Saving ---
+image_freq: 5_000
+image_on_first_step: true
+print_freq: 500
+save_freq: null
+figures_fns: 
+  - name: "ci_histograms"
+  - name: "mean_component_activation_counts"
+  - name: "memorization_ci_plots"
+metrics_fns: 
+  - name: "ci_l0"
+
+# --- Pretrained model info ---
+pretrained_model_class: "spd.experiments.memorization.models.SingleLayerMemorizationMLP"
+pretrained_model_path: "wandb:goodfire/spd-gf-spd_experiments_memorization/runs/j003fphd"
+
+# --- Task Specific ---
+task_config:
+  task_name: memorization

--- a/spd/experiments/memorization/decomp_config_32-128-1x.yaml
+++ b/spd/experiments/memorization/decomp_config_32-128-1x.yaml
@@ -1,0 +1,56 @@
+# Single Layer Memorization Model
+# --- WandB ---
+wandb_project: nathu-memorization
+wandb_run_name: null
+wandb_run_name_prefix: ""
+
+# --- General ---
+seed: 0
+C: 250
+n_mask_samples: 1
+gate_type: "mlp"
+gate_hidden_dims: [128]
+sigmoid_type: "leaky_hard"
+target_module_patterns:
+  - "linear"
+  - "output"
+
+# --- Loss Coefficients ---
+faithfulness_coeff: 100.0
+out_recon_coeff: 0.0
+recon_coeff: null
+stochastic_recon_coeff: 1.0
+recon_layerwise_coeff: null
+stochastic_recon_layerwise_coeff: 1.0
+importance_minimality_coeff: 1e-3
+pnorm: 2
+output_loss_type: mse
+
+# --- Training ---
+batch_size: 2048
+steps: 100_000
+lr: 3e-4
+lr_schedule: cosine
+lr_warmup_pct: 0.1
+n_eval_steps: 100
+n_examples_until_dead: 10000
+
+# --- Logging & Saving ---
+image_freq: 5_000
+image_on_first_step: true
+print_freq: 500
+save_freq: null
+figures_fns: 
+  - name: "ci_histograms"
+  - name: "mean_component_activation_counts"
+  - name: "memorization_ci_plots"
+metrics_fns: 
+  - name: "ci_l0"
+
+# --- Pretrained model info ---
+pretrained_model_class: "spd.experiments.memorization.models.SingleLayerMemorizationMLP"
+pretrained_model_path: "wandb:goodfire/spd-gf-spd_experiments_memorization/runs/qo8a937i"
+
+# --- Task Specific ---
+task_config:
+  task_name: memorization

--- a/spd/experiments/memorization/decomp_config_32-128-2x.yaml
+++ b/spd/experiments/memorization/decomp_config_32-128-2x.yaml
@@ -1,0 +1,56 @@
+# Single Layer Memorization Model
+# --- WandB ---
+wandb_project: nathu-memorization-spd
+wandb_run_name: null
+wandb_run_name_prefix: ""
+
+# --- General ---
+seed: 0
+C: 500
+n_mask_samples: 1
+gate_type: "mlp"
+gate_hidden_dims: [128]
+sigmoid_type: "leaky_hard"
+target_module_patterns:
+  - "linear"
+  - "output"
+
+# --- Loss Coefficients ---
+faithfulness_coeff: 100
+out_recon_coeff: 0.0
+recon_coeff: null
+stochastic_recon_coeff: 1.0
+recon_layerwise_coeff: null
+stochastic_recon_layerwise_coeff: 1.0
+importance_minimality_coeff: 1e-3
+pnorm: 2
+output_loss_type: mse
+
+# --- Training ---
+batch_size: 2048
+steps: 200_000
+lr: 3e-4
+lr_schedule: cosine
+lr_warmup_pct: 0.1
+n_eval_steps: 100
+n_examples_until_dead: 10000
+
+# --- Logging & Saving ---
+image_freq: 5_000
+image_on_first_step: true
+print_freq: 500
+save_freq: null
+figures_fns: 
+  - name: "ci_histograms"
+  - name: "mean_component_activation_counts"
+  - name: "memorization_ci_plots"
+metrics_fns: 
+  - name: "ci_l0"
+
+# --- Pretrained model info ---
+pretrained_model_class: "spd.experiments.memorization.models.SingleLayerMemorizationMLP"
+pretrained_model_path: "wandb:goodfire/spd-gf-spd_experiments_memorization/runs/gkqn4tc1"
+
+# --- Task Specific ---
+task_config:
+  task_name: memorization

--- a/spd/experiments/memorization/memorization_dataset.py
+++ b/spd/experiments/memorization/memorization_dataset.py
@@ -1,0 +1,87 @@
+"""Dataset for memorization experiments with key-value pairs."""
+
+import json
+from pathlib import Path
+
+import torch
+from jaxtyping import Float
+from torch import Tensor
+from torch.utils.data import Dataset
+
+
+class KeyValueMemorizationDataset(Dataset[tuple[Float[Tensor, "..."], Float[Tensor, "..."]]]):
+    def __init__(
+        self,
+        n_pairs: int,
+        d_model: int,
+        device: str,
+        dataset_seed: int | None = None,
+        key_value_pairs: tuple[Float[Tensor, "n_pairs d_model"], Float[Tensor, "n_pairs d_model"]]
+        | None = None,
+    ):
+        """Dataset for memorization experiments.
+
+        Args:
+            n_pairs: Number of key-value pairs
+            d_model: Dimension of both keys and values
+            device: The device to store data on
+            dataset_seed: Seed for generating key-value pairs (ignored if key_value_pairs provided)
+            key_value_pairs: Optional pre-specified (keys, values) tuple
+        """
+        self.n_pairs = n_pairs
+        self.d_model = d_model
+        self.device = device
+
+        if key_value_pairs is not None:
+            self.keys, self.values = key_value_pairs
+            self.keys = self.keys.to(device)
+            self.values = self.values.to(device)
+        else:
+            # Generate random key-value pairs with unit norm
+            gen = torch.Generator(device=device)
+            if dataset_seed is not None:
+                gen.manual_seed(dataset_seed)
+
+            # Generate random vectors and normalize to unit norm
+            keys = torch.randn(n_pairs, d_model, generator=gen, device=device)
+            self.keys = keys / keys.norm(dim=1, keepdim=True)
+
+            values = torch.randn(n_pairs, d_model, generator=gen, device=device)
+            self.values = values / values.norm(dim=1, keepdim=True)
+
+    def __len__(self) -> int:
+        return 2**31
+
+    def generate_batch(
+        self, batch_size: int
+    ) -> tuple[Float[Tensor, "batch d_model"], Float[Tensor, "batch d_model"]]:
+        """Generate a batch by randomly sampling key-value pairs.
+
+        Args:
+            batch_size: Number of pairs to sample
+
+        Returns:
+            Tuple of (keys, values) tensors
+        """
+        indices = torch.randint(0, self.n_pairs, (batch_size,), device=self.device)
+        return self.keys[indices], self.values[indices]
+
+    def save_key_value_pairs(self, path: Path) -> None:
+        """Save key-value pairs to a JSON file."""
+        kv_data = {
+            "keys": self.keys.cpu().tolist(),
+            "values": self.values.cpu().tolist(),
+        }
+        with open(path, "w") as f:
+            json.dump(kv_data, f)
+
+    @classmethod
+    def load_key_value_pairs(
+        cls, path: Path
+    ) -> tuple[Float[Tensor, "n_pairs d_model"], Float[Tensor, "n_pairs d_model"]]:
+        """Load key-value pairs from a JSON file."""
+        with open(path) as f:
+            kv_data = json.load(f)
+        keys = torch.tensor(kv_data["keys"])
+        values = torch.tensor(kv_data["values"])
+        return keys, values

--- a/spd/experiments/memorization/memorization_decomposition.py
+++ b/spd/experiments/memorization/memorization_decomposition.py
@@ -1,0 +1,126 @@
+"""Run SPD on a memorization model."""
+
+from pathlib import Path
+from typing import Any
+
+import fire
+import wandb
+from jaxtyping import Float
+from torch import Tensor
+
+from spd.configs import Config, MemorizationTaskConfig
+from spd.experiments.memorization.memorization_dataset import KeyValueMemorizationDataset
+from spd.experiments.memorization.models import SingleLayerMemorizationMLP
+from spd.log import logger
+from spd.run_spd import optimize
+from spd.utils.data_utils import DatasetGeneratedDataLoader
+from spd.utils.general_utils import get_device, load_config, set_seed
+from spd.utils.run_utils import get_output_dir, save_file
+from spd.utils.wandb_utils import init_wandb
+
+
+def save_target_model_info(
+    save_to_wandb: bool,
+    out_dir: Path,
+    memorization_model: SingleLayerMemorizationMLP,
+    memorization_train_config_dict: dict[str, Any],
+    key_value_pairs: tuple[Float[Tensor, "n_pairs d_model"], Float[Tensor, "n_pairs d_model"]],
+) -> None:
+    save_file(memorization_model.state_dict(), out_dir / "memorization.pth")
+    save_file(memorization_train_config_dict, out_dir / "memorization_train_config.yaml")
+
+    # Save key-value pairs as JSON
+    keys, values = key_value_pairs
+    kv_data = {
+        "keys": keys.cpu().tolist(),
+        "values": values.cpu().tolist(),
+    }
+    save_file(kv_data, out_dir / "key_value_pairs.json")
+
+    if save_to_wandb:
+        wandb.save(str(out_dir / "memorization.pth"), base_path=out_dir, policy="now")
+        wandb.save(str(out_dir / "memorization_train_config.yaml"), base_path=out_dir, policy="now")
+        wandb.save(str(out_dir / "key_value_pairs.json"), base_path=out_dir, policy="now")
+
+
+def main(
+    config_path_or_obj: Path | str | Config,
+    evals_id: str | None = None,
+    sweep_id: str | None = None,
+) -> None:
+    device = get_device()
+    logger.info(f"Using device: {device}")
+
+    config = load_config(config_path_or_obj, config_model=Config)
+
+    if config.wandb_project:
+        tags = ["memorization"]
+        if evals_id:
+            tags.append(evals_id)
+        if sweep_id:
+            tags.append(sweep_id)
+        config = init_wandb(config, config.wandb_project, tags=tags)
+
+    # Get output directory (automatically uses wandb run ID if available)
+    out_dir = get_output_dir()
+
+    task_config = config.task_config
+    assert isinstance(task_config, MemorizationTaskConfig)
+
+    set_seed(config.seed)
+    logger.info(config)
+
+    assert config.pretrained_model_path, "pretrained_model_path must be set"
+    target_model, target_model_train_config_dict, key_value_pairs = (
+        SingleLayerMemorizationMLP.from_pretrained(
+            config.pretrained_model_path,
+        )
+    )
+    target_model = target_model.to(device)
+    target_model.eval()
+
+    if config.wandb_project:
+        assert wandb.run, "wandb.run must be initialized before training"
+        if config.wandb_run_name:
+            wandb.run.name = config.wandb_run_name
+
+    save_file(config.model_dump(mode="json"), out_dir / "final_config.yaml")
+    if config.wandb_project:
+        wandb.save(str(out_dir / "final_config.yaml"), base_path=out_dir, policy="now")
+
+    save_target_model_info(
+        save_to_wandb=config.wandb_project is not None,
+        out_dir=out_dir,
+        memorization_model=target_model,
+        memorization_train_config_dict=target_model_train_config_dict,
+        key_value_pairs=key_value_pairs,
+    )
+
+    # Create dataset with the same key-value pairs used for training
+    keys, values = key_value_pairs
+    dataset = KeyValueMemorizationDataset(
+        n_pairs=target_model.config.n_pairs,
+        d_model=target_model.config.d_model,
+        device=device,
+        key_value_pairs=(keys.to(device), values.to(device)),
+    )
+
+    train_loader = DatasetGeneratedDataLoader(dataset, batch_size=config.batch_size, shuffle=False)
+    eval_loader = DatasetGeneratedDataLoader(dataset, batch_size=config.batch_size, shuffle=False)
+
+    optimize(
+        target_model=target_model,
+        config=config,
+        device=device,
+        train_loader=train_loader,
+        eval_loader=eval_loader,
+        n_eval_steps=config.n_eval_steps,
+        out_dir=out_dir,
+    )
+
+    if config.wandb_project:
+        wandb.finish()
+
+
+if __name__ == "__main__":
+    fire.Fire(main)

--- a/spd/experiments/memorization/memorization_train_config.yaml
+++ b/spd/experiments/memorization/memorization_train_config.yaml
@@ -1,0 +1,16 @@
+wandb_project: "nathu-memorization"
+seed: 0
+# Memorization model parameters
+n_pairs_multiplier: 2
+d_model: 512
+d_hidden: 1024
+act_fn_name: "relu"
+use_bias: true
+# Training parameters
+dataset_seed: 0
+batch_size: 1024
+steps: 1000000
+print_freq: 1000
+lr: 3.0e-4
+lr_schedule: "cosine"
+lr_warmup_steps: 50000

--- a/spd/experiments/memorization/models.py
+++ b/spd/experiments/memorization/models.py
@@ -1,0 +1,155 @@
+"""Memorization model for studying single layer MLPs trained on key-value pairs."""
+
+import json
+from pathlib import Path
+from typing import Any, ClassVar, Literal, override
+
+import torch
+import torch.nn.functional as F
+import wandb
+import yaml
+from jaxtyping import Float
+from pydantic import BaseModel, ConfigDict, Field, PositiveInt
+from torch import Tensor, nn
+from wandb.apis.public import Run
+
+from spd.log import logger
+from spd.spd_types import WANDB_PATH_PREFIX, ModelPath
+from spd.utils.run_utils import check_run_exists
+from spd.utils.wandb_utils import (
+    download_wandb_file,
+    fetch_latest_wandb_checkpoint,
+    fetch_wandb_run_dir,
+)
+
+
+class MemorizationPaths(BaseModel):
+    """Paths to output files from a Memorization model training run."""
+
+    memorization_train_config: Path
+    key_value_pairs: Path
+    checkpoint: Path
+
+
+class MemorizationConfig(BaseModel):
+    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", frozen=True)
+    n_pairs: PositiveInt = Field(description="Number of key-value pairs to memorize")
+    d_model: PositiveInt = Field(description="Dimension of keys and values")
+    d_hidden: PositiveInt = Field(description="Hidden layer dimension")
+    act_fn_name: Literal["gelu", "relu", "none"] = Field(
+        description="Activation function. 'none' means no activation (linear layer only)"
+    )
+    use_bias: bool = Field(default=True, description="Whether to use bias in linear layers")
+
+
+class SingleLayerMemorizationMLP(nn.Module):
+    def __init__(self, config: MemorizationConfig):
+        super().__init__()
+        self.config = config
+
+        self.linear = nn.Linear(config.d_model, config.d_hidden, bias=config.use_bias)
+        self.output = nn.Linear(config.d_hidden, config.d_model, bias=config.use_bias)
+
+        if config.act_fn_name == "gelu":
+            self.act_fn = F.gelu
+        elif config.act_fn_name == "relu":
+            self.act_fn = F.relu
+        else:
+            self.act_fn = lambda x: x
+
+    @override
+    def forward(self, keys: Float[Tensor, "... d_model"]) -> Float[Tensor, "... d_model"]:
+        hidden = self.linear(keys)
+        hidden = self.act_fn(hidden)
+        values = self.output(hidden)
+        return values
+
+    @staticmethod
+    def _download_wandb_files(wandb_project_run_id: str) -> MemorizationPaths:
+        """Download the relevant files from a wandb run."""
+        api = wandb.Api()
+        run: Run = api.run(wandb_project_run_id)
+
+        checkpoint = fetch_latest_wandb_checkpoint(run)
+
+        run_dir = fetch_wandb_run_dir(run.id)
+
+        memorization_train_config_path = download_wandb_file(
+            run, run_dir, "memorization_train_config.yaml"
+        )
+        key_value_pairs_path = download_wandb_file(run, run_dir, "key_value_pairs.json")
+        checkpoint_path = download_wandb_file(run, run_dir, checkpoint.name)
+        logger.info(f"Downloaded checkpoint from {checkpoint_path}")
+        return MemorizationPaths(
+            memorization_train_config=memorization_train_config_path,
+            key_value_pairs=key_value_pairs_path,
+            checkpoint=checkpoint_path,
+        )
+
+    @classmethod
+    def from_pretrained(
+        cls, path: ModelPath
+    ) -> tuple[
+        "SingleLayerMemorizationMLP",
+        dict[str, Any],
+        tuple[Float[Tensor, "n_pairs d_model"], Float[Tensor, "n_pairs d_model"]],
+    ]:
+        """Fetch a pretrained model from wandb or a local path to a checkpoint.
+
+        Args:
+            path: The path to local checkpoint or wandb project. If a wandb project, format must be
+                `wandb:<entity>/<project>/<run_id>` or `wandb:<entity>/<project>/runs/<run_id>`.
+                If `api.entity` is set (e.g. via setting WANDB_ENTITY in .env), <entity> can be
+                omitted, and if `api.project` is set, <project> can be omitted. If local path,
+                assumes that `memorization_train_config.yaml` and `key_value_pairs.json` are in the
+                same directory as the checkpoint.
+
+        Returns:
+            model: The pretrained SingleLayerMemorizationMLP
+            memorization_train_config_dict: The config dict used to train the model
+            key_value_pairs: Tuple of (keys, values) tensors used to train the model
+        """
+        if isinstance(path, str) and path.startswith(WANDB_PATH_PREFIX):
+            # Check if run exists in shared filesystem first
+            run_dir = check_run_exists(path)
+            if run_dir:
+                # Use local files from shared filesystem
+                paths = MemorizationPaths(
+                    memorization_train_config=run_dir / "memorization_train_config.yaml",
+                    key_value_pairs=run_dir / "key_value_pairs.json",
+                    checkpoint=run_dir / "memorization.pth",
+                )
+            else:
+                # Download from wandb
+                wandb_path = path.removeprefix(WANDB_PATH_PREFIX)
+                paths = cls._download_wandb_files(wandb_path)
+        else:
+            # `path` should be a local path to a checkpoint
+            paths = MemorizationPaths(
+                memorization_train_config=Path(path).parent / "memorization_train_config.yaml",
+                key_value_pairs=Path(path).parent / "key_value_pairs.json",
+                checkpoint=Path(path),
+            )
+
+        with open(paths.memorization_train_config) as f:
+            memorization_train_config_dict = yaml.safe_load(f)
+
+        with open(paths.key_value_pairs) as f:
+            kv_data = json.load(f)
+            keys = torch.tensor(kv_data["keys"])
+            values = torch.tensor(kv_data["values"])
+
+        # Extract memorization config fields from the flat config structure
+        memorization_config_fields = {
+            "n_pairs": memorization_train_config_dict.get("n_pairs"),
+            "d_model": memorization_train_config_dict.get("d_model"),
+            "d_hidden": memorization_train_config_dict.get("d_hidden"),
+            "act_fn_name": memorization_train_config_dict.get("act_fn_name", "relu"),
+            "use_bias": memorization_train_config_dict.get("use_bias", True),
+        }
+        memorization_config = MemorizationConfig(**memorization_config_fields)
+        model = cls(memorization_config)
+        params = torch.load(paths.checkpoint, weights_only=True, map_location="cpu")
+        model.load_state_dict(params)
+
+        return model, memorization_train_config_dict, (keys, values)

--- a/spd/experiments/memorization/plotting.py
+++ b/spd/experiments/memorization/plotting.py
@@ -7,7 +7,7 @@ import torch
 from matplotlib import pyplot as plt
 
 from spd.models.component_model import ComponentModel
-from spd.plotting import _plot_causal_importances_figure
+from spd.plotting import _plot_causal_importances_figure, permute_to_identity
 
 
 def create_memorization_plot_results(
@@ -31,9 +31,14 @@ def create_memorization_plot_results(
         detach_inputs=False,
     )
 
+    # Permute to identity for better visualization
+    ci_permuted = {}
+    for k in ci_raw:
+        ci_permuted[k], _ = permute_to_identity(ci_vals=ci_raw[k])
+
     # Step 3: Make the heatmap using _plot_causal_importances_figure
     fig = _plot_causal_importances_figure(
-        ci_vals=ci_raw,
+        ci_vals=ci_permuted,
         title_prefix="memorization causal importances",
         colormap="Blues",
         input_magnitude=1.0,

--- a/spd/experiments/memorization/plotting.py
+++ b/spd/experiments/memorization/plotting.py
@@ -1,0 +1,44 @@
+"""Plotting utilities for memorization experiments."""
+
+from collections.abc import Mapping
+from typing import Any
+
+import torch
+from matplotlib import pyplot as plt
+
+from spd.models.component_model import ComponentModel
+from spd.plotting import _plot_causal_importances_figure
+
+
+def create_memorization_plot_results(
+    model: ComponentModel,
+    device: str | torch.device,
+    dataset: Any,  # KeyValueMemorizationDataset
+) -> Mapping[str, plt.Figure]:
+    """Create plotting results for memorization decomposition experiments."""
+
+    # Step 1: Get all unique keys from dataset (skip n_keys_to_plot logic)
+    keys = dataset.keys.to(device)
+
+    # Step 2: Get pre-weight activations and calculate causal importances
+    pre_weight_acts = model.forward_with_pre_forward_cache_hooks(
+        keys, module_names=model.target_module_paths
+    )[1]
+
+    ci_raw, _ = model.calc_causal_importances(
+        pre_weight_acts=pre_weight_acts,
+        sigmoid_type="leaky_hard",
+        detach_inputs=False,
+    )
+
+    # Step 3: Make the heatmap using _plot_causal_importances_figure
+    fig = _plot_causal_importances_figure(
+        ci_vals=ci_raw,
+        title_prefix="memorization causal importances",
+        colormap="Blues",
+        input_magnitude=1.0,
+        has_pos_dim=False,
+        orientation="vertical",
+    )
+
+    return {"memorization_causal_importances": fig}

--- a/spd/experiments/memorization/train_memorization.py
+++ b/spd/experiments/memorization/train_memorization.py
@@ -1,0 +1,324 @@
+"""Train a single layer MLP to memorize key-value pairs.
+
+Example usage:
+    # Train with default config
+    python spd/experiments/memorization/train_memorization.py spd/experiments/memorization/memorization_train_config.yaml
+
+    # Run training sweep
+    wandb sweep spd/experiments/memorization/train_target_model_sweep.yaml
+    wandb agent <sweep_id>
+"""
+
+from pathlib import Path
+from typing import Literal, cast
+
+import fire
+import torch
+import wandb
+from jaxtyping import Float
+from pydantic import BaseModel, ConfigDict, PositiveFloat, PositiveInt
+from torch import Tensor
+from torch.nn import functional as F
+from tqdm import tqdm
+
+from spd.experiments.memorization.memorization_dataset import KeyValueMemorizationDataset
+from spd.experiments.memorization.models import MemorizationConfig, SingleLayerMemorizationMLP
+from spd.log import logger
+from spd.utils.data_utils import DatasetGeneratedDataLoader
+from spd.utils.general_utils import get_device, load_config, set_seed
+from spd.utils.run_utils import get_output_dir, save_file
+from spd.utils.wandb_utils import init_wandb
+
+
+def evaluate_memorization(
+    model: SingleLayerMemorizationMLP,
+    keys: Float[Tensor, "n_pairs d_model"],
+    values: Float[Tensor, "n_pairs d_model"],
+) -> dict[str, float | Tensor]:
+    """Evaluate memorization performance on all key-value pairs.
+
+    Returns:
+        Dictionary with metrics:
+        - avg_mse: Average MSE across all pairs
+        - worst_mse: Maximum MSE among all pairs
+        - worst_idx: Index of the worst-performing pair
+        - frac_memorized_1e-1: Fraction of pairs with MSE < 1e-1
+        - frac_memorized_1e-2: Fraction of pairs with MSE < 1e-2
+        - frac_memorized_1e-3: Fraction of pairs with MSE < 1e-3
+        - frac_memorized_1e-4: Fraction of pairs with MSE < 1e-4
+        - per_pair_mse: Tensor of MSE values for histogram
+    """
+    model.eval()
+    with torch.no_grad():
+        predicted_values = model(keys)
+        per_pair_mse = ((predicted_values - values) ** 2).sum(dim=1)
+
+        avg_mse = per_pair_mse.mean().item()
+        worst_mse = per_pair_mse.max().item()
+        worst_idx = per_pair_mse.argmax().item()
+
+        # Calculate fraction memorized at different thresholds
+        frac_memorized_1e1 = (per_pair_mse < 1e-1).float().mean().item()
+        frac_memorized_1e2 = (per_pair_mse < 1e-2).float().mean().item()
+        frac_memorized_1e3 = (per_pair_mse < 1e-3).float().mean().item()
+        frac_memorized_1e4 = (per_pair_mse < 1e-4).float().mean().item()
+
+    return {
+        "avg_mse": avg_mse,
+        "worst_mse": worst_mse,
+        "worst_idx": worst_idx,
+        "frac_memorized_1e-1": frac_memorized_1e1,
+        "frac_memorized_1e-2": frac_memorized_1e2,
+        "frac_memorized_1e-3": frac_memorized_1e3,
+        "frac_memorized_1e-4": frac_memorized_1e4,
+        "per_pair_mse": per_pair_mse.cpu(),
+    }
+
+
+class MemorizationTrainConfig(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    wandb_project: str | None = None
+    seed: int = 0
+    # Memorization model parameters (flattened from MemorizationConfig)
+    n_pairs: PositiveInt | None = None
+    n_pairs_multiplier: PositiveFloat | None = (
+        None  # If set, n_pairs = n_pairs_multiplier * d_hidden
+    )
+    d_model: PositiveInt
+    d_hidden: PositiveInt
+    act_fn_name: str = "relu"
+    use_bias: bool = True
+    # Training parameters
+    dataset_seed: int = 0
+    batch_size: PositiveInt
+    steps: PositiveInt
+    print_freq: PositiveInt
+    lr: PositiveFloat
+    lr_schedule: Literal["constant", "cosine"] = "constant"
+    lr_warmup_steps: int = 0  # Number of warmup steps for cosine schedule
+
+
+def train(
+    config: MemorizationTrainConfig,
+    model: SingleLayerMemorizationMLP,
+    dataloader: DatasetGeneratedDataLoader[
+        tuple[
+            Float[Tensor, "batch d_model"],
+            Float[Tensor, "batch d_model"],
+        ]
+    ],
+    device: str,
+    out_dir: Path,
+    run_name: str,
+) -> Float[Tensor, ""]:
+    if config.wandb_project:
+        tags = ["memorization-train"]
+        config = init_wandb(config, config.wandb_project, name=run_name, tags=tags)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    # Save config
+    config_path = out_dir / "memorization_train_config.yaml"
+    save_file(config.model_dump(mode="json"), config_path)
+    logger.info(f"Saved config to {config_path}")
+    if config.wandb_project:
+        wandb.save(str(config_path), base_path=out_dir, policy="now")
+
+    # Save the key-value pairs
+    assert isinstance(dataloader.dataset, KeyValueMemorizationDataset)
+    dataloader.dataset.save_key_value_pairs(out_dir / "key_value_pairs.json")
+    logger.info(f"Saved key-value pairs to {out_dir / 'key_value_pairs.json'}")
+    if config.wandb_project:
+        wandb.save(str(out_dir / "key_value_pairs.json"), base_path=out_dir, policy="now")
+
+    optimizer = torch.optim.AdamW(model.parameters(), lr=config.lr)
+
+    # Setup learning rate scheduler
+    if config.lr_schedule == "cosine":
+        # For cosine schedule with warmup
+        scheduler = torch.optim.lr_scheduler.CosineAnnealingLR(
+            optimizer, T_max=config.steps - config.lr_warmup_steps, eta_min=0.0
+        )
+    else:
+        scheduler = None
+
+    step = 0
+    pbar = tqdm(total=config.steps)
+    while step < config.steps:
+        keys, values = dataloader.dataset.generate_batch(config.batch_size)
+
+        optimizer.zero_grad()
+        keys: Float[Tensor, "batch d_model"] = keys.to(device)
+        values: Float[Tensor, "batch d_model"] = values.to(device)
+
+        predicted_values = model(keys)
+        loss = F.mse_loss(predicted_values, values)
+
+        loss.backward()
+        optimizer.step()
+
+        # Handle learning rate schedule
+        if config.lr_schedule == "cosine":
+            if step < config.lr_warmup_steps:
+                # Linear warmup
+                warmup_lr = config.lr * (step + 1) / config.lr_warmup_steps
+                for param_group in optimizer.param_groups:
+                    param_group["lr"] = warmup_lr
+            else:
+                # Cosine annealing after warmup
+                if scheduler is not None:
+                    scheduler.step()
+
+        if step % config.print_freq == 0:
+            # Evaluate on all pairs
+            metrics = evaluate_memorization(
+                model, dataloader.dataset.keys, dataloader.dataset.values
+            )
+            tqdm.write(
+                f"step {step}: loss={loss.item():.2e}, "
+                f"avg_mse={metrics['avg_mse']:.2e}, "
+                f"worst_mse={metrics['worst_mse']:.2e}, "
+                f"frac_mem(1e-3)={metrics['frac_memorized_1e-3']:.3f}"
+            )
+            if config.wandb_project:
+                log_dict = {
+                    "loss": loss.item(),
+                    "avg_mse": metrics["avg_mse"],
+                    "worst_mse": metrics["worst_mse"],
+                    "frac_memorized_1e-1": metrics["frac_memorized_1e-1"],
+                    "frac_memorized_1e-2": metrics["frac_memorized_1e-2"],
+                    "frac_memorized_1e-3": metrics["frac_memorized_1e-3"],
+                    "frac_memorized_1e-4": metrics["frac_memorized_1e-4"],
+                    "lr": optimizer.param_groups[0]["lr"],
+                }
+                # Log histogram every 5000 steps to avoid too much data
+                if step % 5000 == 0:
+                    mse_tensor = metrics["per_pair_mse"]
+                    if isinstance(mse_tensor, torch.Tensor):
+                        import numpy as np
+
+                        numpy_array = mse_tensor.detach().cpu().numpy()
+                        log_dict["mse_histogram"] = wandb.Histogram(
+                            np.asarray(numpy_array).tolist()
+                        )
+                    else:
+                        # Skip histogram if not a tensor
+                        pass
+                wandb.log(log_dict, step=step)
+            model.train()  # Set back to training mode
+
+        step += 1
+        pbar.update(1)
+
+    model_path = out_dir / "memorization.pth"
+    save_file(model.state_dict(), model_path)
+    if config.wandb_project:
+        wandb.save(str(model_path), base_path=out_dir, policy="now")
+    print(f"Saved model to {model_path}")
+
+    # Calculate final losses by testing each key-value pair
+    final_metrics = evaluate_memorization(model, dataloader.dataset.keys, dataloader.dataset.values)
+
+    print("Final metrics:")
+    print(f"  Average MSE: {final_metrics['avg_mse']:.6f}")
+    print(f"  Worst MSE: {final_metrics['worst_mse']:.6f} (pair {final_metrics['worst_idx']})")
+    print(f"  Fraction memorized (MSE < 1e-1): {final_metrics['frac_memorized_1e-1']:.3f}")
+    print(f"  Fraction memorized (MSE < 1e-2): {final_metrics['frac_memorized_1e-2']:.3f}")
+    print(f"  Fraction memorized (MSE < 1e-3): {final_metrics['frac_memorized_1e-3']:.3f}")
+    print(f"  Fraction memorized (MSE < 1e-4): {final_metrics['frac_memorized_1e-4']:.3f}")
+
+    if config.wandb_project:
+        wandb.log(
+            {
+                "final_avg_mse": final_metrics["avg_mse"],
+                "final_worst_mse": final_metrics["worst_mse"],
+                "final_frac_memorized_1e-1": final_metrics["frac_memorized_1e-1"],
+                "final_frac_memorized_1e-2": final_metrics["frac_memorized_1e-2"],
+                "final_frac_memorized_1e-3": final_metrics["frac_memorized_1e-3"],
+                "final_frac_memorized_1e-4": final_metrics["frac_memorized_1e-4"],
+            }
+        )
+
+    return torch.tensor(final_metrics["avg_mse"])
+
+
+def run_train(config: MemorizationTrainConfig, device: str) -> Float[Tensor, ""]:
+    # Calculate n_pairs from multiplier if provided
+    if config.n_pairs_multiplier is not None:
+        n_pairs = int(config.n_pairs_multiplier * config.d_hidden)
+        logger.info(
+            f"Calculated n_pairs={n_pairs} from n_pairs_multiplier={config.n_pairs_multiplier} * d_hidden={config.d_hidden}"
+        )
+    else:
+        n_pairs = config.n_pairs
+        if n_pairs is None:
+            raise ValueError("Either n_pairs or n_pairs_multiplier must be provided")
+
+    # Log the actual n_pairs to wandb
+    if config.wandb_project and wandb.run is not None:
+        wandb.config.update({"n_pairs": n_pairs}, allow_val_change=True)
+
+    # Create MemorizationConfig from flattened parameters
+    model_cfg = MemorizationConfig(
+        n_pairs=n_pairs,
+        d_model=config.d_model,
+        d_hidden=config.d_hidden,
+        act_fn_name=cast(Literal["gelu", "relu", "none"], config.act_fn_name),
+        use_bias=config.use_bias,
+    )
+    run_name = (
+        f"memorization_n{model_cfg.n_pairs}_d{model_cfg.d_model}_"
+        f"dh{model_cfg.d_hidden}_"
+        f"{model_cfg.act_fn_name}_seed{config.seed}"
+    )
+    out_dir = get_output_dir()
+
+    model = SingleLayerMemorizationMLP(config=model_cfg).to(device)
+
+    dataset = KeyValueMemorizationDataset(
+        n_pairs=model_cfg.n_pairs,
+        d_model=model_cfg.d_model,
+        device=device,
+        dataset_seed=config.dataset_seed,
+    )
+    dataloader = DatasetGeneratedDataLoader(dataset, batch_size=config.batch_size, shuffle=False)
+
+    final_losses = train(
+        config=config,
+        model=model,
+        dataloader=dataloader,
+        device=device,
+        out_dir=out_dir,
+        run_name=run_name,
+    )
+    return final_losses
+
+
+def main(config_path: Path | str | MemorizationTrainConfig) -> None:
+    """Main entry point for training memorization model.
+
+    Args:
+        config_path: Path to YAML config file or config object
+    """
+    device = get_device()
+    logger.info(f"Using device: {device}")
+
+    # Load config from file or object
+    config = load_config(config_path, config_model=MemorizationTrainConfig)
+
+    # Initialize wandb and merge sweep parameters
+    if config.wandb_project:
+        config = init_wandb(config, config.wandb_project, tags=["memorization-train"])
+
+    set_seed(config.seed)
+    logger.info(config)
+
+    # Run training
+    run_train(config, device)
+
+    if config.wandb_project:
+        wandb.finish()
+
+
+if __name__ == "__main__":
+    fire.Fire(main)

--- a/spd/experiments/memorization/train_target_model_sweep.yaml
+++ b/spd/experiments/memorization/train_target_model_sweep.yaml
@@ -1,0 +1,17 @@
+program: spd/experiments/memorization/train_memorization.py
+method: grid
+metric:
+  name: final_avg_mse
+  goal: minimize
+parameters:
+  d_model:
+    values: [16, 32, 64]
+  d_hidden:
+    values: [64, 128, 256]
+  n_pairs_multiplier:
+    values: [1, 1.414, 2, 2.828, 4]
+command:
+  - ${env}
+  - ${interpreter}
+  - ${program}
+  - spd/experiments/memorization/memorization_train_config.yaml

--- a/spd/figures.py
+++ b/spd/figures.py
@@ -89,6 +89,30 @@ def uv_and_identity_ci(inputs: CreateFiguresInputs) -> Mapping[str, plt.Figure]:
     }
 
 
+def memorization_ci_plots(inputs: CreateFiguresInputs) -> Mapping[str, plt.Figure]:
+    """Create memorization-specific CI plots using actual keys from the dataset."""
+    # Import here to avoid circular imports
+    from spd.experiments.memorization.memorization_dataset import KeyValueMemorizationDataset
+    from spd.experiments.memorization.plotting import create_memorization_plot_results
+    from spd.utils.data_utils import DatasetGeneratedDataLoader
+
+    # Try to get the dataset from the eval_loader
+    if isinstance(inputs.eval_loader, DatasetGeneratedDataLoader):
+        dataset = inputs.eval_loader.dataset
+        if isinstance(dataset, KeyValueMemorizationDataset):
+            return create_memorization_plot_results(
+                model=inputs.model,
+                device=inputs.device,
+                dataset=dataset,
+            )
+
+    # If we can't get the memorization dataset, raise an error
+    raise ValueError(
+        f"memorization_ci_plots requires a KeyValueMemorizationDataset, "
+        f"but got eval_loader of type {type(inputs.eval_loader)} with dataset {type(getattr(inputs.eval_loader, 'dataset', None))}"
+    )
+
+
 def create_figures(
     model: ComponentModel,
     causal_importances: dict[str, Float[Tensor, "... C"]],
@@ -150,5 +174,6 @@ FIGURES_FNS: dict[str, CreateFiguresFn] = {
         ci_histograms,
         mean_component_activation_counts,
         uv_and_identity_ci,
+        memorization_ci_plots,
     ]
 }

--- a/spd/registry.py
+++ b/spd/registry.py
@@ -19,7 +19,7 @@ class ExperimentConfig:
         expected_runtime: Expected runtime of the experiment in minutes. Used for SLURM job names.
     """
 
-    experiment_type: Literal["tms", "resid_mlp", "lm"]
+    experiment_type: Literal["tms", "resid_mlp", "lm", "memorization"]
     decomp_script: Path
     config_path: Path
     expected_runtime: int
@@ -74,6 +74,24 @@ EXPERIMENT_REGISTRY: dict[str, ExperimentConfig] = {
     #     config_path=Path("spd/experiments/lm/ss_emb_config.yaml"),
     #     expected_runtime=60,
     # ),
+    "mem_32_1x": ExperimentConfig(
+        experiment_type="memorization",
+        decomp_script=Path("spd/experiments/memorization/memorization_decomposition.py"),
+        config_path=Path("spd/experiments/memorization/decomp_config_32-128-1x.yaml"),
+        expected_runtime=30,
+    ),
+    "mem_32_1p4x": ExperimentConfig(
+        experiment_type="memorization",
+        decomp_script=Path("spd/experiments/memorization/memorization_decomposition.py"),
+        config_path=Path("spd/experiments/memorization/decomp_config_32-128-1p4x.yaml"),
+        expected_runtime=45,
+    ),
+    "mem_32_2x": ExperimentConfig(
+        experiment_type="memorization",
+        decomp_script=Path("spd/experiments/memorization/memorization_decomposition.py"),
+        config_path=Path("spd/experiments/memorization/decomp_config_32-128-2x.yaml"),
+        expected_runtime=60,
+    ),
 }
 
 


### PR DESCRIPTION
## Description
  Adds memorization experiments to train and decompose toy MLP models that memorize key-value pairs. Includes 3 configs for
  different model scales (1x, 1.4x, 2x) and memorization-specific plotting.

  ## Related Issue
  N/A

  ## Motivation and Context
  Enables studying how small MLPs memorize key-value pairs and how SPD can decompose the learned memorization patterns.

  ## How Has This Been Tested?
  - All pre-commit hooks pass
  - Can run: `spd-run --experiments mem_32_1x,mem_32_1p4x,mem_32_2x`

  ## Does this PR introduce a breaking change?
 These experiments are now part of the registry, so `spd-run` will run them in addition to existing toy models. Can easily be
  disabled by commenting out the entries in `spd/registry.py`.
  Otherwise No - purely additive, all existing functionality unchanged.
