### PR TITLE
Fix distributed test strategy

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -50,7 +50,10 @@ jobs:
         run: uv run ruff format .
 
       - name: Run tests
-        run: uv run pytest tests/ --runslow --durations 10 --numprocesses auto
+        run: |
+          NUM_PROCESSES=$(nproc | awk '{print ($1<4?$1:4)}')
+          echo "Using $NUM_PROCESSES pytest workers"
+          uv run pytest tests/ --runslow --durations 10 --numprocesses $NUM_PROCESSES --dist worksteal
         env:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
           OMPI_ALLOW_RUN_AS_ROOT: 1

--- a/tests/test_wandb_run_loading.py
+++ b/tests/test_wandb_run_loading.py
@@ -5,39 +5,41 @@ If you're willing to make breaking changes, see spd/scripts/run.py for creating 
 the canonical configs, and update the registry with your new run(s).
 """
 
-from collections.abc import Callable
-
 import pytest
 
 from spd.models.component_model import ComponentModel, SPDRunInfo
 from spd.registry import EXPERIMENT_REGISTRY
 
 
-def _from_run_info(canonical_run: str) -> ComponentModel:
+def from_run_info(canonical_run: str) -> ComponentModel:
     run_info = SPDRunInfo.from_path(canonical_run)
     return ComponentModel.from_run_info(run_info)
 
 
-def _from_pretrained(canonical_run: str) -> ComponentModel:
+def from_pretrained(canonical_run: str) -> ComponentModel:
     return ComponentModel.from_pretrained(canonical_run)
 
 
 CANONICAL_EXPS = [
-    (exp_name, exp_config.canonical_run, from_func)
+    (exp_name, exp_config.canonical_run)
     for exp_name, exp_config in EXPERIMENT_REGISTRY.items()
     if exp_config.canonical_run is not None
-    for from_func in [_from_run_info, _from_pretrained]
 ]
 
 
 @pytest.mark.requires_wandb
 @pytest.mark.slow
-@pytest.mark.parametrize("exp_name, canonical_run, from_func", CANONICAL_EXPS)
-def test_loading_from_wandb(
-    exp_name: str, canonical_run: str, from_func: Callable[[str], ComponentModel]
-) -> None:
+@pytest.mark.parametrize("exp_name, canonical_run", CANONICAL_EXPS)
+def test_loading_from_wandb(exp_name: str, canonical_run: str) -> None:
+    # We put both from_run_info and from_pretrained in the same test to avoid distributed read
+    # errors from the same wandb cache
     try:
-        from_func(canonical_run)
+        from_run_info(canonical_run)
     except Exception as e:
-        e.add_note(f"Error loading {exp_name} from {canonical_run}")
+        e.add_note(f"Error with from_run_info for {exp_name} from {canonical_run}")
+        raise e
+    try:
+        from_pretrained(canonical_run)
+    except Exception as e:
+        e.add_note(f"Error with from_pretrained for {exp_name} from {canonical_run}")
         raise e


### PR DESCRIPTION
## Description
- Combine from_run_info and from_pretrained to the same test to avoid distributed cache read errors.
- Implement the same distributed pytest command in the CI as we use in makefile. This is unrelated to the specific bug, but it was overlooked previously so just doing it here.

## Motivation and Context
We were getting nondeterministic errors of "RuntimeError: PytorchStreamReader failed reading file data/1: invalid header or archive is corrupted". E.g. [here](https://github.com/goodfire-ai/spd/actions/runs/18537468906/job/52836151378). I think it's due to different processes running tests which both try to load the same wandb model at the same time.

## How Has This Been Tested?
I've just run the CI a few times, no failures.

## Does this PR introduce a breaking change?
No