### PR TITLE
Speedup with torch compile

### DIFF
--- a/scripts/BENCHMARK_RESULTS.md
+++ b/scripts/BENCHMARK_RESULTS.md
@@ -1,0 +1,68 @@
+# torch.compile Benchmark Results for SPD
+
+Benchmarks comparing eager mode vs `torch.compile()` for SPD's masked forward/backward passes.
+
+## Summary
+
+- **Isolated LinearComponents**: No benefit from torch.compile (0-20% slower)
+- **Full ComponentModel**: 30-35% speedup at larger batch sizes
+
+## Full Model Results (SS Llama Simple)
+
+Model: 4-layer Llama with 28 decomposed modules, C=1200 components each.
+
+| Batch | Seq Len | Compile Mode | Eager | Compiled | Speedup |
+|-------|---------|--------------|-------|----------|---------|
+| 16 | 128 | reduce-overhead | 10.56ms | 9.64ms | **1.09x (9.5%)** |
+| 32 | 256 | reduce-overhead | 12.61ms | 11.20ms | **1.13x (12.6%)** |
+| 64 | 256 | reduce-overhead | 20.70ms | 15.96ms | **1.30x (30%)** |
+| 128 | 256 | reduce-overhead | 36.19ms | 28.34ms | **1.28x (28%)** |
+| 64 | 256 | max-autotune | 20.70ms | 15.38ms | **1.35x (35%)** |
+
+## Isolated LinearComponents Results
+
+Testing just the core operation: `out = (x @ V * mask) @ U`
+
+| Test | Dimensions | Compile Mode | Speedup |
+|------|------------|--------------|---------|
+| LinearComponents | d=512, C=512 | reduce-overhead | 1.00x (no benefit) |
+| LinearComponents | d=2048, C=2048 | reduce-overhead | 1.03x (2.6%) |
+| Pure function | d=512, C=512 | reduce-overhead | 0.85x (15% slower) |
+| Pure function | d=4096, C=4096 | reduce-overhead | 0.96x (4% slower) |
+| FP16 | d=512, C=512 | reduce-overhead | 0.78x (22% slower) |
+
+## Why the Difference?
+
+### Full model benefits because:
+- Many operations can be fused (28 masked layers + attention + activations + norms)
+- More compute per kernel launch amortizes dispatch overhead
+- torch.compile can optimize the entire forward/backward graph
+
+### Isolated LinearComponents don't benefit because:
+- The operation `(x @ V * mask) @ U` is just 2 matmuls + 1 multiply
+- cuBLAS is already highly optimized for matmuls
+- No fusion opportunities between matmuls
+- Dispatch overhead exceeds any micro-optimization gains
+
+## Recommendations
+
+1. **Use torch.compile for full SPD training** with `mode="reduce-overhead"` or `mode="max-autotune"`
+2. **Use larger batch sizes** (64+) to maximize compile benefits
+3. **Don't bother compiling isolated components** - eager is faster or equivalent
+4. **Budget for warmup time** - first few steps are slow due to compilation (~24s for reduce-overhead, ~70s for max-autotune)
+
+## Reproduce
+
+```bash
+# Full model benchmark
+python scripts/benchmark_full_model.py --batch_size 64 --seq_len 256
+
+# Isolated LinearComponents benchmark
+python scripts/benchmark_linear_components.py components --C 512
+python scripts/benchmark_linear_components.py pure --d_in 512 --d_out 512 --C 512
+```
+
+## Hardware
+
+- GPU: NVIDIA (CUDA)
+- PyTorch with torch.compile (inductor backend)

--- a/scripts/benchmark_full_model.py
+++ b/scripts/benchmark_full_model.py
@@ -1,0 +1,209 @@
+"""Benchmark torch.compile on a full ComponentModel (e.g., SS Llama).
+
+Tests the masked forward/backward pass on a real model rather than isolated components.
+"""
+
+import time
+from pathlib import Path
+
+import fire
+import torch
+import torch.nn as nn
+from simple_stories_train.run_info import RunInfo as SSRunInfo
+from torch import Tensor
+
+from spd.configs import Config
+from spd.models.component_model import ComponentModel
+from spd.models.components import make_mask_infos
+from spd.utils.general_utils import resolve_class, set_seed
+from spd.utils.module_utils import expand_module_patterns
+
+torch.set_float32_matmul_precision("high")
+
+
+def load_model_and_config(
+    config_path: str = "spd/experiments/lm/ss_llama_simple_config.yaml",
+) -> tuple[nn.Module, Config]:
+    """Load the target model and config."""
+    config = Config.from_file(Path(config_path))
+
+    pretrained_model_class = resolve_class(config.pretrained_model_class)
+    assert config.pretrained_model_name is not None
+
+    if config.pretrained_model_class.startswith("simple_stories_train"):
+        run_info = SSRunInfo.from_path(config.pretrained_model_name)
+        target_model = pretrained_model_class.from_run_info(run_info)
+    else:
+        target_model = pretrained_model_class.from_pretrained(config.pretrained_model_name)
+
+    target_model.eval()
+    target_model.requires_grad_(False)
+
+    return target_model, config
+
+
+def benchmark_full_model(
+    config_path: str = "spd/experiments/lm/ss_llama_simple_config.yaml",
+    batch_size: int = 32,
+    seq_len: int = 256,
+    steps: int = 50,
+    warmup: int = 10,
+    compile_mode: str = "reduce-overhead",
+) -> None:
+    """Benchmark ComponentModel forward/backward with full model.
+
+    Args:
+        config_path: Path to experiment config
+        batch_size: Batch size
+        seq_len: Sequence length
+        steps: Number of benchmark steps
+        warmup: Number of warmup steps
+        compile_mode: torch.compile mode
+    """
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Device: {device}")
+    print(f"Config: {config_path}")
+    print(f"batch_size={batch_size}, seq_len={seq_len}")
+    print(f"Warmup: {warmup}, Steps: {steps}")
+    print(f"Compile mode: {compile_mode}")
+    print()
+
+    set_seed(42)
+
+    print("Loading model...")
+    target_model, config = load_model_and_config(config_path)
+    print(f"Model loaded: {type(target_model).__name__}")
+
+    results = {}
+
+    for use_compile in [False, True]:
+        mode_name = "compiled" if use_compile else "eager"
+        print(f"\n{'=' * 60}")
+        print(f"Running: {mode_name}")
+        print(f"{'=' * 60}")
+
+        # Reload target model fresh each time (ComponentModel modifies it)
+        target_model, config = load_model_and_config(config_path)
+
+        # Create fresh ComponentModel
+        module_path_info = expand_module_patterns(target_model, config.all_module_info)
+
+        model = ComponentModel(
+            target_model=target_model,
+            module_path_info=module_path_info,
+            ci_fn_type=config.ci_fn_type,
+            ci_fn_hidden_dims=config.ci_fn_hidden_dims,
+            pretrained_model_output_attr=config.pretrained_model_output_attr,
+            sigmoid_type=config.sigmoid_type,
+        )
+        model.to(device)
+
+        print(f"ComponentModel created with {len(model.target_module_paths)} modules:")
+        for path in model.target_module_paths[:5]:
+            print(f"  - {path} (C={model.module_to_c[path]})")
+        if len(model.target_module_paths) > 5:
+            print(f"  ... and {len(model.target_module_paths) - 5} more")
+
+        if use_compile:
+            mode = None if compile_mode == "default" else compile_mode
+            print(f"\nCompiling model (mode={mode})...")
+            compile_start = time.perf_counter()
+            model = torch.compile(model, fullgraph=False, mode=mode)  # type: ignore
+            print(f"torch.compile() call took {time.perf_counter() - compile_start:.2f}s")
+
+        component_model = model._orig_mod if use_compile else model  # type: ignore
+
+        # Setup optimizer
+        params = []
+        for name in component_model.target_module_paths:
+            params.extend(component_model.components[name].parameters())
+            params.extend(component_model.ci_fns[name].parameters())
+        optimizer = torch.optim.AdamW(params, lr=1e-4)
+
+        # Create sample mask
+        def create_masks() -> dict[str, Tensor]:
+            masks = {}
+            for name in component_model.target_module_paths:
+                C = component_model.module_to_c[name]
+                masks[name] = torch.rand(batch_size, seq_len, C, device=device)
+            return masks
+
+        # Warmup
+        print(f"\nWarming up ({warmup} steps)...")
+        warmup_start = time.perf_counter()
+        for i in range(warmup):
+            optimizer.zero_grad()
+
+            # Random token input
+            x = torch.randint(0, 1000, (batch_size, seq_len), device=device)
+            masks = create_masks()
+            mask_infos = make_mask_infos(masks)
+
+            # Forward pass with mask
+            out = model(x, mask_infos=mask_infos)  # type: ignore
+
+            # Simple loss
+            loss = out.mean()
+            loss.backward()
+            optimizer.step()
+
+            if (i + 1) % 5 == 0:
+                print(f"  Warmup step {i + 1}/{warmup}")
+
+        warmup_time = time.perf_counter() - warmup_start
+        print(f"Warmup took {warmup_time:.2f}s ({warmup_time / warmup * 1000:.1f}ms/step)")
+
+        # Benchmark
+        print(f"\nBenchmarking ({steps} steps)...")
+        if device == "cuda":
+            torch.cuda.synchronize()
+
+        step_times = []
+        for i in range(steps):
+            x = torch.randint(0, 1000, (batch_size, seq_len), device=device)
+            masks = create_masks()
+            mask_infos = make_mask_infos(masks)
+
+            if device == "cuda":
+                torch.cuda.synchronize()
+            step_start = time.perf_counter()
+
+            optimizer.zero_grad()
+            out = model(x, mask_infos=mask_infos)  # type: ignore
+            loss = out.mean()
+            loss.backward()
+            optimizer.step()
+
+            if device == "cuda":
+                torch.cuda.synchronize()
+            step_times.append(time.perf_counter() - step_start)
+
+        avg_time = sum(step_times) / len(step_times)
+        min_time = min(step_times)
+        max_time = max(step_times)
+
+        results[mode_name] = {"avg": avg_time, "min": min_time, "max": max_time}
+
+        print(f"\n{mode_name.upper()} Results:")
+        print(f"  Avg: {avg_time * 1000:.2f}ms")
+        print(f"  Min: {min_time * 1000:.2f}ms")
+        print(f"  Max: {max_time * 1000:.2f}ms")
+
+        del model, component_model, optimizer
+        if device == "cuda":
+            torch.cuda.empty_cache()
+
+    # Summary
+    print(f"\n{'=' * 60}")
+    print("SUMMARY")
+    print(f"{'=' * 60}")
+    eager_time = results["eager"]["avg"]
+    compiled_time = results["compiled"]["avg"]
+    speedup = eager_time / compiled_time
+    print(f"Eager:    {eager_time * 1000:.2f}ms")
+    print(f"Compiled: {compiled_time * 1000:.2f}ms")
+    print(f"Speedup:  {speedup:.2f}x ({(speedup - 1) * 100:.1f}%)")
+
+
+if __name__ == "__main__":
+    fire.Fire(benchmark_full_model)

