### PR TITLE
fixing state dict mappings

### DIFF
--- a/spd/models/component_model.py
+++ b/spd/models/component_model.py
@@ -551,6 +551,25 @@ class ComponentModel(LoadableModule):
 def handle_deprecated_state_dict_keys_(state_dict: dict[str, Tensor]) -> None:
     """Maps deprecated state dict keys to new state dict keys"""
     for key in list(state_dict.keys()):
+        new_key: str = key
         # We used to have "_gates.*", now we have "_ci_fns.*"
-        if "_gates." in key:
-            state_dict[key.replace("_gates.", "_ci_fns.")] = state_dict.pop(key)
+        if "_gates." in new_key:
+            new_key = new_key.replace("_gates.", "_ci_fns.")
+        # We used to have prefix "patched_model.*", now we have "target_model.*"
+        if new_key.startswith("patched_model."):
+            new_key = "target_model." + new_key.removeprefix("patched_model.")
+        # We used to have "*.original.weight", now we have "*.weight"
+        if new_key.endswith(".original.weight"):
+            new_key = new_key.removesuffix(".original.weight") + ".weight"
+        # We used to have "*.components.{U,V}", now we have "_components.*.{U,V}"
+        if new_key.endswith(".components.U") or new_key.endswith(".components.V"):
+            module_path: str = (
+                new_key.removeprefix("target_model.")
+                .removesuffix(".components.U")
+                .removesuffix(".components.V")
+            )
+            # module path has "." replaced with "-"
+            new_key = f"_components.{module_path.replace('.', '-')}.{new_key.split('.')[-1]}"
+        # replace if modified
+        if new_key != key:
+            state_dict[new_key] = state_dict.pop(key)


### PR DESCRIPTION
## Description

This allows loading of older runs before the state dict path format change.

- used to have prefix `patched_model.*`, now we have `target_model.*`
- used to have `*.original.weight`, now we have `*.weight`
- used to have `*.components.{U,V}`, now we have `_components.*.{U,V}`

## Related Issue
https://mats-program.slack.com/archives/C08N7E5KNG7/p1759745866024549

```python
>>> from spd.models.component_model import ComponentModel, SPDRunInfo
>>> SPD_RUN = SPDRunInfo.from_path("wandb:goodfire/spd/runs/rn9klzfs")
>>> MODEL = ComponentModel.from_pretrained(SPD_RUN.checkpoint_path)

RuntimeError: Error(s) in loading state_dict for ComponentModel:
        Missing key(s) in state_dict: "target_model.model.embed_tokens.weight", "target_model.model.layers.0.self_attn.q_proj.weight", ....
        Unexpected key(s) in state_dict: "patched_model.model.embed_tokens.weight", "patched_model.model.layers.0.self_attn.q_proj.weight", ...
```

## How Has This Been Tested?
fixes model loading in tests in #43 

## Does this PR introduce a breaking change?
I've taken care to make sure we only rename when necessary (i.e. prefix/suffix replacing, not just blind replacing in the whole string)