### PR TITLE
Add grad_clip_norm_components and grad_clip_norm_ci_fns

### DIFF
--- a/spd/configs.py
+++ b/spd/configs.py
@@ -320,9 +320,13 @@ class Config(BaseConfig):
         default=1,
         description="Number of steps to accumulate gradients over before updating parameters",
     )
-    grad_clip_norm: PositiveFloat | None = Field(
+    grad_clip_norm_components: PositiveFloat | None = Field(
         default=None,
-        description="If set, clip gradient norm to this value before each optimiser step",
+        description="If set, apply grad norm clipping to the parameters of the components",
+    )
+    grad_clip_norm_ci_fns: PositiveFloat | None = Field(
+        default=None,
+        description="If set, apply grad norm clipping to the parameters of the CI functions",
     )
 
     # --- Faithfulness Warmup ---
@@ -465,6 +469,7 @@ class Config(BaseConfig):
         "dist_backend",
     ]
     RENAMED_CONFIG_KEYS: ClassVar[dict[str, str]] = {
+        "grad_clip_norm": "grad_clip_norm_components",
         "print_freq": "eval_freq",
         "pretrained_model_name_hf": "pretrained_model_name",
         "recon_coeff": "ci_recon_coeff",

--- a/spd/run_spd.py
+++ b/spd/run_spd.py
@@ -399,8 +399,10 @@ def optimize(
         # Skip gradient step if we are at the last step (last step just for plotting and logging)
         if step != config.steps:
             sync_across_processes()
-            if config.grad_clip_norm is not None:
-                clip_grad_norm_(optimized_params, config.grad_clip_norm)
+            if config.grad_clip_norm_components is not None:
+                clip_grad_norm_(component_params, config.grad_clip_norm_components)
+            if config.grad_clip_norm_ci_fns is not None:
+                clip_grad_norm_(ci_fn_params, config.grad_clip_norm_ci_fns)
             optimizer.step()
 
     if is_main_process():


### PR DESCRIPTION
## Description
- Add grad_clip_norm_components and grad_clip_norm_ci_fns to the main config
- Handle deprecated grad_clip_norm by mapping it to grad_clip_norm_components (although very few runs actually use this).
- Remove division by number of parameters when logging grad norm

## Motivation and Context
We noticed that [this run](https://wandb.ai/goodfire/spd/runs/qaz5j3ku?nw=nwuserlucius_goodfire) exploded. We deduced that grad clip norm was set too low. We also found that our grad norm logging was divided by the number of parameters, whereas the calculation of grad norm clipping doesn't do that

## How Has This Been Tested?
Not much of a test but this [run](https://wandb.ai/goodfire/spd/runs/jz0b6gm6) has both grad_clip options.

## Does this PR introduce a breaking change?
Yes. You can no longer use `grad_clip_norm` in the config.