### PR TITLE
Use pre-built MPI docker image in CI

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:latest
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update && \
+    apt-get install -y -q \
+    openmpi-bin \
+    libopenmpi-dev \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mpicc --version && mpiexec --version

--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -4,6 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
     apt-get install -y -q \
+    git \
     openmpi-bin \
     libopenmpi-dev \
     && apt-get clean \

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -50,3 +50,5 @@ jobs:
         run: uv run python -m pytest tests/ --runslow --durations=10
         env:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          OMPI_ALLOW_RUN_AS_ROOT: 1
+          OMPI_ALLOW_RUN_AS_ROOT_CONFIRM: 1

--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -14,6 +14,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/${{ github.repository }}/ci-mpi:latest
     timeout-minutes: 15
     steps:
       - name: Checkout
@@ -43,11 +45,6 @@ jobs:
 
       - name: Run ruff format
         run: uv run ruff format .
-
-      - name: Install MPI for tests
-        uses: mpi4py/setup-mpi@v1
-        with:
-          mpi: openmpi
 
       - name: Run tests
         run: uv run python -m pytest tests/ --runslow --durations=10

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,6 +1,9 @@
 name: Build Docker Image
 
 on:
+  push:
+    branches:
+      - feature/mpi-image # TODO: This is just temporarily here so I can test it
   workflow_dispatch: # Must manually trigger this workflow in order to build the image
 
 jobs:

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,0 +1,30 @@
+name: Build Docker Image
+
+on:
+  workflow_dispatch: # Must manually trigger this workflow in order to build the image
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .github
+          file: .github/Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}/ci-mpi:latest

--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -1,9 +1,6 @@
 name: Build Docker Image
 
 on:
-  push:
-    branches:
-      - feature/mpi-image # TODO: This is just temporarily here so I can test it
   workflow_dispatch: # Must manually trigger this workflow in order to build the image
 
 jobs:

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -78,10 +78,10 @@ def test_gpt_2_decomposition_happy_path() -> None:
             task_name="lm",
             max_seq_len=16,
             buffer_size=1000,
-            dataset_name="roneneldan/TinyStories",
-            column_name="text",
+            dataset_name="SimpleStories/SimpleStories",
+            column_name="story",
             train_data_split="train[:100]",
-            eval_data_split="validation[:100]",
+            eval_data_split="test[100:200]",
         ),
     )
 


### PR DESCRIPTION
## Description
Reduces CI runtime by >2 mins by loading a custom docker image instead of the default from ubuntu-latest

- Adds a Dockerfile that installs MPI (and git).
- Gives an option to build and publish this dockerfile to github's **public** container registry in a new CI job.
- **This job must be run manually whenever we want to build the image again.**

## Related Issue
Closes #110 

## Motivation and Context
CI currently has to install openmpi everytime. This takes >2 minutes.

## How Has This Been Tested?
See the CI runs in this PR.

## Does this PR introduce a breaking change?
No