### PR TITLE
centralise and improve token string cleaning

### DIFF
--- a/spd/app/backend/lib/activation_contexts.py
+++ b/spd/app/backend/lib/activation_contexts.py
@@ -35,6 +35,28 @@ class SubcomponentExample:
         return self.token_ci_values[self.active_pos_in_window]
 
 
+def get_clean_token_string(tok_str: str) -> str:
+    return " " + (
+        tok_str.replace("Ġ", " ")
+        .replace("Ċ", "\n")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("âĢĻ", "'")
+        .replace("âĢľ", '"')
+        .replace("âĢĿ", '"')
+        .replace("âĢĵ", "-")
+        .replace("âĢĶ", "...")
+        .replace("âĢĭ", "")
+        .replace("âĢį", "")
+        .replace("##", "")
+    )
+
+
+def get_clean_token_strings(tok: PreTrainedTokenizer, ids: list[int]) -> list[str]:
+    tokens = tok.convert_ids_to_tokens(ids)  # pyright: ignore[reportAttributeAccessIssue]
+    return [get_clean_token_string(t) for t in tokens]
+
+
 class _TopKExamples:
     def __init__(self, k: int):
         self.k = k
@@ -55,7 +77,7 @@ class _TopKExamples:
     def as_activation_contexts(self, tok: PreTrainedTokenizer) -> list[ActivationContext]:
         return [
             ActivationContext(
-                token_strings=tok.convert_ids_to_tokens(ex.window_token_ids),  # pyright: ignore[reportAttributeAccessIssue]
+                token_strings=get_clean_token_strings(tok, ex.window_token_ids),
                 token_ci_values=ex.token_ci_values,
                 active_position=ex.active_pos_in_window,
                 ci_value=ex.active_pos_ci,

--- a/spd/app/frontend/src/components/TokenHighlights.svelte
+++ b/spd/app/frontend/src/components/TokenHighlights.svelte
@@ -11,15 +11,6 @@
     const getHighlightColor = (importance: number): string => {
         return `rgba(0, 200, 0, ${importance * 0.5})`;
     };
-
-    function fmtTokenString(s: string): string {
-        // handle wordpieces chunked tokenization
-        if (s.startsWith("##")) {
-            return s.slice(2);
-        } else {
-            return ` ${s}`;
-        }
-    }
 </script>
 
 <span class="token-highlights">
@@ -28,7 +19,7 @@
             class="token-highlight"
             class:active-token={idx === activePosition}
             style={`background-color:${getHighlightColor(tokenCiValues[idx])};`}
-            data-ci={`CI: ${tokenCiValues[idx].toFixed(precision)}`}>{fmtTokenString(tokenString)}</span
+            data-ci={`CI: ${tokenCiValues[idx].toFixed(precision)}`}>{tokenString}</span
         >
     {/each}
 </span>


### PR DESCRIPTION
## Description
Attempts to make tokens appear nicer in the app by handling in a rather hacky way, various aritifacts that tokenizers produce when decoding single tokens.

## Related Issue
N/A

## Motivation and Context
Currently tokens are particularly hard to read on GPT 2 runs. lots of `Ġ` for example.

## How Has This Been Tested?
manually

## Does this PR introduce a breaking change?
No