### PR TITLE
Test that we can load canonical runs

### DIFF
--- a/spd/registry.py
+++ b/spd/registry.py
@@ -14,62 +14,74 @@ class ExperimentConfig:
     """Configuration for a single experiment.
 
     Attributes:
+        task_name: Name of the task the experiment is for.
         decomp_script: Path to the decomposition script
         config_path: Path to the configuration YAML file
         expected_runtime: Expected runtime of the experiment in minutes. Used for SLURM job names.
+        canonical_run: Wandb path (i.e. prefixed with "wandb:") to a canonical run of the experiment.
+            We test that these runs can be loaded to a ComponentModel in
+            `tests/test_wandb_run_loading.py`. If None, no canonical run is available.
     """
 
-    experiment_type: Literal["tms", "resid_mlp", "lm"]
+    task_name: Literal["tms", "resid_mlp", "lm", "ih"]
     decomp_script: Path
     config_path: Path
     expected_runtime: int
+    canonical_run: str | None = None
 
 
 EXPERIMENT_REGISTRY: dict[str, ExperimentConfig] = {
     "tms_5-2": ExperimentConfig(
-        experiment_type="tms",
+        task_name="tms",
         decomp_script=Path("spd/experiments/tms/tms_decomposition.py"),
         config_path=Path("spd/experiments/tms/tms_5-2_config.yaml"),
         expected_runtime=4,
+        canonical_run="wandb:goodfire/spd/runs/u9lslp82",
     ),
     "tms_5-2-id": ExperimentConfig(
-        experiment_type="tms",
+        task_name="tms",
         decomp_script=Path("spd/experiments/tms/tms_decomposition.py"),
         config_path=Path("spd/experiments/tms/tms_5-2-id_config.yaml"),
         expected_runtime=4,
+        canonical_run="wandb:goodfire/spd/runs/hm77qg0d",
     ),
     "tms_40-10": ExperimentConfig(
-        experiment_type="tms",
+        task_name="tms",
         decomp_script=Path("spd/experiments/tms/tms_decomposition.py"),
         config_path=Path("spd/experiments/tms/tms_40-10_config.yaml"),
         expected_runtime=5,
+        canonical_run="wandb:goodfire/spd/runs/pwj1eaj2",
     ),
     "tms_40-10-id": ExperimentConfig(
-        experiment_type="tms",
+        task_name="tms",
         decomp_script=Path("spd/experiments/tms/tms_decomposition.py"),
         config_path=Path("spd/experiments/tms/tms_40-10-id_config.yaml"),
         expected_runtime=5,
+        canonical_run="wandb:goodfire/spd/s2yj41ak",
     ),
     "resid_mlp1": ExperimentConfig(
-        experiment_type="resid_mlp",
+        task_name="resid_mlp",
         decomp_script=Path("spd/experiments/resid_mlp/resid_mlp_decomposition.py"),
         config_path=Path("spd/experiments/resid_mlp/resid_mlp1_config.yaml"),
         expected_runtime=3,
+        canonical_run="wandb:goodfire/spd/runs/pzauyxx8",
     ),
     "resid_mlp2": ExperimentConfig(
-        experiment_type="resid_mlp",
+        task_name="resid_mlp",
         decomp_script=Path("spd/experiments/resid_mlp/resid_mlp_decomposition.py"),
         config_path=Path("spd/experiments/resid_mlp/resid_mlp2_config.yaml"),
         expected_runtime=11,
+        canonical_run=None,
     ),
     "resid_mlp3": ExperimentConfig(
-        experiment_type="resid_mlp",
+        task_name="resid_mlp",
         decomp_script=Path("spd/experiments/resid_mlp/resid_mlp_decomposition.py"),
         config_path=Path("spd/experiments/resid_mlp/resid_mlp3_config.yaml"),
         expected_runtime=60,
+        canonical_run=None,
     ),
     # "ss_emb": ExperimentConfig(
-    #     experiment_type="lm",
+    #     task_name="lm",
     #     decomp_script=Path("spd/experiments/lm/lm_decomposition.py"),
     #     config_path=Path("spd/experiments/lm/ss_emb_config.yaml"),
     #     expected_runtime=60,

--- a/spd/scripts/run.py
+++ b/spd/scripts/run.py
@@ -268,7 +268,7 @@ def create_wandb_report(
             )
         y += loss_plots_height
 
-        if EXPERIMENT_REGISTRY[experiment].experiment_type in ["tms", "resid_mlp"]:
+        if EXPERIMENT_REGISTRY[experiment].task_name in ["tms", "resid_mlp"]:
             # Add target CI error plots
             target_ci_weight = 6
             target_ci_width = REPORT_TOTAL_WIDTH // 2
@@ -291,7 +291,7 @@ def create_wandb_report(
             y += target_ci_weight
 
         # Only add KL loss plots for language model experiments
-        if EXPERIMENT_REGISTRY[experiment].experiment_type == "lm":
+        if EXPERIMENT_REGISTRY[experiment].task_name == "lm":
             kl_height = 6
             kl_width = REPORT_TOTAL_WIDTH // 2
             x_offset = 0

--- a/tests/test_wandb_run_loading.py
+++ b/tests/test_wandb_run_loading.py
@@ -1,39 +1,37 @@
 """Test loading models from wandb runs.
 
-If the CANONICAL_RUNS needs to be updated, you can do so with `spd-run`. See spd/scripts/run.py
-for more details.
+If these tests fail and some canonical runs need to be updated, see spd/scripts/run.py for running
+experiments with the canonical configs.
 """
 
 import pytest
 
 from spd.models.component_model import ComponentModel, SPDRunInfo
-
-CANONICAL_RUNS: dict[str, str] = {
-    "tms_5-2": "wandb:goodfire/spd/runs/u9lslp82",
-    "tms_5-2-id": "wandb:goodfire/spd/runs/hm77qg0d",
-    "tms_40-10": "wandb:goodfire/spd/runs/pwj1eaj2",
-    "tms_40-10-id": "wandb:goodfire/spd/s2yj41ak",
-    "resid_mlp1": "wandb:goodfire/spd/runs/pzauyxx8",
-    "ss_mlp": "wandb:spd/runs/ioprgffh",
-}
+from spd.registry import EXPERIMENT_REGISTRY
 
 
 @pytest.mark.slow
 def test_wandb_loading_run_info():
-    for exp_name, model_path in CANONICAL_RUNS.items():
+    for exp_name, exp_config in EXPERIMENT_REGISTRY.items():
+        if exp_config.canonical_run is None:
+            # No canonical run for this experiment
+            continue
         try:
-            run_info = SPDRunInfo.from_path(model_path)
+            run_info = SPDRunInfo.from_path(exp_config.canonical_run)
             ComponentModel.from_run_info(run_info)
         except Exception as e:
-            e.add_note(f"Error loading {exp_name} from {model_path}")
+            e.add_note(f"Error loading {exp_name} from {exp_config.canonical_run}")
             raise e
 
 
 @pytest.mark.slow
 def test_wandb_loading_pretrained_model():
-    for exp_name, model_path in CANONICAL_RUNS.items():
+    for exp_name, exp_config in EXPERIMENT_REGISTRY.items():
+        if exp_config.canonical_run is None:
+            # No canonical run for this experiment
+            continue
         try:
-            ComponentModel.from_pretrained(model_path)
+            ComponentModel.from_pretrained(exp_config.canonical_run)
         except Exception as e:
-            e.add_note(f"Error loading {exp_name} from {model_path}")
+            e.add_note(f"Error loading {exp_name} from {exp_config.canonical_run}")
             raise e

--- a/tests/test_wandb_run_loading.py
+++ b/tests/test_wandb_run_loading.py
@@ -1,0 +1,39 @@
+"""Test loading models from wandb runs.
+
+If the CANONICAL_RUNS needs to be updated, you can do so with `spd-run`. See spd/scripts/run.py
+for more details.
+"""
+
+import pytest
+
+from spd.models.component_model import ComponentModel, SPDRunInfo
+
+CANONICAL_RUNS: dict[str, str] = {
+    "tms_5-2": "wandb:goodfire/spd/runs/u9lslp82",
+    "tms_5-2-id": "wandb:goodfire/spd/runs/hm77qg0d",
+    "tms_40-10": "wandb:goodfire/spd/runs/pwj1eaj2",
+    "tms_40-10-id": "wandb:goodfire/spd/s2yj41ak",
+    "resid_mlp1": "wandb:goodfire/spd/runs/pzauyxx8",
+    "ss_mlp": "wandb:spd/runs/ioprgffh",
+}
+
+
+@pytest.mark.slow
+def test_wandb_loading_run_info():
+    for exp_name, model_path in CANONICAL_RUNS.items():
+        try:
+            run_info = SPDRunInfo.from_path(model_path)
+            ComponentModel.from_run_info(run_info)
+        except Exception as e:
+            e.add_note(f"Error loading {exp_name} from {model_path}")
+            raise e
+
+
+@pytest.mark.slow
+def test_wandb_loading_pretrained_model():
+    for exp_name, model_path in CANONICAL_RUNS.items():
+        try:
+            ComponentModel.from_pretrained(model_path)
+        except Exception as e:
+            e.add_note(f"Error loading {exp_name} from {model_path}")
+            raise e


### PR DESCRIPTION
## Description
Minorly adapted from @mivanit's tests [here](https://github.com/goodfire-ai/spd/pull/81/files#diff-11e65aea2350d555efc69bcc3004a2cab7e8cb52264f18901492bbba6150d323).

- Allows for defining wandb links to canonical runs alongside each experiment in the registry
- We test that we can load these canonical runs, both with `run_info = SPDRunInfo.from_path(exp_config.canonical_run); ComponentModel.from_run_info(run_info)` and `ComponentModel.from_pretrained(exp_config.canonical_run)`. Doing this will often raise errors when breaking changes are made, usually for changes to the config.
- Marked these tests with `@pytest.mark.slow` decorators. They won't run with `make test` but will run with `make test-all`. They also run in the CI.

If your changes break these tests,  you should consider making your changes backwards compatible so these do run.
If you're willing to make breaking changes, see spd/scripts/run.py for creating new runs with
the canonical configs, and update the registry with your new run(s).

NOTE: An extension of this setup would be to have multiple canonical runs, each from a different point in time. This would allow for better managing backwards compatibility. But this is probably overkill right now.

## Related Issue
N/A

## Motivation and Context
Currently we run into unforeseen breaking changes which we don't realise until someone manually tries to load a model from wandb. We want to keep a set of canonical runs that shouldn't break the tests, and allow for people to handle backwards compatibility in their changes.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Does this PR introduce a breaking change?
<!--- If this PR introduces a breaking change, please describe the impact and migration path for existing applications below. -->