### PR TITLE
Support streaming and tokenized datasets with and without ddp

### DIFF
--- a/spd/data.py
+++ b/spd/data.py
@@ -251,8 +251,7 @@ def create_data_loader(
 
     # Ensure determinicity when not distributed and not streaming
     generator = torch.Generator(device="cpu")
-    if not dataset_config.streaming and not is_ddp:
-        generator.manual_seed(seed)
+    generator.manual_seed(seed)
 
     loader = DataLoader[Dataset | IterableDataset](
         torch_dataset,  # pyright: ignore[reportArgumentType]

--- a/spd/data.py
+++ b/spd/data.py
@@ -194,7 +194,12 @@ def create_data_loader(
 
     if dataset_config.streaming:
         assert isinstance(dataset, IterableDataset)
+        logger.warning(
+            "WARNING: Streaming is currently quite slow and not well tested. In general, we suggest"
+            " setting streaming=False and having the dataset download (and cache)."
+        )
         if is_ddp:
+            logger.warning("WARNING: Streaming with ddp has not been well tested. Use at own risk.")
             ds_num_shards = getattr(dataset, "num_shards", None)
             if isinstance(ds_num_shards, int) and ds_num_shards >= ddp_world_size:
                 dataset = dataset.shard(num_shards=ddp_world_size, index=ddp_rank)

--- a/spd/data.py
+++ b/spd/data.py
@@ -1,6 +1,7 @@
 from typing import Any, ClassVar
 
 import numpy as np
+import torch
 from datasets import Dataset, IterableDataset, load_dataset
 from numpy.typing import NDArray
 from pydantic import BaseModel, ConfigDict
@@ -9,7 +10,6 @@ from torch.utils.data import DataLoader, DistributedSampler
 from transformers import AutoTokenizer, PreTrainedTokenizer
 
 from spd.log import logger
-from spd.utils.distributed_utils import is_distributed
 
 
 class DatasetConfig(BaseModel):
@@ -128,7 +128,9 @@ def tokenize_and_concatenate(
     # Apply the tokenization function to the dataset
     if isinstance(dataset, IterableDataset):
         tokenized_dataset = dataset.map(
-            tokenize_function, batched=True, remove_columns=[column_name]
+            tokenize_function,
+            batched=True,
+            remove_columns=[column_name],
         )
     else:
         tokenized_dataset = dataset.map(
@@ -143,7 +145,7 @@ def tokenize_and_concatenate(
 def create_data_loader(
     dataset_config: DatasetConfig,
     batch_size: int,
-    buffer_size: int = 1000,
+    buffer_size: int,
     global_seed: int = 0,
     ddp_rank: int = 0,
     ddp_world_size: int = 1,
@@ -156,6 +158,17 @@ def create_data_loader(
     - Each rank gets a different subset of the data
     - Data is distributed deterministically based on rank
     - No data is duplicated across ranks
+
+    For shuffling datasets between epochs:
+    - When dp>1 and streaming=True, we shard the dataset across ranks and use the default sampler.
+        If the dataset has fewer dataset shards than we have ddp ranks, we split up the dataset
+        by example. We also use dataset.set_epoch(epoch) during training.
+    - When dp>1 and streaming=False, we use a DistributedSampler and run
+        sampler.set_epoch(epoch) during training.
+    - When dp=1 and streaming=True, we use the default sampler and run
+        dataset.set_epoch(epoch) during training.
+    - When dp=1 and streaming=False, we use the default sampler and set shuffle=True on the
+        DataLoader.
 
     Args:
         dataset_config: The configuration for the dataset.
@@ -177,9 +190,20 @@ def create_data_loader(
     )
     seed = dataset_config.seed if dataset_config.seed is not None else global_seed
 
+    is_ddp = ddp_world_size > 1
+
     if dataset_config.streaming:
-        assert ddp_world_size == 1, "DDP with streaming datasets is not yet supported."
         assert isinstance(dataset, IterableDataset)
+        if is_ddp:
+            ds_num_shards = getattr(dataset, "num_shards", None)
+            if isinstance(ds_num_shards, int) and ds_num_shards >= ddp_world_size:
+                dataset = dataset.shard(num_shards=ddp_world_size, index=ddp_rank)
+            else:
+                # Fallback: example-level partitioning before shuffle
+                dataset = dataset.filter(
+                    lambda _ex, idx, r=ddp_rank, ws=ddp_world_size: idx % ws == r,
+                    with_indices=True,
+                )
         dataset = dataset.shuffle(seed=seed, buffer_size=buffer_size)
     else:
         assert isinstance(dataset, Dataset)
@@ -210,7 +234,7 @@ def create_data_loader(
         )
 
     sampler = None
-    if not dataset_config.streaming and is_distributed():
+    if not dataset_config.streaming and is_ddp:
         sampler = DistributedSampler(
             torch_dataset,  # pyright: ignore[reportArgumentType]
             num_replicas=ddp_world_size,
@@ -220,12 +244,20 @@ def create_data_loader(
             drop_last=True,
         )
 
+    # Ensure determinicity when not distributed and not streaming
+    generator = torch.Generator(device="cpu")
+    if not dataset_config.streaming and not is_ddp:
+        generator.manual_seed(seed)
+
     loader = DataLoader[Dataset | IterableDataset](
         torch_dataset,  # pyright: ignore[reportArgumentType]
         batch_size=batch_size,
         sampler=sampler,
-        shuffle=(sampler is None and dataset_config.shuffle_each_epoch),
+        shuffle=(
+            sampler is None and dataset_config.shuffle_each_epoch and not dataset_config.streaming
+        ),
         drop_last=True,
+        generator=generator,
     )
     return loader, tokenizer
 
@@ -245,5 +277,7 @@ def loop_dataloader[T](dl: DataLoader[T]):
             epoch += 1
             if isinstance(dl.sampler, DistributedSampler):
                 dl.sampler.set_epoch(epoch)
+            if isinstance(dl.dataset, IterableDataset):
+                dl.dataset.set_epoch(epoch)
             dl_iter = iter(dl)
             yield next(dl_iter)

--- a/spd/experiments/lm/configs.py
+++ b/spd/experiments/lm/configs.py
@@ -38,6 +38,10 @@ class LMTaskConfig(BaseModel):
         description="Whether to reshuffle data at each epoch. Set False in tests to keep fixed "
         "order across dp modes.",
     )
+    is_tokenized: bool = Field(
+        default=False,
+        description="Whether the dataset is already tokenized",
+    )
     streaming: bool = Field(
         default=False,
         description="Whether to use a streaming dataset",

--- a/spd/experiments/lm/configs.py
+++ b/spd/experiments/lm/configs.py
@@ -38,3 +38,7 @@ class LMTaskConfig(BaseModel):
         description="Whether to reshuffle data at each epoch. Set False in tests to keep fixed "
         "order across dp modes.",
     )
+    streaming: bool = Field(
+        default=False,
+        description="Whether to use a streaming dataset",
+    )

--- a/spd/experiments/lm/gpt2_config.yaml
+++ b/spd/experiments/lm/gpt2_config.yaml
@@ -9,7 +9,7 @@ seed: 0
 C: 768
 n_mask_samples: 1
 gate_type: "vector_mlp"
-gate_hidden_dims: [64]
+gate_hidden_dims: [12]
 sigmoid_type: "leaky_hard"
 target_module_patterns: ["transformer.h.1.attn.c_attn"]
 
@@ -63,12 +63,12 @@ tokenizer_name: openai-community/gpt2
 # --- Task Specific ---
 task_config:
   task_name: lm 
-  max_seq_len: 512
-  buffer_size: 1000
-  dataset_name: "SimpleStories/SimpleStories"
-  column_name: "story"
+  max_seq_len: 1024
+  dataset_name: "apollo-research/Skylion007-openwebtext-tokenizer-gpt2"
+  is_tokenized: True
+  column_name: "input_ids"
   train_data_split: "train"
-  eval_data_split: "test"
+  eval_data_split: "train"  # TODO: handle different seeding for train and eval
 
 
 # Config details for the target model taken from https://github.com/danbraunai/simple_stories_train/blob/main/simple_stories_train/train_gpt2.py#L165

--- a/spd/experiments/lm/lm_decomposition.py
+++ b/spd/experiments/lm/lm_decomposition.py
@@ -102,7 +102,7 @@ def main(
         hf_tokenizer_path=config.tokenizer_name,
         split=config.task_config.train_data_split,
         n_ctx=config.task_config.max_seq_len,
-        is_tokenized=False,  # TODO: Support pre-tokenized datasets
+        is_tokenized=config.task_config.is_tokenized,
         streaming=config.task_config.streaming,
         column_name=config.task_config.column_name,
         shuffle_each_epoch=config.task_config.shuffle_each_epoch,
@@ -129,7 +129,7 @@ def main(
         hf_tokenizer_path=config.pretrained_model_name_hf,
         split=config.task_config.eval_data_split,
         n_ctx=config.task_config.max_seq_len,
-        is_tokenized=False,  # TODO: Support pre-tokenized datasets
+        is_tokenized=config.task_config.is_tokenized,
         streaming=config.task_config.streaming,
         column_name=config.task_config.column_name,
         shuffle_each_epoch=config.task_config.shuffle_each_epoch,

--- a/spd/experiments/lm/lm_decomposition.py
+++ b/spd/experiments/lm/lm_decomposition.py
@@ -102,8 +102,8 @@ def main(
         hf_tokenizer_path=config.tokenizer_name,
         split=config.task_config.train_data_split,
         n_ctx=config.task_config.max_seq_len,
-        is_tokenized=False,
-        streaming=False,
+        is_tokenized=False,  # TODO: Support pre-tokenized datasets
+        streaming=config.task_config.streaming,
         column_name=config.task_config.column_name,
         shuffle_each_epoch=config.task_config.shuffle_each_epoch,
     )
@@ -129,8 +129,8 @@ def main(
         hf_tokenizer_path=config.pretrained_model_name_hf,
         split=config.task_config.eval_data_split,
         n_ctx=config.task_config.max_seq_len,
-        is_tokenized=False,
-        streaming=False,
+        is_tokenized=False,  # TODO: Support pre-tokenized datasets
+        streaming=config.task_config.streaming,
         column_name=config.task_config.column_name,
         shuffle_each_epoch=config.task_config.shuffle_each_epoch,
     )

--- a/spd/experiments/lm/ss_emb_config.yaml
+++ b/spd/experiments/lm/ss_emb_config.yaml
@@ -61,7 +61,6 @@ tokenizer_name: SimpleStories/SimpleStories-1.25M
 task_config:
   task_name: lm 
   max_seq_len: 512
-  buffer_size: 1000
   dataset_name: "SimpleStories/SimpleStories"
   column_name: "story"
   train_data_split: "train"

--- a/spd/experiments/lm/ss_gpt2_config.yaml
+++ b/spd/experiments/lm/ss_gpt2_config.yaml
@@ -64,7 +64,6 @@ tokenizer_name: SimpleStories/test-SimpleStories-gpt2-1.25M
 task_config:
   task_name: lm 
   max_seq_len: 512
-  buffer_size: 1000
   dataset_name: "SimpleStories/SimpleStories"
   column_name: "story"
   train_data_split: "train"

--- a/spd/experiments/lm/ss_llama_config.yaml
+++ b/spd/experiments/lm/ss_llama_config.yaml
@@ -64,11 +64,11 @@ tokenizer_name: SimpleStories/SimpleStories-1.25M
 task_config:
   task_name: lm 
   max_seq_len: 512
-  buffer_size: 1000
   dataset_name: "SimpleStories/SimpleStories"
   column_name: "story"
   train_data_split: "train"
   eval_data_split: "test"
+  streaming: True
 
 
 # Config details for the target model taken from https://github.com/danbraunai/simple_stories_train/blob/main/simple_stories_train/models/model_configs.py#L54

--- a/spd/experiments/lm/streamlit_v1/component_activation_contexts.py
+++ b/spd/experiments/lm/streamlit_v1/component_activation_contexts.py
@@ -27,6 +27,8 @@ class AnalysisConfig:
     dataset_name: str
     dataset_split: str
     column_name: str
+    is_tokenized: bool
+    streaming: bool
     causal_importance_threshold: float
     n_steps: int
     batch_size: int
@@ -417,6 +419,16 @@ def _render_configuration_form() -> AnalysisConfig | None:
                     value="story",
                     help="Column containing the text to analyze",
                 )
+                is_tokenized = st.checkbox(
+                    "Is Tokenized",
+                    value=False,
+                    help="Whether the dataset is already tokenized",
+                )
+                streaming = st.checkbox(
+                    "Streaming",
+                    value=False,
+                    help="Whether the dataset is streamed",
+                )
                 causal_importance_threshold = st.slider(
                     "Causal Importance Threshold",
                     min_value=0.0,
@@ -485,6 +497,8 @@ def _render_configuration_form() -> AnalysisConfig | None:
                 n_prompts=n_prompts,
                 n_tokens_either_side=n_tokens_either_side,
                 seed=seed,
+                is_tokenized=is_tokenized,
+                streaming=streaming,
             )
     return None
 
@@ -750,8 +764,8 @@ def find_component_activation_contexts(
         hf_tokenizer_path=_model_data.config.pretrained_model_name_hf,
         split=config.dataset_split,
         n_ctx=config.max_seq_len,
-        is_tokenized=False,
-        streaming=False,
+        is_tokenized=config.is_tokenized,
+        streaming=config.streaming,
         column_name=config.column_name,
     )
 

--- a/spd/experiments/lm/streamlit_v1/token_activation_table.py
+++ b/spd/experiments/lm/streamlit_v1/token_activation_table.py
@@ -24,6 +24,8 @@ class AnalysisConfig:
     dataset_name: str
     dataset_split: str
     column_name: str
+    is_tokenized: bool
+    streaming: bool
     causal_importance_threshold: float
     n_steps: int
     batch_size: int
@@ -82,6 +84,16 @@ def _render_configuration_form() -> AnalysisConfig | None:
                     value="story",
                     help="Column containing the text to analyze",
                 )
+                is_tokenized = st.checkbox(
+                    "Is Tokenized",
+                    value=False,
+                    help="Whether the dataset is already tokenized",
+                )
+                streaming = st.checkbox(
+                    "Streaming",
+                    value=False,
+                    help="Whether the dataset is streamed",
+                )
                 causal_importance_threshold = st.slider(
                     "Causal Importance Threshold",
                     min_value=0.0,
@@ -138,6 +150,8 @@ def _render_configuration_form() -> AnalysisConfig | None:
                 dataset_name=dataset_name,
                 dataset_split=dataset_split,
                 column_name=column_name,
+                is_tokenized=is_tokenized,
+                streaming=streaming,
                 causal_importance_threshold=causal_importance_threshold,
                 n_steps=n_steps,
                 batch_size=batch_size,
@@ -433,8 +447,8 @@ def analyze_component_token_table(
         hf_tokenizer_path=_model_data.config.pretrained_model_name_hf,
         split=config.dataset_split,
         n_ctx=config.max_seq_len,
-        is_tokenized=False,
-        streaming=False,
+        is_tokenized=config.is_tokenized,
+        streaming=config.streaming,
         column_name=config.column_name,
     )
 

--- a/spd/experiments/lm/streamlit_v1/token_inspector.py
+++ b/spd/experiments/lm/streamlit_v1/token_inspector.py
@@ -53,8 +53,8 @@ def create_dataloader_iterator(model_data: ModelData) -> Iterator[PromptData]:
         hf_tokenizer_path=model_data.config.pretrained_model_name_hf,
         split=task_cfg.eval_data_split,
         n_ctx=task_cfg.max_seq_len,
-        is_tokenized=False,
-        streaming=False,
+        is_tokenized=task_cfg.is_tokenized,
+        streaming=task_cfg.streaming,
         column_name=task_cfg.column_name,
     )
 

--- a/spd/experiments/lm/ts_config.yaml
+++ b/spd/experiments/lm/ts_config.yaml
@@ -65,7 +65,6 @@ tokenizer_name: EleutherAI/gpt-neo-125M
 task_config:
   task_name: lm
   max_seq_len: 2048
-  buffer_size: 1000
   dataset_name: "roneneldan/TinyStories"
   column_name: "text"
   train_data_split: "train"

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -96,8 +96,8 @@ def test_gpt_2_decomposition_happy_path() -> None:
         hf_tokenizer_path=config.pretrained_model_name_hf,
         split=config.task_config.train_data_split,
         n_ctx=config.task_config.max_seq_len,
-        is_tokenized=False,
-        streaming=False,
+        is_tokenized=config.task_config.is_tokenized,
+        streaming=config.task_config.streaming,
         column_name=config.task_config.column_name,
     )
 
@@ -113,8 +113,8 @@ def test_gpt_2_decomposition_happy_path() -> None:
         hf_tokenizer_path=config.pretrained_model_name_hf,
         split=config.task_config.eval_data_split,
         n_ctx=config.task_config.max_seq_len,
-        is_tokenized=False,
-        streaming=False,
+        is_tokenized=config.task_config.is_tokenized,
+        streaming=config.task_config.streaming,
         column_name=config.task_config.column_name,
     )
     eval_loader, _ = create_data_loader(


### PR DESCRIPTION
## Description
Support streaming datasets with and without ddp, as well as tokenized datasets.

- When dp>1 and streaming=True, we shard the dataset across ranks and use the default sampler.
    If the dataset has fewer dataset shards than we have ddp ranks, we split up the dataset
    by example. We also use dataset.set_epoch(epoch) during training.
- When dp>1 and streaming=False, we use a DistributedSampler and run
    sampler.set_epoch(epoch) during training.
- When dp=1 and streaming=True, we use the default sampler and run
    dataset.set_epoch(epoch) during training.
- When dp=1 and streaming=False, we use the default sampler and set shuffle=True on the
   DataLoader.

Note: When I run with streaming, it's quite slow. It goes fast for ~18 steps, then a slow step, then back to fast. This is likely due to the dataset.map function which does the tokenization. I'm sure that better settings could speed this up, but I think streaming will be sufficiently niche as to not warrant it.

## Related Issue
#111 

## Motivation and Context
We want people to be able to decompose very large datasets.

## How Has This Been Tested?
Testing this would be very time consuming and involve refactors. Right now, I don't think streaming should be a common use case, given that it's also quite slow. People should just set it to false and have the dataset cached.

For this reason, I didn't write tests and just gave warnings to the user that the streaming=True is not well tested and that it's recommended to not use it.

## Does this PR introduce a breaking change?
No