### PR TITLE
Remove unused loss functions and improve naming

### DIFF
--- a/spd/configs.py
+++ b/spd/configs.py
@@ -136,7 +136,7 @@ class Config(BaseModel):
         default=1.0,
         description="Coefficient for matching parameters between components and target weights",
     )
-    recon_coeff: NonNegativeFloat | None = Field(
+    ci_recon_coeff: NonNegativeFloat | None = Field(
         default=None,
         description="Coefficient for recon loss with a causal importance mask",
     )
@@ -144,33 +144,18 @@ class Config(BaseModel):
         default=None,
         description="Coefficient for recon loss with stochastically sampled masks",
     )
-    recon_layerwise_coeff: NonNegativeFloat | None = Field(
+    ci_recon_layerwise_coeff: NonNegativeFloat | None = Field(
         default=None,
-        description="Coefficient for per-layer recon loss with a causal importance mask",
+        description="Coefficient for recon loss with causal importance mask on one layer at a time",
     )
     stochastic_recon_layerwise_coeff: NonNegativeFloat | None = Field(
         default=None,
-        description="Coefficient for per-layer recon loss with stochastically sampled masks",
+        description="Coefficient for recon loss with stochastically sampled masks on one layer at "
+        "a time",
     )
     importance_minimality_coeff: NonNegativeFloat = Field(
         ...,
         description="Coefficient for importance minimality loss",
-    )
-    schatten_coeff: NonNegativeFloat | None = Field(
-        default=None,
-        description="Coefficient for Schatten-norm regularisation (LM only)",
-    )
-    out_recon_coeff: NonNegativeFloat | None = Field(
-        default=None,
-        description="Coefficient for output recon loss",
-    )
-    embedding_recon_coeff: float | None = Field(
-        default=None,
-        description="Coefficient for additional embedding recon loss (LM only)",
-    )
-    is_embed_unembed_recon: bool = Field(
-        default=False,
-        description="If True, apply embedding recon jointly to embed & unembed matrices",
     )
     pnorm: PositiveFloat = Field(
         ...,
@@ -321,10 +306,16 @@ class Config(BaseModel):
         "image_freq",
         "metrics_fns",
         "figures_fns",
+        "schatten_coeff",
+        "embedding_recon_coeff",
+        "is_embed_unembed_recon",
+        "out_recon_coeff",
     ]
     RENAMED_CONFIG_KEYS: ClassVar[dict[str, str]] = {
         "print_freq": "eval_freq",
         "pretrained_model_name_hf": "pretrained_model_name",
+        "recon_coeff": "ci_recon_coeff",
+        "recon_layerwise_coeff": "ci_recon_layerwise_coeff",
     }
 
     @model_validator(mode="before")
@@ -352,7 +343,7 @@ class Config(BaseModel):
     def validate_model(self) -> Self:
         # If any of the coeffs are 0, raise a warning
         msg = "is 0, you may wish to instead set it to null to avoid calculating the loss"
-        if self.recon_coeff == 0:
+        if self.ci_recon_coeff == 0:
             logger.warning(f"recon_coeff {msg}")
         if self.importance_minimality_coeff == 0:
             logger.warning(f"importance_minimality_coeff {msg}")

--- a/spd/eval.py
+++ b/spd/eval.py
@@ -143,7 +143,7 @@ class CEandKLLosses(StreamingEval):
 
         # make sure labels don't "wrap around": you **can't** predict the first token.
         masked_batch = batch.clone()
-        masked_batch[:, 0] = -100  # F.cross_entropy ignores -99
+        masked_batch[:, 0] = -100
         flat_masked_batch = masked_batch.flatten()
 
         def ce_vs_labels(logits: Tensor) -> float:

--- a/spd/experiments/ih/ih_config.yaml
+++ b/spd/experiments/ih/ih_config.yaml
@@ -23,9 +23,9 @@ target_module_patterns: [
 ]
 
 faithfulness_coeff: 100
-recon_coeff: 1
+ci_recon_coeff: 1
 stochastic_recon_coeff: 1
-recon_layerwise_coeff: null
+ci_recon_layerwise_coeff: null
 stochastic_recon_layerwise_coeff: 1
 importance_minimality_coeff: 1e-2
 pnorm: 0.1

--- a/spd/experiments/lm/gpt2_config.yaml
+++ b/spd/experiments/lm/gpt2_config.yaml
@@ -16,14 +16,11 @@ sampling: "continuous"
 
 # --- Loss Coefficients ---
 faithfulness_coeff: null
-recon_coeff: null
+ci_recon_coeff: null
 stochastic_recon_coeff: null
-recon_layerwise_coeff: null
+ci_recon_layerwise_coeff: null
 stochastic_recon_layerwise_coeff: 1
 importance_minimality_coeff: 1e-3
-schatten_coeff: null
-embedding_recon_coeff: null
-is_embed_unembed_recon: false
 pnorm: 1.0
 output_loss_type: kl
 

--- a/spd/experiments/lm/ss_emb_config.yaml
+++ b/spd/experiments/lm/ss_emb_config.yaml
@@ -17,14 +17,11 @@ use_delta_component: true
 
 # --- Loss Coefficients ---
 faithfulness_coeff: null
-recon_coeff: null
+ci_recon_coeff: null
 stochastic_recon_coeff: null
-recon_layerwise_coeff: null
+ci_recon_layerwise_coeff: null
 stochastic_recon_layerwise_coeff: 1
 importance_minimality_coeff: 1e-6
-schatten_coeff: null
-embedding_recon_coeff: null
-is_embed_unembed_recon: false
 pnorm: 2.0
 output_loss_type: kl
 

--- a/spd/experiments/lm/ss_gpt2_config.yaml
+++ b/spd/experiments/lm/ss_gpt2_config.yaml
@@ -16,14 +16,11 @@ use_delta_component: true
 
 # --- Loss Coefficients ---
 faithfulness_coeff: null
-recon_coeff: null
+ci_recon_coeff: null
 stochastic_recon_coeff: null
-recon_layerwise_coeff: null
+ci_recon_layerwise_coeff: null
 stochastic_recon_layerwise_coeff: 1
 importance_minimality_coeff: 1e-3
-schatten_coeff: null
-embedding_recon_coeff: null
-is_embed_unembed_recon: false
 pnorm: 1.0
 output_loss_type: kl
 

--- a/spd/experiments/lm/ss_gpt2_simple_config.yaml
+++ b/spd/experiments/lm/ss_gpt2_simple_config.yaml
@@ -17,14 +17,11 @@ use_delta_component: true
 
 # --- Loss Coefficients ---
 faithfulness_coeff: null
-recon_coeff: null
+ci_recon_coeff: null
 stochastic_recon_coeff: 0.2
-recon_layerwise_coeff: null
+ci_recon_layerwise_coeff: null
 stochastic_recon_layerwise_coeff: 2.0
 importance_minimality_coeff: 3e-4
-schatten_coeff: null
-embedding_recon_coeff: null
-is_embed_unembed_recon: false
 pnorm: 2.0
 p_anneal_start_frac: 0.0
 p_anneal_final_p: 0.3

--- a/spd/experiments/lm/ss_gpt2_simple_noln_config.yaml
+++ b/spd/experiments/lm/ss_gpt2_simple_noln_config.yaml
@@ -17,14 +17,11 @@ use_delta_component: true
 
 # --- Loss Coefficients ---
 faithfulness_coeff: null
-recon_coeff: null
+ci_recon_coeff: null
 stochastic_recon_coeff: 0.2
-recon_layerwise_coeff: null
+ci_recon_layerwise_coeff: null
 stochastic_recon_layerwise_coeff: 2.0
 importance_minimality_coeff: 3e-4
-schatten_coeff: null
-embedding_recon_coeff: null
-is_embed_unembed_recon: false
 pnorm: 2.0
 p_anneal_start_frac: 0.0
 p_anneal_final_p: 0.3

--- a/spd/experiments/lm/ss_llama_config.yaml
+++ b/spd/experiments/lm/ss_llama_config.yaml
@@ -17,15 +17,11 @@ use_delta_component: true
 
 # --- Loss Coefficients ---
 faithfulness_coeff: null
-recon_coeff: null
+ci_recon_coeff: null
 stochastic_recon_coeff: 0.2
-recon_layerwise_coeff: null
+ci_recon_layerwise_coeff: null
 stochastic_recon_layerwise_coeff: 2.0
 importance_minimality_coeff: 0.0003
-schatten_coeff: null
-out_recon_coeff: null
-embedding_recon_coeff: null
-is_embed_unembed_recon: false
 pnorm: 2.0
 p_anneal_start_frac: 0.0
 p_anneal_final_p: 0.3

--- a/spd/experiments/lm/ss_llama_single_gpu_config.yaml
+++ b/spd/experiments/lm/ss_llama_single_gpu_config.yaml
@@ -16,15 +16,11 @@ use_delta_component: true
 
 # --- Loss Coefficients ---
 faithfulness_coeff: null
-recon_coeff: null
+ci_recon_coeff: null
 stochastic_recon_coeff: 1.0
-recon_layerwise_coeff: null
+ci_recon_layerwise_coeff: null
 stochastic_recon_layerwise_coeff: 1.0
 importance_minimality_coeff: 0.0003
-schatten_coeff: null
-out_recon_coeff: null
-embedding_recon_coeff: null
-is_embed_unembed_recon: false
 pnorm: 2.0
 p_anneal_start_frac: 0.0
 p_anneal_final_p: 0.1

--- a/spd/experiments/lm/ts_config.yaml
+++ b/spd/experiments/lm/ts_config.yaml
@@ -19,15 +19,11 @@ use_delta_component: true
 
 # --- Loss Coefficients ---
 faithfulness_coeff: null
-recon_coeff: null
+ci_recon_coeff: null
 stochastic_recon_coeff: null
-recon_layerwise_coeff: null
+ci_recon_layerwise_coeff: null
 stochastic_recon_layerwise_coeff: 1
 importance_minimality_coeff: 1e-6
-schatten_coeff: null
-# embedding_recon_coeff: 1
-embedding_recon_coeff: null
-is_embed_unembed_recon: false
 pnorm: 2.0
 output_loss_type: kl
 

--- a/spd/experiments/resid_mlp/resid_mlp1_config.yaml
+++ b/spd/experiments/resid_mlp/resid_mlp1_config.yaml
@@ -19,10 +19,9 @@ use_delta_component: true
 
 # --- Loss Coefficients ---
 faithfulness_coeff: null
-out_recon_coeff: 0.0
-recon_coeff: null
+ci_recon_coeff: null
 stochastic_recon_coeff: 1.0
-recon_layerwise_coeff: null
+ci_recon_layerwise_coeff: null
 stochastic_recon_layerwise_coeff: 1.0
 importance_minimality_coeff: 1e-5
 pnorm: 2

--- a/spd/experiments/resid_mlp/resid_mlp2_config.yaml
+++ b/spd/experiments/resid_mlp/resid_mlp2_config.yaml
@@ -18,10 +18,9 @@ use_delta_component: true
 
 # --- Loss Coefficients ---
 faithfulness_coeff: null
-out_recon_coeff: 0.0
-recon_coeff: null
+ci_recon_coeff: null
 stochastic_recon_coeff: 1.0
-recon_layerwise_coeff: null
+ci_recon_layerwise_coeff: null
 stochastic_recon_layerwise_coeff: 1.0
 importance_minimality_coeff: 3e-5
 pnorm: 2

--- a/spd/experiments/resid_mlp/resid_mlp3_config.yaml
+++ b/spd/experiments/resid_mlp/resid_mlp3_config.yaml
@@ -18,10 +18,9 @@ use_delta_component: true
 
 # --- Loss Coefficients ---
 faithfulness_coeff: null
-out_recon_coeff: 0.0
-recon_coeff: null
+ci_recon_coeff: null
 stochastic_recon_coeff: 1.0
-recon_layerwise_coeff: null
+ci_recon_layerwise_coeff: null
 stochastic_recon_layerwise_coeff: 1.0
 importance_minimality_coeff: 1e-5
 pnorm: 2

--- a/spd/experiments/tms/tms_40-10-id_config.yaml
+++ b/spd/experiments/tms/tms_40-10-id_config.yaml
@@ -18,9 +18,9 @@ use_delta_component: true
 faithfulness_coeff: null
 pnorm: 2.0
 importance_minimality_coeff: 1e-4
-recon_coeff: null
+ci_recon_coeff: null
 stochastic_recon_coeff: 1
-recon_layerwise_coeff: null
+ci_recon_layerwise_coeff: null
 stochastic_recon_layerwise_coeff: 1.0
 output_loss_type: "mse"
 

--- a/spd/experiments/tms/tms_40-10_config.yaml
+++ b/spd/experiments/tms/tms_40-10_config.yaml
@@ -19,9 +19,9 @@ use_delta_component: true
 faithfulness_coeff: null
 pnorm: 2.0
 importance_minimality_coeff: 1e-4
-recon_coeff: null
+ci_recon_coeff: null
 stochastic_recon_coeff: 1
-recon_layerwise_coeff: null
+ci_recon_layerwise_coeff: null
 stochastic_recon_layerwise_coeff: 1.0
 output_loss_type: "mse"
 

--- a/spd/experiments/tms/tms_5-2-id_config.yaml
+++ b/spd/experiments/tms/tms_5-2-id_config.yaml
@@ -16,9 +16,9 @@ use_delta_component: true
 
 # --- Loss Coefficients ---
 faithfulness_coeff: null
-recon_coeff: null
+ci_recon_coeff: null
 stochastic_recon_coeff: 1
-recon_layerwise_coeff: null
+ci_recon_layerwise_coeff: null
 stochastic_recon_layerwise_coeff: 1.0
 importance_minimality_coeff: 3e-3
 pnorm: 1.0

--- a/spd/experiments/tms/tms_5-2_config.yaml
+++ b/spd/experiments/tms/tms_5-2_config.yaml
@@ -16,9 +16,9 @@ use_delta_component: true
 
 # --- Loss Coefficients ---
 faithfulness_coeff: null
-recon_coeff: null
+ci_recon_coeff: null
 stochastic_recon_coeff: 1
-recon_layerwise_coeff: null
+ci_recon_layerwise_coeff: null
 stochastic_recon_layerwise_coeff: 1.0
 importance_minimality_coeff: 3e-3
 pnorm: 1.0

--- a/spd/losses.py
+++ b/spd/losses.py
@@ -191,17 +191,17 @@ def calculate_losses(
 
     # CI reconstruction loss
     if config.ci_recon_coeff is not None:
-        recon_mask_infos = make_mask_infos(causal_importances, None)
-        recon_loss = calc_masked_recon_loss(
+        ci_recon_mask_infos = make_mask_infos(causal_importances, None)
+        ci_recon_loss = calc_masked_recon_loss(
             model=model,
             batch=batch,
-            mask_infos_list=[recon_mask_infos],
+            mask_infos_list=[ci_recon_mask_infos],
             target_out=target_out,
             loss_type=config.output_loss_type,
             device=device,
         )
-        total_loss += config.ci_recon_coeff * recon_loss
-        loss_terms["recon"] = recon_loss.item()
+        total_loss += config.ci_recon_coeff * ci_recon_loss
+        loss_terms["ci_recon"] = ci_recon_loss.item()
 
     # Stochastic reconstruction loss
     if config.stochastic_recon_coeff is not None:
@@ -241,7 +241,7 @@ def calculate_losses(
 
     # CI reconstruction layerwise loss
     if config.ci_recon_layerwise_coeff is not None:
-        recon_layerwise_loss = calc_masked_recon_layerwise_loss(
+        ci_recon_layerwise_loss = calc_masked_recon_layerwise_loss(
             model=model,
             batch=batch,
             mask_infos_list=[make_mask_infos(causal_importances)],
@@ -249,8 +249,8 @@ def calculate_losses(
             loss_type=config.output_loss_type,
             device=device,
         )
-        total_loss += config.ci_recon_layerwise_coeff * recon_layerwise_loss
-        loss_terms["recon_layerwise"] = recon_layerwise_loss.item()
+        total_loss += config.ci_recon_layerwise_coeff * ci_recon_layerwise_loss
+        loss_terms["ci_recon_layerwise"] = ci_recon_layerwise_loss.item()
 
     # Stochastic reconstruction layerwise loss
     if config.stochastic_recon_layerwise_coeff is not None:

--- a/spd/losses.py
+++ b/spd/losses.py
@@ -1,106 +1,15 @@
 from typing import Literal
 
-import einops
 import torch
-import torch.nn as nn
 from jaxtyping import Float, Int
 from torch import Tensor
 
 from spd.configs import Config
 from spd.mask_info import ComponentsMaskInfo, WeightDeltaAndMask, make_mask_infos
 from spd.models.component_model import ComponentModel
-from spd.models.components import Components, ComponentsOrModule, EmbeddingComponents
+from spd.models.components import ComponentsOrModule
 from spd.utils.component_utils import calc_stochastic_masks
 from spd.utils.general_utils import calc_kl_divergence_lm
-
-
-def calc_embedding_recon_loss(
-    model: ComponentModel,
-    batch: Int[Tensor, "..."],
-    masks: list[dict[str, Float[Tensor, "... C"]]],
-    unembed: bool,
-    device: str,
-) -> Float[Tensor, ""]:
-    """
-    recon loss that directly compares the outputs of the (optionally masked)
-    ``EmbeddingComponents``(s) to the outputs of the original ``nn.Embedding`` modules.
-
-    If ``unembed`` is ``True``, both the masked embedding output and the target embedding
-    output are unembedded using the ``lm_head`` module, and the KL divergence is used as the loss.
-
-    If ``unembed`` is ``False``, the loss is the MSE between the masked embedding output
-    and the target embedding output is used as the loss.
-    """
-
-    assert len(model.components_or_modules) == 1, "Only one embedding component is supported"
-    components_or_module = next(iter(model.components_or_modules.values()))
-    components = components_or_module.components
-    original = components_or_module.original
-    assert isinstance(components, EmbeddingComponents)
-
-    # --- original embedding output --------------------------------------------------------- #
-    target_out: Float[Tensor, "... d_emb"] = original(batch)
-
-    # --- masked embedding output ----------------------------------------------------------- #
-    loss = torch.tensor(0.0, device=device)
-    for mask_info in masks:
-        assert len(mask_info) == 1, "Only one embedding component is supported"
-        mask = next(iter(mask_info.values()))
-        masked_out: Float[Tensor, "... d_emb"] = components(batch, mask=mask)
-
-        if unembed:
-            assert hasattr(model.patched_model, "lm_head"), (
-                "Only supports unembedding named lm_head"
-            )
-            assert isinstance(model.patched_model.lm_head, nn.Module)
-            target_out_unembed = model.patched_model.lm_head(target_out)
-            masked_out_unembed = model.patched_model.lm_head(masked_out)
-            loss += calc_kl_divergence_lm(pred=masked_out_unembed, target=target_out_unembed)
-        else:
-            loss += ((masked_out - target_out) ** 2).sum(dim=-1).mean()
-
-    loss /= len(masks)
-
-    return loss
-
-
-def calc_schatten_loss(
-    ci_upper_leaky: dict[str, Float[Tensor, "... C"]],
-    pnorm: float,
-    components: dict[str, Components],
-    device: str,
-) -> Float[Tensor, ""]:
-    """Calculate the Schatten loss on the active components.
-
-    The Schatten loss is calculated as:
-        L = Σ_{components} mean(ci_upper_leaky^pnorm · (||V||_2^2 + ||U||_2^2))
-
-    where:
-        - ci_upper_leaky are the upper leaky relu causal importances for each component
-        - pnorm is the power to raise the mask to
-        - V and U are the component matrices
-        - ||·||_2 is the L2 norm
-
-    Args:
-        ci_upper_leaky: Dictionary of upper leaky relu causal importances for each layer.
-        pnorm: The pnorm to use for the importance minimality loss. Must be positive.
-        components: Dictionary of components for each layer.
-        device: The device to compute the loss on.
-
-    Returns:
-        The Schatten loss as a scalar tensor.
-    """
-
-    total_loss = torch.tensor(0.0, device=device)
-    for component_name, component in components.items():
-        V_norms = component.V.square().sum(dim=-2)
-        U_norms = component.U.square().sum(dim=-1)
-        schatten_norms = V_norms + U_norms
-        loss = einops.einsum(
-            ci_upper_leaky[component_name] ** pnorm, schatten_norms, "... C, C -> ..."
-        )
-        total_loss += loss.mean()
-    return total_loss
 
 
 def calc_importance_minimality_loss(
@@ -280,8 +189,8 @@ def calculate_losses(
         total_loss += config.faithfulness_coeff * faithfulness_loss
         loss_terms["faithfulness"] = faithfulness_loss.item()
 
-    # Reconstruction loss
-    if config.recon_coeff is not None:
+    # CI reconstruction loss
+    if config.ci_recon_coeff is not None:
         recon_mask_infos = make_mask_infos(causal_importances, None)
         recon_loss = calc_masked_recon_loss(
             model=model,
@@ -291,7 +200,7 @@ def calculate_losses(
             loss_type=config.output_loss_type,
             device=device,
         )
-        total_loss += config.recon_coeff * recon_loss
+        total_loss += config.ci_recon_coeff * recon_loss
         loss_terms["recon"] = recon_loss.item()
 
     # Stochastic reconstruction loss
@@ -330,8 +239,8 @@ def calculate_losses(
         total_loss += config.stochastic_recon_coeff * stochastic_recon_loss
         loss_terms["stochastic_recon"] = stochastic_recon_loss.item()
 
-    # Reconstruction layerwise loss
-    if config.recon_layerwise_coeff is not None:
+    # CI reconstruction layerwise loss
+    if config.ci_recon_layerwise_coeff is not None:
         recon_layerwise_loss = calc_masked_recon_layerwise_loss(
             model=model,
             batch=batch,
@@ -340,7 +249,7 @@ def calculate_losses(
             loss_type=config.output_loss_type,
             device=device,
         )
-        total_loss += config.recon_layerwise_coeff * recon_layerwise_loss
+        total_loss += config.ci_recon_layerwise_coeff * recon_layerwise_loss
         loss_terms["recon_layerwise"] = recon_layerwise_loss.item()
 
     # Stochastic reconstruction layerwise loss
@@ -384,48 +293,6 @@ def calculate_losses(
     )
     total_loss += config.importance_minimality_coeff * importance_minimality_loss
     loss_terms["importance_minimality"] = importance_minimality_loss.item()
-
-    # Schatten loss
-    if config.schatten_coeff is not None:
-        schatten_loss = calc_schatten_loss(
-            ci_upper_leaky=causal_importances_upper_leaky,
-            pnorm=pnorm_value,
-            components=model.components,
-            device=device,
-        )
-        total_loss += config.schatten_coeff * schatten_loss
-        loss_terms["schatten"] = schatten_loss.item()
-
-    # Output reconstruction loss
-    if config.out_recon_coeff is not None:
-        masks_all_ones = {k: torch.ones_like(v) for k, v in causal_importances.items()}
-        out_recon_loss = calc_masked_recon_loss(
-            model=model,
-            batch=batch,
-            mask_infos_list=[make_mask_infos(masks_all_ones)],
-            target_out=target_out,
-            loss_type=config.output_loss_type,
-            device=device,
-        )
-        total_loss += config.out_recon_coeff * out_recon_loss
-        loss_terms["output_recon"] = out_recon_loss.item()
-
-    # Embedding reconstruction loss
-    if config.embedding_recon_coeff is not None:
-        stochastic_masks_list = calc_stochastic_masks(
-            causal_importances=causal_importances,
-            n_mask_samples=config.n_mask_samples,
-            sampling=config.sampling,
-        )
-        embedding_recon_loss = calc_embedding_recon_loss(
-            model=model,
-            batch=batch,
-            masks=[stochastic_masks.component_masks for stochastic_masks in stochastic_masks_list],
-            unembed=config.is_embed_unembed_recon,
-            device=device,
-        )
-        total_loss += config.embedding_recon_coeff * embedding_recon_loss
-        loss_terms["embedding_recon"] = embedding_recon_loss.item()
 
     loss_terms["total"] = total_loss.item()
 

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -36,9 +36,6 @@ TEST_CONFIG = {
     "recon_layerwise_coeff": 1,
     "stochastic_recon_layerwise_coeff": None,  # Otherwise we're non-deterministic with dp>1
     "importance_minimality_coeff": 0.1,
-    "schatten_coeff": None,
-    "embedding_recon_coeff": None,
-    "is_embed_unembed_recon": False,
     "pnorm": 2.0,
     "output_loss_type": "kl",
     # --- Training ---

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -28,12 +28,9 @@ def test_gpt_2_decomposition_happy_path() -> None:
         # Loss Coefficients
         faithfulness_coeff=200,
         stochastic_recon_coeff=1.0,
-        recon_layerwise_coeff=None,
+        ci_recon_layerwise_coeff=None,
         stochastic_recon_layerwise_coeff=1.0,
         importance_minimality_coeff=1e-2,
-        schatten_coeff=None,
-        embedding_recon_coeff=None,
-        is_embed_unembed_recon=False,
         pnorm=0.9,
         output_loss_type="kl",
         # Training

--- a/tests/test_ih_transformer.py
+++ b/tests/test_ih_transformer.py
@@ -43,12 +43,9 @@ def test_ih_transformer_decomposition_happy_path() -> None:
         # Loss Coefficients
         faithfulness_coeff=200,
         stochastic_recon_coeff=1.0,
-        recon_layerwise_coeff=None,
+        ci_recon_layerwise_coeff=None,
         stochastic_recon_layerwise_coeff=1.0,
         importance_minimality_coeff=1e-2,
-        schatten_coeff=None,
-        embedding_recon_coeff=None,
-        is_embed_unembed_recon=False,
         pnorm=0.9,
         output_loss_type="kl",
         # Training

--- a/tests/test_resid_mlp.py
+++ b/tests/test_resid_mlp.py
@@ -41,14 +41,11 @@ def test_resid_mlp_decomposition_happy_path() -> None:
         ],
         # Loss Coefficients
         faithfulness_coeff=1.0,
-        recon_coeff=2.0,
+        ci_recon_coeff=2.0,
         stochastic_recon_coeff=1.0,
-        recon_layerwise_coeff=None,
+        ci_recon_layerwise_coeff=None,
         stochastic_recon_layerwise_coeff=None,
         importance_minimality_coeff=3e-3,
-        schatten_coeff=None,
-        embedding_recon_coeff=None,
-        is_embed_unembed_recon=False,
         pnorm=0.9,
         output_loss_type="mse",
         # Training

--- a/tests/test_tms.py
+++ b/tests/test_tms.py
@@ -42,14 +42,11 @@ def test_tms_decomposition_happy_path() -> None:
         target_module_patterns=["linear1", "linear2", "hidden_layers.0"],
         # Loss Coefficients
         faithfulness_coeff=1.0,
-        recon_coeff=None,
+        ci_recon_coeff=None,
         stochastic_recon_coeff=1.0,
-        recon_layerwise_coeff=1e-1,
+        ci_recon_layerwise_coeff=1e-1,
         stochastic_recon_layerwise_coeff=1.0,
         importance_minimality_coeff=3e-3,
-        schatten_coeff=None,
-        embedding_recon_coeff=None,
-        is_embed_unembed_recon=False,
         pnorm=2.0,
         output_loss_type="mse",
         # Training


### PR DESCRIPTION
## Description
- Removes `schatten_recon_coeff`, `out_recon_coeff`, `embedding_recon_coeff`, `is_embed_unembed_coeff` and associated loss functions.
- Renames `recon_coeff` -> `ci_recon_coeff` and `recon_layerwise_coeff` -> `ci_recon_layerwise_coeff`.
- Handles deprecation for the above.

## Does this PR introduce a breaking change?
No