### PR TITLE
Rename gate → ci_fn across codebase (code, configs, tests, paper); no behavior change

### DIFF
--- a/spd/configs.py
+++ b/spd/configs.py
@@ -21,7 +21,7 @@ from spd.experiments.lm.configs import LMTaskConfig
 from spd.experiments.resid_mlp.configs import ResidMLPTaskConfig
 from spd.experiments.tms.configs import TMSTaskConfig
 from spd.log import logger
-from spd.models.components import GateType
+from spd.models.components import CiFnType
 from spd.spd_types import ModelPath, Probability
 
 
@@ -100,13 +100,13 @@ class Config(BaseModel):
         ...,
         description="Number of stochastic masks to sample when using stochastic recon losses",
     )
-    gate_type: GateType = Field(
+    ci_fn_type: CiFnType = Field(
         default="vector_mlp",
-        description="Type of gate used to calculate the causal importance.",
+        description="Type of causal importance function used to calculate the causal importance.",
     )
-    gate_hidden_dims: list[NonNegativeInt] = Field(
+    ci_fn_hidden_dims: list[NonNegativeInt] = Field(
         default=[8],
-        description="Hidden dimensions for the gate used to calculate the causal importance",
+        description="Hidden dimensions for the causal importance function used to calculate the causal importance",
     )
     sampling: Literal["continuous", "binomial"] = Field(
         default="continuous",

--- a/spd/experiments/ih/ih_config.yaml
+++ b/spd/experiments/ih/ih_config.yaml
@@ -30,8 +30,8 @@ stochastic_recon_layerwise_coeff: 1
 importance_minimality_coeff: 1e-2
 pnorm: 0.1
 output_loss_type: kl
-gate_type: "vector_mlp"
-gate_hidden_dims: [128]
+ci_fn_type: "vector_mlp"
+ci_fn_hidden_dims: [128]
 
 n_examples_until_dead: 10000
 

--- a/spd/experiments/lm/gpt2_config.yaml
+++ b/spd/experiments/lm/gpt2_config.yaml
@@ -8,8 +8,8 @@ wandb_run_name_prefix: ""
 seed: 0
 C: 768
 n_mask_samples: 1
-gate_type: "vector_mlp"
-gate_hidden_dims: [12]
+ci_fn_type: "vector_mlp"
+ci_fn_hidden_dims: [12]
 sigmoid_type: "leaky_hard"
 target_module_patterns: ["transformer.h.1.attn.c_attn"]
 sampling: "continuous"

--- a/spd/experiments/lm/ss_emb_config.yaml
+++ b/spd/experiments/lm/ss_emb_config.yaml
@@ -8,8 +8,8 @@ wandb_run_name_prefix: ""
 seed: 0
 C: 100
 n_mask_samples: 1
-gate_type: "mlp"
-gate_hidden_dims: [1]
+ci_fn_type: "mlp"
+ci_fn_hidden_dims: [1]
 sigmoid_type: "leaky_hard"
 target_module_patterns: ["model.embed_tokens"]
 sampling: "continuous"

--- a/spd/experiments/lm/ss_gpt2_config.yaml
+++ b/spd/experiments/lm/ss_gpt2_config.yaml
@@ -7,8 +7,8 @@ wandb_run_name_prefix: ""
 seed: 0
 C: 4000
 n_mask_samples: 1
-gate_type: "vector_mlp"
-gate_hidden_dims: [12]
+ci_fn_type: "vector_mlp"
+ci_fn_hidden_dims: [12]
 sigmoid_type: "leaky_hard"
 target_module_patterns: ["transformer.h.1.mlp.c_fc"]
 sampling: "continuous"

--- a/spd/experiments/lm/ss_gpt2_simple_config.yaml
+++ b/spd/experiments/lm/ss_gpt2_simple_config.yaml
@@ -7,8 +7,8 @@ wandb_run_name_prefix: ""
 seed: 0
 C: 2000
 n_mask_samples: 1
-gate_type: "vector_mlp"
-gate_hidden_dims: [12]
+ci_fn_type: "vector_mlp"
+ci_fn_hidden_dims: [12]
 sigmoid_type: "leaky_hard"
 target_module_patterns: ["h.*.mlp.c_fc", "h.*.mlp.c_proj", "h.*.attn.k_proj", "h.*.attn.v_proj", "h.*.attn.c_proj"]
 identity_module_patterns: null

--- a/spd/experiments/lm/ss_gpt2_simple_noln_config.yaml
+++ b/spd/experiments/lm/ss_gpt2_simple_noln_config.yaml
@@ -7,8 +7,8 @@ wandb_run_name_prefix: ""
 seed: 0
 C: 2000
 n_mask_samples: 1
-gate_type: "vector_mlp"
-gate_hidden_dims: [12]
+ci_fn_type: "vector_mlp"
+ci_fn_hidden_dims: [12]
 sigmoid_type: "leaky_hard"
 target_module_patterns: ["h.*.mlp.c_fc", "h.*.mlp.c_proj", "h.*.attn.k_proj", "h.*.attn.v_proj", "h.*.attn.c_proj"]
 identity_module_patterns: null

--- a/spd/experiments/lm/ss_llama_config.yaml
+++ b/spd/experiments/lm/ss_llama_config.yaml
@@ -7,8 +7,8 @@ wandb_run_name_prefix: ""
 seed: 0
 C: 4000
 n_mask_samples: 1
-gate_type: "vector_mlp"
-gate_hidden_dims: [12]
+ci_fn_type: "vector_mlp"
+ci_fn_hidden_dims: [12]
 sigmoid_type: "leaky_hard"
 target_module_patterns: ["model.layers.*.mlp.gate_proj", "model.layers.*.mlp.down_proj", "model.layers.*.mlp.up_proj", "model.layers.*.self_attn.q_proj", "model.layers.*.self_attn.k_proj", "model.layers.*.self_attn.v_proj", "model.layers.*.self_attn.o_proj"]
 identity_module_patterns: null

--- a/spd/experiments/lm/ss_llama_single_gpu_config.yaml
+++ b/spd/experiments/lm/ss_llama_single_gpu_config.yaml
@@ -7,8 +7,8 @@ wandb_run_name_prefix: ""
 seed: 0
 C: 4000
 n_mask_samples: 1
-gate_type: "vector_mlp"
-gate_hidden_dims: [12]
+ci_fn_type: "vector_mlp"
+ci_fn_hidden_dims: [12]
 sigmoid_type: "leaky_hard"
 target_module_patterns: ["model.layers.*.mlp.gate_proj", "model.layers.*.mlp.down_proj", "model.layers.*.mlp.up_proj", "model.layers.*.self_attn.q_proj", "model.layers.*.self_attn.k_proj", "model.layers.*.self_attn.v_proj", "model.layers.*.self_attn.o_proj"]
 sampling: "continuous"

--- a/spd/experiments/lm/streamlit_v1/utils.py
+++ b/spd/experiments/lm/streamlit_v1/utils.py
@@ -14,7 +14,7 @@ from transformers import AutoTokenizer, PreTrainedTokenizer
 from spd.configs import Config
 from spd.experiments.lm.configs import LMTaskConfig
 from spd.models.component_model import ComponentModel, SPDRunInfo
-from spd.models.components import EmbeddingComponents, LinearComponents, MLPGates, VectorMLPGates
+from spd.models.components import EmbeddingComponents, LinearComponents, MLPFn, VectorMLPFn
 
 DEFAULT_WANDB_PROJECT = os.environ.get("WANDB_PROJECT", "spd")
 
@@ -26,7 +26,7 @@ class ModelData:
     model: ComponentModel
     tokenizer: PreTrainedTokenizer
     config: Config
-    gates: dict[str, MLPGates | VectorMLPGates]
+    ci_fns: dict[str, MLPFn | VectorMLPFn]
     components: dict[str, LinearComponents | EmbeddingComponents]
     layer_names: list[str]
 
@@ -72,10 +72,10 @@ def load_model(model_path: str) -> ModelData:
 
     tokenizer = AutoTokenizer.from_pretrained(config.tokenizer_name)
 
-    # Extract components and gates
-    gates = {
-        k.removeprefix("gates.").replace("-", "."): cast(MLPGates | VectorMLPGates, v)
-        for k, v in model.gates.items()
+    # Extract components and causal importance functions.
+    ci_fns = {
+        k.removeprefix("ci_fns.").replace("-", "."): cast(MLPFn | VectorMLPFn, v)
+        for k, v in model.ci_fns.items()
     }
     components = {
         k.removeprefix("components.").replace("-", "."): cast(
@@ -88,7 +88,7 @@ def load_model(model_path: str) -> ModelData:
         model=model,
         tokenizer=tokenizer,
         config=config,
-        gates=gates,
+        ci_fns=ci_fns,
         components=components,
         layer_names=sorted(list(components.keys())),
     )

--- a/spd/experiments/lm/ts_config.yaml
+++ b/spd/experiments/lm/ts_config.yaml
@@ -10,8 +10,8 @@ wandb_run_name_prefix: ""
 seed: 0
 C: 100
 n_mask_samples: 1
-gate_type: "vector_mlp"
-gate_hidden_dims: [8]
+ci_fn_type: "vector_mlp"
+ci_fn_hidden_dims: [8]
 sigmoid_type: "leaky_hard"
 target_module_patterns: ["transformer.h.3.mlp.c_fc"]
 sampling: "continuous"

--- a/spd/experiments/resid_mlp/resid_mlp1_config.yaml
+++ b/spd/experiments/resid_mlp/resid_mlp1_config.yaml
@@ -8,8 +8,8 @@ wandb_run_name_prefix: ""
 seed: 0
 C: 100
 n_mask_samples: 1
-gate_type: "mlp"
-gate_hidden_dims: [16]
+ci_fn_type: "mlp"
+ci_fn_hidden_dims: [16]
 sigmoid_type: "leaky_hard"
 target_module_patterns:
   - "layers.*.mlp_in"

--- a/spd/experiments/resid_mlp/resid_mlp2_config.yaml
+++ b/spd/experiments/resid_mlp/resid_mlp2_config.yaml
@@ -8,8 +8,8 @@ wandb_run_name_prefix: ""
 seed: 0
 C: 400
 n_mask_samples: 1
-gate_type: "mlp"
-gate_hidden_dims: [16]
+ci_fn_type: "mlp"
+ci_fn_hidden_dims: [16]
 sigmoid_type: "leaky_hard"
 target_module_patterns:
   - "layers.*.mlp_in"

--- a/spd/experiments/resid_mlp/resid_mlp3_config.yaml
+++ b/spd/experiments/resid_mlp/resid_mlp3_config.yaml
@@ -8,8 +8,8 @@ wandb_run_name_prefix: ""
 seed: 0
 C: 500
 n_mask_samples: 1
-gate_type: "mlp"
-gate_hidden_dims: [128]
+ci_fn_type: "mlp"
+ci_fn_hidden_dims: [128]
 sigmoid_type: "leaky_hard"
 target_module_patterns:
   - "layers.*.mlp_in"

--- a/spd/experiments/tms/tms_40-10-id_config.yaml
+++ b/spd/experiments/tms/tms_40-10-id_config.yaml
@@ -8,8 +8,8 @@ wandb_run_name_prefix: ""
 seed: 0
 C: 200
 n_mask_samples: 1
-gate_type: "mlp"
-gate_hidden_dims: [16]
+ci_fn_type: "mlp"
+ci_fn_hidden_dims: [16]
 sigmoid_type: "leaky_hard"
 target_module_patterns: ["linear1", "linear2", "hidden_layers.0"]
 use_delta_component: true

--- a/spd/experiments/tms/tms_40-10_config.yaml
+++ b/spd/experiments/tms/tms_40-10_config.yaml
@@ -8,8 +8,8 @@ wandb_run_name_prefix: ""
 seed: 0
 C: 200
 n_mask_samples: 1
-gate_type: "mlp"
-gate_hidden_dims: [16]
+ci_fn_type: "mlp"
+ci_fn_hidden_dims: [16]
 sigmoid_type: "leaky_hard"
 target_module_patterns: ["linear1", "linear2"]
 identity_module_patterns: null

--- a/spd/experiments/tms/tms_5-2-id_config.yaml
+++ b/spd/experiments/tms/tms_5-2-id_config.yaml
@@ -8,8 +8,8 @@ wandb_run_name_prefix: ""
 seed: 0
 C: 20
 n_mask_samples: 1
-gate_type: "mlp"
-gate_hidden_dims: [16]
+ci_fn_type: "mlp"
+ci_fn_hidden_dims: [16]
 sigmoid_type: "leaky_hard"
 target_module_patterns: ["linear1", "linear2", "hidden_layers.0"]
 use_delta_component: true

--- a/spd/experiments/tms/tms_5-2_config.yaml
+++ b/spd/experiments/tms/tms_5-2_config.yaml
@@ -8,8 +8,8 @@ wandb_run_name_prefix: ""
 seed: 0
 C: 20
 n_mask_samples: 1
-gate_type: "mlp"
-gate_hidden_dims: [16]
+ci_fn_type: "mlp"
+ci_fn_hidden_dims: [16]
 sigmoid_type: "leaky_hard"
 target_module_patterns: ["linear1", "linear2"]
 use_delta_component: true

--- a/spd/models/component_model.py
+++ b/spd/models/component_model.py
@@ -18,15 +18,15 @@ from spd.configs import Config
 from spd.identity_insertion import insert_identity_operations_
 from spd.interfaces import LoadableModule, RunInfo
 from spd.models.components import (
+    CiFnType,
     Components,
     ComponentsMaskInfo,
     EmbeddingComponents,
-    GateType,
     Identity,
     LinearComponents,
-    MLPGates,
-    VectorMLPGates,
-    VectorSharedMLPGate,
+    MLPFn,
+    VectorMLPFn,
+    VectorSharedMLPFn,
 )
 from spd.models.sigmoids import SIGMOID_TYPES, SigmoidTypes
 from spd.spd_types import WANDB_PATH_PREFIX, ModelPath
@@ -82,7 +82,7 @@ class ComponentModel(LoadableModule):
         inserted in place of the chosen modules with the use of forward hooks.
     - 'input_cache': Forward with caching inputs to chosen modules
 
-    We register components and gates as modules in this class in order to have them update
+    We register components and causal importance functions (ci_fns) as modules in this class in order to have them update
     correctly when the model is wrapped in a `DistributedDataParallel` wrapper (and for other
     conveniences).
     """
@@ -92,8 +92,8 @@ class ComponentModel(LoadableModule):
         target_model: nn.Module,
         target_module_patterns: list[str],
         C: int,
-        gate_type: GateType,
-        gate_hidden_dims: list[int],
+        ci_fn_type: CiFnType,
+        ci_fn_hidden_dims: list[int],
         pretrained_model_output_attr: str | None,
     ):
         super().__init__()
@@ -119,15 +119,15 @@ class ComponentModel(LoadableModule):
             {k.replace(".", "-"): self.components[k] for k in sorted(self.components)}
         )
 
-        self.gates = ComponentModel._create_gates(
+        self.ci_fns = ComponentModel._create_ci_fns(
             target_model=target_model,
             module_paths=module_paths,
             C=C,
-            gate_type=gate_type,
-            gate_hidden_dims=gate_hidden_dims,
+            ci_fn_type=ci_fn_type,
+            ci_fn_hidden_dims=ci_fn_hidden_dims,
         )
-        self._gates = nn.ModuleDict(
-            {k.replace(".", "-"): self.gates[k] for k in sorted(self.gates)}
+        self._ci_fns = nn.ModuleDict(
+            {k.replace(".", "-"): self.ci_fns[k] for k in sorted(self.ci_fns)}
         )
 
     def target_weight(self, module_name: str) -> Float[Tensor, "rows cols"]:
@@ -197,18 +197,18 @@ class ComponentModel(LoadableModule):
         return components
 
     @staticmethod
-    def _create_gate(
+    def _create_ci_fn(
         target_module: nn.Module,
         component_C: int,
-        gate_type: GateType,
-        gate_hidden_dims: list[int],
+        ci_fn_type: CiFnType,
+        ci_fn_hidden_dims: list[int],
     ) -> nn.Module:
-        """Helper to create a gate based on gate_type and module type."""
+        """Helper to create a causal importance function (ci_fn) based on ci_fn_type and module type."""
         if isinstance(target_module, nn.Embedding):
-            assert gate_type == "mlp", "Embedding modules only supported for gate_type='mlp'"
+            assert ci_fn_type == "mlp", "Embedding modules only supported for ci_fn_type='mlp'"
 
-        if gate_type == "mlp":
-            return MLPGates(C=component_C, hidden_dims=gate_hidden_dims)
+        if ci_fn_type == "mlp":
+            return MLPFn(C=component_C, hidden_dims=ci_fn_hidden_dims)
 
         match target_module:
             case nn.Linear():
@@ -218,36 +218,36 @@ class ComponentModel(LoadableModule):
             case Identity():
                 input_dim = target_module.d
             case _:
-                raise ValueError(f"Module {type(target_module)} not supported for {gate_type=}")
+                raise ValueError(f"Module {type(target_module)} not supported for {ci_fn_type=}")
 
-        match gate_type:
+        match ci_fn_type:
             case "vector_mlp":
-                return VectorMLPGates(
-                    C=component_C, input_dim=input_dim, hidden_dims=gate_hidden_dims
+                return VectorMLPFn(
+                    C=component_C, input_dim=input_dim, hidden_dims=ci_fn_hidden_dims
                 )
             case "shared_mlp":
-                return VectorSharedMLPGate(
-                    C=component_C, input_dim=input_dim, hidden_dims=gate_hidden_dims
+                return VectorSharedMLPFn(
+                    C=component_C, input_dim=input_dim, hidden_dims=ci_fn_hidden_dims
                 )
 
     @staticmethod
-    def _create_gates(
+    def _create_ci_fns(
         target_model: nn.Module,
         module_paths: list[str],
         C: int,
-        gate_type: GateType,
-        gate_hidden_dims: list[int],
+        ci_fn_type: CiFnType,
+        ci_fn_hidden_dims: list[int],
     ) -> dict[str, nn.Module]:
-        gates: dict[str, nn.Module] = {}
+        ci_fns: dict[str, nn.Module] = {}
         for module_path in module_paths:
             target_module = target_model.get_submodule(module_path)
-            gates[module_path] = ComponentModel._create_gate(
+            ci_fns[module_path] = ComponentModel._create_ci_fn(
                 target_module,
                 C,
-                gate_type,
-                gate_hidden_dims,
+                ci_fn_type,
+                ci_fn_hidden_dims,
             )
-        return gates
+        return ci_fns
 
     def _extract_output(self, raw_output: Any) -> Any:
         """Extract the desired output from the model's raw output.
@@ -464,8 +464,8 @@ class ComponentModel(LoadableModule):
             target_model=target_model,
             target_module_patterns=config.all_module_patterns,
             C=config.C,
-            gate_hidden_dims=config.gate_hidden_dims,
-            gate_type=config.gate_type,
+            ci_fn_hidden_dims=config.ci_fn_hidden_dims,
+            ci_fn_type=config.ci_fn_type,
             pretrained_model_output_attr=config.pretrained_model_output_attr,
         )
 
@@ -497,7 +497,7 @@ class ComponentModel(LoadableModule):
         Args:
             pre_weight_acts: The activations before each layer in the target model.
             sigmoid_type: Type of sigmoid to use.
-            detach_inputs: Whether to detach the inputs to the gates.
+            detach_inputs: Whether to detach the inputs to the causal importance function.
 
         Returns:
             Tuple of (causal_importances, causal_importances_upper_leaky) dictionaries for each layer.
@@ -507,20 +507,20 @@ class ComponentModel(LoadableModule):
 
         for param_name in pre_weight_acts:
             acts = pre_weight_acts[param_name]
-            gates = self.gates[param_name]
+            ci_fns = self.ci_fns[param_name]
 
-            match gates:
-                case MLPGates():
-                    gate_input = self.components[param_name].get_inner_acts(acts)
-                case VectorMLPGates() | VectorSharedMLPGate():
-                    gate_input = acts
+            match ci_fns:
+                case MLPFn():
+                    ci_fn_input = self.components[param_name].get_inner_acts(acts)
+                case VectorMLPFn() | VectorSharedMLPFn():
+                    ci_fn_input = acts
                 case _:
-                    raise ValueError(f"Unknown gate type: {type(gates)}")
+                    raise ValueError(f"Unknown ci_fn type: {type(ci_fns)}")
 
             if detach_inputs:
-                gate_input = gate_input.detach()
+                ci_fn_input = ci_fn_input.detach()
 
-            gate_output = gates(gate_input)
+            ci_fn_output = ci_fns(ci_fn_input)
 
             if sigmoid_type == "leaky_hard":
                 lower_leaky_fn = SIGMOID_TYPES["lower_leaky_hard"]
@@ -530,14 +530,14 @@ class ComponentModel(LoadableModule):
                 lower_leaky_fn = SIGMOID_TYPES[sigmoid_type]
                 upper_leaky_fn = SIGMOID_TYPES[sigmoid_type]
 
-            gate_output_for_lower_leaky = gate_output
+            ci_fn_output_for_lower_leaky = ci_fn_output
             if sampling == "binomial":
-                gate_output_for_lower_leaky = 1.05 * gate_output - 0.05 * torch.rand_like(
-                    gate_output
+                ci_fn_output_for_lower_leaky = 1.05 * ci_fn_output - 0.05 * torch.rand_like(
+                    ci_fn_output
                 )
 
-            causal_importances[param_name] = lower_leaky_fn(gate_output_for_lower_leaky)
-            causal_importances_upper_leaky[param_name] = upper_leaky_fn(gate_output).abs()
+            causal_importances[param_name] = lower_leaky_fn(ci_fn_output_for_lower_leaky)
+            causal_importances_upper_leaky[param_name] = upper_leaky_fn(ci_fn_output).abs()
 
         return causal_importances, causal_importances_upper_leaky
 

--- a/spd/models/components.py
+++ b/spd/models/components.py
@@ -9,7 +9,7 @@ from torch import Tensor, nn
 
 from spd.utils.module_utils import _NonlinearityType, init_param_
 
-GateType = Literal["mlp", "vector_mlp", "shared_mlp"]
+CiFnType = Literal["mlp", "vector_mlp", "shared_mlp"]
 
 
 class ParallelLinear(nn.Module):
@@ -44,8 +44,8 @@ class Linear(nn.Module):
         return einops.einsum(x, self.W, "... d_in, d_in d_out -> ... d_out") + self.b
 
 
-class MLPGates(nn.Module):
-    """MLP-based gates that map component 'inner acts' to a scalar output for each component."""
+class MLPFn(nn.Module):
+    """MLP-based function that map component 'inner acts' to a scalar output for each component."""
 
     def __init__(self, C: int, hidden_dims: list[int]):
         super().__init__()
@@ -68,7 +68,7 @@ class MLPGates(nn.Module):
         return x[..., 0]
 
 
-class VectorMLPGates(nn.Module):
+class VectorMLPFn(nn.Module):
     """Contains a separate network for each component and takes a module's input vector as input."""
 
     def __init__(self, C: int, input_dim: int, hidden_dims: list[int]):
@@ -93,7 +93,7 @@ class VectorMLPGates(nn.Module):
         return x[..., 0]
 
 
-class VectorSharedMLPGate(nn.Module):
+class VectorSharedMLPFn(nn.Module):
     """Maps a module's input vector to a scalar output for each component with a 'pure' MLP."""
 
     def __init__(self, C: int, input_dim: int, hidden_dims: list[int]):

--- a/tests/test_component_model.py
+++ b/tests/test_component_model.py
@@ -21,10 +21,10 @@ from spd.models.components import (
     ComponentsMaskInfo,
     EmbeddingComponents,
     LinearComponents,
-    MLPGates,
+    MLPFn,
     ParallelLinear,
-    VectorMLPGates,
-    VectorSharedMLPGate,
+    VectorMLPFn,
+    VectorSharedMLPFn,
     make_mask_infos,
 )
 from spd.spd_types import ModelPath
@@ -79,8 +79,8 @@ def test_correct_parameters_require_grad():
         target_model=target_model,
         target_module_patterns=["linear1", "linear2", "embedding", "conv1d1", "conv1d2"],
         C=4,
-        gate_type="mlp",
-        gate_hidden_dims=[4],
+        ci_fn_type="mlp",
+        ci_fn_hidden_dims=[4],
         pretrained_model_output_attr=None,
     )
 
@@ -126,8 +126,8 @@ def test_from_run_info():
             target_module_patterns=["linear1", "linear2", "embedding", "conv1d1", "conv1d2"],
             identity_module_patterns=["linear1"],
             C=4,
-            gate_type="mlp",
-            gate_hidden_dims=[4],
+            ci_fn_type="mlp",
+            ci_fn_hidden_dims=[4],
             batch_size=1,
             steps=1,
             lr=1e-3,
@@ -157,8 +157,8 @@ def test_from_run_info():
             target_model=target_model,
             target_module_patterns=config.all_module_patterns,
             C=config.C,
-            gate_type=config.gate_type,
-            gate_hidden_dims=config.gate_hidden_dims,
+            ci_fn_type=config.ci_fn_type,
+            ci_fn_hidden_dims=config.ci_fn_hidden_dims,
             pretrained_model_output_attr=config.pretrained_model_output_attr,
         )
 
@@ -227,31 +227,31 @@ def test_parallel_linear_shapes_and_forward():
 
 
 @pytest.mark.parametrize("hidden_dims", [[8], [4, 3]])
-def test_mlp_gates_scalar_per_component(hidden_dims: list[int]):
+def test_mlp_ci_fn_scalar_per_component(hidden_dims: list[int]):
     C = 5
-    gates = MLPGates(C=C, hidden_dims=hidden_dims)
+    ci_fns = MLPFn(C=C, hidden_dims=hidden_dims)
     x = torch.randn(BATCH_SIZE, C)  # two items, C components
-    y = gates(x)
+    y = ci_fns(x)
     assert y.shape == (BATCH_SIZE, C)
 
 
 @pytest.mark.parametrize("hidden_dims", [[4], [6, 3]])
-def test_vector_mlp_gates(hidden_dims: list[int]):
+def test_vector_mlp_ci_fns(hidden_dims: list[int]):
     C = 3
     d_in = 10
-    gates = VectorMLPGates(C=C, input_dim=d_in, hidden_dims=hidden_dims)
+    ci_fns = VectorMLPFn(C=C, input_dim=d_in, hidden_dims=hidden_dims)
     x = torch.randn(BATCH_SIZE, d_in)
-    y = gates(x)
+    y = ci_fns(x)
     assert y.shape == (BATCH_SIZE, C)
 
 
 @pytest.mark.parametrize("hidden_dims", [[], [7], [8, 5]])
-def test_vector_shared_mlp_gate(hidden_dims: list[int]):
+def test_vector_shared_mlp_fn(hidden_dims: list[int]):
     C = 3
     d_in = 10
-    gate = VectorSharedMLPGate(C=C, input_dim=d_in, hidden_dims=hidden_dims)
+    ci_fn = VectorSharedMLPFn(C=C, input_dim=d_in, hidden_dims=hidden_dims)
     x = torch.randn(BATCH_SIZE, d_in)
-    y = gate(x)
+    y = ci_fn(x)
     assert y.shape == (BATCH_SIZE, C)
 
 
@@ -288,8 +288,8 @@ def test_full_weight_delta_matches_target_behaviour():
         target_model=target_model,
         target_module_patterns=target_module_paths,
         C=4,
-        gate_type="mlp",
-        gate_hidden_dims=[4],
+        ci_fn_type="mlp",
+        ci_fn_hidden_dims=[4],
         pretrained_model_output_attr=None,
     )
 
@@ -320,8 +320,8 @@ def test_input_cache_captures_pre_weight_input():
         target_model=target_model,
         target_module_patterns=target_module_paths,
         C=2,
-        gate_type="mlp",
-        gate_hidden_dims=[2],
+        ci_fn_type="mlp",
+        ci_fn_hidden_dims=[2],
         pretrained_model_output_attr=None,
     )
 
@@ -355,8 +355,8 @@ def test_weight_deltas():
         target_model=target_model,
         target_module_patterns=target_module_paths,
         C=3,
-        gate_type="mlp",
-        gate_hidden_dims=[2],
+        ci_fn_type="mlp",
+        ci_fn_hidden_dims=[2],
         pretrained_model_output_attr=None,
     )
 
