### PR TITLE
Use half period instead of quarter period cosine schedule

### DIFF
--- a/spd/utils/general_utils.py
+++ b/spd/utils/general_utils.py
@@ -111,7 +111,9 @@ def get_lr_schedule_fn(
     elif lr_schedule == "constant":
         return lambda *_: 1.0
     elif lr_schedule == "cosine":
-        return lambda step, steps: 1.0 if steps == 1 else np.cos(0.5 * np.pi * step / (steps - 1))
+        return (
+            lambda step, steps: 0.5 * (1 + np.cos(np.pi * step / (steps - 1))) if steps > 1 else 1.0
+        )
     else:
         # Exponential
         assert lr_exponential_halflife is not None  # Should have been caught by model validator


### PR DESCRIPTION
TODO: Lucius has tested that using the half period cosine schedule does work (on his own code). But he let the min lr be 1/10th of the max lr. We should add a hyperparameter for this. Ideally as part of a general set of "schedule" hyperparams that we can use for pnorm or any loss coefficient.

## Description
Changed the cosine schedule to use a half period.

Note: We'll be making a PR to clean up all the scheduling. See #237 

## Motivation and Context
For some weird reason, we were using cosine schedules that only had a quarter period (i.e. from pi/2 to pi). The standard thing to do is to use a half period (but scale it to between 1 and 0).

## How Has This Been Tested?
- Toy model [report](https://wandb.ai/goodfire/spd/reports/SPD-Run-Report---run_20251028_105407--VmlldzoxNDg2MDMzMw==) shows the same results (solves everything except for resid_mlp3, with slight noise on resid_mlp2).
- Lucius:  I tried it out on ss_llama, run [here](https://wandb.ai/goodfire/spd?nw=5i50tmxtm90). I used the same configs as [this run](https://wandb.ai/goodfire/spd?nw=2tatttb8mop) . Results are a bit worse, higher CE loss when using rounded_masked or unmasked.


## Does this PR introduce a breaking change?
Yes. The lr will now be different everywhere.