### PR TITLE
Speed up by reducing precision

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -165,6 +165,19 @@
             }
         },
         {
+            "name": "ss_llama_simple_mlp-1L",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${workspaceFolder}/spd/experiments/lm/lm_decomposition.py",
+            "args": "${workspaceFolder}/spd/experiments/lm/ss_llama_simple_mlp-1L.yaml",
+            "python": "${command:python.interpreterPath}",
+            "console": "integratedTerminal",
+            "justMyCode": true,
+            "env": {
+                "PYDEVD_DISABLE_FILE_VALIDATION": "1"
+            }
+        },
+        {
             "name": "ss_gpt2",
             "type": "debugpy",
             "request": "launch",

--- a/spd/app/backend/lib/activation_contexts.py
+++ b/spd/app/backend/lib/activation_contexts.py
@@ -182,18 +182,18 @@ def get_activations_data(
             ci_at_active = window_ci_values[:, n_tokens_either_side]
 
             # Move to CPU/numpy once (faster than .tolist())
-            batch_idx_np = batch_idx.cpu().numpy()
-            seq_idx_np = seq_idx.cpu().numpy()
-            comp_idx_np = comp_idx.cpu().numpy()
-            window_token_ids_np = window_token_ids.cpu().numpy()
-            window_ci_values_np = window_ci_values.cpu().numpy()
-            ci_at_active_np = ci_at_active.cpu().numpy()
+            batch_idx_np = batch_idx.cpu().float().numpy()
+            seq_idx_np = seq_idx.cpu().float().numpy()
+            comp_idx_np = comp_idx.cpu().float().numpy()
+            window_token_ids_np = window_token_ids.cpu().float().numpy()
+            window_ci_values_np = window_ci_values.cpu().float().numpy()
+            ci_at_active_np = ci_at_active.cpu().float().numpy()
 
             # Get token IDs at active position for token counting
             active_token_ids = window_token_ids_np[:, n_tokens_either_side]
 
             # Get predicted tokens at each firing position
-            firing_predicted_tokens = predicted_token_ids[batch_idx, seq_idx].cpu().numpy()
+            firing_predicted_tokens = predicted_token_ids[batch_idx, seq_idx].cpu().float().numpy()
 
             # Process by component - group firings and use batch add
             unique_components = np.unique(comp_idx_np)

--- a/spd/app/frontend/vite.config.ts
+++ b/spd/app/frontend/vite.config.ts
@@ -4,7 +4,7 @@ import { svelte } from "@sveltejs/vite-plugin-svelte";
 // https://vite.dev/config/
 export default defineConfig({
     plugins: [svelte()],
-    // server: {
-    //     hmr: false,
-    // },
+    server: {
+        hmr: false,
+    },
 });

--- a/spd/configs.py
+++ b/spd/configs.py
@@ -248,7 +248,7 @@ class Config(BaseConfig):
     # --- General ---
     seed: int = Field(default=0, description="Random seed for reproducibility")
     dtype: DType = Field(
-        default="float32",
+        default="bfloat16",
         description="Default torch dtype for computation. Supports 'float32' and 'bfloat16'.",
     )
     C: PositiveInt = Field(

--- a/spd/configs.py
+++ b/spd/configs.py
@@ -227,6 +227,8 @@ TaskConfig = TMSTaskConfig | ResidMLPTaskConfig | LMTaskConfig | IHTaskConfig
 
 SamplingType = Literal["continuous", "binomial"]
 
+DType = Literal["float32", "bfloat16"]
+
 
 class Config(BaseConfig):
     # --- WandB
@@ -245,6 +247,10 @@ class Config(BaseConfig):
 
     # --- General ---
     seed: int = Field(default=0, description="Random seed for reproducibility")
+    dtype: DType = Field(
+        default="float32",
+        description="Default torch dtype for computation. Supports 'float32' and 'bfloat16'.",
+    )
     C: PositiveInt = Field(
         ...,
         description="The number of subcomponents per layer",

--- a/spd/experiments/ih/train_ih.py
+++ b/spd/experiments/ih/train_ih.py
@@ -230,8 +230,8 @@ def plot_attention_maps_post_training(
 
         for layer_index in range(model.config.n_layers):
             for head_index in range(model.config.n_heads):
-                avg_attn = avg_attn_weights[layer_index, head_index, :, :].cpu().numpy()
-                max_attn = max_attn_weights[layer_index, head_index, :, :].cpu().numpy()
+                avg_attn = avg_attn_weights[layer_index, head_index, :, :].cpu().float().numpy()
+                max_attn = max_attn_weights[layer_index, head_index, :, :].cpu().float().numpy()
 
                 fig, ax = plt.subplots(1, 2, figsize=(12, 6))
                 assert isinstance(ax, np.ndarray), "Expected ax to be a numpy array of axes"

--- a/spd/experiments/lm/lm_decomposition.py
+++ b/spd/experiments/lm/lm_decomposition.py
@@ -12,7 +12,7 @@ from spd.configs import Config
 from spd.data import DatasetConfig, create_data_loader
 from spd.experiments.lm.configs import LMTaskConfig
 from spd.log import logger
-from spd.run_spd import optimize
+from spd.run_spd import DTYPE_MAP, optimize
 from spd.utils.distributed_utils import (
     DistributedState,
     call_on_rank0_then_broadcast,
@@ -107,6 +107,8 @@ def main(
             pretrained_model_class.from_pretrained,  # pyright: ignore[reportAttributeAccessIssue]
             config.pretrained_model_name,
         )
+
+    target_model.to(DTYPE_MAP[config.dtype])
     target_model.eval()
 
     if is_main_process():

--- a/spd/experiments/lm/lm_decomposition.py
+++ b/spd/experiments/lm/lm_decomposition.py
@@ -5,14 +5,15 @@ import os
 from pathlib import Path
 
 import fire
+import torch
 import wandb
 from simple_stories_train.run_info import RunInfo as SSRunInfo
 
-from spd.configs import Config
+from spd.configs import Config, DType
 from spd.data import DatasetConfig, create_data_loader
 from spd.experiments.lm.configs import LMTaskConfig
 from spd.log import logger
-from spd.run_spd import DTYPE_MAP, optimize
+from spd.run_spd import optimize
 from spd.utils.distributed_utils import (
     DistributedState,
     call_on_rank0_then_broadcast,
@@ -25,6 +26,11 @@ from spd.utils.distributed_utils import (
 from spd.utils.general_utils import resolve_class, save_pre_run_info, set_seed
 from spd.utils.run_utils import get_output_dir
 from spd.utils.wandb_utils import init_wandb
+
+DTYPE_MAP: dict[DType, torch.dtype] = {
+    "float32": torch.float32,
+    "bfloat16": torch.bfloat16,
+}
 
 
 @with_distributed_cleanup
@@ -108,7 +114,7 @@ def main(
             config.pretrained_model_name,
         )
 
-    target_model.to(DTYPE_MAP[config.dtype])
+    # target_model.to(DTYPE_MAP[config.dtype])
     target_model.eval()
 
     if is_main_process():

--- a/spd/experiments/lm/ss_llama_simple_mlp-1L.yaml
+++ b/spd/experiments/lm/ss_llama_simple_mlp-1L.yaml
@@ -10,12 +10,12 @@ ci_fn_hidden_dims:
 sampling: continuous
 sigmoid_type: leaky_hard
 target_module_patterns:
-  - "h.*.mlp.c_fc"
-  - "h.*.mlp.down_proj"
-  - "h.*.attn.q_proj"
-  - "h.*.attn.k_proj"
-  - "h.*.attn.v_proj"
-  - "h.*.attn.o_proj"
+- h.*.mlp.c_fc
+- h.*.mlp.down_proj
+- h.*.attn.q_proj
+- h.*.attn.k_proj
+- h.*.attn.v_proj
+- h.*.attn.o_proj
 identity_module_patterns: null
 use_delta_component: true
 loss_metric_configs:
@@ -28,12 +28,16 @@ loss_metric_configs:
   eps: 1.0e-12
 - coeff: 0.5
   classname: StochasticReconSubsetLoss
+  routing:
+    type: uniform_k_subset
 - coeff: 0.5
   init: random
   step_size: 1.0
   n_steps: 1
   mask_scope: shared_across_batch
   classname: PGDReconSubsetLoss
+  routing:
+    type: uniform_k_subset
 - coeff: 1000000.0
   classname: FaithfulnessLoss
 output_loss_type: kl
@@ -41,6 +45,8 @@ lr: 0.0002
 steps: 400000
 batch_size: 64
 gradient_accumulation_steps: 1
+grad_clip_norm_components: null
+grad_clip_norm_ci_fns: null
 faithfulness_warmup_steps: 200
 faithfulness_warmup_lr: 0.001
 faithfulness_warmup_weight_decay: 0.0
@@ -54,7 +60,7 @@ eval_batch_size: 64
 slow_eval_freq: 10000
 n_eval_steps: 5
 slow_eval_on_first_step: true
-save_freq: 60000
+save_freq: null
 eval_metric_configs:
 - classname: CIHistograms
   n_batches_accum: 5

--- a/spd/experiments/resid_mlp/plotting.py
+++ b/spd/experiments/resid_mlp/plotting.py
@@ -65,7 +65,7 @@ def plot_individual_feature_response(
                 color=cmap_viridis(f / n_features),
                 marker=".",
                 s=s[order],
-                alpha=alpha[order].numpy(),  # pyright: ignore[reportArgumentType]
+                alpha=alpha[order].float().numpy(),  # pyright: ignore[reportArgumentType]
                 # According to the announcement, alpha is allowed to be an iterable since v3.4.0,
                 # but the docs & type annotations seem to be wrong. Here's the announcement:
                 # https://matplotlib.org/stable/users/prev_whats_new/whats_new_3.4.0.html#transparency-alpha-can-be-set-as-an-array-in-collections

--- a/spd/experiments/resid_mlp/resid_mlp_interp.py
+++ b/spd/experiments/resid_mlp/resid_mlp_interp.py
@@ -406,8 +406,8 @@ def plot_neuron_contribution_pairs(
 
     # Plot points separately for each layer with different colors
     for layer in range(n_layers):
-        x_values = relu_conns[layer].flatten().cpu().detach().numpy()
-        y_values = max_component_contributions[layer].flatten().cpu().detach().numpy()
+        x_values = relu_conns[layer].flatten().cpu().detach().float().numpy()
+        y_values = max_component_contributions[layer].flatten().cpu().detach().float().numpy()
 
         layer_label = {0: "First MLP", 1: "Second MLP", 2: "Third MLP"}.get(layer, f"Layer {layer}")
 
@@ -451,8 +451,8 @@ def plot_neuron_contribution_pairs(
 
     # Add some statistics to the plot
     # Calculate correlation for all points combined
-    all_x = relu_conns.flatten().cpu().detach().numpy()
-    all_y = max_component_contributions.flatten().cpu().detach().numpy()
+    all_x = relu_conns.flatten().cpu().detach().float().numpy()
+    all_y = max_component_contributions.flatten().cpu().detach().float().numpy()
     correlation = np.corrcoef(all_x, all_y)[0, 1]
     ax.text(
         0.05,

--- a/spd/experiments/resid_mlp/train_resid_mlp.py
+++ b/spd/experiments/resid_mlp/train_resid_mlp.py
@@ -130,7 +130,7 @@ def train(
         loss = loss.mean()
         final_losses.append(loss)
     final_losses = torch.stack(final_losses).mean().cpu().detach()
-    logger.info(f"Final losses: {final_losses.numpy()}")
+    logger.info(f"Final losses: {final_losses.float().numpy()}")
     return final_losses
 
 

--- a/spd/experiments/tms/train_tms.py
+++ b/spd/experiments/tms/train_tms.py
@@ -97,7 +97,7 @@ def plot_intro_diagram(model: TMSModel, filepath: Path) -> None:
     plt.rcParams["figure.dpi"] = 200
     _, ax = plt.subplots(1, 1, figsize=(2, 2))
 
-    W = WA.cpu().detach().numpy()
+    W = WA.cpu().detach().float().numpy()
     ax.scatter(W[:, 0], W[:, 1], c=color)
     ax.set_aspect("equal")
     ax.add_collection(
@@ -135,7 +135,7 @@ def plot_cosine_similarity_distribution(
 
     _, ax = plt.subplots(1, 1, figsize=(4, 4))
 
-    sims = masked_sims.cpu().numpy()
+    sims = masked_sims.cpu().float().numpy()
     ax.scatter(sims, np.zeros_like(sims), alpha=0.5)
     ax.set_xlim(-1, 1)
     ax.set_xlabel("Cosine Similarity")

--- a/spd/metrics/ce_and_kl_losses.py
+++ b/spd/metrics/ce_and_kl_losses.py
@@ -141,7 +141,7 @@ class CEandKLLosses(Metric):
 
         # Rounded causal importances as masks
         rounded_mask_infos = make_mask_infos(
-            {k: (v > self.rounding_threshold).float() for k, v in ci.items()}
+            {k: (v > self.rounding_threshold).to(v.dtype) for k, v in ci.items()}
         )
         rounded_masked_logits = self.model(batch, mask_infos=rounded_mask_infos)
         rounded_masked_ce_loss = ce_vs_labels(rounded_masked_logits)

--- a/spd/models/component_model.py
+++ b/spd/models/component_model.py
@@ -91,6 +91,7 @@ class ComponentModel(LoadableModule):
             )
 
         self.target_model = target_model
+        self.target_model.compile()
         self.C = C
         self.pretrained_model_output_attr = pretrained_model_output_attr
         self.target_module_paths = get_target_module_paths(target_model, target_module_patterns)

--- a/spd/plotting.py
+++ b/spd/plotting.py
@@ -61,7 +61,7 @@ def _plot_causal_importances_figure(
     images = []
     for j, (mask_name, mask) in enumerate(ci_vals.items()):
         # mask has shape (batch, C) or (batch, pos, C)
-        mask_data = mask.detach().cpu().numpy()
+        mask_data = mask.detach().cpu().float().numpy()
         if has_pos_dim:
             assert mask_data.ndim == 3
             mask_data = mask_data[:, 0, :]
@@ -127,7 +127,7 @@ def plot_mean_component_cis_both_scales(
     processed_data = []
     for module_name, mean_component_ci in mean_component_cis.items():
         sorted_components = torch.sort(mean_component_ci, descending=True)[0]
-        processed_data.append((module_name, sorted_components.detach().cpu().numpy()))
+        processed_data.append((module_name, sorted_components.detach().cpu().float().numpy()))
 
     # Create both figures
     images = []
@@ -326,7 +326,7 @@ def plot_UV_matrices(
     for j, (name, component) in enumerate(sorted(components.items())):
         # Plot V matrix
         V = component.V if all_perm_indices is None else component.V[:, all_perm_indices[name]]
-        V_np = V.detach().cpu().numpy()
+        V_np = V.detach().cpu().float().numpy()
         im = axs[j, 0].matshow(V_np, aspect="auto", cmap="coolwarm")
         axs[j, 0].set_ylabel("d_in index")
         axs[j, 0].set_xlabel("Component index")
@@ -335,7 +335,7 @@ def plot_UV_matrices(
 
         # Plot U matrix
         U = component.U if all_perm_indices is None else component.U[all_perm_indices[name], :]
-        U_np = U.detach().cpu().numpy()
+        U_np = U.detach().cpu().float().numpy()
         im = axs[j, 1].matshow(U_np, aspect="auto", cmap="coolwarm")
         axs[j, 1].set_ylabel("Component index")
         axs[j, 1].set_xlabel("d_out index")
@@ -400,7 +400,7 @@ def plot_component_activation_density(
         col = i // n_rows
         ax = axs[row, col]
 
-        data = density.detach().cpu().numpy()
+        data = density.detach().cpu().float().numpy()
         ax.hist(data, bins=bins)
         ax.set_yscale("log")  # Beware, memory leak unless gc.collect() is called after eval loop
         ax.set_title(module_name)  # Add module name as title to each subplot
@@ -469,7 +469,7 @@ def plot_ci_values_histograms(
         col = i // n_rows
         ax = axs[row, col]
 
-        data = layer_ci.flatten().cpu().numpy()
+        data = layer_ci.flatten().cpu().float().numpy()
         ax.hist(data, bins=bins)
         ax.set_yscale("log")  # Beware, memory leak unless gc.collect() is called after eval loop
         ax.set_title(f"Causal importances for {layer_name}")

--- a/spd/run_spd.py
+++ b/spd/run_spd.py
@@ -20,6 +20,7 @@ from tqdm import tqdm
 
 from spd.configs import (
     Config,
+    DType,
     LossMetricConfigType,
     MetricConfigType,
     PGDMultiBatchConfig,
@@ -51,6 +52,11 @@ from spd.utils.logging_utils import get_grad_norms_dict, local_log
 from spd.utils.module_utils import replace_std_values_in_layernorm
 from spd.utils.run_utils import save_file
 from spd.utils.wandb_utils import try_wandb
+
+DTYPE_MAP: dict[DType, torch.dtype] = {
+    "float32": torch.float32,
+    "bfloat16": torch.bfloat16,
+}
 
 
 def run_faithfulness_warmup(
@@ -126,6 +132,11 @@ def optimize(
     ln_stds: dict[str, float] | None = None,
 ) -> None:
     """Run the optimization loop for LM decomposition."""
+
+    # Set default dtype for all tensor operations
+    torch_dtype = DTYPE_MAP[config.dtype]
+    torch.set_default_dtype(torch_dtype)
+    logger.info(f"Set default torch dtype to {config.dtype}")
 
     train_iterator = loop_dataloader(train_loader)
     eval_iterator = loop_dataloader(eval_loader)

--- a/spd/utils/component_utils.py
+++ b/spd/utils/component_utils.py
@@ -22,9 +22,9 @@ def calc_stochastic_component_mask_info(
     for layer, ci in causal_importances.items():
         match component_mask_sampling:
             case "binomial":
-                stochastic_source = torch.randint(0, 2, ci.shape, device=device).float()
+                stochastic_source = torch.randint(0, 2, ci.shape, device=device).to(dtype)
             case "continuous":
-                stochastic_source = torch.rand_like(ci)
+                stochastic_source = torch.rand_like(ci).to(dtype)
         component_masks[layer] = ci + (1 - ci) * stochastic_source
 
     weight_deltas_and_masks: dict[str, WeightDeltaAndMask] | None = None

--- a/spd/utils/target_ci_solutions.py
+++ b/spd/utils/target_ci_solutions.py
@@ -71,7 +71,7 @@ def permute_to_identity_hungarian(
     effective_rows = min(batch, C)
 
     # Hungarian algorithm on the effective_rows x C submatrix
-    cost_matrix = -ci_vals[:effective_rows].detach().cpu().numpy()
+    cost_matrix = -ci_vals[:effective_rows].detach().cpu().float().numpy()
     _, col_indices = linear_sum_assignment(cost_matrix)
 
     # Build complete permutation


### PR DESCRIPTION
STATUS:
initial tests showed that bfloat16 everywhere was ~3 times faster but diverged wildly, and that mixed precision with torch.autocast was ~0.5x faster. But later tests in multi-node setup didn't seem to be faster at all. Needs investigating.

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- Use the keywords 'Close', 'Closes', 'Fix', or 'Fixes' followed by the issue number(s) to close the related issue(s) -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Does this PR introduce a breaking change?
<!--- If this PR introduces a breaking change, please describe the impact and migration path for existing applications below. -->