### PR TITLE
Add weight_deltas to stoch recon eval metrics

### DIFF
--- a/spd/losses.py
+++ b/spd/losses.py
@@ -45,7 +45,7 @@ def compute_total_loss(
     batch: Int[Tensor, "..."],
     ci: CIOutputs,
     target_out: Tensor,
-    weight_deltas: dict[str, Float[Tensor, " d_out d_in"]],
+    weight_deltas: dict[str, Float[Tensor, "d_out d_in"]],
     pre_weight_acts: dict[str, Float[Tensor, "..."]],
     current_frac_of_training: float,
     sampling: SamplingType,

--- a/spd/metrics/ce_and_kl_losses.py
+++ b/spd/metrics/ce_and_kl_losses.py
@@ -3,7 +3,7 @@ from typing import Any, ClassVar, override
 import einops
 import torch
 import torch.nn.functional as F
-from jaxtyping import Int
+from jaxtyping import Float, Int
 from torch import Tensor
 from torch.distributed import ReduceOp
 
@@ -68,7 +68,7 @@ class CEandKLLosses(Metric):
         batch: Tensor,
         target_out: Tensor,
         ci: CIOutputs,
-        weight_deltas: dict[str, Tensor],
+        weight_deltas: dict[str, Float[Tensor, "d_out d_in"]],
         **_: Any,
     ) -> None:
         ce_losses = self._calc_ce_and_kl_losses(
@@ -96,7 +96,7 @@ class CEandKLLosses(Metric):
         batch: Tensor,
         target_out: Tensor,
         ci: dict[str, Tensor],
-        weight_deltas: dict[str, Tensor],
+        weight_deltas: dict[str, Float[Tensor, "d_out d_in"]],
     ) -> dict[str, float]:
         assert batch.ndim == 2, "Batch must be 2D (batch, seq_len)"
         masked_batch = batch.clone()

--- a/spd/metrics/stochastic_hidden_acts_recon_loss.py
+++ b/spd/metrics/stochastic_hidden_acts_recon_loss.py
@@ -21,7 +21,7 @@ def _stochastic_hidden_acts_recon_loss_update(
     batch: Int[Tensor, "..."] | Float[Tensor, "..."],
     pre_weight_acts: dict[str, Float[Tensor, "..."]],
     ci: dict[str, Float[Tensor, "... C"]],
-    weight_deltas: dict[str, Float[Tensor, " d_out d_in"]] | None,
+    weight_deltas: dict[str, Float[Tensor, "d_out d_in"]] | None,
 ) -> tuple[Float[Tensor, ""], int]:
     assert ci, "Empty ci"
     assert pre_weight_acts, "Empty pre_weight_acts"
