### PR TITLE
Cursor: Implement remaining plan features

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,7 @@ Please read our [CONTRIBUTING.md](CONTRIBUTING.md) file for guidelines on how to
 
 ### Custom Metrics and Figures
 
-Metrics and figures are defined in `spd/metrics.py` and `spd/figures.py`.
-These files expose dictionaries of functions that can be selected and parameterized in the config of a given experiment.
+Metrics and figures are defined in `spd/eval.py` as classes implementing the `Metric` interface (constructor, `watch_batch`, `compute`, and convenience `forward`). These can be selected and parameterized in the config of a given experiment via `eval_metrics`. During eval, a default `LossTermsMetric` aggregates loss terms unless disabled via `include_loss_metrics_in_eval=false` in the config.
 
 ### Development Commands
 

--- a/spd/configs.py
+++ b/spd/configs.py
@@ -266,6 +266,15 @@ class Config(BaseModel):
         description="List of metrics to use for evaluation",
     )
 
+    # --- Eval Loss Metrics ---
+    include_loss_metrics_in_eval: bool = Field(
+        default=True,
+        description=(
+            "If True, include default loss metrics during eval (aggregated per-term means and"
+            " total weighted loss) in addition to configured metrics."
+        ),
+    )
+
     # --- Component Tracking ---
     ci_alive_threshold: Probability = Field(
         default=0.0,

--- a/tests/test_evaluate_includes_loss_metrics.py
+++ b/tests/test_evaluate_includes_loss_metrics.py
@@ -1,0 +1,92 @@
+from unittest.mock import Mock, patch
+
+import torch
+
+from spd.configs import Config, EvalMetricConfig
+from spd.eval import evaluate
+from spd.models.component_model import ComponentModel
+
+
+def test_evaluate_includes_loss_terms_metric_when_enabled():
+    # Minimal config enabling default loss metrics
+    config = Mock(spec=Config)
+    config.eval_metrics = []
+    config.sigmoid_type = "leaky_hard"
+    config.sampling = "continuous"
+    config.include_loss_metrics_in_eval = True
+
+    # Component model with minimal API
+    model = Mock(spec=ComponentModel)
+    model.components = {"layer": Mock()}
+
+    # Iterator yielding a couple of dummy batches
+    def iterator():
+        for _ in range(2):
+            yield torch.zeros(2, 3, dtype=torch.long)
+
+    # Mock pre_forward_cache forward and calc_causal_importances
+    def fake_pre_forward(batch, mode, module_names):  # type: ignore[unused-argument]
+        return torch.zeros(2, 3, 5), {"layer": torch.zeros(2, 3, 7)}
+
+    model.__call__.side_effect = fake_pre_forward  # type: ignore[attr-defined]
+    model.calc_causal_importances.return_value = (
+        {"layer": torch.zeros(2, 3, 4)},
+        {"layer": torch.zeros(2, 3, 4)},
+    )
+
+    with patch("spd.eval.calculate_losses", autospec=True) as mock_calc_losses:
+        # Return deterministic loss terms so we can check presence
+        mock_calc_losses.return_value = (torch.tensor(2.0), {"faithfulness": 2.0, "total": 2.0})
+
+        out = evaluate(
+            model=model,
+            eval_iterator=iterator(),
+            device="cpu",
+            config=config,  # type: ignore[arg-type]
+            run_slow=False,
+            n_steps=2,
+        )
+
+    assert "loss/faithfulness" in out
+    assert "loss/total_weighted" in out
+
+
+def test_evaluate_skips_faithfulness_metric_when_loss_metrics_enabled():
+    # If user configured FaithfulnessLoss explicitly and default loss metrics are enabled,
+    # we skip the explicit metric to prevent key collisions.
+    cfg = Mock(spec=Config)
+    cfg.eval_metrics = [EvalMetricConfig(classname="FaithfulnessLoss", extra_init_kwargs={})]
+    cfg.sigmoid_type = "leaky_hard"
+    cfg.sampling = "continuous"
+    cfg.include_loss_metrics_in_eval = True
+
+    model = Mock(spec=ComponentModel)
+    model.components = {"layer": Mock()}
+
+    def iterator():
+        for _ in range(1):
+            yield torch.zeros(2, 3, dtype=torch.long)
+
+    def fake_pre_forward(batch, mode, module_names):  # type: ignore[unused-argument]
+        return torch.zeros(2, 3, 5), {"layer": torch.zeros(2, 3, 7)}
+
+    model.__call__.side_effect = fake_pre_forward  # type: ignore[attr-defined]
+    model.calc_causal_importances.return_value = (
+        {"layer": torch.zeros(2, 3, 4)},
+        {"layer": torch.zeros(2, 3, 4)},
+    )
+
+    with patch("spd.eval.calculate_losses", autospec=True) as mock_calc_losses:
+        mock_calc_losses.return_value = (torch.tensor(1.0), {"faithfulness": 1.0, "total": 1.0})
+
+        out = evaluate(
+            model=model,
+            eval_iterator=iterator(),
+            device="cpu",
+            config=cfg,  # type: ignore[arg-type]
+            run_slow=False,
+            n_steps=1,
+        )
+
+    # Should still include the aggregated key, but not duplicate
+    assert "loss/faithfulness" in out

--- a/tests/test_loss_terms_metric.py
+++ b/tests/test_loss_terms_metric.py
@@ -1,0 +1,64 @@
+from unittest.mock import Mock, patch
+
+import torch
+from jaxtyping import Float
+from torch import Tensor
+
+from spd.configs import Config
+from spd.eval import LossTermsMetric
+from spd.models.component_model import ComponentModel
+
+
+def _make_ci(batch: int = 2, seq: int = 3, C: int = 4):
+    return {"layer": torch.zeros(batch, seq, C)}
+
+
+def test_loss_terms_metric_aggregates_means():
+    # Mocks
+    model = Mock(spec=ComponentModel)
+    model.components = {"layer": Mock()}
+
+    # calc_weight_deltas is used inside metric; we'll let it return a dummy dict via real impl
+    # We'll patch calculate_losses to control outputs deterministically
+    config = Mock(spec=Config)
+    config.sigmoid_type = "leaky_hard"
+    config.sampling = "continuous"
+    config.output_loss_type = "kl"
+    config.faithfulness_coeff = 1.0
+    config.recon_coeff = None
+    config.stochastic_recon_coeff = None
+    config.recon_layerwise_coeff = None
+    config.stochastic_recon_layerwise_coeff = None
+    config.importance_minimality_coeff = 0.1
+    config.schatten_coeff = None
+    config.out_recon_coeff = None
+    config.embedding_recon_coeff = None
+
+    # Prepare model forward stubs for pre_forward_cache path
+    def fake_pre_forward(batch, mode, module_names):  # type: ignore[unused-argument]
+        return torch.zeros(2, 3, 5), {"layer": torch.zeros(2, 3, 7)}
+
+    model.__call__.side_effect = fake_pre_forward  # type: ignore[attr-defined]
+
+    metric = LossTermsMetric(model, config)  # type: ignore[arg-type]
+
+    batch = torch.zeros(2, 3, dtype=torch.long)
+    target_out: Float[Tensor, "... vocab"] = torch.zeros(2, 3, 5)
+    ci = _make_ci()
+
+    with patch("spd.eval.calculate_losses", autospec=True) as mock_calc_losses:
+        # Two batches with different values
+        mock_calc_losses.side_effect = [
+            (torch.tensor(2.0), {"faithfulness": 2.0, "importance_minimality": 1.0, "total": 2.0}),
+            (torch.tensor(4.0), {"faithfulness": 4.0, "importance_minimality": 3.0, "total": 4.0}),
+        ]
+
+        metric.watch_batch(batch=batch, target_out=target_out, ci=ci)
+        metric.watch_batch(batch=batch, target_out=target_out, ci=ci)
+
+        out = metric.compute()
+
+    # Means across 2 batches
+    assert out["loss/faithfulness"] == 3.0
+    assert out["loss/importance_minimality"] == 2.0
+    assert out["loss/total_weighted"] == 3.0

--- a/tests/test_metric_interface.py
+++ b/tests/test_metric_interface.py
@@ -1,0 +1,46 @@
+from typing import Mapping
+
+import torch
+from jaxtyping import Float, Int
+from PIL import Image
+from torch import Tensor
+
+from spd.configs import Config
+from spd.eval import Metric
+from spd.models.component_model import ComponentModel
+
+
+class _ToyMetric(Metric):
+    SLOW = False
+
+    def __init__(self, model: ComponentModel, config: Config) -> None:  # type: ignore[override]
+        self.calls = []
+
+    def watch_batch(  # type: ignore[override]
+        self,
+        batch: Int[Tensor, "..."] | Float[Tensor, "..."],
+        target_out: Float[Tensor, "... vocab"],
+        ci: dict[str, Float[Tensor, "... C"]],
+    ) -> None:
+        self.calls.append(("watch_batch", batch.shape, target_out.shape, list(ci.keys())))
+
+    def compute(self) -> Mapping[str, float | Image.Image]:  # type: ignore[override]
+        self.calls.append(("compute",))
+        return {"toy/value": 1.0}
+
+
+def test_metric_forward_calls_watch_then_compute(monkeypatch):
+    dummy_model = object()  # not used
+    dummy_config = object()  # not used
+    metric = _ToyMetric(dummy_model, dummy_config)  # type: ignore[arg-type]
+
+    batch = torch.zeros(2, 3, dtype=torch.long)
+    target_out = torch.zeros(2, 3, 5)
+    ci = {"layer": torch.zeros(2, 3, 7)}
+
+    out = metric.forward(batch=batch, target_out=target_out, ci=ci)
+
+    assert out == {"toy/value": 1.0}
+    # Ensure call order
+    assert metric.calls[0][0] == "watch_batch"
+    assert metric.calls[1][0] == "compute"


### PR DESCRIPTION
## Description
This PR refactors the metric interface by renaming `StreamingEval` to `Metric` and introduces a new `LossTermsMetric` to aggregate and report default loss terms during evaluation. The `evaluate()` function is updated to use this new metric, controlled by a configuration flag.

## Related Issue
N/A

## Motivation and Context
This change implements the remaining phases of `PLAN.md` (excluding phase 5 as per user request), aiming to standardize the metric interface and provide comprehensive, default reporting of all loss terms during evaluation without requiring explicit configuration for each loss.

## How Has This Been Tested?
New dedicated test files have been added:
-   `tests/test_metric_interface.py`: Validates the `Metric.forward()` lifecycle.
-   `tests/test_loss_terms_metric.py`: Checks the aggregation logic of `LossTermsMetric`.
-   `tests/test_evaluate_includes_loss_metrics.py`: Verifies the inclusion of default loss metrics in `evaluate()` and the handling of `FaithfulnessLoss` to prevent key collisions.

## Does this PR introduce a breaking change?
Yes.
-   The `StreamingEval` base class has been renamed to `Metric`. Any custom metrics inheriting from `StreamingEval` will need to be updated to inherit from `Metric`.
-   The `__init__` signature for `Metric` has been updated to include type hints.
-   The `watch_batch` signature for `Metric` has been updated to include type hints.

---
<a href="https://cursor.com/background-agent?bcId=bc-44f5f5ae-7db9-4636-8128-f72a5d212f5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-44f5f5ae-7db9-4636-8128-f72a5d212f5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