--- a/scripts/benchmark_linear_components.py
+++ b/scripts/benchmark_linear_components.py
@@ -1,0 +1,727 @@
+"""Minimal benchmark for LinearComponents masked forward/backward pass.
+
+Tests torch.compile() efficiency on the core LinearComponents operation:
+  out = (x @ V * mask) @ U
+"""
+
+import time
+
+import fire
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+from spd.models.components import LinearComponents
+
+torch.set_float32_matmul_precision("high")
+
+
+def benchmark_linear_components(
+    d_in: int = 512,
+    d_out: int = 512,
+    C: int = 100,
+    batch_size: int = 64,
+    seq_len: int = 256,
+    steps: int = 200,
+    warmup: int = 50,
+    compile_mode: str = "default",
+) -> None:
+    """Benchmark LinearComponents masked forward and backward pass.
+
+    Args:
+        d_in: Input dimension
+        d_out: Output dimension
+        C: Number of components
+        batch_size: Batch size
+        seq_len: Sequence length
+        steps: Number of benchmark steps
+        warmup: Number of warmup steps
+        compile_mode: torch.compile mode (default, reduce-overhead, max-autotune)
+    """
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Device: {device}")
+    print(f"d_in={d_in}, d_out={d_out}, C={C}, batch_size={batch_size}, seq_len={seq_len}")
+    print(f"Warmup: {warmup}, Steps: {steps}")
+    print()
+
+    results = {}
+
+    for use_compile in [False, True]:
+        mode_name = "compiled" if use_compile else "eager"
+        print(f"{'=' * 60}")
+        print(f"Running: {mode_name}")
+        print(f"{'=' * 60}")
+
+        # Create LinearComponents
+        components = LinearComponents(C=C, d_in=d_in, d_out=d_out, bias=None)
+        components.to(device)
+
+        # Define the forward function we want to benchmark
+        def forward_backward(
+            x: Tensor, mask: Tensor, components: nn.Module, target: Tensor
+        ) -> Tensor:
+            out = components(x, mask=mask)
+            loss = (out - target).pow(2).mean()
+            return loss
+
+        if use_compile:
+            mode = None if compile_mode == "default" else compile_mode
+            print(f"Compiling (mode={mode})...")
+            compile_start = time.perf_counter()
+            forward_backward = torch.compile(forward_backward, fullgraph=True, mode=mode)
+            print(f"torch.compile() call took {time.perf_counter() - compile_start:.2f}s")
+
+        # Setup optimizer
+        optimizer = torch.optim.AdamW(components.parameters(), lr=1e-4)
+
+        # Warmup
+        print(f"Warming up ({warmup} steps)...")
+        for _ in range(warmup):
+            optimizer.zero_grad()
+            x = torch.randn(batch_size, seq_len, d_in, device=device)
+            mask = torch.rand(batch_size, seq_len, C, device=device)
+            target = torch.randn(batch_size, seq_len, d_out, device=device)
+
+            loss = forward_backward(x, mask, components, target)
+            loss.backward()
+            optimizer.step()
+
+        # Benchmark
+        print(f"Benchmarking ({steps} steps)...")
+        if device == "cuda":
+            torch.cuda.synchronize()
+
+        step_times = []
+        for _ in range(steps):
+            x = torch.randn(batch_size, seq_len, d_in, device=device)
+            mask = torch.rand(batch_size, seq_len, C, device=device)
+            target = torch.randn(batch_size, seq_len, d_out, device=device)
+
+            if device == "cuda":
+                torch.cuda.synchronize()
+            step_start = time.perf_counter()
+
+            optimizer.zero_grad()
+            loss = forward_backward(x, mask, components, target)
+            loss.backward()
+            optimizer.step()
+
+            if device == "cuda":
+                torch.cuda.synchronize()
+            step_times.append(time.perf_counter() - step_start)
+
+        avg_time = sum(step_times) / len(step_times)
+        min_time = min(step_times)
+        max_time = max(step_times)
+
+        results[mode_name] = {"avg": avg_time, "min": min_time, "max": max_time}
+
+        print(f"\n{mode_name.upper()} Results:")
+        print(f"  Avg: {avg_time * 1000:.3f}ms")
+        print(f"  Min: {min_time * 1000:.3f}ms")
+        print(f"  Max: {max_time * 1000:.3f}ms")
+        print()
+
+        del components, optimizer
+        if device == "cuda":
+            torch.cuda.empty_cache()
+
+    # Summary
+    print(f"{'=' * 60}")
+    print("SUMMARY")
+    print(f"{'=' * 60}")
+    eager_time = results["eager"]["avg"]
+    compiled_time = results["compiled"]["avg"]
+    speedup = eager_time / compiled_time
+    print(f"Eager:    {eager_time * 1000:.3f}ms")
+    print(f"Compiled: {compiled_time * 1000:.3f}ms")
+    print(f"Speedup:  {speedup:.2f}x ({(speedup - 1) * 100:.1f}%)")
+
+
+def benchmark_raw_einsum(
+    d_in: int = 512,
+    d_out: int = 512,
+    C: int = 100,
+    batch_size: int = 64,
+    seq_len: int = 256,
+    steps: int = 200,
+    warmup: int = 50,
+) -> None:
+    """Benchmark raw einsum operations (equivalent to LinearComponents) to isolate overhead.
+
+    The core operation is: out = (x @ V * mask) @ U
+    """
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Device: {device}")
+    print(f"d_in={d_in}, d_out={d_out}, C={C}, batch_size={batch_size}, seq_len={seq_len}")
+    print()
+    print("Testing RAW einsum: out = (x @ V * mask) @ U")
+    print()
+
+    results = {}
+
+    for use_compile in [False, True]:
+        mode_name = "compiled" if use_compile else "eager"
+        print(f"{'=' * 60}")
+        print(f"Running: {mode_name}")
+        print(f"{'=' * 60}")
+
+        # Create parameters directly
+        V = nn.Parameter(torch.randn(d_in, C, device=device) * 0.02)
+        U = nn.Parameter(torch.randn(C, d_out, device=device) * 0.02)
+
+        def forward_backward(x: Tensor, mask: Tensor, V: Tensor, U: Tensor, target: Tensor) -> Tensor:
+            inner = x @ V  # (batch, seq, C)
+            masked = inner * mask
+            out = masked @ U  # (batch, seq, d_out)
+            loss = (out - target).pow(2).mean()
+            return loss
+
+        if use_compile:
+            print("Compiling...")
+            compile_start = time.perf_counter()
+            forward_backward = torch.compile(forward_backward, fullgraph=True)
+            print(f"torch.compile() call took {time.perf_counter() - compile_start:.2f}s")
+
+        optimizer = torch.optim.AdamW([V, U], lr=1e-4)
+
+        # Warmup
+        print(f"Warming up ({warmup} steps)...")
+        for _ in range(warmup):
+            optimizer.zero_grad()
+            x = torch.randn(batch_size, seq_len, d_in, device=device)
+            mask = torch.rand(batch_size, seq_len, C, device=device)
+            target = torch.randn(batch_size, seq_len, d_out, device=device)
+
+            loss = forward_backward(x, mask, V, U, target)
+            loss.backward()
+            optimizer.step()
+
+        # Benchmark
+        print(f"Benchmarking ({steps} steps)...")
+        if device == "cuda":
+            torch.cuda.synchronize()
+
+        step_times = []
+        for _ in range(steps):
+            x = torch.randn(batch_size, seq_len, d_in, device=device)
+            mask = torch.rand(batch_size, seq_len, C, device=device)
+            target = torch.randn(batch_size, seq_len, d_out, device=device)
+
+            if device == "cuda":
+                torch.cuda.synchronize()
+            step_start = time.perf_counter()
+
+            optimizer.zero_grad()
+            loss = forward_backward(x, mask, V, U, target)
+            loss.backward()
+            optimizer.step()
+
+            if device == "cuda":
+                torch.cuda.synchronize()
+            step_times.append(time.perf_counter() - step_start)
+
+        avg_time = sum(step_times) / len(step_times)
+        results[mode_name] = {"avg": avg_time}
+
+        print(f"{mode_name.upper()}: {avg_time * 1000:.3f}ms")
+        print()
+
+        del V, U, optimizer
+        if device == "cuda":
+            torch.cuda.empty_cache()
+
+    speedup = results["eager"]["avg"] / results["compiled"]["avg"]
+    print(f"Speedup: {speedup:.2f}x ({(speedup - 1) * 100:.1f}%)")
+
+
+def benchmark_no_mask(
+    d_in: int = 512,
+    d_out: int = 512,
+    C: int = 100,
+    batch_size: int = 64,
+    seq_len: int = 256,
+    steps: int = 200,
+    warmup: int = 50,
+) -> None:
+    """Benchmark LinearComponents WITHOUT mask to see if masking is the bottleneck."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Device: {device}")
+    print(f"d_in={d_in}, d_out={d_out}, C={C}, batch_size={batch_size}, seq_len={seq_len}")
+    print()
+    print("Testing LinearComponents WITHOUT mask")
+    print()
+
+    results = {}
+
+    for use_compile in [False, True]:
+        mode_name = "compiled" if use_compile else "eager"
+        print(f"{'=' * 60}")
+        print(f"Running: {mode_name}")
+        print(f"{'=' * 60}")
+
+        components = LinearComponents(C=C, d_in=d_in, d_out=d_out, bias=None)
+        components.to(device)
+
+        def forward_backward(x: Tensor, components: nn.Module, target: Tensor) -> Tensor:
+            out = components(x, mask=None)
+            loss = (out - target).pow(2).mean()
+            return loss
+
+        if use_compile:
+            print("Compiling...")
+            compile_start = time.perf_counter()
+            forward_backward = torch.compile(forward_backward, fullgraph=True)
+            print(f"torch.compile() call took {time.perf_counter() - compile_start:.2f}s")
+
+        optimizer = torch.optim.AdamW(components.parameters(), lr=1e-4)
+
+        # Warmup
+        print(f"Warming up ({warmup} steps)...")
+        for _ in range(warmup):
+            optimizer.zero_grad()
+            x = torch.randn(batch_size, seq_len, d_in, device=device)
+            target = torch.randn(batch_size, seq_len, d_out, device=device)
+
+            loss = forward_backward(x, components, target)
+            loss.backward()
+            optimizer.step()
+
+        # Benchmark
+        print(f"Benchmarking ({steps} steps)...")
+        if device == "cuda":
+            torch.cuda.synchronize()
+
+        step_times = []
+        for _ in range(steps):
+            x = torch.randn(batch_size, seq_len, d_in, device=device)
+            target = torch.randn(batch_size, seq_len, d_out, device=device)
+
+            if device == "cuda":
+                torch.cuda.synchronize()
+            step_start = time.perf_counter()
+
+            optimizer.zero_grad()
+            loss = forward_backward(x, components, target)
+            loss.backward()
+            optimizer.step()
+
+            if device == "cuda":
+                torch.cuda.synchronize()
+            step_times.append(time.perf_counter() - step_start)
+
+        avg_time = sum(step_times) / len(step_times)
+        results[mode_name] = {"avg": avg_time}
+
+        print(f"{mode_name.upper()}: {avg_time * 1000:.3f}ms")
+        print()
+
+        del components, optimizer
+        if device == "cuda":
+            torch.cuda.empty_cache()
+
+    speedup = results["eager"]["avg"] / results["compiled"]["avg"]
+    print(f"Speedup: {speedup:.2f}x ({(speedup - 1) * 100:.1f}%)")
+
+
+def benchmark_forward_only(
+    d_in: int = 512,
+    d_out: int = 512,
+    C: int = 100,
+    batch_size: int = 64,
+    seq_len: int = 256,
+    steps: int = 500,
+    warmup: int = 100,
+    compile_mode: str = "default",
+) -> None:
+    """Benchmark LinearComponents forward pass only (no backward)."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Device: {device}")
+    print(f"d_in={d_in}, d_out={d_out}, C={C}, batch_size={batch_size}, seq_len={seq_len}")
+    print(f"Compile mode: {compile_mode}")
+    print()
+    print("Testing FORWARD ONLY (no backward)")
+    print()
+
+    results = {}
+
+    for use_compile in [False, True]:
+        mode_name = "compiled" if use_compile else "eager"
+        print(f"{'=' * 60}")
+        print(f"Running: {mode_name}")
+        print(f"{'=' * 60}")
+
+        components = LinearComponents(C=C, d_in=d_in, d_out=d_out, bias=None)
+        components.to(device)
+
+        def forward_fn(x: Tensor, mask: Tensor, components: nn.Module) -> Tensor:
+            return components(x, mask=mask)
+
+        if use_compile:
+            mode = None if compile_mode == "default" else compile_mode
+            print(f"Compiling (mode={mode})...")
+            compile_start = time.perf_counter()
+            forward_fn = torch.compile(forward_fn, fullgraph=True, mode=mode)
+            print(f"torch.compile() call took {time.perf_counter() - compile_start:.2f}s")
+
+        # Fixed mask for fair comparison
+        mask = torch.rand(batch_size, seq_len, C, device=device)
+
+        # Warmup
+        print(f"Warming up ({warmup} steps)...")
+        with torch.no_grad():
+            for _ in range(warmup):
+                x = torch.randn(batch_size, seq_len, d_in, device=device)
+                _ = forward_fn(x, mask, components)
+
+        # Benchmark
+        print(f"Benchmarking ({steps} steps)...")
+        if device == "cuda":
+            torch.cuda.synchronize()
+
+        step_times = []
+        with torch.no_grad():
+            for _ in range(steps):
+                x = torch.randn(batch_size, seq_len, d_in, device=device)
+
+                if device == "cuda":
+                    torch.cuda.synchronize()
+                step_start = time.perf_counter()
+
+                _ = forward_fn(x, mask, components)
+
+                if device == "cuda":
+                    torch.cuda.synchronize()
+                step_times.append(time.perf_counter() - step_start)
+
+        avg_time = sum(step_times) / len(step_times)
+        results[mode_name] = {"avg": avg_time}
+
+        print(f"{mode_name.upper()}: {avg_time * 1000:.3f}ms")
+        print()
+
+        del components
+        if device == "cuda":
+            torch.cuda.empty_cache()
+
+    speedup = results["eager"]["avg"] / results["compiled"]["avg"]
+    print(f"Speedup: {speedup:.2f}x ({(speedup - 1) * 100:.1f}%)")
+
+
+class MaskedLinearComponents(nn.Module):
+    """Wrapper that stores mask as a module property for simpler forward signature."""
+
+    def __init__(self, C: int, d_in: int, d_out: int):
+        super().__init__()
+        self.components = LinearComponents(C=C, d_in=d_in, d_out=d_out, bias=None)
+        self.mask: Tensor | None = None
+
+    def set_mask(self, mask: Tensor) -> None:
+        self.mask = mask
+
+    def forward(self, x: Tensor) -> Tensor:
+        return self.components(x, mask=self.mask)
+
+
+def benchmark_module_compile(
+    d_in: int = 512,
+    d_out: int = 512,
+    C: int = 512,
+    batch_size: int = 64,
+    seq_len: int = 256,
+    steps: int = 200,
+    warmup: int = 50,
+    compile_mode: str = "reduce-overhead",
+) -> None:
+    """Benchmark compiling the module directly instead of a function wrapper."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Device: {device}")
+    print(f"d_in={d_in}, d_out={d_out}, C={C}, batch_size={batch_size}, seq_len={seq_len}")
+    print(f"Compile mode: {compile_mode}")
+    print()
+    print("Testing MODULE compile (mask as property)")
+    print()
+
+    results = {}
+
+    for use_compile in [False, True]:
+        mode_name = "compiled" if use_compile else "eager"
+        print(f"{'=' * 60}")
+        print(f"Running: {mode_name}")
+        print(f"{'=' * 60}")
+
+        model = MaskedLinearComponents(C=C, d_in=d_in, d_out=d_out)
+        model.to(device)
+
+        if use_compile:
+            mode = None if compile_mode == "default" else compile_mode
+            print(f"Compiling module (mode={mode})...")
+            compile_start = time.perf_counter()
+            model = torch.compile(model, fullgraph=True, mode=mode)  # type: ignore
+            print(f"torch.compile() call took {time.perf_counter() - compile_start:.2f}s")
+
+        base_model = model._orig_mod if use_compile else model  # type: ignore
+        optimizer = torch.optim.AdamW(base_model.components.parameters(), lr=1e-4)
+
+        # Warmup with fixed mask
+        print(f"Warming up ({warmup} steps)...")
+        warmup_mask = torch.rand(batch_size, seq_len, C, device=device)
+        base_model.set_mask(warmup_mask)
+        for _ in range(warmup):
+            optimizer.zero_grad()
+            x = torch.randn(batch_size, seq_len, d_in, device=device)
+            target = torch.randn(batch_size, seq_len, d_out, device=device)
+
+            out = model(x)
+            loss = (out - target).pow(2).mean()
+            loss.backward()
+            optimizer.step()
+
+        # Benchmark with FIXED mask (no recompilation)
+        print(f"Benchmarking ({steps} steps) with FIXED mask...")
+        if device == "cuda":
+            torch.cuda.synchronize()
+
+        fixed_mask = torch.rand(batch_size, seq_len, C, device=device)
+        base_model.set_mask(fixed_mask)
+
+        step_times = []
+        for _ in range(steps):
+            x = torch.randn(batch_size, seq_len, d_in, device=device)
+            target = torch.randn(batch_size, seq_len, d_out, device=device)
+
+            if device == "cuda":
+                torch.cuda.synchronize()
+            step_start = time.perf_counter()
+
+            optimizer.zero_grad()
+            out = model(x)
+            loss = (out - target).pow(2).mean()
+            loss.backward()
+            optimizer.step()
+
+            if device == "cuda":
+                torch.cuda.synchronize()
+            step_times.append(time.perf_counter() - step_start)
+
+        avg_time = sum(step_times) / len(step_times)
+        results[mode_name] = {"avg": avg_time}
+
+        print(f"{mode_name.upper()}: {avg_time * 1000:.3f}ms")
+        print()
+
+        del model, base_model, optimizer
+        if device == "cuda":
+            torch.cuda.empty_cache()
+
+    speedup = results["eager"]["avg"] / results["compiled"]["avg"]
+    print(f"Speedup: {speedup:.2f}x ({(speedup - 1) * 100:.1f}%)")
+
+
+def benchmark_pure_function(
+    d_in: int = 512,
+    d_out: int = 512,
+    C: int = 512,
+    batch_size: int = 64,
+    seq_len: int = 256,
+    steps: int = 200,
+    warmup: int = 50,
+    compile_mode: str = "reduce-overhead",
+) -> None:
+    """Benchmark a pure function (no module state) with explicit parameters."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Device: {device}")
+    print(f"d_in={d_in}, d_out={d_out}, C={C}, batch_size={batch_size}, seq_len={seq_len}")
+    print(f"Compile mode: {compile_mode}")
+    print()
+    print("Testing PURE FUNCTION: out = (x @ V * mask) @ U")
+    print()
+
+    def masked_linear(x: Tensor, V: Tensor, U: Tensor, mask: Tensor) -> Tensor:
+        """Pure function: (x @ V * mask) @ U"""
+        inner = x @ V
+        masked = inner * mask
+        return masked @ U
+
+    results = {}
+
+    for use_compile in [False, True]:
+        mode_name = "compiled" if use_compile else "eager"
+        print(f"{'=' * 60}")
+        print(f"Running: {mode_name}")
+        print(f"{'=' * 60}")
+
+        V = nn.Parameter(torch.randn(d_in, C, device=device) * 0.02)
+        U = nn.Parameter(torch.randn(C, d_out, device=device) * 0.02)
+
+        fn = masked_linear
+        if use_compile:
+            mode = None if compile_mode == "default" else compile_mode
+            print(f"Compiling (mode={mode})...")
+            compile_start = time.perf_counter()
+            fn = torch.compile(masked_linear, fullgraph=True, mode=mode)
+            print(f"torch.compile() call took {time.perf_counter() - compile_start:.2f}s")
+
+        optimizer = torch.optim.AdamW([V, U], lr=1e-4)
+
+        # Warmup
+        print(f"Warming up ({warmup} steps)...")
+        for _ in range(warmup):
+            optimizer.zero_grad()
+            x = torch.randn(batch_size, seq_len, d_in, device=device)
+            mask = torch.rand(batch_size, seq_len, C, device=device)
+            target = torch.randn(batch_size, seq_len, d_out, device=device)
+
+            out = fn(x, V, U, mask)
+            loss = (out - target).pow(2).mean()
+            loss.backward()
+            optimizer.step()
+
+        # Benchmark
+        print(f"Benchmarking ({steps} steps)...")
+        if device == "cuda":
+            torch.cuda.synchronize()
+
+        step_times = []
+        for _ in range(steps):
+            x = torch.randn(batch_size, seq_len, d_in, device=device)
+            mask = torch.rand(batch_size, seq_len, C, device=device)
+            target = torch.randn(batch_size, seq_len, d_out, device=device)
+
+            if device == "cuda":
+                torch.cuda.synchronize()
+            step_start = time.perf_counter()
+
+            optimizer.zero_grad()
+            out = fn(x, V, U, mask)
+            loss = (out - target).pow(2).mean()
+            loss.backward()
+            optimizer.step()
+
+            if device == "cuda":
+                torch.cuda.synchronize()
+            step_times.append(time.perf_counter() - step_start)
+
+        avg_time = sum(step_times) / len(step_times)
+        results[mode_name] = {"avg": avg_time}
+
+        print(f"{mode_name.upper()}: {avg_time * 1000:.3f}ms")
+        print()
+
+        del V, U, optimizer
+        if device == "cuda":
+            torch.cuda.empty_cache()
+
+    speedup = results["eager"]["avg"] / results["compiled"]["avg"]
+    print(f"Speedup: {speedup:.2f}x ({(speedup - 1) * 100:.1f}%)")
+
+
+def benchmark_fp16(
+    d_in: int = 512,
+    d_out: int = 512,
+    C: int = 512,
+    batch_size: int = 64,
+    seq_len: int = 256,
+    steps: int = 200,
+    warmup: int = 50,
+    compile_mode: str = "reduce-overhead",
+) -> None:
+    """Benchmark with fp16 to see if tensor cores + compile helps."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Device: {device}")
+    print(f"d_in={d_in}, d_out={d_out}, C={C}, batch_size={batch_size}, seq_len={seq_len}")
+    print(f"Compile mode: {compile_mode}")
+    print()
+    print("Testing FP16: out = (x @ V * mask) @ U")
+    print()
+
+    def masked_linear(x: Tensor, V: Tensor, U: Tensor, mask: Tensor) -> Tensor:
+        inner = x @ V
+        masked = inner * mask
+        return masked @ U
+
+    results = {}
+
+    for use_compile in [False, True]:
+        mode_name = "compiled" if use_compile else "eager"
+        print(f"{'=' * 60}")
+        print(f"Running: {mode_name}")
+        print(f"{'=' * 60}")
+
+        V = nn.Parameter(torch.randn(d_in, C, device=device, dtype=torch.float16) * 0.02)
+        U = nn.Parameter(torch.randn(C, d_out, device=device, dtype=torch.float16) * 0.02)
+
+        fn = masked_linear
+        if use_compile:
+            mode = None if compile_mode == "default" else compile_mode
+            print(f"Compiling (mode={mode})...")
+            compile_start = time.perf_counter()
+            fn = torch.compile(masked_linear, fullgraph=True, mode=mode)
+            print(f"torch.compile() call took {time.perf_counter() - compile_start:.2f}s")
+
+        optimizer = torch.optim.AdamW([V, U], lr=1e-4)
+
+        # Warmup
+        print(f"Warming up ({warmup} steps)...")
+        for _ in range(warmup):
+            optimizer.zero_grad()
+            x = torch.randn(batch_size, seq_len, d_in, device=device, dtype=torch.float16)
+            mask = torch.rand(batch_size, seq_len, C, device=device, dtype=torch.float16)
+            target = torch.randn(batch_size, seq_len, d_out, device=device, dtype=torch.float16)
+
+            out = fn(x, V, U, mask)
+            loss = (out - target).pow(2).mean()
+            loss.backward()
+            optimizer.step()
+
+        # Benchmark
+        print(f"Benchmarking ({steps} steps)...")
+        if device == "cuda":
+            torch.cuda.synchronize()
+
+        step_times = []
+        for _ in range(steps):
+            x = torch.randn(batch_size, seq_len, d_in, device=device, dtype=torch.float16)
+            mask = torch.rand(batch_size, seq_len, C, device=device, dtype=torch.float16)
+            target = torch.randn(batch_size, seq_len, d_out, device=device, dtype=torch.float16)
+
+            if device == "cuda":
+                torch.cuda.synchronize()
+            step_start = time.perf_counter()
+
+            optimizer.zero_grad()
+            out = fn(x, V, U, mask)
+            loss = (out - target).pow(2).mean()
+            loss.backward()
+            optimizer.step()
+
+            if device == "cuda":
+                torch.cuda.synchronize()
+            step_times.append(time.perf_counter() - step_start)
+
+        avg_time = sum(step_times) / len(step_times)
+        results[mode_name] = {"avg": avg_time}
+
+        print(f"{mode_name.upper()}: {avg_time * 1000:.3f}ms")
+        print()
+
+        del V, U, optimizer
+        if device == "cuda":
+            torch.cuda.empty_cache()
+
+    speedup = results["eager"]["avg"] / results["compiled"]["avg"]
+    print(f"Speedup: {speedup:.2f}x ({(speedup - 1) * 100:.1f}%)")
+
+
+if __name__ == "__main__":
+    fire.Fire(
+        {
+            "components": benchmark_linear_components,
+            "einsum": benchmark_raw_einsum,
+            "no_mask": benchmark_no_mask,
+            "forward": benchmark_forward_only,
+            "module": benchmark_module_compile,
+            "pure": benchmark_pure_function,
+            "fp16": benchmark_fp16,
+        }
+    )

--- a/scripts/benchmark_toy.py
+++ b/scripts/benchmark_toy.py
@@ -1,0 +1,457 @@
+"""Minimal toy benchmark to isolate torch.compile() performance.
+
+This tests a single linear layer with component decomposition to understand
+why torch.compile() isn't providing more speedup.
+"""
+
+import time
+from typing import override
+
+import fire
+import torch
+import torch.nn as nn
+from torch import Tensor
+
+from spd.models.component_model import ComponentModel
+from spd.models.components import ComponentsMaskInfo, make_mask_infos
+from spd.utils.module_utils import ModulePathInfo
+
+torch.set_float32_matmul_precision("high")
+
+
+class ToyModel(nn.Module):
+    """Simple model with a single linear layer."""
+
+    def __init__(self, d_in: int, d_out: int):
+        super().__init__()
+        self.linear = nn.Linear(d_in, d_out, bias=False)
+
+    @override
+    def forward(self, x: Tensor) -> Tensor:
+        return self.linear(x)
+
+
+def benchmark_toy(
+    d_in: int = 512,
+    d_out: int = 512,
+    C: int = 100,
+    batch_size: int = 64,
+    seq_len: int = 256,
+    steps: int = 100,
+    warmup: int = 20,
+) -> None:
+    """Benchmark a toy model with component decomposition.
+
+    Args:
+        d_in: Input dimension
+        d_out: Output dimension
+        C: Number of components
+        batch_size: Batch size
+        seq_len: Sequence length
+        steps: Number of benchmark steps
+        warmup: Number of warmup steps
+    """
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Device: {device}")
+    print(f"d_in={d_in}, d_out={d_out}, C={C}, batch_size={batch_size}, seq_len={seq_len}")
+    print(f"Warmup: {warmup}, Steps: {steps}")
+    print()
+
+    results = {}
+
+    for use_compile in [False, True]:
+        mode_name = "compiled" if use_compile else "eager"
+        print(f"{'=' * 60}")
+        print(f"Running: {mode_name}")
+        print(f"{'=' * 60}")
+
+        # Create fresh model
+        target_model = ToyModel(d_in, d_out)
+        target_model.eval()
+        target_model.requires_grad_(False)
+
+        model = ComponentModel(
+            target_model=target_model,
+            module_path_info=[ModulePathInfo(module_path="linear", C=C)],
+            ci_fn_type="mlp",
+            ci_fn_hidden_dims=[32],
+            pretrained_model_output_attr=None,
+            sigmoid_type="leaky_hard",
+        )
+        model.to(device)
+
+        if use_compile:
+            print("Compiling model...")
+            compile_start = time.perf_counter()
+            model = torch.compile(model, fullgraph=False)  # type: ignore
+            print(f"torch.compile() call took {time.perf_counter() - compile_start:.2f}s")
+
+        component_model = model._orig_mod if use_compile else model  # type: ignore
+
+        # Setup optimizer
+        params = list(component_model.components["linear"].parameters())
+        params += list(component_model.ci_fns["linear"].parameters())
+        optimizer = torch.optim.AdamW(params, lr=1e-4)
+
+        # Warmup
+        print(f"Warming up ({warmup} steps)...")
+        warmup_start = time.perf_counter()
+        for _ in range(warmup):
+            optimizer.zero_grad()
+
+            # Random input
+            x = torch.randn(batch_size, seq_len, d_in, device=device)
+
+            # Forward with caching
+            out, cache = model(x, cache_type="input")  # type: ignore
+
+            # Calculate CI
+            ci = component_model.calc_causal_importances(
+                pre_weight_acts=cache,
+                detach_inputs=False,
+                sampling="continuous",
+            )
+
+            # Create binary mask from CI
+            mask = (ci.lower_leaky["linear"] > 0.5).float()
+            mask_infos = make_mask_infos({"linear": mask})
+
+            # Forward with mask
+            masked_out = model(x, mask_infos=mask_infos)  # type: ignore
+
+            # Simple MSE loss
+            loss = (masked_out - out.detach()).pow(2).mean()
+            loss.backward()
+            optimizer.step()
+
+        warmup_time = time.perf_counter() - warmup_start
+        print(f"Warmup took {warmup_time:.2f}s ({warmup_time / warmup * 1000:.1f}ms/step)")
+
+        # Benchmark
+        print(f"Benchmarking ({steps} steps)...")
+        torch.cuda.synchronize() if device == "cuda" else None
+
+        step_times = []
+        for _ in range(steps):
+            step_start = time.perf_counter()
+
+            optimizer.zero_grad()
+            x = torch.randn(batch_size, seq_len, d_in, device=device)
+
+            out, cache = model(x, cache_type="input")  # type: ignore
+
+            ci = component_model.calc_causal_importances(
+                pre_weight_acts=cache,
+                detach_inputs=False,
+                sampling="continuous",
+            )
+
+            mask = (ci.lower_leaky["linear"] > 0.5).float()
+            mask_infos = make_mask_infos({"linear": mask})
+
+            masked_out = model(x, mask_infos=mask_infos)  # type: ignore
+
+            loss = (masked_out - out.detach()).pow(2).mean()
+            loss.backward()
+            optimizer.step()
+
+            if device == "cuda":
+                torch.cuda.synchronize()
+            step_times.append(time.perf_counter() - step_start)
+
+        avg_time = sum(step_times) / len(step_times)
+        min_time = min(step_times)
+        max_time = max(step_times)
+
+        results[mode_name] = {
+            "avg": avg_time,
+            "min": min_time,
+            "max": max_time,
+        }
+
+        print(f"\n{mode_name.upper()} Results:")
+        print(f"  Avg: {avg_time * 1000:.2f}ms")
+        print(f"  Min: {min_time * 1000:.2f}ms")
+        print(f"  Max: {max_time * 1000:.2f}ms")
+        print()
+
+        del model, component_model, optimizer
+        torch.cuda.empty_cache() if device == "cuda" else None
+
+    # Summary
+    print(f"{'=' * 60}")
+    print("SUMMARY")
+    print(f"{'=' * 60}")
+    eager_time = results["eager"]["avg"]
+    compiled_time = results["compiled"]["avg"]
+    speedup = eager_time / compiled_time
+    print(f"Eager:    {eager_time * 1000:.2f}ms")
+    print(f"Compiled: {compiled_time * 1000:.2f}ms")
+    print(f"Speedup:  {speedup:.2f}x ({(speedup - 1) * 100:.1f}%)")
+
+
+def benchmark_raw_linear(
+    d_in: int = 512,
+    d_out: int = 512,
+    batch_size: int = 64,
+    seq_len: int = 256,
+    steps: int = 100,
+    warmup: int = 20,
+) -> None:
+    """Benchmark a raw linear layer (no SPD) to establish baseline."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Device: {device}")
+    print(f"d_in={d_in}, d_out={d_out}, batch_size={batch_size}, seq_len={seq_len}")
+    print(f"Warmup: {warmup}, Steps: {steps}")
+    print()
+    print("This tests a RAW linear layer without SPD to establish baseline.")
+    print()
+
+    results = {}
+
+    for use_compile in [False, True]:
+        mode_name = "compiled" if use_compile else "eager"
+        print(f"{'=' * 60}")
+        print(f"Running: {mode_name}")
+        print(f"{'=' * 60}")
+
+        model = nn.Linear(d_in, d_out, bias=False).to(device)
+
+        if use_compile:
+            print("Compiling model...")
+            model = torch.compile(model, fullgraph=False)  # type: ignore
+
+        optimizer = torch.optim.AdamW(model.parameters(), lr=1e-4)
+
+        # Warmup
+        print(f"Warming up ({warmup} steps)...")
+        for _ in range(warmup):
+            optimizer.zero_grad()
+            x = torch.randn(batch_size, seq_len, d_in, device=device)
+            out = model(x)
+            loss = out.pow(2).mean()
+            loss.backward()
+            optimizer.step()
+
+        # Benchmark
+        print(f"Benchmarking ({steps} steps)...")
+        torch.cuda.synchronize() if device == "cuda" else None
+
+        step_times = []
+        for _ in range(steps):
+            step_start = time.perf_counter()
+
+            optimizer.zero_grad()
+            x = torch.randn(batch_size, seq_len, d_in, device=device)
+            out = model(x)
+            loss = out.pow(2).mean()
+            loss.backward()
+            optimizer.step()
+
+            if device == "cuda":
+                torch.cuda.synchronize()
+            step_times.append(time.perf_counter() - step_start)
+
+        avg_time = sum(step_times) / len(step_times)
+        results[mode_name] = {"avg": avg_time}
+
+        print(f"{mode_name.upper()}: {avg_time * 1000:.2f}ms")
+        print()
+
+        del model, optimizer
+        torch.cuda.empty_cache() if device == "cuda" else None
+
+    speedup = results["eager"]["avg"] / results["compiled"]["avg"]
+    print(f"Speedup: {speedup:.2f}x ({(speedup - 1) * 100:.1f}%)")
+
+
+def benchmark_forward_only(
+    d_in: int = 512,
+    d_out: int = 512,
+    C: int = 100,
+    batch_size: int = 64,
+    seq_len: int = 256,
+    steps: int = 200,
+    warmup: int = 50,
+) -> None:
+    """Benchmark just the forward pass (no backward) to isolate compilation benefit."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Device: {device}")
+    print(f"d_in={d_in}, d_out={d_out}, C={C}, batch_size={batch_size}, seq_len={seq_len}")
+    print(f"Warmup: {warmup}, Steps: {steps}")
+    print()
+    print("Testing FORWARD ONLY (no backward)")
+    print()
+
+    results = {}
+
+    for use_compile in [False, True]:
+        mode_name = "compiled" if use_compile else "eager"
+        print(f"{'=' * 60}")
+        print(f"Running: {mode_name}")
+        print(f"{'=' * 60}")
+
+        # Create fresh model
+        target_model = ToyModel(d_in, d_out)
+        target_model.eval()
+        target_model.requires_grad_(False)
+
+        model = ComponentModel(
+            target_model=target_model,
+            module_path_info=[ModulePathInfo(module_path="linear", C=C)],
+            ci_fn_type="mlp",
+            ci_fn_hidden_dims=[32],
+            pretrained_model_output_attr=None,
+            sigmoid_type="leaky_hard",
+        )
+        model.to(device)
+
+        if use_compile:
+            print("Compiling model...")
+            compile_start = time.perf_counter()
+            model = torch.compile(model, fullgraph=False)  # type: ignore
+            print(f"torch.compile() call took {time.perf_counter() - compile_start:.2f}s")
+
+        # Prepare fixed mask
+        mask = torch.ones(batch_size, seq_len, C, device=device)
+        mask_infos = make_mask_infos({"linear": mask})
+
+        # Warmup
+        print(f"Warming up ({warmup} steps)...")
+        with torch.no_grad():
+            for _ in range(warmup):
+                x = torch.randn(batch_size, seq_len, d_in, device=device)
+                _ = model(x, mask_infos=mask_infos)  # type: ignore
+
+        # Benchmark
+        print(f"Benchmarking ({steps} steps)...")
+        torch.cuda.synchronize() if device == "cuda" else None
+
+        step_times = []
+        with torch.no_grad():
+            for _ in range(steps):
+                x = torch.randn(batch_size, seq_len, d_in, device=device)
+
+                torch.cuda.synchronize() if device == "cuda" else None
+                step_start = time.perf_counter()
+
+                _ = model(x, mask_infos=mask_infos)  # type: ignore
+
+                torch.cuda.synchronize() if device == "cuda" else None
+                step_times.append(time.perf_counter() - step_start)
+
+        avg_time = sum(step_times) / len(step_times)
+        results[mode_name] = {"avg": avg_time}
+
+        print(f"{mode_name.upper()}: {avg_time * 1000:.3f}ms")
+        print()
+
+        del model
+        torch.cuda.empty_cache() if device == "cuda" else None
+
+    speedup = results["eager"]["avg"] / results["compiled"]["avg"]
+    print(f"Speedup: {speedup:.2f}x ({(speedup - 1) * 100:.1f}%)")
+
+
+def benchmark_masked_module_direct(
+    d_in: int = 512,
+    d_out: int = 512,
+    C: int = 100,
+    batch_size: int = 64,
+    seq_len: int = 256,
+    steps: int = 200,
+    warmup: int = 50,
+) -> None:
+    """Benchmark MaskedModule directly to isolate its performance."""
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+    print(f"Device: {device}")
+    print(f"d_in={d_in}, d_out={d_out}, C={C}, batch_size={batch_size}, seq_len={seq_len}")
+    print()
+    print("Testing MaskedModule.forward() DIRECTLY")
+    print()
+
+    from spd.models.components import LinearComponents
+    from spd.models.masked_module import MaskedModule
+
+    results = {}
+
+    for use_compile in [False, True]:
+        mode_name = "compiled" if use_compile else "eager"
+        print(f"{'=' * 60}")
+        print(f"Running: {mode_name}")
+        print(f"{'=' * 60}")
+
+        # Create MaskedModule directly
+        base = nn.Linear(d_in, d_out, bias=False)
+        base.requires_grad_(False)
+        components = LinearComponents(C=C, d_in=d_in, d_out=d_out, bias=None)
+
+        masked_module = MaskedModule(
+            module_name="test",
+            base=base,
+            components=components,
+        )
+        masked_module.to(device)
+
+        # Set up state for active forward
+        mask = torch.ones(batch_size, seq_len, C, device=device)
+        mask_info = ComponentsMaskInfo(component_mask=mask)
+        masked_module.set_runtime_state(
+            active=True,
+            mask_info=mask_info,
+            cache_type="none",
+            cache=None,
+        )
+
+        if use_compile:
+            print("Compiling MaskedModule...")
+            compile_start = time.perf_counter()
+            masked_module = torch.compile(masked_module, fullgraph=False)  # type: ignore
+            print(f"torch.compile() call took {time.perf_counter() - compile_start:.2f}s")
+
+        # Warmup
+        print(f"Warming up ({warmup} steps)...")
+        with torch.no_grad():
+            for _ in range(warmup):
+                x = torch.randn(batch_size, seq_len, d_in, device=device)
+                _ = masked_module(x)
+
+        # Benchmark
+        print(f"Benchmarking ({steps} steps)...")
+        torch.cuda.synchronize() if device == "cuda" else None
+
+        step_times = []
+        with torch.no_grad():
+            for _ in range(steps):
+                x = torch.randn(batch_size, seq_len, d_in, device=device)
+
+                torch.cuda.synchronize() if device == "cuda" else None
+                step_start = time.perf_counter()
+
+                _ = masked_module(x)
+
+                torch.cuda.synchronize() if device == "cuda" else None
+                step_times.append(time.perf_counter() - step_start)
+
+        avg_time = sum(step_times) / len(step_times)
+        results[mode_name] = {"avg": avg_time}
+
+        print(f"{mode_name.upper()}: {avg_time * 1000:.3f}ms")
+        print()
+
+        del masked_module
+        torch.cuda.empty_cache() if device == "cuda" else None
+
+    speedup = results["eager"]["avg"] / results["compiled"]["avg"]
+    print(f"Speedup: {speedup:.2f}x ({(speedup - 1) * 100:.1f}%)")
+
+
+if __name__ == "__main__":
+    fire.Fire(
+        {
+            "toy": benchmark_toy,
+            "raw": benchmark_raw_linear,
+            "forward": benchmark_forward_only,
+            "masked": benchmark_masked_module_direct,
+        }
+    )

--- a/spd/configs.py
+++ b/spd/configs.py
@@ -404,6 +404,11 @@ class Config(BaseConfig):
         default="leaky_hard",
         description="Type of sigmoid to use for causal importance calculation",
     )
+    torch_compile: bool = Field(
+        default=False,
+        description="Whether to use torch.compile() for the forward pass. "
+        "Can provide speedups but may increase compilation time on first steps.",
+    )
     module_info: list[ModulePatternInfoConfig] = Field(
         ...,
         description="List of module patterns with C values specifying which modules to decompose. "

--- a/spd/models/masked_module.py
+++ b/spd/models/masked_module.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from typing import Literal, override
+
+import torch
+from jaxtyping import Bool, Float
+from torch import Tensor, nn
+
+from spd.models.components import Components, ComponentsMaskInfo
+
+
+class MaskedModule(nn.Module):
+    """Wraps a frozen base module with trainable SPD Components, without forward hooks.
+
+    This module is designed to replace an `nn.Linear` / `nn.Embedding` / `Conv1D` / `Identity` leaf
+    module inside an arbitrary PyTorch model.
+
+    Why this design (vs forward hooks):
+        The previous hook-based approach used `register_forward_hook()` with dynamic
+        registration/removal via context managers. This was incompatible with `torch.compile()`
+        because dynamic hook management breaks graph tracing. This module-patching approach
+        keeps the module structure static, making it compatible with compilation.
+
+    Usage:
+        `ComponentModel.forward(...)` MUST call `set_runtime_state()` on each MaskedModule
+        BEFORE executing the target model's forward pass. This configures:
+        - active: whether to use components (True) or pass through to base module (False)
+        - mask_info: component mask, routing mask, and optional weight-delta mask
+        - cache_type: whether to cache inputs or component activations
+        - cache: dictionary to populate with cached values
+
+        After configuring state, the target model is executed normally, and this wrapper
+        applies the component replacement logic in its forward() method.
+
+    Note on torch.compile():
+        The mutable state pattern (setting attributes before forward) works with torch.compile(),
+        but may cause recompilation if the pattern of `active` flags changes frequently across
+        forward calls. For best performance, try to maintain consistent activation patterns.
+    """
+
+    def __init__(self, *, module_name: str, base: nn.Module, components: Components) -> None:
+        super().__init__()
+        self.module_name = module_name
+        self.base = base
+        self.components = components
+
+        # Per-forward runtime state, set by ComponentModel.forward(...) before execution.
+        self.active: bool = False
+        self.mask_info: ComponentsMaskInfo | None = None
+        self.cache_type: Literal["none", "input", "component_acts"] = "none"
+        self.cache: dict[str, Tensor] | None = None
+
+    @override
+    def __getattr__(self, name: str) -> Tensor | nn.Module:
+        """Forward attribute access to base module for nested submodule compatibility.
+
+        This allows code to access nested submodules (e.g., model.linear1.pre_identity)
+        even after linear1 has been wrapped with MaskedModule.
+        """
+        # nn.Module stores _modules in self._modules dict, access it directly to avoid recursion
+        _modules = object.__getattribute__(self, "_modules")
+        if "base" in _modules:
+            base = _modules["base"]
+            if hasattr(base, name):
+                return getattr(base, name)
+        # Fall back to nn.Module's __getattr__ for standard behavior
+        return super().__getattr__(name)
+
+    def set_runtime_state(
+        self,
+        *,
+        active: bool,
+        mask_info: ComponentsMaskInfo | None,
+        cache_type: Literal["none", "input", "component_acts"],
+        cache: dict[str, Tensor] | None,
+    ) -> None:
+        self.active = active
+        self.mask_info = mask_info
+        self.cache_type = cache_type
+        self.cache = cache
+
+    def validate_state(self) -> None:
+        """Validate that runtime state is consistent. Call this for debugging.
+
+        Raises:
+            AssertionError: If state is inconsistent (e.g., active=True but mask_info=None).
+        """
+        if self.active:
+            assert self.mask_info is not None, (
+                f"MaskedModule '{self.module_name}': active=True but mask_info is None. "
+                "set_runtime_state() must be called with mask_info when active=True."
+            )
+        if self.cache_type != "none":
+            assert self.cache is not None, (
+                f"MaskedModule '{self.module_name}': cache_type='{self.cache_type}' but cache is None. "
+                "set_runtime_state() must be called with a cache dict when caching is enabled."
+            )
+
+    @override
+    def forward(self, x: Tensor) -> Tensor:  # type: ignore[override]
+        if self.cache_type == "input":
+            assert self.cache is not None
+            self.cache[self.module_name] = x
+
+        if not self.active:
+            return self.base(x)
+
+        assert self.mask_info is not None
+        mask_info = self.mask_info
+
+        component_acts_cache: dict[str, Float[Tensor, "... C"]] | None = (
+            {} if self.cache_type == "component_acts" else None
+        )
+
+        components_out = self.components(
+            x,
+            mask=mask_info.component_mask,
+            weight_delta_and_mask=mask_info.weight_delta_and_mask,
+            component_acts_cache=component_acts_cache,
+        )
+
+        if component_acts_cache is not None:
+            assert self.cache is not None
+            for k, v in component_acts_cache.items():
+                self.cache[f"{self.module_name}_{k}"] = v
+
+        if mask_info.routing_mask == "all":
+            return components_out
+
+        base_out = self.base(x)
+        routing_mask: Bool[Tensor, ...] = mask_info.routing_mask
+        return torch.where(routing_mask[..., None], components_out, base_out)


### PR DESCRIPTION
extremely messy test of whether we can speed up things by using torch.compile(). This requires getting rid of our hooks and monkeypatching the target model to insert the components. Not sure it'll work with identity components. Anyway, results are apparently:
```
  | Batch | Seq Len | Mode            | Eager   | Compiled | Speedup       |
  |-------|---------|-----------------|---------|----------|---------------|
  | 16    | 128     | reduce-overhead | 10.56ms | 9.64ms   | 1.09x (9.5%)  |
  | 32    | 256     | reduce-overhead | 12.61ms | 11.20ms  | 1.13x (12.6%) |
  | 64    | 256     | reduce-overhead | 20.70ms | 15.96ms  | 1.30x (30%)   |
  | 128   | 256     | reduce-overhead | 36.19ms | 28.34ms  | 1.28x (28%)   |
  | 64    | 256     | max-autotune    | 20.70ms | 15.38ms  | 1.35x (35%)   |
```
For a very stripped down version of our computation which does just masked forward and backward passes through the full ss_llama_simple_mlp (4L).
I think our batch size will be <64 in practice to avoid OOMs in our full training setup.
Probably going to leave this on the shelf. Not keen on the drastic core code change and skeptical that we could get >1.2x speedup for our workflows. Though might be worth picking up when we go to bigger models. (edited) 

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- Use the keywords 'Close', 'Closes', 'Fix', or 'Fixes' followed by the issue number(s) to close the related issue(s) -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->

## Does this PR introduce a breaking change?
<!--- If this PR introduces a breaking change, please describe the impact and migration path for existing applications below. -->