### PR TITLE
Fix metric structure and hidden_act_recon

### DIFF
--- a/spd/run_spd.py
+++ b/spd/run_spd.py
@@ -254,6 +254,7 @@ def optimize(
                 ci_upper_leaky=causal_importances_upper_leaky,
                 target_out=target_model_output.output,
                 weight_deltas=weight_deltas,
+                pre_weight_acts=target_model_output.cache,
                 current_frac_of_training=step / config.steps,
                 sampling=config.sampling,
                 use_delta_component=config.use_delta_component,


### PR DESCRIPTION
## Description
- Change the type of `TrainMetricConfig.coeff` from `float` to `float | None`. When a metric that inherits from this class is specified in loss_metric_configs, we assert that coeff is not None. When it's specified in eval_metric_configs, we don't care.
- Make hidden act recon a "loss metric" (i.e. make it inherit from TrainMetricConfig, move it from EvalMetricConfigType to TrainMetricConfigType, handle its initialization in losses.py).
- Rename EvalMetricConfigType to EvalOnlyMetricConfigType, to make it clear than nothing there can also be a loss metric (if it was, it'd belong in TrainMetricConfigType.


## Motivation and Context
We had a couple of bugs in #162:
1. hidden_act_recon was an "eval" and not a "train metric". Concretely, it didn't inherit from TrainMetricConfig. This means that it couldn't be used as a train metric. Lee noticed this [here](https://github.com/goodfire-ai/spd/pull/180#issuecomment-3376534046).
2. There was no way to specify a loss metric in eval_metric_configs. This means that we couldn't eval a loss metric unless we also wanted to use it as a loss.


## How Has This Been Tested?
Manual running with StochasticHiddenActsReconLoss as in loss_metric_configs and in eval_metric_configs (and in both).

## Does this PR introduce a breaking change?
No