### PR TITLE
Fix: Allow for cuda when distributed state is None

### DIFF
--- a/spd/utils/distributed_utils.py
+++ b/spd/utils/distributed_utils.py
@@ -129,9 +129,11 @@ def is_main_process() -> bool:
 
 
 def get_device() -> str:
-    """Get device for current process in distributed setting."""
+    """Get device for current process."""
     state = get_distributed_state()
-    if state is None or state.backend == "gloo":
+    if state is None:
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    if state.backend == "gloo":
         return "cpu"
     return f"cuda:{state.local_rank}"
 


### PR DESCRIPTION
## Description
Allow for running with cuda when `get_distributed_state()` returns None in `get_device()`

## Motivation and Context
When running locally (e.g. by `python lm_decomposition config.yaml`), it will run on cpu even if a gpu is available. This was introduced in #264.

## How Has This Been Tested?
Ran manually, it uses gpu after fix

## Does this PR introduce a breaking change?
Yes, fixes issue.