### PR TITLE
Add inference_mode to dataset generation code

### DIFF
--- a/spd/data_utils.py
+++ b/spd/data_utils.py
@@ -104,6 +104,7 @@ class SparseFeatureDataset(
             batch = torch.where(mask, random_values, batch)
         return batch
 
+    @torch.inference_mode()
     def generate_batch(
         self, batch_size: int
     ) -> tuple[Float[Tensor, "batch n_features"], Float[Tensor, "batch n_features"]]:

--- a/spd/experiments/resid_mlp/resid_mlp_dataset.py
+++ b/spd/experiments/resid_mlp/resid_mlp_dataset.py
@@ -73,6 +73,7 @@ class ResidualMLPDataset(SparseFeatureDataset):
             elif label_type == "abs":
                 self.label_fn = lambda batch: self.calc_abs_labels(batch)
 
+    @torch.inference_mode()
     def generate_batch(
         self, batch_size: int
     ) -> tuple[Float[Tensor, "batch n_functions"], Float[Tensor, "batch n_functions"]]:


### PR DESCRIPTION
Fixes #54

Adds `@torch.inference_mode()` decorators to dataset generation methods:
- `SparseFeatureDataset.generate_batch`
- `ResidualMLPDataset.generate_batch`

These methods perform pure data generation without needing gradient tracking, making `inference_mode` more explicit and potentially slightly more efficient.

Generated with [Claude Code](https://claude.ai/code)

## Does this PR introduce a breaking change?
No