### PR TITLE
Add 'Hide unconnected edges' checkbox to attribution graph

### DIFF
--- a/spd/app/frontend/src/components/LocalAttributionsTab.svelte
+++ b/spd/app/frontend/src/components/LocalAttributionsTab.svelte
@@ -91,6 +91,7 @@
 
     // Edge count is derived from the graph rendering, not stored per-graph
     let filteredEdgeCount = $state<number | null>(null);
+    let hideUnconnectedEdges = $state(false);
 
     // Component details cache (shared across graphs)
     let componentDetailsCache = $state<Record<string, ComponentDetail>>({});
@@ -706,11 +707,13 @@
                                         normalizeEdges={activeGraph.viewSettings.normalizeEdges}
                                         ciThreshold={activeGraph.viewSettings.ciThreshold}
                                         ciThresholdLoading={refetchingGraphId === activeGraph.id}
+                                        {hideUnconnectedEdges}
                                         onTopKChange={handleTopKChange}
                                         onComponentGapChange={handleComponentGapChange}
                                         onLayerGapChange={handleLayerGapChange}
                                         onNormalizeChange={handleNormalizeChange}
                                         onCiThresholdChange={handleCiThresholdChange}
+                                        onHideUnconnectedEdgesChange={(v) => (hideUnconnectedEdges = v)}
                                     />
                                     {#key activeGraph.id}
                                         <LocalAttributionsGraph
@@ -718,6 +721,7 @@
                                             topK={activeGraph.viewSettings.topK}
                                             componentGap={activeGraph.viewSettings.componentGap}
                                             layerGap={activeGraph.viewSettings.layerGap}
+                                            {hideUnconnectedEdges}
                                             {activationContextsSummary}
                                             stagedNodes={pinnedNodes}
                                             {componentDetailsCache}

--- a/spd/app/frontend/src/components/local-attr/ViewControls.svelte
+++ b/spd/app/frontend/src/components/local-attr/ViewControls.svelte
@@ -9,11 +9,13 @@
         normalizeEdges: NormalizeType;
         ciThreshold: number;
         ciThresholdLoading: boolean;
+        hideUnconnectedEdges: boolean;
         onTopKChange: (value: number) => void;
         onComponentGapChange: (value: number) => void;
         onLayerGapChange: (value: number) => void;
         onNormalizeChange: (value: NormalizeType) => void;
         onCiThresholdChange: (value: number) => void;
+        onHideUnconnectedEdgesChange: (value: boolean) => void;
     };
 
     let {
@@ -24,11 +26,13 @@
         normalizeEdges,
         ciThreshold,
         ciThresholdLoading,
+        hideUnconnectedEdges,
         onTopKChange,
         onComponentGapChange,
         onLayerGapChange,
         onNormalizeChange,
         onCiThresholdChange,
+        onHideUnconnectedEdgesChange,
     }: Props = $props();
 
     // Local state for CI threshold input - allows typing without immediate updates
@@ -119,6 +123,14 @@
             step={5}
         />
     </label>
+    <label class="checkbox">
+        <input
+            type="checkbox"
+            checked={hideUnconnectedEdges}
+            onchange={(e) => onHideUnconnectedEdgesChange(e.currentTarget.checked)}
+        />
+        <span>Hide unconnected edges</span>
+    </label>
 
     {#if filteredEdgeCount !== null}
         <div class="legend">
@@ -195,6 +207,15 @@
     select:focus {
         outline: none;
         border-color: var(--accent-primary-dim);
+    }
+
+    .checkbox {
+        cursor: pointer;
+    }
+
+    .checkbox input[type="checkbox"] {
+        cursor: pointer;
+        accent-color: var(--accent-primary);
     }
 
     .legend {


### PR DESCRIPTION
## Description

Add a checkbox to the ViewControls bar that, when enabled, hides all edges not connected to the currently selected (pinned or hovered) node. This makes it easier to focus on the connections of a specific component.

- Add hideUnconnectedEdges state to LocalAttributionsTab
- Add checkbox UI to ViewControls with appropriate styling
- Extend edge highlighting effect to also manage hidden class
- Use CSS display:none for hidden edges for performance

The feature preserves the original behavior when unchecked.

## Related Issue

N/A

## Motivation and Context

When analyzing attribution graphs with many edges, it can be difficult to trace connections from a specific node. This feature allows users to focus on just the edges connected to their selected node(s) by hiding all other edges.

## How Has This Been Tested?

   - Verified checkbox appears in controls bar after Layer Gap input
   - Tested clicking nodes with checkbox disabled - edges highlight as before
   - Tested clicking nodes with checkbox enabled - unconnected edges hidden
   - Tested disabling checkbox - all edges reappear
   - Verified existing dimmed edge behavior (hovering an edge) still works
   - All frontend checks pass (`npm run check`, `npm run lint`)

## Does this PR introduce a breaking change?

No. This is a purely additive feature with no changes to existing behavior when the checkbox is unchecked (default).

🤖 Generated with [Claude Code](https://claude.com/claude-code)