### PR TITLE
Update canonical runs and change target model path

### DIFF
--- a/spd/experiments/resid_mlp/resid_mlp1_config.yaml
+++ b/spd/experiments/resid_mlp/resid_mlp1_config.yaml
@@ -72,7 +72,7 @@ eval_metric_configs:
 
 # --- Pretrained model info ---
 pretrained_model_class: "spd.experiments.resid_mlp.models.ResidMLP"
-pretrained_model_path: "wandb:goodfire/spd/runs/pziyck78"
+pretrained_model_path: "wandb:goodfire/spd-pre-Sep-2025/runs/pziyck78"
 
 # --- Task Specific ---
 task_config:

--- a/spd/experiments/resid_mlp/resid_mlp2_config.yaml
+++ b/spd/experiments/resid_mlp/resid_mlp2_config.yaml
@@ -72,7 +72,7 @@ eval_metric_configs:
 
 # --- Pretrained model info ---
 pretrained_model_class: "spd.experiments.resid_mlp.models.ResidMLP"
-pretrained_model_path: "wandb:goodfire/spd/runs/any9ekl9"
+pretrained_model_path: "wandb:goodfire/spd-pre-Sep-2025/runs/any9ekl9"
 
 # --- Task Specific ---
 task_config:

--- a/spd/experiments/resid_mlp/resid_mlp3_config.yaml
+++ b/spd/experiments/resid_mlp/resid_mlp3_config.yaml
@@ -71,7 +71,7 @@ eval_metric_configs:
 
 # --- Pretrained model info ---
 pretrained_model_class: "spd.experiments.resid_mlp.models.ResidMLP"
-pretrained_model_path: "wandb:goodfire/spd/runs/6hk3uciu"
+pretrained_model_path: "wandb:goodfire/spd-pre-Sep-2025/runs/6hk3uciu"
 
 # --- Task Specific ---
 task_config:

--- a/spd/experiments/tms/tms_40-10-id_config.yaml
+++ b/spd/experiments/tms/tms_40-10-id_config.yaml
@@ -70,7 +70,7 @@ eval_metric_configs:
 
 # --- Pretrained model info ---
 pretrained_model_class: "spd.experiments.tms.models.TMSModel"
-pretrained_model_path: "wandb:goodfire/spd/runs/eggs3wp8" # 1 hidden w/fixed identity
+pretrained_model_path: "wandb:goodfire/spd-pre-Sep-2025/runs/eggs3wp8" # 1 hidden w/fixed identity
 
 # --- Task Specific ---
 task_config:

--- a/spd/experiments/tms/tms_40-10_config.yaml
+++ b/spd/experiments/tms/tms_40-10_config.yaml
@@ -68,7 +68,7 @@ eval_metric_configs:
 
 # --- Pretrained model info ---
 pretrained_model_class: "spd.experiments.tms.models.TMSModel"
-pretrained_model_path: "wandb:goodfire/spd/runs/urpntmfu"
+pretrained_model_path: "wandb:goodfire/spd-pre-Sep-2025/runs/urpntmfu"
 
 # --- Task Specific ---
 task_config:

--- a/spd/experiments/tms/tms_5-2-id_config.yaml
+++ b/spd/experiments/tms/tms_5-2-id_config.yaml
@@ -69,7 +69,7 @@ eval_metric_configs:
 
 # --- Pretrained model info ---
 pretrained_model_class: "spd.experiments.tms.models.TMSModel"
-pretrained_model_path: "wandb:goodfire/spd/runs/gfgchmxj" # 1 hidden w/fixed identity
+pretrained_model_path: "wandb:goodfire/spd-pre-Sep-2025/runs/gfgchmxj" # 1 hidden w/fixed identity
 
 # --- Task Specific ---
 task_config:

--- a/spd/experiments/tms/tms_5-2_config.yaml
+++ b/spd/experiments/tms/tms_5-2_config.yaml
@@ -67,7 +67,7 @@ eval_metric_configs:
 
 # --- Pretrained model info ---
 pretrained_model_class: "spd.experiments.tms.models.TMSModel"
-pretrained_model_path: "wandb:goodfire/spd/runs/0hsp07o4"
+pretrained_model_path: "wandb:goodfire/spd-pre-Sep-2025/runs/0hsp07o4"
 
 # --- Task Specific ---
 task_config:

