### PR TITLE
Add gc.collect() to fix matplotlib GPU memory leak

### DIFF
--- a/spd/plotting.py
+++ b/spd/plotting.py
@@ -280,6 +280,7 @@ def plot_UV_matrices(
 
 def plot_component_activation_density(
     component_activation_density: dict[str, Float[Tensor, " C"]],
+    bins: int = 100,
 ) -> Image.Image:
     """Plot the activation density of each component as a histogram, stacked vertically."""
 
@@ -297,8 +298,9 @@ def plot_component_activation_density(
     # Iterate through modules and plot each histogram on its corresponding axis
     for i, (module_name, density) in enumerate(component_activation_density.items()):
         ax = axs[i]
-        ax.hist(density.detach().cpu().numpy(), bins=100)
-        ax.set_yscale("log")
+        data = density.detach().cpu().numpy()
+        ax.hist(data, bins=bins)
+        ax.set_yscale("log")  # Beware, memory leak unless gc.collect() is called after eval loop
         ax.set_title(module_name)  # Add module name as title to each subplot
         ax.set_xlabel("Activation density")
         ax.set_ylabel("Frequency")
@@ -339,10 +341,12 @@ def plot_ci_values_histograms(
     for i, (layer_name_raw, layer_ci) in enumerate(causal_importances.items()):
         layer_name = layer_name_raw.replace(".", "_")
         ax = axs[i]
-        ax.hist(layer_ci.flatten().cpu().numpy(), bins=bins)
+
+        data = layer_ci.flatten().cpu().numpy()
+        ax.hist(data, bins=bins)
+        ax.set_yscale("log")  # Beware, memory leak unless gc.collect() is called after eval loop
         ax.set_title(f"Causal importances for {layer_name}")
         ax.set_xlabel("Causal importance value")
-        ax.set_yscale("log")
         ax.set_ylabel("Frequency")
 
     fig.tight_layout()

--- a/spd/run_spd.py
+++ b/spd/run_spd.py
@@ -1,5 +1,6 @@
 """Run SPD on a model."""
 
+import gc
 import json
 from collections import defaultdict
 from collections.abc import Mapping
@@ -229,6 +230,10 @@ def optimize(
                         for k, v in metrics.items()
                     }
                     wandb.log(wandb_logs, step=step)
+
+                del metrics
+                torch.cuda.empty_cache()
+                gc.collect()
 
         # --- Saving Checkpoint --- #
         if (


### PR DESCRIPTION
## Description
- Adds gc.collect() at the end of the eval loop to avoid GPU memory leaks
- For good measure, also calls `del metrics` and `torch.cuda.empty_cache()` at the end of evaluation loops. I haven't noticed these being necessary, but thought they'd be reasonable things to do. In the feature we might have eval running on a separate process to the main training process. Not needed now IMO.

I have not investigated what is actually causing this memory leak at a lower level, or submitted a bug report to matplotlib. But this would be a reasonable thing to do.

## Related Issue
Closes #86 

## Motivation and Context
We noticed that often we would have unusual GPU memory leaks at sporadic times throughout training.

It turns out that the gpu memory leak is due to the inclusion of `ax.set_yscale("log")`. This is extremely weird. Nothing should be on the GPU when the plotting is called. I also get the leak when writing a custom log scale function, but didn't narrow it down to the specific numpy operation that causes it.

<img width="1463" height="918" alt="image" src="https://github.com/user-attachments/assets/83101941-ec48-41ab-84ed-151e2a6b6271" />


## How Has This Been Tested?
See run [here](https://wandb.ai/goodfire/spd?nw=4ftnmglztzk&yAxisMin=0&yAxisMax=100&panelDisplayName=GPU+Memory+Allocated+%28%25%29&panelSectionName=System) without the leak. Note that the gpu memory still fluctuates a little bit during an eval run, but doesn't seem to leak.

## Does this PR introduce a breaking change?
No