### PR TITLE
Fix: diverge global RNG across DDP ranks

### DIFF
--- a/spd/run_spd.py
+++ b/spd/run_spd.py
@@ -39,8 +39,10 @@ from spd.settings import SPD_OUT_DIR
 from spd.utils.component_utils import calc_ci_l_zero
 from spd.utils.distributed_utils import (
     avg_metrics_across_ranks,
+    broadcast_model_params,
     get_distributed_state,
     is_main_process,
+    seed_per_rank,
     sync_across_processes,
 )
 from spd.utils.general_utils import (
@@ -162,6 +164,10 @@ def optimize(
     )
 
     model.to(device)
+    broadcast_model_params(model)
+
+    # Diverge global RNG per rank so stochastic masks/sources differ across DP workers.
+    seed_per_rank(config.seed)
 
     # Wrap model with DDP if distributed
     dist_state = get_distributed_state()

--- a/tests/test_seed_per_rank_distributed.py
+++ b/tests/test_seed_per_rank_distributed.py
@@ -1,0 +1,130 @@
+"""Distributed tests for per-rank RNG seeding.
+
+Verifies that:
+- After seed_per_rank, torch random calls produce different values across ranks
+- broadcast_model_params makes model parameters identical across ranks despite divergent RNG
+
+This file can be run in two ways:
+
+1. Directly with torchrun (fastest):
+   torchrun --standalone --nproc_per_node=2 --master_port=29505 tests/test_seed_per_rank_distributed.py
+
+2. Via pytest (runs torchrun in subprocess):
+   pytest tests/test_seed_per_rank_distributed.py
+"""
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn as nn
+
+from spd.utils.distributed_utils import (
+    broadcast_model_params,
+    cleanup_distributed,
+    gather_all_tensors,
+    get_distributed_state,
+    init_distributed,
+    seed_per_rank,
+    sync_across_processes,
+)
+
+
+def _test_rng_diverges_across_ranks():
+    """After seed_per_rank, torch.randn produces different values on each rank."""
+    state = get_distributed_state()
+    assert state is not None
+
+    seed_per_rank(42)
+    samples = torch.randn(10)
+
+    gathered = gather_all_tensors(samples)
+
+    if state.rank == 0:
+        assert not torch.allclose(gathered[0], gathered[1]), (
+            "Random samples should differ across ranks after seed_per_rank"
+        )
+        print("  pass: RNG diverges across ranks")
+
+
+def _test_broadcast_model_params_syncs():
+    """broadcast_model_params makes model params identical despite divergent RNG."""
+    state = get_distributed_state()
+    assert state is not None
+
+    seed_per_rank(42)
+
+    model = nn.Linear(8, 4)
+    broadcast_model_params(model)
+
+    weight_gathered = gather_all_tensors(model.weight.data)
+    bias_gathered = gather_all_tensors(model.bias.data)
+
+    if state.rank == 0:
+        for r in range(1, state.world_size):
+            torch.testing.assert_close(weight_gathered[0], weight_gathered[r])
+            torch.testing.assert_close(bias_gathered[0], bias_gathered[r])
+        print("  pass: broadcast_model_params syncs parameters")
+
+
+def run_all_tests():
+    init_distributed()
+    try:
+        state = get_distributed_state()
+        assert state is not None
+        assert state.world_size == 2, f"Tests require exactly 2 ranks, got {state.world_size}"
+
+        tests = [
+            ("rng diverges across ranks", _test_rng_diverges_across_ranks),
+            ("broadcast_model_params syncs", _test_broadcast_model_params_syncs),
+        ]
+
+        if state.rank == 0:
+            print(f"\nRunning {len(tests)} seed_per_rank distributed tests...\n")
+
+        for test_name, test_func in tests:
+            try:
+                test_func()
+            except Exception as e:
+                if state.rank == 0:
+                    print(f"  FAIL: {test_name}: {e}")
+                raise
+            sync_across_processes()
+
+        if state.rank == 0:
+            print(f"\nAll {len(tests)} seed_per_rank distributed tests passed!\n")
+    finally:
+        cleanup_distributed()
+
+
+@pytest.mark.slow
+class TestSeedPerRank:
+    def test_seed_per_rank_distributed(self):
+        script_path = Path(__file__).resolve()
+
+        cmd = [
+            "torchrun",
+            "--standalone",
+            "--nproc_per_node=2",
+            "--master_port",
+            "29505",
+            str(script_path),
+        ]
+
+        new_env = os.environ.copy()
+        new_env["CUDA_VISIBLE_DEVICES"] = ""
+
+        result = subprocess.run(cmd, env=new_env, capture_output=True, text=True, timeout=120)
+
+        if result.returncode != 0:
+            print(f"STDOUT:\n{result.stdout}")
+            print(f"STDERR:\n{result.stderr}")
+            raise RuntimeError(f"Distributed test failed with code {result.returncode}")
+
+        print(result.stderr)
+
+
+if __name__ == "__main__":
+    run_all_tests()


### PR DESCRIPTION
## Description

Adds per-rank RNG seeding so that stochastic operations (mask sampling, PGD source init) diverge across DDP ranks, giving more diverse gradient estimates. Model parameters are explicitly broadcast from rank 0 to ensure identical initialization despite divergent RNG.

Changes:
- **`spd/utils/distributed_utils.py`**: Added `seed_per_rank(base_seed)` (uses `base_seed * world_size + rank` for collision-free seeds) and `broadcast_model_params(model)` (broadcasts all params from rank 0).
- **`spd/run_spd.py`**: Call `broadcast_model_params(model)` after `model.to(device)`, then `seed_per_rank(config.seed)` before DDP wrapping and the training loop.
- **`tests/test_seed_per_rank_distributed.py`**: 2 distributed tests verifying RNG divergence across ranks and broadcast param sync.

## Motivation and Context

Previously all DDP ranks shared the same global RNG seed, so stochastic mask sampling produced identical masks on every rank. This wasted the diversity benefit of data parallelism — each rank got different data but identical masks. With per-rank seeding, each rank samples different masks, giving more diverse gradient estimates for the same compute cost.

## How Has This Been Tested?

- 2 new distributed tests (torchrun with 2 ranks on CPU/gloo) verifying: RNG diverges across ranks, `broadcast_model_params` syncs parameters.

## Does this PR introduce a breaking change?

Yes — the global RNG now diverges per rank, which changes the random state during training. Runs with `dp > 1` will produce different results than before (by design). Single-GPU runs are unaffected since `seed * 1 + 0 = seed`.