@@ -390,8 +390,8 @@ def test_replacement_effects_fwd_pass():
         target_model=model,
         target_module_patterns=["linear"],
         C=C,
-        gate_type="mlp",
-        gate_hidden_dims=[2],
+        ci_fn_type="mlp",
+        ci_fn_hidden_dims=[2],
         pretrained_model_output_attr=None,
     )
 
@@ -447,8 +447,8 @@ def test_replacing_identity():
         target_model=model,
         target_module_patterns=["linear.pre_identity"],
         C=C,
-        gate_type="mlp",
-        gate_hidden_dims=[2],
+        ci_fn_type="mlp",
+        ci_fn_hidden_dims=[2],
         pretrained_model_output_attr=None,
     )
 
@@ -499,8 +499,8 @@ def test_routing():
         target_model=model,
         target_module_patterns=["linear"],
         C=C,
-        gate_type="mlp",
-        gate_hidden_dims=[2],
+        ci_fn_type="mlp",
+        ci_fn_hidden_dims=[2],
         pretrained_model_output_attr=None,
     )
 

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -25,8 +25,8 @@ TEST_CONFIG = {
     "seed": 0,
     "C": 3,
     "n_mask_samples": 1,
-    "gate_type": "vector_mlp",
-    "gate_hidden_dims": [2],
+    "ci_fn_type": "vector_mlp",
+    "ci_fn_hidden_dims": [2],
     "sigmoid_type": "leaky_hard",
     "target_module_patterns": ["model.layers.0.mlp.gate_proj"],
     # --- Loss Coefficients ---
@@ -252,8 +252,8 @@ class TestDistributedDeterminicity:
         # Compare each parameter
         for param_name in sorted(dp1_state.keys()):
             # We know that the target model is not trained, so we only care about params with
-            # "components" or "gates" in the name.
-            if "components" not in param_name and "gates" not in param_name:
+            # "components" or "ci_fns" in the name.
+            if "components" not in param_name and "ci_fns" not in param_name:
                 continue
 
             dp1_param = dp1_state[param_name]

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -23,8 +23,8 @@ def test_gpt_2_decomposition_happy_path() -> None:
         seed=0,
         C=10,  # Smaller C for faster testing
         n_mask_samples=1,
-        gate_type="vector_mlp",
-        gate_hidden_dims=[128],
+        ci_fn_type="vector_mlp",
+        ci_fn_hidden_dims=[128],
         target_module_patterns=["transformer.h.*.attn.c_attn", "transformer.h.*.attn.c_proj"],
         identity_module_patterns=["transformer.h.*.attn.c_attn"],
         # Loss Coefficients

--- a/tests/test_ih_transformer.py
+++ b/tests/test_ih_transformer.py
@@ -35,8 +35,8 @@ def test_ih_transformer_decomposition_happy_path() -> None:
         seed=0,
         C=10,  # Smaller C for faster testing
         n_mask_samples=1,
-        gate_type="vector_mlp",
-        gate_hidden_dims=[128],
+        ci_fn_type="vector_mlp",
+        ci_fn_hidden_dims=[128],
         target_module_patterns=["blocks.*.attn.q_proj", "blocks.*.attn.k_proj"],
         identity_module_patterns=["blocks.*.attn.q_proj"],
         # Loss Coefficients

--- a/tests/test_resid_mlp.py
+++ b/tests/test_resid_mlp.py
@@ -34,8 +34,8 @@ def test_resid_mlp_decomposition_happy_path() -> None:
         seed=0,
         C=10,  # Smaller C for faster testing
         n_mask_samples=1,
-        gate_type="mlp",
-        gate_hidden_dims=[8],
+        ci_fn_type="mlp",
+        ci_fn_hidden_dims=[8],
         target_module_patterns=["layers.*.mlp_in", "layers.*.mlp_out"],
         identity_module_patterns=["layers.*.mlp_in"],
         # Loss Coefficients

--- a/tests/test_spd_losses.py
+++ b/tests/test_spd_losses.py
@@ -24,8 +24,8 @@ def _make_component_model(weight: Float[Tensor, " d_out d_in"]) -> ComponentMode
         target_model=target,
         target_module_patterns=["fc"],
         C=1,
-        gate_hidden_dims=[2],
-        gate_type="mlp",
+        ci_fn_hidden_dims=[2],
+        ci_fn_type="mlp",
         pretrained_model_output_attr=None,
     )
 

