### PR TITLE
Fix pos encoding in induction head experiment

### DIFF
--- a/spd/experiments/ih/model.py
+++ b/spd/experiments/ih/model.py
@@ -49,7 +49,9 @@ class PositionalEncoding(nn.Module):
         super().__init__()
         pe = torch.zeros(max_len, d_model)
         position = torch.arange(0, max_len, dtype=torch.float32).unsqueeze(1)
-        div_term = 10000.0 ** (torch.arange(0, d_model, 2).float() / d_model)
+        div_term = torch.exp(
+            torch.arange(0, d_model, 2, dtype=torch.float32) * (-math.log(10000.0) / d_model)
+        )              
         pe[:, 0::2] = torch.sin(position * div_term)
         pe[:, 1::2] = torch.cos(position * div_term)
         self.register_buffer("pe", pe.unsqueeze(0))


### PR DESCRIPTION
## Description
Realised I'd made a pretty egregious error on the positional encodings; multiplying rather than dividing.

## Related Issue
<!--- Use the keywords 'Close', 'Closes', 'Fix', or 'Fixes' followed by the issue number(s) to close the related issue(s) -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Prevents pos-enc from blowing up -- makes model training and likely decomposition more stable

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
Locally

## Does this PR introduce a breaking change?
<!--- If this PR introduces a breaking change, please describe the impact and migration path for existing applications below. -->
Nope