### PR TITLE
Remove deprecated flag

### DIFF
--- a/spd/scripts/run.py
+++ b/spd/scripts/run.py
@@ -163,7 +163,6 @@ def generate_commands(
             command = (
                 "NCCL_DEBUG=WARN "
                 "TORCH_NCCL_ASYNC_ERROR_HANDLING=1 "
-                "NCCL_ASYNC_ERROR_HANDLING=1 "
                 f"{mpi_prefix}"
                 f"python {exp_config.decomp_script} "
                 f"--config_json '{config_json}' "
@@ -196,7 +195,6 @@ def generate_commands(
                 command = (
                     "NCCL_DEBUG=WARN "
                     "TORCH_NCCL_ASYNC_ERROR_HANDLING=1 "
-                    "NCCL_ASYNC_ERROR_HANDLING=1 "
                     f"{mpi_prefix}"
                     f"python {exp_config.decomp_script} "
                     f"--config_json '{config_json}' "

--- a/tests/scripts_run/test_main.py
+++ b/tests/scripts_run/test_main.py
@@ -148,9 +148,8 @@ class TestSPDRun:
             assert isinstance(args, list)
             assert args[0] == "NCCL_DEBUG=WARN"
             assert args[1] == "TORCH_NCCL_ASYNC_ERROR_HANDLING=1"
-            assert args[2] == "NCCL_ASYNC_ERROR_HANDLING=1"
-            assert args[3] == "python"
-            assert "_decomposition.py" in args[4]
+            assert args[2] == "python"
+            assert "_decomposition.py" in args[3]
 
             # Check for required arguments in the command
             cmd_str = " ".join(args)


### PR DESCRIPTION
## Description
Removes the `NCCL_ASYNC_ERROR_HANDLING=1` flag.

## Motivation and Context
noticed: `[rank0]:[W1111 11:55:57.148815586 Utils.hpp:112] Warning: Environment variable NCCL_ASYNC_ERROR_HANDLING is deprecated; use TORCH_NCCL_ASYNC_ERROR_HANDLING instead (function operator())`

## How Has This Been Tested?
manually

## Does this PR introduce a breaking change?
No