### PR TITLE
Fix: scale component activation density correctly

### DIFF
--- a/spd/metrics/component_activation_density.py
+++ b/spd/metrics/component_activation_density.py
@@ -36,9 +36,7 @@ class ComponentActivationDensity(Metric):
         for module_name, ci_vals in ci.lower_leaky.items():
             active_components = ci_vals > self.ci_alive_threshold
             n_activations_per_component = reduce(active_components, "... C -> C", "sum")
-            self.component_activation_counts[module_name] += (
-                n_activations_per_component * n_examples_this_batch
-            )
+            self.component_activation_counts[module_name] += n_activations_per_component
 
     @override
     def compute(self) -> dict[str, Image.Image]:


### PR DESCRIPTION
## Description
From Dan:
> Our current ComponentActivationDensity doesn't make sense to me. I think the values should be between 0 and 1. It should represent the % of samples in which each component activates. Instead, we get numbers that go up to [e.g.](https://wandb.ai/goodfire/spd/runs/cxgvdkm1?nw=nwuserdanbraun) 2000
>
> I think the issue is that for some reason [we multiply](https://github.com/goodfire-ai/spd/blob/main/spd/metrics/component_activation_density.py#L40) by n_examples_this_batch when calculating that batch's activation count. I think we just need to remove this and then we get the metric we want.

And yea, he's completely right. I've just done Dan's suggested fix.

## Related Issue
N/A

## How Has This Been Tested?
manually: https://wandb.ai/goodfire/spd/runs/bntb7htq

## Does this PR introduce a breaking change?
The plot is now correct