### PR TITLE
run registry

### DIFF
--- a/spd/registry.py
+++ b/spd/registry.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from pydantic import BaseModel
 
 from spd.settings import REPO_ROOT
 from spd.spd_types import TaskName
@@ -151,3 +152,14 @@ def get_max_expected_runtime(experiments_list: list[str]) -> str:
         EXPERIMENT_REGISTRY[experiment].expected_runtime for experiment in experiments_list
     )
     return f"{max_expected_runtime // 60}h{max_expected_runtime % 60}m"
+
+
+class RegisteredRun(BaseModel):
+    wandb_path: str
+    description: str
+
+
+def get_registered_runs() -> list[RegisteredRun]:
+    run_registry_path = REPO_ROOT / "spd" / "run_registry.yml"
+    run_dicts = yaml.safe_load(run_registry_path.read_text())
+    return [RegisteredRun.model_validate(run_dict) for run_dict in run_dicts]

--- a/spd/run_registry.yml
+++ b/spd/run_registry.yml
@@ -1,0 +1,2 @@
+- wandb_path: https://wandb.ai/goodfire/spd/runs/lxs77xye
+  description: https://opensourcemechanistic.slack.com/archives/C08N7E5KNG7/p1760362289923269


### PR DESCRIPTION
## Description
structured way of keeping track of runs, instead of just pinning things on slack

## Related Issue
https://opensourcemechanistic.slack.com/archives/C08N7E5KNG7/p1762432153667829

## Questions

- what does the interface for interacting with this table look like, if we have one at all?
  - the runs are not "keyed", its just a list -- no way to get a specific element besides index. 
- format?
  - TOML would be preferable to YAML here IMO, but we are using YAML in most places already
- integration with wandb persistence?
  - we have a "keep" tag on wandb and periodically clear all runs older than X with that tag. perhaps tests for this should be "assert each referenced run has the `keep` tag"
- adding new runs
  - might be also good to have a persistent issue on the repo for adding new runs -- commenting a link is less friction than making a PR, pretty easy to periodically ask claude to turn all comments into a single PR


## Does this PR introduce a breaking change?
No.