--- a/tests/test_tms.py
+++ b/tests/test_tms.py
@@ -38,8 +38,8 @@ def test_tms_decomposition_happy_path() -> None:
         seed=0,
         C=10,  # Smaller C for faster testing
         n_mask_samples=1,
-        gate_type="mlp",
-        gate_hidden_dims=[8],
+        ci_fn_type="mlp",
+        ci_fn_hidden_dims=[8],
         target_module_patterns=["linear1", "linear2", "hidden_layers.0"],
         identity_module_patterns=["linear1"],
         # Loss Coefficients


### PR DESCRIPTION
## Description
This PR renames the "gate" terminology to "ci_fn" (causal importance function) across the codebase, configs, tests, and paper.  
This is a refactor-only change, with **no behavior changes**.

## Related Issue
Closes #48

## Motivation and Context
Unifies terminology across the project (issue #48) and makes it clearer that "ci_fn" refers to causal importance functions.

## How Has This Been Tested?
- Ran `make check` → lint + type check passed
- Ran `pytest tests/` → 149 tests passed, 15 skipped, 3 failed  
  - The 3 failing tests are **pre-existing** in `tests/scripts_run/test_main.py` (subprocess calling issue).  
  - They are unrelated to this change.

## Does this PR introduce a breaking change?
- No