--- a/spd/registry.py
+++ b/spd/registry.py
@@ -37,42 +37,42 @@ EXPERIMENT_REGISTRY: dict[str, ExperimentConfig] = {
         decomp_script=Path("spd/experiments/tms/tms_decomposition.py"),
         config_path=Path("spd/experiments/tms/tms_5-2_config.yaml"),
         expected_runtime=4,
-        canonical_run="wandb:goodfire/spd/runs/6uq40sap",
+        canonical_run="wandb:goodfire/spd/runs/4stmo6p5",
     ),
     "tms_5-2-id": ExperimentConfig(
         task_name="tms",
         decomp_script=Path("spd/experiments/tms/tms_decomposition.py"),
         config_path=Path("spd/experiments/tms/tms_5-2-id_config.yaml"),
         expected_runtime=4,
-        canonical_run="wandb:goodfire/spd/runs/093t8oob",
+        canonical_run="wandb:goodfire/spd/runs/dwalcejo",
     ),
     "tms_40-10": ExperimentConfig(
         task_name="tms",
         decomp_script=Path("spd/experiments/tms/tms_decomposition.py"),
         config_path=Path("spd/experiments/tms/tms_40-10_config.yaml"),
         expected_runtime=5,
-        canonical_run="wandb:goodfire/spd/runs/t809osa9",
+        canonical_run="wandb:goodfire/spd/runs/c378e2l9",
     ),
     "tms_40-10-id": ExperimentConfig(
         task_name="tms",
         decomp_script=Path("spd/experiments/tms/tms_decomposition.py"),
         config_path=Path("spd/experiments/tms/tms_40-10-id_config.yaml"),
         expected_runtime=5,
-        canonical_run="wandb:goodfire/spd/runs/6bnzto4g",
+        canonical_run="wandb:goodfire/spd/runs/galdqemo",
     ),
     "resid_mlp1": ExperimentConfig(
         task_name="resid_mlp",
         decomp_script=Path("spd/experiments/resid_mlp/resid_mlp_decomposition.py"),
         config_path=Path("spd/experiments/resid_mlp/resid_mlp1_config.yaml"),
         expected_runtime=3,
-        canonical_run="wandb:goodfire/spd/runs/2ki9tfsx",
+        canonical_run="wandb:goodfire/spd/runs/my96hvv6",
     ),
     "resid_mlp2": ExperimentConfig(
         task_name="resid_mlp",
         decomp_script=Path("spd/experiments/resid_mlp/resid_mlp_decomposition.py"),
         config_path=Path("spd/experiments/resid_mlp/resid_mlp2_config.yaml"),
         expected_runtime=5,
-        canonical_run="wandb:goodfire/spd/runs/byd0almm",
+        canonical_run="wandb:goodfire/spd/runs/6vpsvdl5",
     ),
     "resid_mlp3": ExperimentConfig(
         task_name="resid_mlp",
@@ -111,12 +111,12 @@ EXPERIMENT_REGISTRY: dict[str, ExperimentConfig] = {
         config_path=Path("spd/experiments/lm/ss_gpt2_simple_noln_config.yaml"),
         expected_runtime=330,
     ),
-    # "ts": ExperimentConfig(
-    #     task_name="lm",
-    #     decomp_script=Path("spd/experiments/lm/lm_decomposition.py"),
-    #     config_path=Path("spd/experiments/lm/ts_config.yaml"),
-    #     expected_runtime=120,
-    # ),
+    "ts": ExperimentConfig(
+        task_name="lm",
+        decomp_script=Path("spd/experiments/lm/lm_decomposition.py"),
+        config_path=Path("spd/experiments/lm/ts_config.yaml"),
+        expected_runtime=120,
+    ),
 }
 
 


### PR DESCRIPTION
## Description
- Set the pretrained_model_path to use spd-pre-Sep-2025 instead of spd as the wandb project for all of our target models
- Ran spd-run and updated the canonical runs

## Motivation and Context
All wandb runs created before September 2025 have been moved from the spd project to the spd-pre-Sep-2025 project. This caused errors when trying to load our canonical runs which referenced an old target model that got moved.

## Does this PR introduce a breaking change?
No