### PR TITLE
Add flags for better distributed errors

### DIFF
--- a/spd/scripts/run.py
+++ b/spd/scripts/run.py
@@ -161,7 +161,9 @@ def generate_commands(
             mpi_prefix = _build_mpi_prefix(run_id, cmd_idx, dp) if dp > 1 else ""
 
             command = (
-                f"NCCL_DEBUG=WARN "
+                "NCCL_DEBUG=WARN "
+                "TORCH_NCCL_ASYNC_ERROR_HANDLING=1 "
+                "NCCL_ASYNC_ERROR_HANDLING=1 "
                 f"{mpi_prefix}"
                 f"python {exp_config.decomp_script} "
                 f"--config_json '{config_json}' "
@@ -192,7 +194,9 @@ def generate_commands(
 
                 mpi_prefix = _build_mpi_prefix(run_id, cmd_idx, dp) if dp > 1 else ""
                 command = (
-                    f"NCCL_DEBUG=WARN "
+                    "NCCL_DEBUG=WARN "
+                    "TORCH_NCCL_ASYNC_ERROR_HANDLING=1 "
+                    "NCCL_ASYNC_ERROR_HANDLING=1 "
                     f"{mpi_prefix}"
                     f"python {exp_config.decomp_script} "
                     f"--config_json '{config_json}' "
@@ -229,7 +233,9 @@ def run_commands_locally(commands: list[str]) -> None:
         args = shlex.split(command)
 
         # Extract experiment name from script path for cleaner output
-        script_name = args[1].split("/")[-1]
+        # Skip environment variables (VAR=value format) to find the python script
+        script_path = next(arg for arg in args if "=" not in arg and arg.endswith(".py"))
+        script_name = script_path.split("/")[-1]
         logger.section(f"[{i}/{len(commands)}] Executing: {script_name}...")
 
         result = subprocess.run(args)

--- a/tests/scripts_run/test_main.py
+++ b/tests/scripts_run/test_main.py
@@ -147,8 +147,10 @@ class TestSPDRun:
             # Should be a list of arguments
             assert isinstance(args, list)
             assert args[0] == "NCCL_DEBUG=WARN"
-            assert args[1] == "python"
-            assert "_decomposition.py" in args[2]
+            assert args[1] == "TORCH_NCCL_ASYNC_ERROR_HANDLING=1"
+            assert args[2] == "NCCL_ASYNC_ERROR_HANDLING=1"
+            assert args[3] == "python"
+            assert "_decomposition.py" in args[4]
 
             # Check for required arguments in the command
             cmd_str = " ".join(args)


### PR DESCRIPTION
## Description
Adds `NCCL_ASYNC_ERROR_HANDLING` and `TORCH_NCCL_ASYNC_ERROR_HANDLING` flags to give more informative errors in the case of distributed errors.

## Motivation and Context
We've been having weird issues with the new cluster ([example](https://goodfire-ai.slack.com/archives/C08JHTURSQ3/p1762858288831219)). This is just defensive so that we have more information in the case of further failures.

## Related Issue
N/A

## How Has This Been Tested?
manually: `[put run here]`

## Does this PR introduce a breaking change?
No