@@ -66,7 +66,7 @@ def stochastic_hidden_acts_recon_loss(
     batch: Int[Tensor, "..."] | Float[Tensor, "..."],
     pre_weight_acts: dict[str, Float[Tensor, "..."]],
     ci: dict[str, Float[Tensor, "... C"]],
-    weight_deltas: dict[str, Float[Tensor, " d_out d_in"]] | None,
+    weight_deltas: dict[str, Float[Tensor, "d_out d_in"]] | None,
 ) -> Float[Tensor, ""]:
     sum_mse, n_examples = _stochastic_hidden_acts_recon_loss_update(
         model,
@@ -107,7 +107,7 @@ class StochasticHiddenActsReconLoss(Metric):
         batch: Int[Tensor, "..."] | Float[Tensor, "..."],
         pre_weight_acts: dict[str, Float[Tensor, "..."]],
         ci: CIOutputs,
-        weight_deltas: dict[str, Float[Tensor, " d_out d_in"]],
+        weight_deltas: dict[str, Float[Tensor, "d_out d_in"]],
         **_: Any,
     ) -> None:
         sum_mse, n_examples = _stochastic_hidden_acts_recon_loss_update(

--- a/spd/metrics/stochastic_recon_layerwise_loss.py
+++ b/spd/metrics/stochastic_recon_layerwise_loss.py
@@ -22,7 +22,7 @@ def _stochastic_recon_layerwise_loss_update(
     batch: Int[Tensor, "..."] | Float[Tensor, "..."],
     target_out: Float[Tensor, "... vocab"],
     ci: dict[str, Float[Tensor, "... C"]],
-    weight_deltas: dict[str, Float[Tensor, " d_out d_in"]] | None,
+    weight_deltas: dict[str, Float[Tensor, "d_out d_in"]] | None,
 ) -> tuple[Float[Tensor, ""], int]:
     assert ci, "Empty ci"
     device = get_obj_device(ci)
@@ -63,7 +63,7 @@ def stochastic_recon_layerwise_loss(
     batch: Int[Tensor, "..."] | Float[Tensor, "..."],
     target_out: Float[Tensor, "... vocab"],
     ci: dict[str, Float[Tensor, "... C"]],
-    weight_deltas: dict[str, Float[Tensor, " d_out d_in"]] | None,
+    weight_deltas: dict[str, Float[Tensor, "d_out d_in"]] | None,
 ) -> Float[Tensor, ""]:
     sum_loss, n_examples = _stochastic_recon_layerwise_loss_update(
         model=model,
@@ -107,7 +107,7 @@ class StochasticReconLayerwiseLoss(Metric):
         batch: Int[Tensor, "..."] | Float[Tensor, "..."],
         target_out: Float[Tensor, "... vocab"],
         ci: CIOutputs,
-        weight_deltas: dict[str, Float[Tensor, " d_out d_in"]],
+        weight_deltas: dict[str, Float[Tensor, "d_out d_in"]],
         **_: Any,
     ) -> None:
         sum_loss, n_examples = _stochastic_recon_layerwise_loss_update(

--- a/spd/metrics/stochastic_recon_loss.py
+++ b/spd/metrics/stochastic_recon_loss.py
@@ -22,7 +22,7 @@ def _stochastic_recon_loss_update(
     batch: Int[Tensor, "..."] | Float[Tensor, "..."],
     target_out: Float[Tensor, "... vocab"],
     ci: dict[str, Float[Tensor, "... C"]],
-    weight_deltas: dict[str, Float[Tensor, " d_out d_in"]] | None,
+    weight_deltas: dict[str, Float[Tensor, "d_out d_in"]] | None,
 ) -> tuple[Float[Tensor, ""], int]:
     assert ci, "Empty ci"
     device = get_obj_device(ci)
@@ -61,7 +61,7 @@ def stochastic_recon_loss(
     batch: Int[Tensor, "..."] | Float[Tensor, "..."],
     target_out: Float[Tensor, "... vocab"],
     ci: dict[str, Float[Tensor, "... C"]],
-    weight_deltas: dict[str, Float[Tensor, " d_out d_in"]] | None,
+    weight_deltas: dict[str, Float[Tensor, "d_out d_in"]] | None,
 ) -> Float[Tensor, ""]:
     sum_loss, n_examples = _stochastic_recon_loss_update(
         model,
@@ -105,7 +105,7 @@ class StochasticReconLoss(Metric):
         batch: Int[Tensor, "..."] | Float[Tensor, "..."],
         target_out: Float[Tensor, "... vocab"],
         ci: CIOutputs,
-        weight_deltas: dict[str, Float[Tensor, " d_out d_in"]],
+        weight_deltas: dict[str, Float[Tensor, "d_out d_in"]],
         **_: Any,
     ) -> None:
         sum_loss, n_examples = _stochastic_recon_loss_update(

--- a/spd/metrics/stochastic_recon_subset_ce_and_kl.py
+++ b/spd/metrics/stochastic_recon_subset_ce_and_kl.py
@@ -81,7 +81,7 @@ class StochasticReconSubsetCEAndKL(Metric):
         batch: Int[Tensor, "..."] | Float[Tensor, "..."],
         target_out: Float[Tensor, "... vocab"],
         ci: CIOutputs,
-        weight_deltas: dict[str, Float[Tensor, " d_out d_in"]],
+        weight_deltas: dict[str, Float[Tensor, "d_out d_in"]],
         **_: Any,
     ) -> None:
         losses = self._calc_subset_losses(

--- a/spd/metrics/stochastic_recon_subset_loss.py
+++ b/spd/metrics/stochastic_recon_subset_loss.py
@@ -22,7 +22,7 @@ def _stochastic_recon_subset_loss_update(
     batch: Int[Tensor, "..."] | Float[Tensor, "..."],
     target_out: Float[Tensor, "... vocab"],
     ci: dict[str, Float[Tensor, "... C"]],
-    weight_deltas: dict[str, Float[Tensor, " d_out d_in"]] | None,
+    weight_deltas: dict[str, Float[Tensor, "d_out d_in"]] | None,
     router: Router,
 ) -> tuple[Float[Tensor, ""], int]:
     assert ci, "Empty ci"
@@ -64,7 +64,7 @@ def stochastic_recon_subset_loss(
     batch: Int[Tensor, "..."] | Float[Tensor, "..."],
     target_out: Float[Tensor, "... vocab"],
     ci: dict[str, Float[Tensor, "... C"]],
-    weight_deltas: dict[str, Float[Tensor, " d_out d_in"]] | None,
+    weight_deltas: dict[str, Float[Tensor, "d_out d_in"]] | None,
     routing: SubsetRoutingType,
 ) -> Float[Tensor, ""]:
     sum_loss, n_examples = _stochastic_recon_subset_loss_update(
@@ -112,7 +112,7 @@ class StochasticReconSubsetLoss(Metric):
         batch: Int[Tensor, "..."] | Float[Tensor, "..."],
         target_out: Float[Tensor, "... vocab"],
         ci: CIOutputs,
-        weight_deltas: dict[str, Float[Tensor, " d_out d_in"]],
+        weight_deltas: dict[str, Float[Tensor, "d_out d_in"]],
         **_: Any,
     ) -> None:
         sum_loss, n_examples = _stochastic_recon_subset_loss_update(

--- a/spd/models/component_model.py
+++ b/spd/models/component_model.py
@@ -593,9 +593,9 @@ class ComponentModel(LoadableModule):
             pre_sigmoid=pre_sigmoid,
         )
 
-    def calc_weight_deltas(self) -> dict[str, Float[Tensor, " d_out d_in"]]:
+    def calc_weight_deltas(self) -> dict[str, Float[Tensor, "d_out d_in"]]:
         """Calculate the weight differences between the target and component weights (V@U) for each layer."""
-        weight_deltas: dict[str, Float[Tensor, " d_out d_in"]] = {}
+        weight_deltas: dict[str, Float[Tensor, "d_out d_in"]] = {}
         for comp_name, components in self.components.items():
             weight_deltas[comp_name] = self.target_weight(comp_name) - components.weight
         return weight_deltas

--- a/spd/models/components.py
+++ b/spd/models/components.py
@@ -112,7 +112,7 @@ class VectorSharedMLPCiFn(nn.Module):
         return self.layers(x)
 
 
-WeightDeltaAndMask = tuple[Float[Tensor, " d_out d_in"], Float[Tensor, "..."]]
+WeightDeltaAndMask = tuple[Float[Tensor, "d_out d_in"], Float[Tensor, "..."]]
 
 
 class Components(ABC, nn.Module):

--- a/spd/utils/component_utils.py
+++ b/spd/utils/component_utils.py
@@ -10,7 +10,7 @@ from spd.routing import Router
 def calc_stochastic_component_mask_info(
     causal_importances: dict[str, Float[Tensor, "... C"]],
     component_mask_sampling: SamplingType,
-    weight_deltas: dict[str, Float[Tensor, " d_out d_in"]] | None,
+    weight_deltas: dict[str, Float[Tensor, "d_out d_in"]] | None,
     router: Router,
 ) -> dict[str, ComponentsMaskInfo]:
     ci_sample = next(iter(causal_importances.values()))

--- a/tests/metrics/fixtures.py
+++ b/tests/metrics/fixtures.py
@@ -37,7 +37,7 @@ class TwoLayerLinearModel(nn.Module):
         return x
 
 
-def make_one_layer_component_model(weight: Float[Tensor, " d_out d_in"]) -> ComponentModel:
+def make_one_layer_component_model(weight: Float[Tensor, "d_out d_in"]) -> ComponentModel:
     """Create a ComponentModel with a single linear layer for testing.
 
     Args:

--- a/tests/test_spd_losses.py
+++ b/tests/test_spd_losses.py
@@ -29,7 +29,7 @@ class TinyLinearModel(nn.Module):
         return self.fc(x)
 
 
-def _make_component_model(weight: Float[Tensor, " d_out d_in"]) -> ComponentModel:
+def _make_component_model(weight: Float[Tensor, "d_out d_in"]) -> ComponentModel:
     d_out, d_in = weight.shape
     target = TinyLinearModel(d_in=d_in, d_out=d_out)
     with torch.no_grad():


### PR DESCRIPTION
## Description
- Passes weight_deltas to `CEandKLLosses.update()` and `CEandKLLosses._calc_ce_and_kl_losses`
- Removed a stray whitespace in jaxtypes " d_out d_in" -> "d_out d_in".

## Motivation and Context
For some reason we weren't using weight deltas for stochastic losses in evals.

## How Has This Been Tested?
- [Run](https://wandb.ai/goodfire/spd/runs/d5s8zu7n?nw=06ipq0fh8wc) on main
- [Run](https://wandb.ai/goodfire/spd/runs/wanr7ur0?nw=nwuserdanbraun) with weight delta in eval stoch recon
Unfortunately the runs are not identical on other metrics (we can't expect full determinicity), but there's not egregious differences, especially in the stoch recon eval losses.

## Does this PR introduce a breaking change?
No