### PR TITLE
allow installing cpu-only torch in CI

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -32,7 +32,10 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --extra cpu --link-mode copy
+
+      - name: clear uv cache
+        run: uv cache clean || true
 
       - name: Print dependencies
         run: uv pip list

--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 # setup
+CUDA_EXTRA ?= cu128
+
 .PHONY: install
 install: copy-templates
-	uv sync --no-dev
+	uv sync --no-dev --extra ${CUDA_EXTRA}
 
 .PHONY: install-dev
 install-dev: copy-templates
-	uv sync
+	uv sync --extra ${CUDA_EXTRA}
 	pre-commit install
+
 
 .PHONY: copy-templates
 copy-templates:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,7 @@ urls = { "Homepage" = "https://github.com/goodfire-ai/spd" }
 license = { text = "MIT" }
 readme = "README.md"
 dependencies = [
+    # NOTE: if you need to change either torch dep, also change them in [project.optional-dependencies]
     "torch>=2.6",
     "torchvision",
     "pydantic",
@@ -126,3 +127,44 @@ filterwarnings = [
     # Ignore Pydantic V1 deprecation warnings from wandb_workspaces
     "ignore:Pydantic V1 style.*:DeprecationWarning:wandb_workspaces",
 ]
+
+
+# installing with only CPU in CI
+
+[project.optional-dependencies]
+cu128 = [
+    "torch>=2.6",
+    "torchvision",
+]
+cpu = [
+    "torch>=2.6",
+    "torchvision",
+]
+
+[tool.uv]
+conflicts = [
+  [
+    { extra = "cu128" },
+    { extra = "cpu" },
+  ],
+]
+
+[tool.uv.sources]
+torch = [
+  { index = "pytorch-cu128", extra = "cu128" },
+  { index = "pytorch-cpu", extra = "cpu" },
+]
+torchvision = [
+  { index = "pytorch-cu128", extra = "cu128" },
+  { index = "pytorch-cpu", extra = "cpu" },
+]
+
+[[tool.uv.index]]
+name = "pytorch-cpu"
+url = "https://download.pytorch.org/whl/cpu"
+explicit = true
+
+[[tool.uv.index]]
+name = "pytorch-cu128"
+url = "https://download.pytorch.org/whl/cu128"
+explicit = true


### PR DESCRIPTION
## Motivation and Context

CI runs were failing due to insufficient disk space:
https://github.com/goodfire-ai/spd/actions/runs/18292296525/job/52082212638

a few GB of space are taken up by the docker container, but the main culprits are:
- UV installs torch with cuda deps, despite no cuda device in CI
- UV installs by copy since symlinks/hardlinks seem to fail, which leaves a giant cache that is not being used

## Description
- add (conflicting) extras `cpu` and `cu128` with their respective indecies
  - `make install` and `make install-dev` install with `cu128` by default, configurable via `CUDA_EXTRA=foo make install-dev`
    - unfortunately `uv sync` as of `uv==0.8.23` will now install torch with cpu by default, no way to change this as far as I can tell. see: https://docs.astral.sh/uv/guides/integration/pytorch/#automatic-backend-selection
- modified installation of deps in CI:
  - install via `uv sync --extra cpu --link-mode copy`
  - install followed by `uv cache clean`

This results in a huge increase in disk space and a modest reduction in CI installation time:

|        |  disk space  | install time         | link  |
| :---:  | :---:        | :---:                | :---: |
| Before | 6.7GB        | ~60s                 | [`actions/runs/18293012119/job/52084684178`](https://github.com/goodfire-ai/spd/actions/runs/18293012119/job/52084684178)
| After  | 21GB         | 12s + 2s cache clean | [`actions/runs/18294570560/job/52089849831`](https://github.com/goodfire-ai/spd/actions/runs/18294570560/job/52089849831) |

> Note: "disk space" meaning "disk space available right before tests start"

## Related Issue

CI runs were failing due to insufficient disk space:

https://github.com/goodfire-ai/spd/actions/runs/18292296525/job/52082212638


## Does this PR introduce a breaking change?

possibly, if any of our tests rely on torch+cuda being installed