### PR TITLE
Add short name reminder to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,6 +131,7 @@ Each experiment (`spd/experiments/{tms,resid_mlp,lm}/`) contains:
 - WandB integration for experiment tracking and model storage
 - Supports both local paths and `wandb:project/runs/run_id` format for model loading
 - Centralized experiment registry (`spd/registry.py`) manages all experiment configurations
+- **When adding a new metric config class**, also add a short name entry in `METRIC_CONFIG_SHORT_NAMES` in `spd/utils/wandb_utils.py` — this is used for WandB run names and flattened config keys
 
 **Harvest, Autointerp & Dataset Attributions Modules:**
 


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
When dealing with metrics, Claude often forgets to add a short name for the metric in `wandb_utils`. This PR adds a reminder to do this in `CLAUDE.md`.

## Related Issue
<!--- Use the keywords 'Close', 'Closes', 'Fix', or 'Fixes' followed by the issue number(s) to close the related issue(s) -->
NA.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See above.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
I implemented a new eval and this time Claude did had a short name.

## Does this PR introduce a breaking change?
<!--- If this PR introduces a breaking change, please describe the impact and migration path for existing applications below. -->
No.