### PR TITLE
feat: Add SubsetReconstructionLoss evaluation metric

### DIFF
--- a/spd/eval.py
+++ b/spd/eval.py
@@ -7,6 +7,7 @@ These can be selected and configured in the Config.
 from abc import ABC, abstractmethod
 from collections import defaultdict
 from collections.abc import Iterator, Mapping
+from fnmatch import fnmatch
 from typing import Any, ClassVar, override
 
 import einops
@@ -426,6 +427,186 @@ class IdentityCIError(StreamingEval):
         return target_metrics
 
 
+class SubsetReconstructionLoss(StreamingEval):
+    """Compute reconstruction loss for specific subsets of components."""
+
+    SLOW = False
+
+    def __init__(
+        self,
+        model: ComponentModel,
+        config: Config,
+        include_patterns: dict[str, list[str]] | None = None,
+        exclude_patterns: dict[str, list[str]] | None = None,
+        use_all_ones_for_non_replaced: bool = False,
+        n_mask_samples: int = 5,
+    ):
+        """Initialize SubsetReconstructionLoss.
+
+        Args:
+            include_patterns: Dict mapping subset names to patterns for modules to REPLACE
+                            e.g., {"layer_0_only": ["model.layers.0.*"]}
+            exclude_patterns: Dict mapping subset names to patterns for modules to EXCLUDE from replacement
+                            e.g., {"all_but_layer_0": ["model.layers.0.*"]}
+            use_all_ones_for_non_replaced: If True, use all-ones mask for non-replaced modules
+            n_mask_samples: Number of stochastic mask samples to average over
+        """
+        self.model = model
+        self.config = config
+        self.use_all_ones_for_non_replaced = use_all_ones_for_non_replaced
+        self.n_mask_samples = n_mask_samples
+        self.include_patterns = include_patterns or {}
+        self.exclude_patterns = exclude_patterns or {}
+
+        if not self.include_patterns and not self.exclude_patterns:
+            raise ValueError(
+                "At least one of include_patterns or exclude_patterns must be provided"
+            )
+
+        self.losses = defaultdict[str, list[float]](list)
+
+    @override
+    def watch_batch(
+        self,
+        batch: Int[Tensor, "..."] | Float[Tensor, "..."],
+        target_out: Float[Tensor, "... vocab"],
+        ci: dict[str, Float[Tensor, "... C"]],
+    ) -> None:
+        losses = self._calc_subset_losses(batch, target_out, ci)
+        for key, value in losses.items():
+            self.losses[key].append(value)
+
+    def _calc_subset_losses(
+        self,
+        batch: Int[Tensor, "..."] | Float[Tensor, "..."],
+        target_out: Float[Tensor, "... vocab"],
+        ci: dict[str, Float[Tensor, "... C"]],
+    ) -> Mapping[str, float]:
+        assert batch.ndim == 2, "Batch must be 2D (batch, seq_len)"
+
+        # Setup CE calculation
+        masked_batch = batch.clone()
+        masked_batch[:, 0] = -100
+        flat_masked_batch = masked_batch.flatten()
+
+        def ce_vs_labels(logits: Tensor) -> float:
+            flat_logits = einops.rearrange(logits, "b seq_len vocab -> (b seq_len) vocab")
+            return F.cross_entropy(
+                flat_logits[:-1], flat_masked_batch[1:], ignore_index=-100
+            ).item()
+
+        def kl_vs_target(logits: Tensor) -> float:
+            return calc_kl_divergence_lm(pred=logits, target=target_out).item()
+
+        # Compute baselines for CE unrecovered
+        target_ce = ce_vs_labels(target_out)
+        zero_masks = {k: torch.zeros_like(v) for k, v in ci.items()}
+        zero_out = self.model(batch, mode="components", masks=zero_masks)
+        zero_ce = ce_vs_labels(zero_out)
+
+        # Generate stochastic masks
+        stoch_masks = calc_stochastic_masks(ci, self.n_mask_samples, self.config.sampling)
+
+        results = {}
+        all_modules = list(ci.keys())
+
+        # Process include patterns
+        for name, patterns in self.include_patterns.items():
+            active = [m for m in all_modules if any(fnmatch(m, p) for p in patterns)]
+
+            kl_losses, ce_losses = [], []
+            for stoch_mask in stoch_masks:
+                mask = {}
+                for m in all_modules:
+                    if m in active:
+                        mask[m] = stoch_mask[m]
+                    elif self.use_all_ones_for_non_replaced:
+                        mask[m] = torch.ones_like(stoch_mask[m])
+
+                out = self.model(batch, mode="components", masks=mask)
+                kl_losses.append(kl_vs_target(out))
+                ce_losses.append(ce_vs_labels(out))
+
+            mean_kl = sum(kl_losses) / len(kl_losses)
+            mean_ce = sum(ce_losses) / len(ce_losses)
+            ce_unrec = (mean_ce - target_ce) / (zero_ce - target_ce) if zero_ce != target_ce else 0
+
+            suffix = "_all_ones" if self.use_all_ones_for_non_replaced else ""
+            results[f"subset/{name}/kl{suffix}"] = mean_kl
+            results[f"subset/{name}/ce{suffix}"] = mean_ce
+            results[f"subset/{name}/ce_unrec{suffix}"] = ce_unrec
+
+        # Process exclude patterns
+        for name, patterns in self.exclude_patterns.items():
+            excluded = [m for m in all_modules if any(fnmatch(m, p) for p in patterns)]
+            active = [m for m in all_modules if m not in excluded]
+
+            kl_losses, ce_losses = [], []
+            for stoch_mask in stoch_masks:
+                mask = {}
+                for m in all_modules:
+                    if m in active:
+                        mask[m] = stoch_mask[m]
+                    elif self.use_all_ones_for_non_replaced:
+                        mask[m] = torch.ones_like(stoch_mask[m])
+
+                out = self.model(batch, mode="components", masks=mask)
+                kl_losses.append(kl_vs_target(out))
+                ce_losses.append(ce_vs_labels(out))
+
+            mean_kl = sum(kl_losses) / len(kl_losses)
+            mean_ce = sum(ce_losses) / len(ce_losses)
+            ce_unrec = (mean_ce - target_ce) / (zero_ce - target_ce) if zero_ce != target_ce else 0
+
+            suffix = "_all_ones" if self.use_all_ones_for_non_replaced else ""
+            results[f"subset/{name}/kl{suffix}"] = mean_kl
+            results[f"subset/{name}/ce{suffix}"] = mean_ce
+            results[f"subset/{name}/ce_unrec{suffix}"] = ce_unrec
+
+        return results
+
+    @override
+    def compute(self) -> Mapping[str, float]:
+        # Compute averages for all metrics
+        results = {k: sum(v) / len(v) for k, v in self.losses.items()}
+
+        # Find worst (highest) metrics across all subsets
+        metrics_by_type = {"kl": {}, "ce": {}, "ce_unrec": {}}
+
+        for key, value in results.items():
+            if not key.startswith("subset/"):
+                continue
+
+            parts = key.split("/")
+            if len(parts) != 3:
+                continue
+
+            subset_name = parts[1]
+            metric_type = parts[2]
+
+            # Skip all_ones variants for worst tracking
+            if metric_type.endswith("_all_ones"):
+                continue
+
+            # Group metrics by type
+            if metric_type == "kl":
+                metrics_by_type["kl"][subset_name] = value
+            elif metric_type == "ce":
+                metrics_by_type["ce"][subset_name] = value
+            elif metric_type == "ce_unrec":
+                metrics_by_type["ce_unrec"][subset_name] = value
+
+        # Add worst metrics to results
+        for metric_type, subset_values in metrics_by_type.items():
+            if subset_values:
+                worst_subset = max(subset_values, key=lambda k: subset_values[k])
+                worst_value = subset_values[worst_subset]
+                results[f"subset_worst/{metric_type}"] = worst_value
+                results[f"subset_worst/{metric_type}_subset"] = worst_subset
+
+        return results
+
+
 EVAL_CLASSES = {
     cls.__name__: cls
     for cls in [
@@ -436,6 +617,7 @@ EVAL_CLASSES = {
         PermutedCIPlots,
         UVPlots,
         IdentityCIError,
+        SubsetReconstructionLoss,
     ]
 }
 

--- a/spd/experiments/lm/ss_llama_subset_eval_config.yaml
+++ b/spd/experiments/lm/ss_llama_subset_eval_config.yaml
@@ -1,0 +1,113 @@
+# --- WandB ---
+wandb_project: spd
+wandb_run_name: null
+wandb_run_name_prefix: ""
+
+# --- General ---
+seed: 0
+C: 4000
+n_mask_samples: 1
+gate_type: "vector_mlp"
+gate_hidden_dims: [12]
+sigmoid_type: "leaky_hard"
+target_module_patterns: ["model.layers.*.mlp.gate_proj", "model.layers.*.mlp.down_proj", "model.layers.*.mlp.up_proj", "model.layers.*.self_attn.q_proj", "model.layers.*.self_attn.k_proj", "model.layers.*.self_attn.v_proj", "model.layers.*.self_attn.o_proj"]
+sampling: "continuous"
+
+# --- Loss Coefficients ---
+faithfulness_coeff: 10000000.0
+recon_coeff: null
+stochastic_recon_coeff: 1.0
+recon_layerwise_coeff: null
+stochastic_recon_layerwise_coeff: 1.0
+importance_minimality_coeff: 0.0003
+schatten_coeff: null
+out_recon_coeff: null
+embedding_recon_coeff: null
+is_embed_unembed_recon: false
+pnorm: 2.0
+p_anneal_start_frac: 0.0
+p_anneal_final_p: 0.1
+p_anneal_end_frac: 1.0
+output_loss_type: kl
+
+# --- Training ---
+batch_size: 48
+eval_batch_size: 48
+steps: 300000
+lr: 0.0005
+lr_schedule: cosine
+lr_warmup_pct: 0.0
+lr_exponential_halflife: null
+gradient_accumulation_steps: 1
+
+# --- Logging & Saving ---
+train_log_freq: 100
+eval_freq: 1000
+slow_eval_freq: 5000
+slow_eval_on_first_step: true
+n_eval_steps: 5
+save_freq: null
+ci_alive_threshold: 0.0
+n_examples_until_dead: 1368400
+eval_metrics:
+  - classname: "CIHistograms"
+    extra_init_kwargs:
+      n_batches_accum: 5
+  - classname: "ComponentActivationDensity"
+    extra_init_kwargs: {}
+  - classname: "CI_L0"
+    extra_init_kwargs: {}
+  - classname: "CEandKLLosses"
+    extra_init_kwargs:
+      rounding_threshold: 0.0
+  - classname: "SubsetReconstructionLoss"
+    extra_init_kwargs:
+      n_mask_samples: 1
+      use_all_ones_for_non_replaced: false
+      include_patterns:
+        layer_0_only: ["model.layers.0.*"]
+        layer_1_only: ["model.layers.1.*"]
+        layer_2_only: ["model.layers.2.*"]
+        layer_3_only: ["model.layers.3.*"]
+        mlp_only: ["*.mlp.*"]
+        attention_only: ["*.self_attn.*"]
+      exclude_patterns:
+        all_but_layer_0: ["model.layers.0.*"]
+        all_but_layer_1: ["model.layers.1.*"]
+        all_but_layer_2: ["model.layers.2.*"]
+        all_but_layer_3: ["model.layers.3.*"]
+
+# --- Pretrained model info ---
+pretrained_model_class: transformers.LlamaForCausalLM
+pretrained_model_name: SimpleStories/SimpleStories-1.25M
+pretrained_model_path: null
+pretrained_model_output_attr: logits
+tokenizer_name: SimpleStories/SimpleStories-1.25M
+
+# --- Task Specific ---
+task_config:
+  task_name: lm 
+  max_seq_len: 512
+  buffer_size: 1000
+  dataset_name: "SimpleStories/SimpleStories"
+  column_name: "story"
+  train_data_split: "train"
+  eval_data_split: "test"
+  shuffle_each_epoch: true
+  is_tokenized: false
+  streaming: false
+
+
+# Config details for the target model taken from https://github.com/danbraunai/simple_stories_train/blob/main/simple_stories_train/models/model_configs.py#L54
+  # "1.25M": LlamaConfig(
+  #     block_size=512,
+  #     vocab_size=4096,
+  #     n_layer=4,
+  #     n_head=4,
+  #     n_embd=128,
+  #     n_intermediate=128 * 4 * 2 // 3 = 341,
+  #     rotary_dim=128 // 4 = 32,
+  #     n_ctx=512,
+  #     n_key_value_heads=2,
+  #     flash_attention=True,
+  # ),

--- a/spd/registry.py
+++ b/spd/registry.py
@@ -86,6 +86,12 @@ EXPERIMENT_REGISTRY: dict[str, ExperimentConfig] = {
         config_path=Path("spd/experiments/lm/ss_llama_config.yaml"),
         expected_runtime=60,
     ),
+    "ss_llama_all": ExperimentConfig(
+        task_name="lm",
+        decomp_script=Path("spd/experiments/lm/lm_decomposition.py"),
+        config_path=Path("spd/experiments/lm/ss_llama_subset_eval_config.yaml"),
+        expected_runtime=60 * 16,
+    ),
     "ss_gpt2": ExperimentConfig(
         task_name="lm",
         decomp_script=Path("spd/experiments/lm/lm_decomposition.py"),


### PR DESCRIPTION
  ## Description
  Adds evaluation logging to compute reconstruction loss where we only use SPD components on a subset of the layers. We support this via regex matching.

  ## Related Issue
  Related to issues in current SPD runs on SimpleStories where the final MLP down layer has high L0.

  ## Motivation and Context
  We noticed the final MLP down layer has high L0 in SimpleStories runs. These runs fail sanity checks where using SPD components on earlier layers but the original model weights on the high l0 mlp down module leads to worse reconstruction loss. By computing reconstruction loss on subsets, we can catch this issue earlier in training.

  ## How Has This Been Tested?
  Added a new config reproducing Lucius's current best SimpleStories Llama SPD run with these metrics. Run looks good and metrics already show higher recon loss when not using SPD components to replace the final MLP.
  https://wandb.ai/goodfire/spd/reports/test-subset-metrics--VmlldzoxNDMyNTA2OA

  ## Does this PR introduce a breaking change?
  No
