### PR TITLE
Merge 2/3: New modules (graph_interp, investigate, editing, postprocess)

### DIFF
--- a/spd/editing/README.md
+++ b/spd/editing/README.md
@@ -1,0 +1,95 @@
+# spd.editing
+
+Component-level model editing for VPD decompositions.
+
+## Setup
+
+```python
+from spd.editing import EditableModel, generate, measure_kl, measure_token_probs
+from spd.harvest.repo import HarvestRepo
+from spd.autointerp.repo import InterpRepo
+
+em, tok = EditableModel.from_wandb("wandb:goodfire/spd/s-892f140b")
+harvest = HarvestRepo("s-892f140b")
+interp = InterpRepo("s-892f140b")
+```
+
+## Finding components
+
+By autointerp label:
+```python
+from spd.editing import search_interpretations
+matches = search_interpretations(harvest, interp, r"male pronoun")
+# -> [ComponentMatch(key='h.1.attn.v_proj:52', label='male pronouns', ...)]
+```
+
+By output token PMI (best for ablation targets):
+```python
+from spd.editing import search_by_token_pmi
+he_id = tok.encode("he")
+matches = search_by_token_pmi(harvest, he_id, side="output", min_pmi=1.0)
+```
+
+By circuit optimization across examples:
+```python
+examples = [(tokens1, target_pos1), (tokens2, target_pos2), ...]
+components = em.find_components_by_examples(examples, optim_steps=100)
+# -> [('h.1.attn.v_proj:52', 0.9), ('h.1.mlp.down_proj:798', 0.8), ...]
+```
+
+## Inspecting components
+
+```python
+from spd.editing import inspect_component
+data = inspect_component(harvest, interp, "h.1.mlp.down_proj:798", tok)
+# Prints: label, input/output PMI tokens, activation examples
+```
+
+Component geometry:
+```python
+vecs = em.get_component_vectors("h.1.mlp.down_proj:798")  # read (V) and write (U) vectors
+alignment = em.component_alignment("h.1.attn.o_proj:82", "h.1.mlp.c_fc:144")  # cosine, percentile
+boosted, suppressed = em.unembed_alignment("h.1.mlp.down_proj:798", tok)  # top logit-lens tokens
+```
+
+## Editing (runtime masks)
+
+```python
+# 0.0 = ablate, 2.0 = boost
+edit_fn = em.make_edit_fn({"h.1.mlp.down_proj:798": 0.0, "h.1.attn.v_proj:52": 0.0})
+
+# Generate with edits
+text = generate(edit_fn, tokens, tok)
+
+# Measure effect
+effect = measure_kl(em, edit_fn, eval_seqs)
+print(f"KL={effect.mean_kl:.3f}, PPL: {effect.baseline_ppl:.1f} -> {effect.edited_ppl:.1f}")
+
+# Token group probability shifts
+shifts = measure_token_probs(em, edit_fn, eval_seqs, {
+    "he": tok.encode("he"),
+    "she": tok.encode("she"),
+})
+print(f"P(he) change: {shifts['he'].change_pct:+.1f}%")
+```
+
+CI-conditional editing (only edit where component is active):
+```python
+edit_fn = em.make_edit_fn({"h.1.mlp.down_proj:798": 0.0}, ci_threshold=0.1)
+```
+
+## Permanent weight editing
+
+```python
+clean_em = em.without_components(["h.1.mlp.down_proj:798"])
+# Returns a new EditableModel with rank-1 subtraction baked into weights
+text = generate(clean_em, tokens, tok)
+```
+
+## Circuit analysis
+
+```python
+circuit = em.optimize_circuit(tokens, target_position=15, target_token=tok.encode("he")[0])
+em.print_circuit(circuit, tokens, tok, interp=interp)
+# Prints: edges, node CI, component labels
+```

--- a/spd/editing/__init__.py
+++ b/spd/editing/__init__.py
@@ -1,0 +1,44 @@
+"""Component-level model editing for VPD decompositions."""
+
+# Re-export everything from the main module so `from spd.editing import ...` still works
+from spd.app.backend.app_tokenizer import AppTokenizer
+from spd.app.backend.compute import OptimizedPromptAttributionResult
+from spd.editing._editing import (
+    AblationEffect,
+    AlignmentResult,
+    ComponentMatch,
+    ComponentVectors,
+    EditableModel,
+    ForwardFn,
+    TokenGroupShift,
+    TokenPMIMatch,
+    UnembedMatch,
+    generate,
+    inspect_component,
+    measure_kl,
+    measure_token_probs,
+    parse_component_key,
+    search_by_token_pmi,
+    search_interpretations,
+)
+
+__all__ = [
+    "AblationEffect",
+    "AlignmentResult",
+    "AppTokenizer",
+    "OptimizedPromptAttributionResult",
+    "ComponentMatch",
+    "ComponentVectors",
+    "EditableModel",
+    "ForwardFn",
+    "TokenGroupShift",
+    "TokenPMIMatch",
+    "UnembedMatch",
+    "generate",
+    "inspect_component",
+    "measure_kl",
+    "measure_token_probs",
+    "parse_component_key",
+    "search_by_token_pmi",
+    "search_interpretations",
+]

--- a/spd/editing/_editing.py
+++ b/spd/editing/_editing.py
@@ -1,0 +1,808 @@
+"""Component-level model editing for VPD decompositions.
+
+Core class: EditableModel wraps ComponentModel + TransformerTopology and provides
+methods for component analysis, editing, and measurement. It's callable
+(tokens → logits) so it works as a ForwardFn anywhere.
+
+Usage:
+    from spd.editing import EditableModel, search_interpretations, generate
+
+    em = EditableModel.from_wandb("wandb:goodfire/spd/s-892f140b")
+    matches = search_interpretations(harvest, interp, r"male pronoun")
+
+    edit_fn = em.make_edit_fn({m.key: 0.0 for m in matches[:3]})
+    text = generate(edit_fn, tokens, tokenizer)
+    effect = em.measure_kl(edit_fn, token_seqs)
+"""
+
+import copy
+import re
+import sqlite3
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import orjson
+import torch
+import torch.nn.functional as F
+from jaxtyping import Float, Int
+from torch import Tensor
+
+from spd.app.backend.app_tokenizer import AppTokenizer
+from spd.app.backend.compute import OptimizedPromptAttributionResult
+from spd.autointerp.repo import InterpRepo
+from spd.harvest.repo import HarvestRepo
+from spd.harvest.schemas import ComponentData
+from spd.models.component_model import ComponentModel, SPDRunInfo
+from spd.models.components import make_mask_infos
+from spd.topology.topology import TransformerTopology
+
+ForwardFn = Callable[[Int[Tensor, " seq"]], Float[Tensor, "seq vocab"]]
+
+
+# -- Component key utilities ---------------------------------------------------
+
+
+def parse_component_key(key: str) -> tuple[str, int]:
+    """'h.1.mlp.c_fc:802' -> ('h.1.mlp.c_fc', 802)."""
+    layer, idx_str = key.rsplit(":", 1)
+    return layer, int(idx_str)
+
+
+# -- Search (free functions, don't need the model) -----------------------------
+
+
+@dataclass
+class ComponentMatch:
+    key: str
+    label: str
+    confidence: str
+    firing_density: float
+    mean_activations: dict[str, float]
+
+
+def search_interpretations(
+    harvest: HarvestRepo,
+    interp: InterpRepo,
+    pattern: str,
+    min_firing_density: float = 0.0,
+) -> list[ComponentMatch]:
+    """Search component interpretations by regex on label. Sorted by firing density desc."""
+    all_interps = interp.get_all_interpretations()
+    summary = harvest.get_summary()
+
+    matches = []
+    for key, result in all_interps.items():
+        if key not in summary:
+            continue
+        if not re.search(pattern, result.label, re.IGNORECASE):
+            continue
+        s = summary[key]
+        if s.firing_density < min_firing_density:
+            continue
+        matches.append(
+            ComponentMatch(
+                key=key,
+                label=result.label,
+                confidence=result.confidence,
+                firing_density=s.firing_density,
+                mean_activations=s.mean_activations,
+            )
+        )
+
+    matches.sort(key=lambda m: -m.firing_density)
+    return matches
+
+
+@dataclass
+class TokenPMIMatch:
+    key: str
+    pmi: float
+    firing_density: float
+
+
+def search_by_token_pmi(
+    harvest: HarvestRepo,
+    token_ids: list[int],
+    side: str,
+    min_pmi: float = 0.5,
+    min_firing_density: float = 0.01,
+    top_k: int = 20,
+) -> list[TokenPMIMatch]:
+    """Find components by input or output token PMI.
+
+    side="output" finds components that PREDICT the given tokens.
+    side="input" finds components that RESPOND TO (fire on) the given tokens.
+
+    For ablation, you almost always want side="output" — ablating output-side
+    components suppresses token production with far less collateral damage than
+    ablating input-side components.
+    """
+    assert side in ("input", "output")
+    column = "output_token_pmi" if side == "output" else "input_token_pmi"
+    target_set = set(token_ids)
+    summary = harvest.get_summary()
+
+    db_path = harvest._dir / "harvest.db"
+    conn = sqlite3.connect(f"file:{db_path}?immutable=1", uri=True)
+
+    results = []
+    for row in conn.execute(f"SELECT component_key, {column} FROM components"):
+        key: str = row[0]
+        if key not in summary or summary[key].firing_density < min_firing_density:
+            continue
+        pmi_data: dict[str, list[list[float]]] = orjson.loads(row[1])
+        max_pmi = 0.0
+        for tok_id, pmi in pmi_data.get("top", []):
+            if int(tok_id) in target_set and pmi > max_pmi:
+                max_pmi = pmi
+        if max_pmi >= min_pmi:
+            results.append(
+                TokenPMIMatch(
+                    key=key,
+                    pmi=max_pmi,
+                    firing_density=summary[key].firing_density,
+                )
+            )
+
+    conn.close()
+    results.sort(key=lambda r: -r.pmi)
+    return results[:top_k]
+
+
+def inspect_component(
+    harvest: HarvestRepo,
+    interp: InterpRepo,
+    key: str,
+    tokenizer: AppTokenizer,
+    n_examples: int = 5,
+    n_pmi_tokens: int = 10,
+) -> ComponentData:
+    """Print a detailed inspection of a component and return its data."""
+    comp = harvest.get_component(key)
+    assert comp is not None, f"No harvest data for {key}"
+    interp_result = interp.get_interpretation(key)
+
+    ci = comp.mean_activations.get("causal_importance", None)
+    ci_str = f", ci={ci:.4f}" if ci is not None else ""
+    print(f"{'=' * 70}")
+    print(f"{key}  (density={comp.firing_density:.4f}{ci_str})")
+    if interp_result:
+        print(f"Label: [{interp_result.confidence}] {interp_result.label}")
+    print()
+
+    decode = tokenizer.decode
+
+    print("INPUT tokens (what makes it fire):")
+    for tok_id, pmi in comp.input_token_pmi.top[:n_pmi_tokens]:
+        print(f"  {decode([tok_id]):15s} PMI={pmi:.2f}")
+
+    print("\nOUTPUT tokens (what it predicts):")
+    for tok_id, pmi in comp.output_token_pmi.top[:n_pmi_tokens]:
+        print(f"  {decode([tok_id]):15s} PMI={pmi:.2f}")
+
+    print(f"\nActivation examples ({n_examples}):")
+    for ex in comp.activation_examples[:n_examples]:
+        parts = []
+        for tid, firing in zip(ex.token_ids, ex.firings, strict=True):
+            tok_str = decode([tid])
+            parts.append(f">>>{tok_str}<<<" if firing else tok_str)
+        act_vals = ex.activations.get("causal_importance", ex.activations.get("activation", []))
+        max_act = max(act_vals) if act_vals else 0
+        print(f"  [max_act={max_act:.3f}] {''.join(parts)}")
+    print()
+
+    return comp
+
+
+# -- Result types --------------------------------------------------------------
+
+
+@dataclass
+class ComponentVectors:
+    """Read (V) and write (U) vectors for a single rank-1 component.
+
+    The component forward is: act = x @ read, out = act * write.
+    So `read` is the input direction (d_in) and `write` is the output direction (d_out).
+    """
+
+    key: str
+    read: Tensor
+    write: Tensor
+    d_in: int
+    d_out: int
+
+
+@dataclass
+class AlignmentResult:
+    cosine: float
+    dot: float
+    norm_a: float
+    norm_b: float
+    percentile: float
+    space_dim: int
+    space_name: str
+
+
+@dataclass
+class UnembedMatch:
+    token_id: int
+    token_str: str
+    cosine: float
+    dot: float
+
+
+@dataclass
+class AblationEffect:
+    mean_kl: float
+    baseline_ppl: float
+    edited_ppl: float
+    n_tokens: int
+
+    @property
+    def ppl_increase_pct(self) -> float:
+        return (self.edited_ppl / self.baseline_ppl - 1) * 100
+
+
+@dataclass
+class TokenGroupShift:
+    group_name: str
+    baseline_mean_prob: float
+    edited_mean_prob: float
+    n_positions: int
+
+    @property
+    def change_pct(self) -> float:
+        if self.baseline_mean_prob == 0:
+            return float("inf") if self.edited_mean_prob > 0 else 0.0
+        return (self.edited_mean_prob / self.baseline_mean_prob - 1) * 100
+
+
+# -- EditableModel -------------------------------------------------------------
+
+
+class EditableModel:
+    """ComponentModel + TransformerTopology with methods for editing and analysis.
+
+    Callable: em(tokens) returns logits, so it works as a ForwardFn.
+    """
+
+    def __init__(self, model: ComponentModel) -> None:
+        self.model = model
+        self.topology = TransformerTopology(model.target_model)
+
+    @classmethod
+    def from_wandb(
+        cls, wandb_path: str, device: str = "cuda"
+    ) -> tuple["EditableModel", AppTokenizer]:
+        """Load from wandb path. Returns (editable_model, tokenizer)."""
+        run_info = SPDRunInfo.from_path(wandb_path)
+        model = ComponentModel.from_run_info(run_info).to(device).eval()
+        assert run_info.config.tokenizer_name is not None
+        tokenizer = AppTokenizer.from_pretrained(run_info.config.tokenizer_name)
+        return cls(model), tokenizer
+
+    def __call__(self, tokens: Int[Tensor, " seq"]) -> Float[Tensor, "seq vocab"]:
+        return self.model(tokens.unsqueeze(0)).squeeze(0)
+
+    # -- Component geometry ----------------------------------------------------
+
+    def get_component_vectors(self, key: str) -> ComponentVectors:
+        """Get the read (V[:, c]) and write (U[c, :]) vectors for a component."""
+        layer, idx = parse_component_key(key)
+        comp = self.model.components[layer]
+        return ComponentVectors(
+            key=key,
+            read=comp.V[:, idx],
+            write=comp.U[idx, :],
+            d_in=int(comp.d_in),  # pyright: ignore[reportArgumentType]
+            d_out=int(comp.d_out),  # pyright: ignore[reportArgumentType]
+        )
+
+    def component_alignment(self, key_a: str, key_b: str) -> AlignmentResult:
+        """Cosine/dot between key_a's write direction and key_b's read direction.
+
+        Asserts they share a space (key_a's d_out == key_b's d_in).
+        Percentile is empirical over all pairs in the same two layers.
+        """
+        a = self.get_component_vectors(key_a)
+        b = self.get_component_vectors(key_b)
+        assert a.d_out == b.d_in, (
+            f"{key_a} writes d={a.d_out}, {key_b} reads d={b.d_in} — no shared space"
+        )
+
+        cos = F.cosine_similarity(a.write.unsqueeze(0), b.read.unsqueeze(0)).item()
+        dot = (a.write * b.read).sum().item()
+
+        layer_a, _ = parse_component_key(key_a)
+        layer_b, _ = parse_component_key(key_b)
+        all_writes = self.model.components[layer_a].U
+        all_reads = self.model.components[layer_b].V
+        all_cos = F.normalize(all_writes, dim=1) @ F.normalize(all_reads, dim=0)
+        percentile = (all_cos.abs() < abs(cos)).float().mean().item() * 100
+
+        resid_dim = self.topology.unembed_module.in_features
+        space_name = "residual" if a.d_out == resid_dim else "neuron"
+
+        return AlignmentResult(
+            cosine=cos,
+            dot=dot,
+            norm_a=a.write.norm().item(),
+            norm_b=b.read.norm().item(),
+            percentile=percentile,
+            space_dim=a.d_out,
+            space_name=space_name,
+        )
+
+    def unembed_alignment(
+        self,
+        key: str,
+        tokenizer: AppTokenizer,
+        top_k: int = 10,
+    ) -> tuple[list[UnembedMatch], list[UnembedMatch]]:
+        """Top boosted and suppressed tokens by alignment with write direction.
+
+        Only works for components that write to the residual stream.
+        Returns (top_boosted, top_suppressed).
+        """
+        vecs = self.get_component_vectors(key)
+        unembed = self.topology.unembed_module.weight  # [vocab, d_model]
+        assert vecs.d_out == unembed.shape[1], (
+            f"{key} writes d={vecs.d_out}, unembed expects d={unembed.shape[1]}"
+        )
+
+        all_cos = F.cosine_similarity(vecs.write.unsqueeze(0), unembed, dim=1)
+        all_dot = (vecs.write.unsqueeze(0) * unembed).sum(dim=1)
+
+        decode = tokenizer.decode
+
+        top_vals, top_ids = all_cos.topk(top_k)
+        boosted = [
+            UnembedMatch(int(t), decode([int(t)]), v.item(), all_dot[t].item())
+            for v, t in zip(top_vals, top_ids, strict=True)
+        ]
+
+        bot_vals, bot_ids = all_cos.topk(top_k, largest=False)
+        suppressed = [
+            UnembedMatch(int(t), decode([int(t)]), v.item(), all_dot[t].item())
+            for v, t in zip(bot_vals, bot_ids, strict=True)
+        ]
+
+        return boosted, suppressed
+
+    def get_component_activations(
+        self,
+        tokens: Int[Tensor, " seq"],
+        key: str,
+    ) -> Float[Tensor, " seq"]:
+        """Component activation (v_c^T @ x) at each sequence position."""
+        layer, idx = parse_component_key(key)
+        with torch.no_grad():
+            out = self.model(tokens.unsqueeze(0), cache_type="input")
+        pre_weight_acts = out.cache[layer]  # [1, seq, d_in]
+        comp = self.model.components[layer]
+        return (pre_weight_acts @ comp.V[:, idx]).squeeze(0)  # [seq]
+
+    def get_ci(
+        self,
+        tokens: Int[Tensor, " seq"],
+    ) -> dict[str, Float[Tensor, " seq C"]]:
+        """Get CI values for all components at all positions. Returns {layer: [seq, C]}."""
+        with torch.no_grad():
+            out = self.model(tokens.unsqueeze(0), cache_type="input")
+            ci = self.model.calc_causal_importances(
+                pre_weight_acts=out.cache,
+                sampling="continuous",
+                detach_inputs=False,
+            )
+        return {layer: vals.squeeze(0) for layer, vals in ci.lower_leaky.items()}
+
+    def find_components_by_examples(
+        self,
+        examples: list[tuple[Int[Tensor, " seq"], int]],
+        optim_steps: int = 100,
+        context_window: int = 10,
+        ci_alive_threshold: float = 0.0,
+        min_frequency: float = 0.7,
+        top_k: int = 20,
+    ) -> list[tuple[str, float]]:
+        """Find components needed for a behavior by optimizing sparse CI on examples.
+
+        For each (token_sequence, target_position) pair, runs CI optimization
+        to find the minimal set of components needed to predict the token at
+        target_position. Components that appear in the sparse set across
+        >= min_frequency of examples are returned.
+
+        Args:
+            examples: List of (token_sequence, target_position) pairs.
+                target_position is the sequence index of the token whose
+                prediction we want to explain.
+            optim_steps: Number of optimization steps per example.
+            ci_alive_threshold: CI threshold for considering a component "active"
+                in the optimized mask.
+            min_frequency: Fraction of examples where a component must be active.
+            top_k: Number of components to return.
+
+        Returns:
+            List of (component_key, frequency) sorted by frequency descending.
+        """
+        from spd.app.backend.optim_cis import (
+            CELossConfig,
+            OptimCIConfig,
+            optimize_ci_values,
+        )
+        from spd.configs import ImportanceMinimalityLossConfig
+
+        counts: dict[str, int] = {}
+        n_examples = len(examples)
+
+        for i, (tokens, target_pos) in enumerate(examples):
+            assert target_pos > 0, "target_position must be > 0 (need a previous position)"
+
+            # Truncate to context window ending at target_pos (inclusive)
+            start = max(0, target_pos - context_window + 1)
+            window = tokens[start : target_pos + 1]
+            window_target_pos = target_pos - start
+            target_token = window[window_target_pos].item()
+
+            config = OptimCIConfig(
+                seed=42,
+                lr=0.1,
+                steps=optim_steps,
+                weight_decay=0.0,
+                lr_schedule="cosine",
+                lr_exponential_halflife=None,
+                lr_warmup_pct=0.1,
+                log_freq=optim_steps + 1,  # suppress logging
+                imp_min_config=ImportanceMinimalityLossConfig(coeff=0.1, pnorm=0.5, beta=1.0),
+                loss_config=CELossConfig(
+                    coeff=20.0,
+                    position=window_target_pos - 1,
+                    label_token=int(target_token),
+                ),
+                sampling="continuous",
+                ce_kl_rounding_threshold=0.5,
+                mask_type="ci",
+                adv_pgd=None,
+            )
+
+            result = optimize_ci_values(
+                model=self.model,
+                tokens=window.unsqueeze(0),
+                config=config,
+                device=str(tokens.device),
+            )
+
+            # Extract active components from optimized CI
+            ci_outputs = result.params.create_ci_outputs(self.model, str(tokens.device))
+            for layer_name, ci_vals in ci_outputs.lower_leaky.items():
+                # ci_vals: [1, window_len, C]
+                pred_pos = window_target_pos - 1
+                active = ci_vals[0, pred_pos, :] > ci_alive_threshold
+                for c in active.nonzero(as_tuple=True)[0]:
+                    key = f"{layer_name}:{c.item()}"
+                    counts[key] = counts.get(key, 0) + 1
+
+            print(f"  Example {i + 1}/{n_examples}: L0={result.metrics.l0_total:.0f}")
+
+        min_count = int(min_frequency * n_examples)
+        freq_results = [
+            (key, count / n_examples) for key, count in counts.items() if count >= min_count
+        ]
+        freq_results.sort(key=lambda x: -x[1])
+        return freq_results[:top_k]
+
+    def optimize_circuit(
+        self,
+        tokens: Int[Tensor, " seq"],
+        target_position: int,
+        target_token: int,
+        optim_steps: int = 200,
+        imp_min_coeff: float = 0.1,
+        ce_coeff: float = 20.0,
+    ) -> OptimizedPromptAttributionResult:
+        """Optimize a sparse circuit for predicting target_token at target_position.
+
+        Returns the full attribution graph (edges between components) from the
+        app's compute pipeline. The result includes node CI values, component
+        activations, and edge strengths.
+
+        target_position is the sequence index of the token being predicted
+        (the logits at position target_position predict this token, so internally
+        we optimize for loss at position target_position).
+        """
+        from spd.app.backend.compute import compute_prompt_attributions_optimized
+        from spd.app.backend.optim_cis import CELossConfig, OptimCIConfig
+        from spd.configs import ImportanceMinimalityLossConfig
+        from spd.topology.gradient_connectivity import get_sources_by_target
+
+        device = str(tokens.device)
+        batched = tokens.unsqueeze(0)
+
+        sources_by_target = get_sources_by_target(self.model, self.topology, device, "continuous")
+
+        config = OptimCIConfig(
+            seed=42,
+            lr=0.1,
+            steps=optim_steps,
+            weight_decay=0.0,
+            lr_schedule="cosine",
+            lr_exponential_halflife=None,
+            lr_warmup_pct=0.1,
+            log_freq=optim_steps + 1,
+            imp_min_config=ImportanceMinimalityLossConfig(coeff=imp_min_coeff, pnorm=0.5, beta=1.0),
+            loss_config=CELossConfig(
+                coeff=ce_coeff,
+                position=target_position,
+                label_token=target_token,
+            ),
+            sampling="continuous",
+            ce_kl_rounding_threshold=0.5,
+            mask_type="ci",
+            adv_pgd=None,
+        )
+
+        return compute_prompt_attributions_optimized(
+            model=self.model,
+            topology=self.topology,
+            tokens=batched,
+            sources_by_target=sources_by_target,
+            optim_config=config,
+            output_prob_threshold=0.01,
+            device=device,
+        )
+
+    def print_circuit(
+        self,
+        circuit: OptimizedPromptAttributionResult,
+        tokens: Int[Tensor, " seq"],
+        tok: AppTokenizer,
+        interp: "InterpRepo | None" = None,
+        top_edges: int = 5,
+        min_ci: float = 0.0,
+    ) -> None:
+        """Print a human-readable summary of an optimized circuit."""
+        from collections import defaultdict
+
+        spans = tok.get_spans(tokens.tolist())
+
+        def parse_node(key: str) -> tuple[str, int, int]:
+            parts = key.split(":")
+            return ":".join(parts[:-2]), int(parts[-2]), int(parts[-1])
+
+        def node_label(key: str) -> str:
+            layer, seq, cidx = parse_node(key)
+            label = ""
+            if interp is not None:
+                ir = interp.get_interpretation(f"{layer}:{cidx}")
+                if ir:
+                    label = f" [{ir.label[:35]}]"
+            return f"{layer}:{cidx}@{spans[seq].strip()}(p{seq}){label}"
+
+        edges_by_target: dict[str, list[tuple[str, float, bool]]] = defaultdict(list)
+        for e in circuit.edges:
+            edges_by_target[str(e.target)].append((str(e.source), e.strength, e.is_cross_seq))
+
+        print(f"Circuit: {len(circuit.edges)} edges, L0={circuit.metrics.l0_total:.0f}")
+        print(f"Tokens: {list(enumerate(spans))}\n")
+
+        for tgt_key in sorted(edges_by_target.keys()):
+            ci = circuit.node_ci_vals.get(tgt_key, 0)
+            if ci <= min_ci:
+                continue
+
+            sources = edges_by_target[tgt_key]
+            sources.sort(key=lambda x: -abs(x[1]))
+
+            print(f"{node_label(tgt_key)}  ci={ci:.3f}")
+            for src_key, strength, cross_seq in sources[:top_edges]:
+                cross = " [x-seq]" if cross_seq else ""
+                print(f"  <- {node_label(src_key)}  attr={strength:+.4f}{cross}")
+            print()
+
+    # -- Editing (mask-based, runtime) -----------------------------------------
+
+    def _edited_forward_batched(
+        self,
+        tokens: Int[Tensor, "1 seq"],
+        edits: dict[str, float],
+    ) -> Float[Tensor, "1 seq vocab"]:
+        """Forward with component mask edits applied uniformly (batched internal)."""
+        seq_len = tokens.shape[1]
+        device = tokens.device
+
+        component_masks = {
+            layer: torch.ones(1, seq_len, C, device=device)
+            for layer, C in self.model.module_to_c.items()
+        }
+        for key, value in edits.items():
+            layer, idx = parse_component_key(key)
+            assert layer in component_masks, f"Unknown layer: {layer}"
+            component_masks[layer][0, :, idx] = value
+
+        mask_infos = make_mask_infos(component_masks, routing_masks="all")
+        return self.model(tokens, mask_infos=mask_infos)
+
+    def _ci_guided_forward_batched(
+        self,
+        tokens: Int[Tensor, "1 seq"],
+        edits: dict[str, float],
+        ci_threshold: float,
+    ) -> Float[Tensor, "1 seq vocab"]:
+        """Forward with edits applied only where component CI exceeds threshold (batched)."""
+        seq_len = tokens.shape[1]
+        device = tokens.device
+
+        output_with_cache = self.model(tokens, cache_type="input")
+        ci_outputs = self.model.calc_causal_importances(
+            pre_weight_acts=output_with_cache.cache,
+            sampling="continuous",
+            detach_inputs=False,
+        )
+        ci_vals = ci_outputs.lower_leaky
+
+        component_masks = {
+            layer: torch.ones(1, seq_len, C, device=device)
+            for layer, C in self.model.module_to_c.items()
+        }
+        for key, value in edits.items():
+            layer, idx = parse_component_key(key)
+            assert layer in component_masks, f"Unknown layer: {layer}"
+            high_ci = ci_vals[layer][0, :, idx] > ci_threshold
+            component_masks[layer][0, high_ci, idx] = value
+
+        mask_infos = make_mask_infos(component_masks, routing_masks="all")
+        return self.model(tokens, mask_infos=mask_infos)
+
+    def make_edit_fn(
+        self,
+        edits: dict[str, float],
+        ci_threshold: float | None = None,
+    ) -> ForwardFn:
+        """Create a reusable unbatched tokens [seq] → logits [seq, vocab] function."""
+        if ci_threshold is not None:
+            return lambda tokens: self._ci_guided_forward_batched(
+                tokens.unsqueeze(0), edits, ci_threshold
+            ).squeeze(0)
+        return lambda tokens: self._edited_forward_batched(tokens.unsqueeze(0), edits).squeeze(0)
+
+    # -- Permanent weight editing ----------------------------------------------
+
+    def without_components(self, ablate_keys: list[str]) -> "EditableModel":
+        """Deep copy with components permanently subtracted from target model weights.
+
+        The returned model's target_model is a standard transformer — no CI
+        function or mask_infos needed at inference.
+        """
+        edited_model = copy.deepcopy(self.model)
+
+        by_layer: dict[str, list[int]] = {}
+        for key in ablate_keys:
+            layer, idx = parse_component_key(key)
+            by_layer.setdefault(layer, []).append(idx)
+
+        for layer_name, indices in by_layer.items():
+            components = edited_model.components[layer_name]
+            target_module = edited_model.target_model.get_submodule(layer_name)
+
+            for idx in indices:
+                contribution = (components.V[:, idx : idx + 1] @ components.U[idx : idx + 1, :]).T
+                target_module.weight.data -= contribution  # pyright: ignore[reportOperatorIssue]
+
+        return EditableModel(edited_model)
+
+
+# -- Free functions (work with any ForwardFn) ----------------------------------
+
+
+def generate(
+    forward_fn: ForwardFn,
+    tokens: Int[Tensor, " seq"],
+    tokenizer: AppTokenizer,
+    max_new_tokens: int = 30,
+    temperature: float = 0.0,
+) -> str:
+    """Greedy (temperature=0) or sampled generation from an arbitrary forward function.
+
+    Takes unbatched tokens [seq]. Strips trailing EOS to avoid the model
+    treating the prompt as complete.
+    """
+    eos_id = tokenizer.eos_token_id
+    if tokens[-1].item() == eos_id:
+        tokens = tokens[:-1]
+    generated = tokens.clone()
+    for _ in range(max_new_tokens):
+        logits = forward_fn(generated)
+        next_logits = logits[-1]
+        if temperature == 0:
+            next_id = next_logits.argmax()
+        else:
+            probs = F.softmax(next_logits / temperature, dim=-1)
+            next_id = torch.multinomial(probs, 1).squeeze()
+        generated = torch.cat([generated, next_id.unsqueeze(0)])
+        if next_id.item() == tokenizer.eos_token_id:
+            break
+    return tokenizer.decode(generated.tolist())
+
+
+def measure_kl(
+    baseline_fn: ForwardFn,
+    edited_fn: ForwardFn,
+    token_seqs: list[Int[Tensor, " seq"]],
+) -> AblationEffect:
+    """KL divergence and perplexity shift between two forward functions.
+
+    Takes unbatched token sequences [seq].
+    """
+    total_kl = 0.0
+    total_baseline_nll = 0.0
+    total_edited_nll = 0.0
+    total_tokens = 0
+
+    for tokens in token_seqs:
+        if tokens.shape[0] < 3:
+            continue
+
+        with torch.no_grad():
+            baseline_logits = baseline_fn(tokens)
+            edited_logits = edited_fn(tokens)
+
+        baseline_lp = F.log_softmax(baseline_logits[:-1], dim=-1)
+        edited_lp = F.log_softmax(edited_logits[:-1], dim=-1)
+
+        kl = F.kl_div(edited_lp, baseline_lp.exp(), reduction="sum", log_target=False)
+
+        targets = tokens[1:]
+        baseline_nll = -baseline_lp[range(len(targets)), targets].sum()
+        edited_nll = -edited_lp[range(len(targets)), targets].sum()
+
+        total_kl += kl.item()
+        total_baseline_nll += baseline_nll.item()
+        total_edited_nll += edited_nll.item()
+        total_tokens += len(targets)
+
+    assert total_tokens > 0, "No tokens to evaluate"
+    return AblationEffect(
+        mean_kl=total_kl / total_tokens,
+        baseline_ppl=torch.exp(torch.tensor(total_baseline_nll / total_tokens)).item(),
+        edited_ppl=torch.exp(torch.tensor(total_edited_nll / total_tokens)).item(),
+        n_tokens=total_tokens,
+    )
+
+
+def measure_token_probs(
+    baseline_fn: ForwardFn,
+    edited_fn: ForwardFn,
+    token_seqs: list[Int[Tensor, " seq"]],
+    token_groups: dict[str, list[int]],
+) -> dict[str, TokenGroupShift]:
+    """Probability shift for named groups of token IDs between two forward functions.
+
+    Takes unbatched token sequences [seq].
+    """
+    baseline_sums: dict[str, float] = {name: 0.0 for name in token_groups}
+    edited_sums: dict[str, float] = {name: 0.0 for name in token_groups}
+    total_positions = 0
+
+    for tokens in token_seqs:
+        with torch.no_grad():
+            baseline_logits = baseline_fn(tokens)
+            edited_logits = edited_fn(tokens)
+
+        bp = F.softmax(baseline_logits, dim=-1)
+        ep = F.softmax(edited_logits, dim=-1)
+
+        for name, ids in token_groups.items():
+            baseline_sums[name] += bp[:, ids].sum().item()
+            edited_sums[name] += ep[:, ids].sum().item()
+        total_positions += bp.shape[0]
+
+    assert total_positions > 0
+    return {
+        name: TokenGroupShift(
+            group_name=name,
+            baseline_mean_prob=baseline_sums[name] / total_positions,
+            edited_mean_prob=edited_sums[name] / total_positions,
+            n_positions=total_positions,
+        )
+        for name in token_groups
+    }

--- a/spd/editing/generate_token_divergence.py
+++ b/spd/editing/generate_token_divergence.py
@@ -1,0 +1,198 @@
+"""Generate per-token divergence data for the token divergence visualisation.
+
+Runs forward passes on dataset text under named component ablations,
+computes KL, reverse KL, JSD, and CE diff per token, writes JSON.
+
+Usage:
+    python -m spd.editing.generate_token_divergence \\
+        wandb:goodfire/spd/s-892f140b \\
+        --edits edits.yaml \\
+        --n_tokens 1500 \\
+        --out_path /path/to/www/data/kl_tokens.json
+
+edits.yaml format:
+    Male pronouns:
+      - h.1.mlp.down_proj:798
+      - h.1.mlp.c_fc:144
+      - h.1.attn.o_proj:82
+    Question marks:
+      - h.1.mlp.down_proj:534
+"""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+import yaml
+from datasets import load_dataset
+
+from spd.app.backend.app_tokenizer import AppTokenizer
+from spd.editing import EditableModel, ForwardFn
+from spd.settings import SPD_OUT_DIR
+
+TokenData = dict[str, Any]
+
+
+def compute_token_divergence(
+    em: EditableModel,
+    edit_fn: ForwardFn,
+    token_ids: list[int],
+    tok: AppTokenizer,
+    top_k: int = 5,
+) -> list[TokenData]:
+    tokens = torch.tensor(token_ids, device="cuda")
+    spans = tok.get_spans(token_ids)
+
+    with torch.no_grad():
+        bl_logits = em(tokens)
+        ed_logits = edit_fn(tokens)
+
+    bl_probs = F.softmax(bl_logits, dim=-1)
+    ed_probs = F.softmax(ed_logits, dim=-1)
+    bl_lp = F.log_softmax(bl_logits, dim=-1)
+    ed_lp = F.log_softmax(ed_logits, dim=-1)
+
+    # All metrics at positions [0..seq-2], predicting tokens [1..seq-1]
+    fwd_kl_per_vocab = bl_probs[:-1] * (bl_lp[:-1] - ed_lp[:-1])
+    fwd_kl = fwd_kl_per_vocab.sum(dim=-1)
+    rev_kl = (ed_probs[:-1] * (ed_lp[:-1] - bl_lp[:-1])).sum(dim=-1)
+
+    m_probs = 0.5 * (bl_probs[:-1] + ed_probs[:-1])
+    m_lp = m_probs.log()
+    jsd = 0.5 * (bl_probs[:-1] * (bl_lp[:-1] - m_lp)).sum(-1) + 0.5 * (
+        ed_probs[:-1] * (ed_lp[:-1] - m_lp)
+    ).sum(-1)
+
+    targets = tokens[1:]
+    ce_diff = -ed_lp[:-1][range(len(targets)), targets] - (
+        -bl_lp[:-1][range(len(targets)), targets]
+    )
+
+    result: list[TokenData] = []
+    for i in range(len(tokens)):
+        if i == 0:
+            result.append(
+                {"s": spans[i], "kl": 0, "rkl": 0, "jsd": 0, "ce": 0, "bl": [], "ed": [], "kc": []}
+            )
+            continue
+
+        prev = i - 1
+        bl_top_v, bl_top_i = bl_probs[prev].topk(top_k)
+        ed_top_v, ed_top_i = ed_probs[prev].topk(top_k)
+
+        bl_top = [
+            [tok.decode([int(t)]), round(v.item(), 4)]
+            for v, t in zip(bl_top_v, bl_top_i, strict=True)
+        ]
+        ed_top = [
+            [tok.decode([int(t)]), round(v.item(), 4)]
+            for v, t in zip(ed_top_v, ed_top_i, strict=True)
+        ]
+
+        kl_contribs = fwd_kl_per_vocab[prev]
+        _, kl_top_i = kl_contribs.abs().topk(top_k)
+        kl_top = [
+            [
+                tok.decode([int(idx)]),
+                round(bl_probs[prev, idx].item(), 4),
+                round(ed_probs[prev, idx].item(), 4),
+                round(kl_contribs[idx].item(), 5),
+            ]
+            for idx in kl_top_i
+        ]
+
+        result.append(
+            {
+                "s": spans[i],
+                "kl": round(fwd_kl[prev].item(), 5),
+                "rkl": round(rev_kl[prev].item(), 5),
+                "jsd": round(jsd[prev].item(), 5),
+                "ce": round(ce_diff[prev].item(), 5),
+                "bl": bl_top,
+                "ed": ed_top,
+                "kc": kl_top,
+            }
+        )
+
+    return result
+
+
+def load_stories(n_tokens: int, max_seq_len: int = 300) -> list[list[int]]:
+    """Load stories from SimpleStories until we have >= n_tokens."""
+    ds = load_dataset("SimpleStories/SimpleStories", split="train", streaming=True)
+    tok = AppTokenizer.from_pretrained("goodfire/SimpleStories-Llama-tokenizer")
+    stories = []
+    total = 0
+    for item in ds:
+        token_ids = tok.encode(item["story"])
+        if len(token_ids) > max_seq_len:
+            token_ids = token_ids[:max_seq_len]
+        stories.append(token_ids)
+        total += len(token_ids)
+        if total >= n_tokens:
+            break
+    return stories
+
+
+def main(
+    wandb_path: str,
+    edits: str,
+    n_tokens: int = 1500,
+    out_path: str | None = None,
+) -> None:
+    edits_path = Path(edits)
+    assert edits_path.exists(), f"Edits file not found: {edits_path}"
+    with open(edits_path) as f:
+        edits_config: dict[str, list[str]] = yaml.safe_load(f)
+
+    if out_path is None:
+        out_path = str(SPD_OUT_DIR / "www" / "data" / "kl_tokens.json")
+    out = Path(out_path)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    em, tok = EditableModel.from_wandb(wandb_path)
+    stories = load_stories(n_tokens)
+    total_tokens = sum(len(s) for s in stories)
+    print(f"Loaded {len(stories)} stories, {total_tokens} tokens")
+
+    all_data: dict[str, Any] = {}
+    for edit_name, component_keys in edits_config.items():
+        edit_dict = {k: 0.0 for k in component_keys}
+        edit_fn = em.make_edit_fn(edit_dict)
+
+        edit_stories = []
+        for story_ids in stories:
+            tokens = compute_token_divergence(em, edit_fn, story_ids, tok)
+            edit_stories.append(tokens)
+
+        all_data[edit_name] = {"components": component_keys, "stories": edit_stories}
+        print(f"  {edit_name}: done")
+
+    # Global p99 scales
+    def p99(vals: list[float]) -> float:
+        s = sorted(vals)
+        return s[int(0.99 * len(s))]
+
+    def collect(key: str) -> list[float]:
+        return [t[key] for e in all_data.values() for s in e["stories"] for t in s if t[key] != 0]
+
+    all_data["_meta"] = {
+        "kl_max": round(p99(collect("kl")), 4),
+        "rkl_max": round(p99(collect("rkl")), 4),
+        "jsd_max": round(p99(collect("jsd")), 4),
+        "ce_max": round(p99([abs(v) for v in collect("ce")]), 4),
+    }
+
+    with open(out, "w") as f:
+        json.dump(all_data, f, separators=(",", ":"))
+
+    size_kb = out.stat().st_size / 1024
+    print(f"Wrote {size_kb:.0f} KB to {out}")
+
+
+if __name__ == "__main__":
+    import fire
+
+    fire.Fire(main)

--- a/spd/graph_interp/CLAUDE.md
+++ b/spd/graph_interp/CLAUDE.md
@@ -1,0 +1,71 @@
+# Graph Interpretation Module
+
+Context-aware component labeling using network graph structure. Unlike standard autointerp (one-shot per component), this module uses dataset attributions to provide graph context: each component's prompt includes labels from already-labeled components connected via the attribution graph.
+
+## Usage
+
+```bash
+# Via SLURM (standalone)
+spd-graph-interp <decomposition_id> --config config.yaml
+
+# Direct execution
+python -m spd.graph_interp.scripts.run <decomposition_id> --config_json '{...}'
+```
+
+Requires `OPENROUTER_API_KEY` env var. Requires both harvest data and dataset attributions to exist.
+
+## Three-Phase Pipeline
+
+1. **Output pass** (late → early): "What does this component DO?" Each component's prompt includes top-K downstream components (by attribution) with their labels. Late layers labeled first so earlier layers see labeled downstream context.
+
+2. **Input pass** (early → late): "What TRIGGERS this component?" Each component's prompt includes top-K upstream components (by attribution) + co-firing components (Jaccard/PMI). Early layers labeled first so later layers see labeled upstream context. Independent of the output pass.
+
+3. **Unification** (parallel): Synthesizes output + input labels into a single unified label per component.
+
+All three phases run in a single invocation. Resume is per-phase via completed key sets in the DB.
+
+## Data Storage
+
+```
+SPD_OUT_DIR/graph_interp/<decomposition_id>/
+└── ti-YYYYMMDD_HHMMSS/
+    ├── interp.db       # SQLite: output_labels, input_labels, unified_labels, prompt_edges
+    └── config.yaml
+```
+
+## Database Schema
+
+- `output_labels`: component_key → label, confidence, reasoning, raw_response, prompt
+- `input_labels`: same schema as output_labels
+- `unified_labels`: same schema as output_labels
+- `prompt_edges`: directed filtered graph of (component, related_key, pass, attribution, related_label)
+- `config`: key-value store
+
+## Architecture
+
+| File | Purpose |
+|------|---------|
+| `config.py` | `GraphInterpConfig`, `GraphInterpSlurmConfig` |
+| `schemas.py` | `LabelResult`, `PromptEdge`, path helpers |
+| `db.py` | `GraphInterpDB` — SQLite with WAL mode |
+| `ordering.py` | Topological sort via `CanonicalWeight` from topology module |
+| `graph_context.py` | `RelatedComponent`, gather attributed + co-firing components |
+| `prompts.py` | Three prompt formatters (output, input, unification) |
+| `interpret.py` | Main three-phase execution loop |
+| `repo.py` | `GraphInterpRepo` — read-only access to results |
+| `scripts/run.py` | CLI entry point (called by SLURM) |
+| `scripts/run_slurm.py` | SLURM submission |
+| `scripts/run_slurm_cli.py` | Thin CLI wrapper for `spd-graph-interp` |
+
+## Dependencies
+
+- Harvest data (component stats, correlations, token stats)
+- Dataset attributions (component-to-component attribution strengths)
+- Reuses `map_llm_calls` from `spd/autointerp/llm_api.py`
+- Reuses prompt helpers from `spd/autointerp/prompt_helpers.py`
+
+## SLURM Integration
+
+- 0 GPUs, 16 CPUs, 240GB memory (CPU-only, LLM API calls)
+- Depends on both harvest merge AND attribution merge jobs
+- Entry point: `spd-graph-interp`

--- a/spd/graph_interp/CLAUDE.md
+++ b/spd/graph_interp/CLAUDE.md
@@ -47,7 +47,7 @@ SPD_OUT_DIR/graph_interp/<decomposition_id>/
 |------|---------|
 | `config.py` | `GraphInterpConfig`, `GraphInterpSlurmConfig` |
 | `schemas.py` | `LabelResult`, `PromptEdge`, path helpers |
-| `db.py` | `GraphInterpDB` — SQLite with WAL mode |
+| `db.py` | `GraphInterpDB` — SQLite via `open_nfs_sqlite` (NFS-safe, no WAL) |
 | `ordering.py` | Topological sort via `CanonicalWeight` from topology module |
 | `graph_context.py` | `RelatedComponent`, gather attributed + co-firing components |
 | `prompts.py` | Three prompt formatters (output, input, unification) |

--- a/spd/graph_interp/__init__.py
+++ b/spd/graph_interp/__init__.py
@@ -1,0 +1,1 @@
+"""Graph interpretation: context-aware component labeling using graph structure."""

--- a/spd/graph_interp/config.py
+++ b/spd/graph_interp/config.py
@@ -1,0 +1,26 @@
+"""Graph interpretation configuration."""
+
+from openrouter.components import Effort
+
+from spd.base_config import BaseConfig
+from spd.dataset_attributions.storage import AttrMetric
+from spd.settings import DEFAULT_PARTITION_NAME
+
+
+class GraphInterpConfig(BaseConfig):
+    model: str = "google/gemini-3-flash-preview"
+    reasoning_effort: Effort = "low"
+    attr_metric: AttrMetric = "attr_abs"
+    top_k_attributed: int = 8
+    max_examples: int = 20
+    label_max_words: int = 8
+    cost_limit_usd: float | None = None
+    max_requests_per_minute: int = 500
+    max_concurrent: int = 50
+    limit: int | None = None
+
+
+class GraphInterpSlurmConfig(BaseConfig):
+    config: GraphInterpConfig
+    partition: str = DEFAULT_PARTITION_NAME
+    time: str = "24:00:00"

--- a/spd/graph_interp/db.py
+++ b/spd/graph_interp/db.py
@@ -1,9 +1,10 @@
-"""SQLite database for graph interpretation data."""
+"""SQLite database for graph interpretation data. NFS-hosted, single writer then read-only."""
 
 import sqlite3
 from pathlib import Path
 
 from spd.graph_interp.schemas import LabelResult, PromptEdge
+from spd.utils.sqlite import open_nfs_sqlite
 
 DONE_MARKER = ".done"
 
@@ -53,17 +54,13 @@ CREATE TABLE IF NOT EXISTS config (
 
 
 class GraphInterpDB:
+    """NFS-hosted. Uses open_nfs_sqlite (no WAL). Single writer, then read-only."""
+
     def __init__(self, db_path: Path, readonly: bool = False) -> None:
-        if readonly:
-            self._conn = sqlite3.connect(
-                f"file:{db_path}?immutable=1", uri=True, check_same_thread=False
-            )
-        else:
-            self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
-            self._conn.execute("PRAGMA journal_mode=WAL")
+        self._conn = open_nfs_sqlite(db_path, readonly)
+        if not readonly:
             self._conn.executescript(_SCHEMA)
         self._db_path = db_path
-        self._conn.row_factory = sqlite3.Row
 
     def mark_done(self) -> None:
         (self._db_path.parent / DONE_MARKER).touch()

--- a/spd/graph_interp/db.py
+++ b/spd/graph_interp/db.py
@@ -1,0 +1,234 @@
+"""SQLite database for graph interpretation data."""
+
+import sqlite3
+from pathlib import Path
+
+from spd.graph_interp.schemas import LabelResult, PromptEdge
+
+DONE_MARKER = ".done"
+
+_SCHEMA = """\
+CREATE TABLE IF NOT EXISTS output_labels (
+    component_key TEXT PRIMARY KEY,
+    label TEXT NOT NULL,
+    confidence TEXT NOT NULL,
+    reasoning TEXT NOT NULL,
+    raw_response TEXT NOT NULL,
+    prompt TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS input_labels (
+    component_key TEXT PRIMARY KEY,
+    label TEXT NOT NULL,
+    confidence TEXT NOT NULL,
+    reasoning TEXT NOT NULL,
+    raw_response TEXT NOT NULL,
+    prompt TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS unified_labels (
+    component_key TEXT PRIMARY KEY,
+    label TEXT NOT NULL,
+    confidence TEXT NOT NULL,
+    reasoning TEXT NOT NULL,
+    raw_response TEXT NOT NULL,
+    prompt TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS prompt_edges (
+    component_key TEXT NOT NULL,
+    related_key TEXT NOT NULL,
+    pass TEXT NOT NULL,
+    attribution REAL NOT NULL,
+    related_label TEXT,
+    related_confidence TEXT,
+    PRIMARY KEY (component_key, related_key, pass)
+);
+
+CREATE TABLE IF NOT EXISTS config (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+);
+"""
+
+
+class GraphInterpDB:
+    def __init__(self, db_path: Path, readonly: bool = False) -> None:
+        if readonly:
+            self._conn = sqlite3.connect(
+                f"file:{db_path}?immutable=1", uri=True, check_same_thread=False
+            )
+        else:
+            self._conn = sqlite3.connect(str(db_path), check_same_thread=False)
+            self._conn.execute("PRAGMA journal_mode=WAL")
+            self._conn.executescript(_SCHEMA)
+        self._db_path = db_path
+        self._conn.row_factory = sqlite3.Row
+
+    def mark_done(self) -> None:
+        (self._db_path.parent / DONE_MARKER).touch()
+
+    # -- Output labels ---------------------------------------------------------
+
+    def save_output_label(self, result: LabelResult) -> None:
+        self._conn.execute(
+            "INSERT OR REPLACE INTO output_labels VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                result.component_key,
+                result.label,
+                result.confidence,
+                result.reasoning,
+                result.raw_response,
+                result.prompt,
+            ),
+        )
+        self._conn.commit()
+
+    def get_output_label(self, component_key: str) -> LabelResult | None:
+        row = self._conn.execute(
+            "SELECT * FROM output_labels WHERE component_key = ?", (component_key,)
+        ).fetchone()
+        if row is None:
+            return None
+        return _row_to_label_result(row)
+
+    def get_all_output_labels(self) -> dict[str, LabelResult]:
+        rows = self._conn.execute("SELECT * FROM output_labels").fetchall()
+        return {row["component_key"]: _row_to_label_result(row) for row in rows}
+
+    def get_completed_output_keys(self) -> set[str]:
+        rows = self._conn.execute("SELECT component_key FROM output_labels").fetchall()
+        return {row["component_key"] for row in rows}
+
+    # -- Input labels ----------------------------------------------------------
+
+    def save_input_label(self, result: LabelResult) -> None:
+        self._conn.execute(
+            "INSERT OR REPLACE INTO input_labels VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                result.component_key,
+                result.label,
+                result.confidence,
+                result.reasoning,
+                result.raw_response,
+                result.prompt,
+            ),
+        )
+        self._conn.commit()
+
+    def get_input_label(self, component_key: str) -> LabelResult | None:
+        row = self._conn.execute(
+            "SELECT * FROM input_labels WHERE component_key = ?", (component_key,)
+        ).fetchone()
+        if row is None:
+            return None
+        return _row_to_label_result(row)
+
+    def get_all_input_labels(self) -> dict[str, LabelResult]:
+        rows = self._conn.execute("SELECT * FROM input_labels").fetchall()
+        return {row["component_key"]: _row_to_label_result(row) for row in rows}
+
+    def get_completed_input_keys(self) -> set[str]:
+        rows = self._conn.execute("SELECT component_key FROM input_labels").fetchall()
+        return {row["component_key"] for row in rows}
+
+    # -- Unified labels --------------------------------------------------------
+
+    def save_unified_label(self, result: LabelResult) -> None:
+        self._conn.execute(
+            "INSERT OR REPLACE INTO unified_labels VALUES (?, ?, ?, ?, ?, ?)",
+            (
+                result.component_key,
+                result.label,
+                result.confidence,
+                result.reasoning,
+                result.raw_response,
+                result.prompt,
+            ),
+        )
+        self._conn.commit()
+
+    def get_unified_label(self, component_key: str) -> LabelResult | None:
+        row = self._conn.execute(
+            "SELECT * FROM unified_labels WHERE component_key = ?", (component_key,)
+        ).fetchone()
+        if row is None:
+            return None
+        return _row_to_label_result(row)
+
+    def get_all_unified_labels(self) -> dict[str, LabelResult]:
+        rows = self._conn.execute("SELECT * FROM unified_labels").fetchall()
+        return {row["component_key"]: _row_to_label_result(row) for row in rows}
+
+    def get_completed_unified_keys(self) -> set[str]:
+        rows = self._conn.execute("SELECT component_key FROM unified_labels").fetchall()
+        return {row["component_key"] for row in rows}
+
+    # -- Prompt edges ----------------------------------------------------------
+
+    def save_prompt_edges(self, edges: list[PromptEdge]) -> None:
+        rows = [
+            (
+                e.component_key,
+                e.related_key,
+                e.pass_name,
+                e.attribution,
+                e.related_label,
+                e.related_confidence,
+            )
+            for e in edges
+        ]
+        self._conn.executemany(
+            "INSERT OR REPLACE INTO prompt_edges VALUES (?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+        self._conn.commit()
+
+    def get_prompt_edges(self, component_key: str) -> list[PromptEdge]:
+        rows = self._conn.execute(
+            "SELECT * FROM prompt_edges WHERE component_key = ?", (component_key,)
+        ).fetchall()
+        return [_row_to_prompt_edge(row) for row in rows]
+
+    def get_all_prompt_edges(self) -> list[PromptEdge]:
+        rows = self._conn.execute("SELECT * FROM prompt_edges").fetchall()
+        return [_row_to_prompt_edge(row) for row in rows]
+
+    # -- Config ----------------------------------------------------------------
+
+    def save_config(self, key: str, value: str) -> None:
+        self._conn.execute("INSERT OR REPLACE INTO config VALUES (?, ?)", (key, value))
+        self._conn.commit()
+
+    # -- Stats -----------------------------------------------------------------
+
+    def get_label_count(self, table: str) -> int:
+        assert table in ("output_labels", "input_labels", "unified_labels")
+        row = self._conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()
+        assert row is not None
+        return row[0]
+
+    def close(self) -> None:
+        self._conn.close()
+
+
+def _row_to_label_result(row: sqlite3.Row) -> LabelResult:
+    return LabelResult(
+        component_key=row["component_key"],
+        label=row["label"],
+        confidence=row["confidence"],
+        reasoning=row["reasoning"],
+        raw_response=row["raw_response"],
+        prompt=row["prompt"],
+    )
+
+
+def _row_to_prompt_edge(row: sqlite3.Row) -> PromptEdge:
+    return PromptEdge(
+        component_key=row["component_key"],
+        related_key=row["related_key"],
+        pass_name=row["pass"],
+        attribution=row["attribution"],
+        related_label=row["related_label"],
+        related_confidence=row["related_confidence"],
+    )

--- a/spd/graph_interp/graph_context.py
+++ b/spd/graph_interp/graph_context.py
@@ -1,0 +1,98 @@
+"""Gather related components from attribution graph."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Literal
+
+from spd.dataset_attributions.storage import DatasetAttributionEntry
+from spd.graph_interp.ordering import parse_component_key
+from spd.graph_interp.schemas import LabelResult
+from spd.harvest.analysis import get_correlated_components
+from spd.harvest.storage import CorrelationStorage
+
+
+@dataclass
+class RelatedComponent:
+    component_key: str
+    attribution: float
+    label: str | None
+    confidence: str | None
+    jaccard: float | None
+    pmi: float | None
+
+
+GetAttributed = Callable[[str, int, Literal["positive", "negative"]], list[DatasetAttributionEntry]]
+
+
+def get_related_components(
+    component_key: str,
+    get_attributed: GetAttributed,
+    correlation_storage: CorrelationStorage,
+    labels_so_far: dict[str, LabelResult],
+    k: int,
+) -> list[RelatedComponent]:
+    """Top-K components connected via attribution, enriched with co-firing stats and labels."""
+    my_layer, _ = parse_component_key(component_key)
+
+    pos = get_attributed(component_key, k * 2, "positive")
+    neg = get_attributed(component_key, k * 2, "negative")
+
+    candidates = pos + neg
+    candidates.sort(key=lambda e: abs(e.value), reverse=True)
+    candidates = candidates[:k]
+
+    cofiring = _build_cofiring_lookup(component_key, correlation_storage, k * 3)
+    result = [_build_related(e.component_key, e.value, cofiring, labels_so_far) for e in candidates]
+
+    for r in result:
+        r_layer, _ = parse_component_key(r.component_key)
+        assert r_layer != my_layer, (
+            f"Same-layer component {r.component_key} in related list for {component_key}"
+        )
+
+    return result
+
+
+def _build_cofiring_lookup(
+    component_key: str,
+    correlation_storage: CorrelationStorage,
+    k: int,
+) -> dict[str, tuple[float, float | None]]:
+    lookup: dict[str, tuple[float, float | None]] = {}
+
+    jaccard_results = get_correlated_components(
+        correlation_storage, component_key, metric="jaccard", top_k=k
+    )
+    for c in jaccard_results:
+        lookup[c.component_key] = (c.score, None)
+
+    pmi_results = get_correlated_components(
+        correlation_storage, component_key, metric="pmi", top_k=k
+    )
+    for c in pmi_results:
+        if c.component_key in lookup:
+            jaccard_val = lookup[c.component_key][0]
+            lookup[c.component_key] = (jaccard_val, c.score)
+        else:
+            lookup[c.component_key] = (0.0, c.score)
+
+    return lookup
+
+
+def _build_related(
+    related_key: str,
+    attribution: float,
+    cofiring: dict[str, tuple[float, float | None]],
+    labels_so_far: dict[str, LabelResult],
+) -> RelatedComponent:
+    label = labels_so_far.get(related_key)
+    jaccard, pmi = cofiring.get(related_key, (None, None))
+
+    return RelatedComponent(
+        component_key=related_key,
+        attribution=attribution,
+        label=label.label if label else None,
+        confidence=label.confidence if label else None,
+        jaccard=jaccard,
+        pmi=pmi,
+    )

--- a/spd/graph_interp/interpret.py
+++ b/spd/graph_interp/interpret.py
@@ -1,0 +1,381 @@
+"""Main three-phase graph interpretation execution.
+
+Structure:
+    output_labels = scan(layers_reversed, step)
+    input_labels  = scan(layers_forward,  step)
+    unified       = map(output_labels + input_labels, unify)
+
+Each scan folds over layers. Within a layer, components are labeled in parallel
+via async LLM calls. The fold accumulator (labels_so_far) lets each component's
+prompt include labels from previously-processed layers.
+"""
+
+import asyncio
+from collections.abc import AsyncGenerator, Awaitable, Callable, Iterable
+from functools import partial
+from pathlib import Path
+from typing import Literal
+
+from spd.app.backend.app_tokenizer import AppTokenizer
+from spd.autointerp.llm_api import CostTracker, LLMError, LLMJob, LLMResult, map_llm_calls
+from spd.autointerp.schemas import ModelMetadata
+from spd.dataset_attributions.storage import (
+    AttrMetric,
+    DatasetAttributionEntry,
+    DatasetAttributionStorage,
+)
+from spd.graph_interp import graph_context
+from spd.graph_interp.config import GraphInterpConfig
+from spd.graph_interp.db import GraphInterpDB
+from spd.graph_interp.graph_context import RelatedComponent, get_related_components
+from spd.graph_interp.ordering import group_and_sort_by_layer
+from spd.graph_interp.prompts import (
+    LABEL_SCHEMA,
+    format_input_prompt,
+    format_output_prompt,
+    format_unification_prompt,
+)
+from spd.graph_interp.schemas import LabelResult, PromptEdge
+from spd.harvest.analysis import get_input_token_stats, get_output_token_stats
+from spd.harvest.repo import HarvestRepo
+from spd.harvest.storage import CorrelationStorage, TokenStatsStorage
+from spd.log import logger
+
+GetRelated = Callable[[str, dict[str, LabelResult]], list[RelatedComponent]]
+Step = Callable[[list[str], dict[str, LabelResult]], Awaitable[dict[str, LabelResult]]]
+
+
+def run_graph_interp(
+    openrouter_api_key: str,
+    config: GraphInterpConfig,
+    harvest: HarvestRepo,
+    attribution_storage: DatasetAttributionStorage,
+    correlation_storage: CorrelationStorage,
+    token_stats: TokenStatsStorage,
+    model_metadata: ModelMetadata,
+    db_path: Path,
+    tokenizer_name: str,
+) -> None:
+    logger.info("Loading tokenizer...")
+    app_tok = AppTokenizer.from_pretrained(tokenizer_name)
+
+    logger.info("Loading component summaries...")
+    summaries = harvest.get_summary()
+    alive = {k: s for k, s in summaries.items() if s.firing_density > 0.0}
+    all_keys = sorted(alive, key=lambda k: alive[k].firing_density, reverse=True)
+    if config.limit is not None:
+        all_keys = all_keys[: config.limit]
+
+    layers = group_and_sort_by_layer(all_keys, model_metadata.layer_descriptions)
+    total = len(all_keys)
+    logger.info(f"Graph interp: {total} components across {len(layers)} layers")
+
+    # -- Injected behaviours ---------------------------------------------------
+
+    shared_cost = CostTracker(limit_usd=config.cost_limit_usd)
+
+    async def llm_map(
+        jobs: Iterable[LLMJob], n_total: int | None = None
+    ) -> AsyncGenerator[LLMResult | LLMError]:
+        async for result in map_llm_calls(
+            openrouter_api_key=openrouter_api_key,
+            model=config.model,
+            reasoning_effort=config.reasoning_effort,
+            jobs=jobs,
+            max_tokens=8000,
+            max_concurrent=config.max_concurrent,
+            max_requests_per_minute=config.max_requests_per_minute,
+            cost_limit_usd=None,
+            response_schema=LABEL_SCHEMA,
+            n_total=n_total,
+            cost_tracker=shared_cost,
+        ):
+            yield result
+
+    concrete_to_canon = model_metadata.layer_descriptions
+    canon_to_concrete = {v: k for k, v in concrete_to_canon.items()}
+
+    def _translate_entries(entries: list[DatasetAttributionEntry]) -> list[DatasetAttributionEntry]:
+        for e in entries:
+            if e.layer in canon_to_concrete:
+                e.layer = canon_to_concrete[e.layer]
+                e.component_key = f"{e.layer}:{e.component_idx}"
+        return entries
+
+    def _to_canon(concrete_key: str) -> str:
+        layer, idx = concrete_key.rsplit(":", 1)
+        return f"{concrete_to_canon[layer]}:{idx}"
+
+    def _make_get_targets(metric: AttrMetric) -> "graph_context.GetAttributed":
+        def get(
+            key: str, k: int, sign: Literal["positive", "negative"]
+        ) -> list[DatasetAttributionEntry]:
+            return _translate_entries(
+                attribution_storage.get_top_targets(_to_canon(key), k=k, sign=sign, metric=metric)
+            )
+
+        return get
+
+    def _make_get_sources(metric: AttrMetric) -> "graph_context.GetAttributed":
+        def get(
+            key: str, k: int, sign: Literal["positive", "negative"]
+        ) -> list[DatasetAttributionEntry]:
+            return _translate_entries(
+                attribution_storage.get_top_sources(_to_canon(key), k=k, sign=sign, metric=metric)
+            )
+
+        return get
+
+    def _get_related(get_attributed: "graph_context.GetAttributed") -> GetRelated:
+        def get(key: str, labels_so_far: dict[str, LabelResult]) -> list[RelatedComponent]:
+            return get_related_components(
+                key,
+                get_attributed,
+                correlation_storage,
+                labels_so_far,
+                config.top_k_attributed,
+            )
+
+        return get
+
+    # -- Layer processors ------------------------------------------------------
+
+    async def process_output_layer(
+        get_related: GetRelated,
+        save_label: Callable[[LabelResult], None],
+        pending: list[str],
+        labels_so_far: dict[str, LabelResult],
+    ) -> dict[str, LabelResult]:
+        def jobs() -> Iterable[LLMJob]:
+            for key in pending:
+                component = harvest.get_component(key)
+                assert component is not None, f"Component {key} not found in harvest DB"
+                o_stats = get_output_token_stats(token_stats, key, app_tok, top_k=50)
+                assert o_stats is not None, f"No output token stats for {key}"
+
+                related = get_related(key, labels_so_far)
+                _save_edges(db, key, related, "output")
+                prompt = format_output_prompt(
+                    component=component,
+                    model_metadata=model_metadata,
+                    app_tok=app_tok,
+                    output_token_stats=o_stats,
+                    related=related,
+                    label_max_words=config.label_max_words,
+                    max_examples=config.max_examples,
+                )
+                yield LLMJob(prompt=prompt, schema=LABEL_SCHEMA, key=key)
+
+        return await _collect_labels(llm_map, jobs(), len(pending), save_label)
+
+    async def process_input_layer(
+        get_related: GetRelated,
+        save_label: Callable[[LabelResult], None],
+        pending: list[str],
+        labels_so_far: dict[str, LabelResult],
+    ) -> dict[str, LabelResult]:
+        def jobs() -> Iterable[LLMJob]:
+            for key in pending:
+                component = harvest.get_component(key)
+                assert component is not None, f"Component {key} not found in harvest DB"
+                i_stats = get_input_token_stats(token_stats, key, app_tok, top_k=20)
+                assert i_stats is not None, f"No input token stats for {key}"
+
+                related = get_related(key, labels_so_far)
+                _save_edges(db, key, related, "input")
+                prompt = format_input_prompt(
+                    component=component,
+                    model_metadata=model_metadata,
+                    app_tok=app_tok,
+                    input_token_stats=i_stats,
+                    related=related,
+                    label_max_words=config.label_max_words,
+                    max_examples=config.max_examples,
+                )
+                yield LLMJob(prompt=prompt, schema=LABEL_SCHEMA, key=key)
+
+        return await _collect_labels(llm_map, jobs(), len(pending), save_label)
+
+    # -- Scan (fold over layers) -----------------------------------------------
+
+    async def scan(
+        layer_order: list[tuple[str, list[str]]],
+        initial: dict[str, LabelResult],
+        step: Step,
+    ) -> dict[str, LabelResult]:
+        labels = dict(initial)
+        if labels:
+            logger.info(f"Resuming, {len(labels)} already completed")
+
+        completed_so_far = 0
+        for layer, keys in layer_order:
+            pending = [k for k in keys if k not in labels]
+            if not pending:
+                completed_so_far += len(keys)
+                continue
+
+            new_labels = await step(pending, labels)
+            labels.update(new_labels)
+
+            completed_so_far += len(keys)
+            logger.info(f"Completed layer {layer} ({completed_so_far}/{total})")
+
+        return labels
+
+    # -- Map (parallel over all components) ------------------------------------
+
+    async def map_unify(
+        output_labels: dict[str, LabelResult],
+        input_labels: dict[str, LabelResult],
+    ) -> None:
+        completed = db.get_completed_unified_keys()
+        keys = [k for k in all_keys if k not in completed]
+        if not keys:
+            logger.info("Unification: all labels already completed")
+            return
+        if completed:
+            logger.info(f"Unification: resuming, {len(completed)} already completed")
+
+        n_skipped = 0
+
+        def jobs() -> Iterable[LLMJob]:
+            nonlocal n_skipped
+            for key in keys:
+                out = output_labels.get(key)
+                inp = input_labels.get(key)
+                if out is None or inp is None:
+                    n_skipped += 1
+                    continue
+                component = harvest.get_component(key)
+                assert component is not None, f"Component {key} not found in harvest DB"
+                prompt = format_unification_prompt(
+                    output_label=out,
+                    input_label=inp,
+                    component=component,
+                    model_metadata=model_metadata,
+                    app_tok=app_tok,
+                    label_max_words=config.label_max_words,
+                    max_examples=config.max_examples,
+                )
+                yield LLMJob(prompt=prompt, schema=LABEL_SCHEMA, key=key)
+
+        logger.info(f"Unifying {len(keys)} components")
+        new_labels = await _collect_labels(llm_map, jobs(), len(keys), db.save_unified_label)
+
+        if n_skipped:
+            logger.warning(f"Skipped {n_skipped} components missing output or input labels")
+        logger.info(f"Unification: completed {len(new_labels)}/{len(keys)}")
+
+    # -- Run -------------------------------------------------------------------
+
+    logger.info("Initializing DB and building scan steps...")
+    db = GraphInterpDB(db_path)
+
+    metric = config.attr_metric
+    get_targets = _make_get_targets(metric)
+    get_sources = _make_get_sources(metric)
+
+    label_output = partial(
+        process_output_layer,
+        _get_related(get_targets),
+        db.save_output_label,
+    )
+    label_input = partial(
+        process_input_layer,
+        _get_related(get_sources),
+        db.save_input_label,
+    )
+
+    async def _run() -> None:
+        logger.section("Phase 1: Output pass (late → early)")
+        output_labels = await scan(list(reversed(layers)), db.get_all_output_labels(), label_output)
+
+        logger.section("Phase 2: Input pass (early → late)")
+        input_labels = await scan(list(layers), db.get_all_input_labels(), label_input)
+
+        logger.section("Phase 3: Unification")
+        await map_unify(output_labels, input_labels)
+
+        logger.info(
+            f"Completed: {db.get_label_count('output_labels')} output, "
+            f"{db.get_label_count('input_labels')} input, "
+            f"{db.get_label_count('unified_labels')} unified labels -> {db_path}"
+        )
+        db.mark_done()
+
+    try:
+        asyncio.run(_run())
+    finally:
+        db.close()
+
+
+# -- Shared LLM call machinery ------------------------------------------------
+
+
+async def _collect_labels(
+    llm_map: Callable[[Iterable[LLMJob], int | None], AsyncGenerator[LLMResult | LLMError]],
+    jobs: Iterable[LLMJob],
+    n_total: int,
+    save_label: Callable[[LabelResult], None],
+) -> dict[str, LabelResult]:
+    """Run LLM jobs, parse results, save to DB, return new labels."""
+    new_labels: dict[str, LabelResult] = {}
+    n_errors = 0
+
+    async for outcome in llm_map(jobs, n_total):
+        match outcome:
+            case LLMResult(job=job, parsed=parsed, raw=raw):
+                result = _parse_label(job.key, parsed, raw, job.prompt)
+                save_label(result)
+                new_labels[job.key] = result
+            case LLMError(job=job, error=e):
+                n_errors += 1
+                logger.error(f"Skipping {job.key}: {type(e).__name__}: {e}")
+        _check_error_rate(n_errors, len(new_labels))
+
+    return new_labels
+
+
+def _parse_label(key: str, parsed: dict[str, object], raw: str, prompt: str) -> LabelResult:
+    assert len(parsed) == 3, f"Expected 3 fields, got {len(parsed)}"
+    label = parsed["label"]
+    confidence = parsed["confidence"]
+    reasoning = parsed["reasoning"]
+    assert isinstance(label, str) and isinstance(confidence, str) and isinstance(reasoning, str)
+    return LabelResult(
+        component_key=key,
+        label=label,
+        confidence=confidence,
+        reasoning=reasoning,
+        raw_response=raw,
+        prompt=prompt,
+    )
+
+
+def _check_error_rate(n_errors: int, n_done: int) -> None:
+    total = n_errors + n_done
+    if total > 10 and n_errors / total > 0.05:
+        raise RuntimeError(
+            f"Error rate {n_errors / total:.0%} ({n_errors}/{total}) exceeds 5% threshold"
+        )
+
+
+def _save_edges(
+    db: GraphInterpDB,
+    component_key: str,
+    related: list[RelatedComponent],
+    pass_name: Literal["output", "input"],
+) -> None:
+    edges = [
+        PromptEdge(
+            component_key=component_key,
+            related_key=r.component_key,
+            pass_name=pass_name,
+            attribution=r.attribution,
+            related_label=r.label,
+            related_confidence=r.confidence,
+        )
+        for r in related
+    ]
+    if edges:
+        db.save_prompt_edges(edges)

--- a/spd/graph_interp/ordering.py
+++ b/spd/graph_interp/ordering.py
@@ -1,0 +1,88 @@
+"""Layer ordering for graph interpretation.
+
+Uses the topology module's CanonicalWeight system for correct ordering
+across all model architectures. Canonical addresses are provided by
+ModelMetadata.layer_descriptions (concrete path → canonical string).
+"""
+
+from spd.topology.canonical import (
+    CanonicalWeight,
+    FusedAttnWeight,
+    GLUWeight,
+    LayerWeight,
+    MLPWeight,
+    SeparateAttnWeight,
+)
+
+_SUBLAYER_ORDER = {"attn": 0, "attn_fused": 0, "glu": 1, "mlp": 1}
+
+_PROJECTION_ORDER: dict[type, dict[str, int]] = {
+    SeparateAttnWeight: {"q": 0, "k": 1, "v": 2, "o": 3},
+    FusedAttnWeight: {"qkv": 0, "o": 1},
+    GLUWeight: {"gate": 0, "up": 1, "down": 2},
+    MLPWeight: {"up": 0, "down": 1},
+}
+
+
+def canonical_sort_key(canonical: str) -> tuple[int, int, int]:
+    """Sort key for a canonical address string like '0.attn.q' or '1.mlp.down'."""
+    weight = CanonicalWeight.parse(canonical)
+    assert isinstance(weight, LayerWeight), f"Expected LayerWeight, got {type(weight).__name__}"
+
+    match weight.name:
+        case SeparateAttnWeight(weight=p):
+            sublayer_idx = _SUBLAYER_ORDER["attn"]
+            proj_idx = _PROJECTION_ORDER[SeparateAttnWeight][p]
+        case FusedAttnWeight(weight=p):
+            sublayer_idx = _SUBLAYER_ORDER["attn_fused"]
+            proj_idx = _PROJECTION_ORDER[FusedAttnWeight][p]
+        case GLUWeight(weight=p):
+            sublayer_idx = _SUBLAYER_ORDER["glu"]
+            proj_idx = _PROJECTION_ORDER[GLUWeight][p]
+        case MLPWeight(weight=p):
+            sublayer_idx = _SUBLAYER_ORDER["mlp"]
+            proj_idx = _PROJECTION_ORDER[MLPWeight][p]
+
+    return weight.layer_idx, sublayer_idx, proj_idx
+
+
+def parse_component_key(key: str) -> tuple[str, int]:
+    """Split 'h.1.mlp.c_fc:42' into ('h.1.mlp.c_fc', 42)."""
+    layer, idx_str = key.rsplit(":", 1)
+    return layer, int(idx_str)
+
+
+def group_and_sort_by_layer(
+    component_keys: list[str],
+    layer_descriptions: dict[str, str],
+) -> list[tuple[str, list[str]]]:
+    """Group component keys by layer, return [(layer, [keys])] in topological order.
+
+    Args:
+        component_keys: Component keys like 'h.0.attn.q_proj:42'.
+        layer_descriptions: Mapping from concrete layer path to canonical address
+            (from ModelMetadata.layer_descriptions).
+    """
+    by_layer: dict[str, list[str]] = {}
+    for key in component_keys:
+        layer, _ = parse_component_key(key)
+        by_layer.setdefault(layer, []).append(key)
+
+    def sort_key(layer: str) -> tuple[int, int, int]:
+        canonical = layer_descriptions[layer]
+        return canonical_sort_key(canonical)
+
+    sorted_layers = sorted(by_layer.keys(), key=sort_key)
+
+    result: list[tuple[str, list[str]]] = []
+    for layer in sorted_layers:
+        keys = sorted(by_layer[layer], key=lambda k: parse_component_key(k)[1])
+        result.append((layer, keys))
+    return result
+
+
+def is_later_layer(earlier: str, later: str, layer_descriptions: dict[str, str]) -> bool:
+    """Check if `later` is topologically after `earlier`."""
+    return canonical_sort_key(layer_descriptions[earlier]) < canonical_sort_key(
+        layer_descriptions[later]
+    )

--- a/spd/graph_interp/prompts.py
+++ b/spd/graph_interp/prompts.py
@@ -1,0 +1,227 @@
+"""Prompt formatters for graph interpretation.
+
+Three prompts:
+1. Output pass (late→early): "What does this component DO?" — output tokens, says examples, downstream
+2. Input pass (early→late): "What TRIGGERS this component?" — input tokens, fires-on examples, upstream
+3. Unification: Synthesize output + input labels into unified label.
+"""
+
+from spd.app.backend.app_tokenizer import AppTokenizer
+from spd.autointerp.prompt_helpers import (
+    build_fires_on_examples,
+    build_input_section,
+    build_output_section,
+    build_says_examples,
+    density_note,
+    human_layer_desc,
+    layer_position_note,
+)
+from spd.autointerp.schemas import ModelMetadata
+from spd.graph_interp.graph_context import RelatedComponent
+from spd.graph_interp.schemas import LabelResult
+from spd.harvest.analysis import TokenPRLift
+from spd.harvest.schemas import ComponentData
+
+LABEL_SCHEMA: dict[str, object] = {
+    "type": "object",
+    "properties": {
+        "label": {"type": "string"},
+        "confidence": {"type": "string", "enum": ["low", "medium", "high"]},
+        "reasoning": {"type": "string"},
+    },
+    "required": ["label", "confidence", "reasoning"],
+    "additionalProperties": False,
+}
+
+
+def _component_header(
+    component: ComponentData,
+    model_metadata: ModelMetadata,
+) -> str:
+    canonical = model_metadata.layer_descriptions.get(component.layer, component.layer)
+    layer_desc = human_layer_desc(canonical, model_metadata.n_blocks)
+    position_note = layer_position_note(canonical, model_metadata.n_blocks)
+    dens_note = density_note(component.firing_density)
+
+    rate_str = (
+        f"~1 in {int(1 / component.firing_density)} tokens"
+        if component.firing_density > 0.0
+        else "extremely rare"
+    )
+
+    context_notes = " ".join(filter(None, [position_note, dens_note]))
+
+    return f"""\
+## Context
+- Component: {layer_desc} (component {component.component_idx}), {model_metadata.n_blocks}-block model
+- Firing rate: {component.firing_density * 100:.2f}% ({rate_str})
+{context_notes}"""
+
+
+def format_output_prompt(
+    component: ComponentData,
+    model_metadata: ModelMetadata,
+    app_tok: AppTokenizer,
+    output_token_stats: TokenPRLift,
+    related: list[RelatedComponent],
+    label_max_words: int,
+    max_examples: int,
+) -> str:
+    header = _component_header(component, model_metadata)
+
+    output_pmi = (
+        [(app_tok.get_tok_display(tid), pmi) for tid, pmi in component.output_token_pmi.top]
+        if component.output_token_pmi.top
+        else None
+    )
+    output_section = build_output_section(output_token_stats, output_pmi)
+    says = build_says_examples(component, app_tok, max_examples)
+    related_table = _format_related_table(related, model_metadata, app_tok)
+
+    return f"""\
+You are analyzing a component in a neural network to understand its OUTPUT FUNCTION — what it does when it fires.
+
+{header}
+
+## Output tokens (what the model produces when this component fires)
+{output_section}
+## Activation examples — what the model produces
+{says}
+## Downstream components (what this component influences)
+These components in later layers are most influenced by this component (by gradient attribution):
+{related_table}
+## Task
+Give a {label_max_words}-word-or-fewer label describing this component's OUTPUT FUNCTION — what it does when it fires.
+
+Say "unclear" if the evidence is too weak.
+
+Respond with JSON: {{"label": "...", "confidence": "low|medium|high", "reasoning": "..."}}
+"""
+
+
+def format_input_prompt(
+    component: ComponentData,
+    model_metadata: ModelMetadata,
+    app_tok: AppTokenizer,
+    input_token_stats: TokenPRLift,
+    related: list[RelatedComponent],
+    label_max_words: int,
+    max_examples: int,
+) -> str:
+    header = _component_header(component, model_metadata)
+
+    input_pmi = (
+        [(app_tok.get_tok_display(tid), pmi) for tid, pmi in component.input_token_pmi.top]
+        if component.input_token_pmi.top
+        else None
+    )
+    input_section = build_input_section(input_token_stats, input_pmi)
+    fires_on = build_fires_on_examples(component, app_tok, max_examples)
+    related_table = _format_related_table(related, model_metadata, app_tok)
+
+    return f"""\
+You are analyzing a component in a neural network to understand its INPUT FUNCTION — what triggers it to fire.
+
+{header}
+
+## Input tokens (what causes this component to fire)
+{input_section}
+## Activation examples — where the component fires
+{fires_on}
+## Upstream components (what feeds into this component)
+These components in earlier layers most strongly attribute to this component:
+{related_table}
+## Task
+Give a {label_max_words}-word-or-fewer label describing this component's INPUT FUNCTION — what conditions trigger it to fire.
+
+Say "unclear" if the evidence is too weak.
+
+Respond with JSON: {{"label": "...", "confidence": "low|medium|high", "reasoning": "..."}}
+"""
+
+
+def format_unification_prompt(
+    output_label: LabelResult,
+    input_label: LabelResult,
+    component: ComponentData,
+    model_metadata: ModelMetadata,
+    app_tok: AppTokenizer,
+    label_max_words: int,
+    max_examples: int,
+) -> str:
+    header = _component_header(component, model_metadata)
+    fires_on = build_fires_on_examples(component, app_tok, max_examples)
+    says = build_says_examples(component, app_tok, max_examples)
+
+    return f"""\
+A neural network component has been analyzed from two perspectives.
+
+{header}
+
+## Activation examples — where the component fires
+{fires_on}
+## Activation examples — what the model produces
+{says}
+## Two-perspective analysis
+
+OUTPUT FUNCTION: "{output_label.label}" (confidence: {output_label.confidence})
+  Reasoning: {output_label.reasoning}
+
+INPUT FUNCTION: "{input_label.label}" (confidence: {input_label.confidence})
+  Reasoning: {input_label.reasoning}
+
+## Task
+Synthesize these into a single unified label (max {label_max_words} words) that captures the component's complete role. If input and output suggest the same concept, unify them. If they describe genuinely different aspects (e.g. fires on X, produces Y), combine both.
+
+Respond with JSON: {{"label": "...", "confidence": "low|medium|high", "reasoning": "..."}}
+"""
+
+
+def _format_related_table(
+    components: list[RelatedComponent],
+    model_metadata: ModelMetadata,
+    app_tok: AppTokenizer,
+) -> str:
+    # Filter: only show labeled components and token entries (embed/output)
+    visible = [n for n in components if n.label is not None or _is_token_entry(n.component_key)]
+    if not visible:
+        return "(no related components with labels found)\n"
+
+    # Normalize attributions: strongest = 1.0
+    max_attr = max(abs(n.attribution) for n in visible)
+    norm = max_attr if max_attr > 0 else 1.0
+
+    lines: list[str] = []
+    for n in visible:
+        display = _component_display(n.component_key, model_metadata, app_tok)
+        rel_attr = n.attribution / norm
+
+        parts = [f"  {display} (relative attribution: {rel_attr:+.2f}"]
+        if n.jaccard is not None:
+            parts.append(f", co-firing Jaccard: {n.jaccard:.3f}")
+        parts.append(")")
+
+        line = "".join(parts)
+        if n.label is not None:
+            line += f'\n    label: "{n.label}" (confidence: {n.confidence})'
+        lines.append(line)
+
+    return "\n".join(lines) + "\n"
+
+
+def _is_token_entry(key: str) -> bool:
+    layer = key.rsplit(":", 1)[0]
+    return layer in ("embed", "output")
+
+
+def _component_display(key: str, model_metadata: ModelMetadata, app_tok: AppTokenizer) -> str:
+    layer, idx_str = key.rsplit(":", 1)
+    match layer:
+        case "embed":
+            return f'input token "{app_tok.get_tok_display(int(idx_str))}"'
+        case "output":
+            return f'output token "{app_tok.get_tok_display(int(idx_str))}"'
+        case _:
+            canonical = model_metadata.layer_descriptions.get(layer, layer)
+            desc = human_layer_desc(canonical, model_metadata.n_blocks)
+            return f"component from {desc}"

--- a/spd/graph_interp/repo.py
+++ b/spd/graph_interp/repo.py
@@ -1,0 +1,95 @@
+"""Graph interpretation data repository.
+
+Owns SPD_OUT_DIR/graph_interp/<decomposition_id>/ and provides read access
+to output, input, and unified labels.
+
+Use GraphInterpRepo.open() to construct — returns None if no data exists.
+"""
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from spd.graph_interp.db import DONE_MARKER, GraphInterpDB
+from spd.graph_interp.schemas import LabelResult, PromptEdge, get_graph_interp_dir
+
+
+class GraphInterpRepo:
+    """Read access to graph interpretation data for a single run."""
+
+    def __init__(self, db: GraphInterpDB, subrun_dir: Path, run_id: str) -> None:
+        self._db = db
+        self._subrun_dir = subrun_dir
+        self.subrun_id = subrun_dir.name
+        self.run_id = run_id
+
+    @classmethod
+    def open(cls, run_id: str) -> "GraphInterpRepo | None":
+        """Open graph interp data for a run. Returns None if no data exists."""
+        base_dir = get_graph_interp_dir(run_id)
+        if not base_dir.exists():
+            return None
+        candidates = sorted(
+            [
+                d
+                for d in base_dir.iterdir()
+                if d.is_dir() and d.name.startswith("ti-") and (d / DONE_MARKER).exists()
+            ],
+            key=lambda d: d.name,
+        )
+        if not candidates:
+            return None
+        subrun_dir = candidates[-1]
+        db_path = subrun_dir / "interp.db"
+        if not db_path.exists():
+            return None
+        return cls(
+            db=GraphInterpDB(db_path, readonly=True),
+            subrun_dir=subrun_dir,
+            run_id=run_id,
+        )
+
+    def get_config(self) -> dict[str, Any] | None:
+        config_path = self._subrun_dir / "config.yaml"
+        if not config_path.exists():
+            return None
+        with open(config_path) as f:
+            return yaml.safe_load(f)
+
+    # -- Labels ----------------------------------------------------------------
+
+    def get_all_output_labels(self) -> dict[str, LabelResult]:
+        return self._db.get_all_output_labels()
+
+    def get_all_input_labels(self) -> dict[str, LabelResult]:
+        return self._db.get_all_input_labels()
+
+    def get_all_unified_labels(self) -> dict[str, LabelResult]:
+        return self._db.get_all_unified_labels()
+
+    def get_output_label(self, component_key: str) -> LabelResult | None:
+        return self._db.get_output_label(component_key)
+
+    def get_input_label(self, component_key: str) -> LabelResult | None:
+        return self._db.get_input_label(component_key)
+
+    def get_unified_label(self, component_key: str) -> LabelResult | None:
+        return self._db.get_unified_label(component_key)
+
+    # -- Edges -----------------------------------------------------------------
+
+    def get_prompt_edges(self, component_key: str) -> list[PromptEdge]:
+        return self._db.get_prompt_edges(component_key)
+
+    def get_all_prompt_edges(self) -> list[PromptEdge]:
+        return self._db.get_all_prompt_edges()
+
+    # -- Stats -----------------------------------------------------------------
+
+    def get_label_counts(self) -> dict[str, int]:
+        return {
+            "output": self._db.get_label_count("output_labels"),
+            "input": self._db.get_label_count("input_labels"),
+            "unified": self._db.get_label_count("unified_labels"),
+        }

--- a/spd/graph_interp/schemas.py
+++ b/spd/graph_interp/schemas.py
@@ -1,0 +1,37 @@
+"""Data types and path helpers for graph interpretation."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from spd.settings import SPD_OUT_DIR
+
+GRAPH_INTERP_DIR = SPD_OUT_DIR / "graph_interp"
+
+
+def get_graph_interp_dir(decomposition_id: str) -> Path:
+    return GRAPH_INTERP_DIR / decomposition_id
+
+
+def get_graph_interp_subrun_dir(decomposition_id: str, subrun_id: str) -> Path:
+    return get_graph_interp_dir(decomposition_id) / subrun_id
+
+
+@dataclass
+class LabelResult:
+    component_key: str
+    label: str
+    confidence: str
+    reasoning: str
+    raw_response: str
+    prompt: str
+
+
+@dataclass
+class PromptEdge:
+    component_key: str
+    related_key: str
+    pass_name: Literal["output", "input"]
+    attribution: float
+    related_label: str | None
+    related_confidence: str | None

--- a/spd/graph_interp/scripts/export_html.py
+++ b/spd/graph_interp/scripts/export_html.py
@@ -1,0 +1,268 @@
+"""Export graph interpretation data to JSON for the static HTML page.
+
+Usage:
+    python -m spd.graph_interp.scripts.export_html s-17805b61
+    python -m spd.graph_interp.scripts.export_html s-17805b61 --subrun_id ti-20260223_213443
+    python -m spd.graph_interp.scripts.export_html s-17805b61 --mock
+"""
+
+import json
+import random
+from dataclasses import asdict
+from typing import Any
+
+from spd.graph_interp.repo import GraphInterpRepo
+from spd.graph_interp.schemas import LabelResult, get_graph_interp_dir
+from spd.settings import SPD_OUT_DIR
+
+WWW_DIR = SPD_OUT_DIR / "www"
+DATA_DIR = WWW_DIR / "data"
+
+
+def _label_to_dict(label: LabelResult) -> dict[str, str]:
+    return {
+        "label": label.label,
+        "confidence": label.confidence,
+        "reasoning": label.reasoning,
+    }
+
+
+def _parse_component_key(key: str) -> tuple[str, int]:
+    layer, idx_str = key.rsplit(":", 1)
+    return layer, int(idx_str)
+
+
+def export_from_repo(repo: GraphInterpRepo) -> dict[str, Any]:
+    output_labels = repo.get_all_output_labels()
+    input_labels = repo.get_all_input_labels()
+    unified_labels = repo.get_all_unified_labels()
+
+    all_keys = sorted(
+        set(output_labels) | set(input_labels) | set(unified_labels),
+        key=lambda k: (_parse_component_key(k)[0], _parse_component_key(k)[1]),
+    )
+
+    components = []
+    for key in all_keys:
+        layer, component_idx = _parse_component_key(key)
+        entry: dict[str, Any] = {
+            "key": key,
+            "layer": layer,
+            "component_idx": component_idx,
+        }
+        if key in output_labels:
+            entry["output_label"] = _label_to_dict(output_labels[key])
+        if key in input_labels:
+            entry["input_label"] = _label_to_dict(input_labels[key])
+        if key in unified_labels:
+            entry["unified_label"] = _label_to_dict(unified_labels[key])
+
+        edges = repo.get_prompt_edges(key)
+        if edges:
+            entry["edges"] = [asdict(e) for e in edges]
+
+        components.append(entry)
+
+    label_counts = repo.get_label_counts()
+
+    return {
+        "decomposition_id": repo.run_id,
+        "subrun_id": repo.subrun_id,
+        "label_counts": label_counts,
+        "components": components,
+    }
+
+
+def generate_mock_data(decomposition_id: str) -> dict[str, Any]:
+    random.seed(42)
+
+    layers = [
+        "h.0.mlp.c_fc",
+        "h.0.mlp.down_proj",
+        "h.0.attn.q_proj",
+        "h.0.attn.k_proj",
+        "h.0.attn.v_proj",
+        "h.0.attn.o_proj",
+        "h.1.mlp.c_fc",
+        "h.1.mlp.down_proj",
+        "h.1.attn.q_proj",
+        "h.1.attn.k_proj",
+        "h.1.attn.v_proj",
+        "h.1.attn.o_proj",
+    ]
+
+    output_labels_pool = [
+        "sentence-final punctuation and period prediction",
+        "proper nouns and character name completions",
+        "emotional adjectives describing characters",
+        "temporal adverbs and time-related transitions",
+        "morphological suffix completion (-ing, -ed, -ly)",
+        "determiners preceding concrete nouns",
+        "dialogue-opening quotation marks and speech verbs",
+        "plural noun suffixes after quantity words",
+        "conjunction and clause boundary detection",
+        "verb tense agreement and auxiliary verbs",
+        "spatial prepositions and location descriptors",
+        "possessive pronouns and genitive markers",
+        "narrative action verbs (walked, looked, said)",
+        "abstract emotion nouns (fear, joy, anger)",
+        "comparative and superlative adjective forms",
+    ]
+
+    input_labels_pool = [
+        "punctuation and common function words",
+        "sentence-initial capital letters and proper nouns",
+        "mid-sentence verbs following subject nouns",
+        "adjective-noun boundaries in descriptive phrases",
+        "clause-final positions before conjunctions",
+        "article-noun sequences in noun phrases",
+        "subject pronouns at clause boundaries",
+        "preposition-object sequences",
+        "verb stems preceding inflectional suffixes",
+        "quotation marks and dialogue boundaries",
+        "comma-separated list items",
+        "sentence-medial adverbs after auxiliaries",
+        "concrete nouns following determiners",
+        "coordinating conjunctions between clauses",
+        "word stems requiring morphological completion",
+    ]
+
+    unified_labels_pool = [
+        "sentence termination tracking and terminal punctuation prediction",
+        "character name recognition and proper noun completion",
+        "emotional state description through adjective selection",
+        "temporal transition signaling via adverbs and tense markers",
+        "morphological word completion from stems to suffixed forms",
+        "noun phrase construction: determiners predicting concrete nouns",
+        "dialogue framing through quotation marks and speech attribution",
+        "plural morphology following quantifiers and numerals",
+        "clause coordination and syntactic boundary marking",
+        "verbal agreement and auxiliary verb selection",
+        "spatial relationship encoding via prepositional phrases",
+        "possessive construction and genitive case marking",
+        "narrative action sequencing through core verbs",
+        "abstract emotional vocabulary and sentiment expression",
+        "degree modification and comparative construction",
+    ]
+
+    confidences = ["high", "high", "high", "medium", "medium", "low"]
+
+    reasoning_templates = [
+        "The output function focuses on {output_focus}, while the input function responds to {input_focus}. Together, this component acts as a bridge between {bridge_from} and {bridge_to}, consistent with its position in {layer}.",
+        "This component's output pattern of {output_focus} is activated by {input_focus} in the input. The unified interpretation captures how {bridge_from} contexts trigger {bridge_to} predictions.",
+        "Downstream context shows this component feeds into {output_focus} pathways, while upstream context reveals activation by {input_focus}. The synthesis reflects a coherent role in {bridge_from}-to-{bridge_to} processing.",
+    ]
+
+    focus_terms = [
+        "punctuation patterns",
+        "noun completions",
+        "verb inflections",
+        "emotional descriptors",
+        "syntactic boundaries",
+        "morphological suffixes",
+        "dialogue markers",
+        "temporal signals",
+        "spatial relationships",
+    ]
+
+    components = []
+    for layer in layers:
+        n_components = random.randint(8, 20)
+        indices = sorted(random.sample(range(500), n_components))
+        for idx in indices:
+            key = f"{layer}:{idx}"
+            conf = random.choice(confidences)
+            output_conf = random.choice(confidences)
+            input_conf = random.choice(confidences)
+
+            output_label = random.choice(output_labels_pool)
+            input_label = random.choice(input_labels_pool)
+            unified_label = random.choice(unified_labels_pool)
+
+            reasoning = random.choice(reasoning_templates).format(
+                output_focus=random.choice(focus_terms),
+                input_focus=random.choice(focus_terms),
+                bridge_from=random.choice(focus_terms),
+                bridge_to=random.choice(focus_terms),
+                layer=layer,
+            )
+
+            components.append(
+                {
+                    "key": key,
+                    "layer": layer,
+                    "component_idx": idx,
+                    "output_label": {
+                        "label": output_label,
+                        "confidence": output_conf,
+                        "reasoning": f"Output: {reasoning}",
+                    },
+                    "input_label": {
+                        "label": input_label,
+                        "confidence": input_conf,
+                        "reasoning": f"Input: {reasoning}",
+                    },
+                    "unified_label": {
+                        "label": unified_label,
+                        "confidence": conf,
+                        "reasoning": reasoning,
+                    },
+                }
+            )
+
+    return {
+        "decomposition_id": decomposition_id,
+        "subrun_id": "ti-mock",
+        "label_counts": {
+            "output": len(components),
+            "input": len(components),
+            "unified": len(components),
+        },
+        "components": components,
+    }
+
+
+def main(
+    decomposition_id: str,
+    subrun_id: str | None = None,
+    mock: bool = False,
+) -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    out_path = DATA_DIR / f"graph_interp_{decomposition_id}.json"
+
+    if mock:
+        data = generate_mock_data(decomposition_id)
+        print(f"Generated mock data: {len(data['components'])} components")
+    else:
+        if subrun_id is not None:
+            base_dir = get_graph_interp_dir(decomposition_id)
+            subrun_dir = base_dir / subrun_id
+            assert subrun_dir.exists(), f"Subrun dir not found: {subrun_dir}"
+            db_path = subrun_dir / "interp.db"
+            assert db_path.exists(), f"No interp.db in {subrun_dir}"
+            from spd.graph_interp.db import GraphInterpDB
+
+            db = GraphInterpDB(db_path, readonly=True)
+            repo = GraphInterpRepo(db=db, subrun_dir=subrun_dir, run_id=decomposition_id)
+        else:
+            repo = GraphInterpRepo.open(decomposition_id)
+            if repo is None:
+                print(f"No graph interp data for {decomposition_id}. Generating mock data instead.")
+                data = generate_mock_data(decomposition_id)
+                with open(out_path, "w") as f:
+                    json.dump(data, f)
+                print(f"Wrote mock data to {out_path}")
+                return
+
+        data = export_from_repo(repo)
+        print(f"Exported {len(data['components'])} components from {data['subrun_id']}")
+
+    with open(out_path, "w") as f:
+        json.dump(data, f)
+    print(f"Wrote {out_path}")
+
+
+if __name__ == "__main__":
+    import fire
+
+    fire.Fire(main)

--- a/spd/graph_interp/scripts/run.py
+++ b/spd/graph_interp/scripts/run.py
@@ -1,0 +1,104 @@
+"""CLI entry point for graph interpretation.
+
+Called by SLURM or directly:
+    python -m spd.graph_interp.scripts.run <decomposition_id> --config_json '{...}'
+"""
+
+import os
+from datetime import datetime
+from typing import Any
+
+from dotenv import load_dotenv
+
+from spd.adapters import adapter_from_id
+from spd.adapters.spd import SPDAdapter
+from spd.dataset_attributions.repo import AttributionRepo
+from spd.graph_interp.config import GraphInterpConfig
+from spd.graph_interp.interpret import run_graph_interp
+from spd.graph_interp.schemas import get_graph_interp_subrun_dir
+from spd.harvest.repo import HarvestRepo
+from spd.log import logger
+
+
+def main(
+    decomposition_id: str,
+    config_json: dict[str, Any],
+    harvest_subrun_id: str | None = None,
+    subrun_id: str | None = None,
+) -> None:
+    assert isinstance(config_json, dict), f"Expected dict from fire, got {type(config_json)}"
+    config = GraphInterpConfig.model_validate(config_json)
+
+    load_dotenv()
+    openrouter_api_key = os.environ.get("OPENROUTER_API_KEY")
+    assert openrouter_api_key, "OPENROUTER_API_KEY not set"
+
+    if subrun_id is None:
+        subrun_id = "ti-" + datetime.now().strftime("%Y%m%d_%H%M%S")
+    subrun_dir = get_graph_interp_subrun_dir(decomposition_id, subrun_id)
+    subrun_dir.mkdir(parents=True, exist_ok=True)
+    config.to_file(subrun_dir / "config.yaml")
+    db_path = subrun_dir / "interp.db"
+    logger.info(f"Graph interp run: {subrun_dir}")
+
+    logger.info("Loading adapter and model metadata...")
+    adapter = adapter_from_id(decomposition_id)
+    assert isinstance(adapter, SPDAdapter)
+    logger.info("Loading harvest data...")
+    if harvest_subrun_id is not None:
+        harvest = HarvestRepo(decomposition_id, subrun_id=harvest_subrun_id, readonly=True)
+    else:
+        harvest = HarvestRepo.open_most_recent(decomposition_id, readonly=True)
+        assert harvest is not None, f"No harvest data for {decomposition_id}"
+
+    logger.info("Loading dataset attributions...")
+    attributions = AttributionRepo.open(decomposition_id)
+    assert attributions is not None, f"Dataset attributions required for {decomposition_id}"
+    attribution_storage = attributions.get_attributions()
+    logger.info(
+        f"  {attribution_storage.n_components} components, {attribution_storage.n_tokens_processed:,} tokens"
+    )
+
+    logger.info("Loading component correlations...")
+    correlations = harvest.get_correlations()
+    assert correlations is not None, f"Component correlations required for {decomposition_id}"
+
+    logger.info("Loading token stats...")
+    token_stats = harvest.get_token_stats()
+    assert token_stats is not None, f"Token stats required for {decomposition_id}"
+
+    logger.info("Data loading complete")
+
+    run_graph_interp(
+        openrouter_api_key=openrouter_api_key,
+        config=config,
+        harvest=harvest,
+        attribution_storage=attribution_storage,
+        correlation_storage=correlations,
+        token_stats=token_stats,
+        model_metadata=adapter.model_metadata,
+        db_path=db_path,
+        tokenizer_name=adapter.tokenizer_name,
+    )
+
+
+def get_command(
+    decomposition_id: str,
+    config: GraphInterpConfig,
+    harvest_subrun_id: str | None = None,
+) -> str:
+    config_json = config.model_dump_json(exclude_none=True)
+    cmd = (
+        "python -m spd.graph_interp.scripts.run "
+        f"--decomposition_id {decomposition_id} "
+        f"--config_json '{config_json}' "
+    )
+    if harvest_subrun_id is not None:
+        cmd += f"--harvest_subrun_id {harvest_subrun_id} "
+    return cmd
+
+
+if __name__ == "__main__":
+    import fire
+
+    fire.Fire(main)

--- a/spd/graph_interp/scripts/run_slurm.py
+++ b/spd/graph_interp/scripts/run_slurm.py
@@ -1,0 +1,69 @@
+"""SLURM launcher for graph interpretation.
+
+Submits a single CPU job that runs the three-phase interpretation pipeline.
+Depends on both harvest merge and attribution merge jobs.
+"""
+
+from dataclasses import dataclass
+
+from spd.graph_interp.config import GraphInterpSlurmConfig
+from spd.graph_interp.scripts import run
+from spd.log import logger
+from spd.utils.slurm import SlurmConfig, SubmitResult, generate_script, submit_slurm_job
+
+
+@dataclass
+class GraphInterpSubmitResult:
+    result: SubmitResult
+
+
+def submit_graph_interp(
+    decomposition_id: str,
+    config: GraphInterpSlurmConfig,
+    dependency_job_ids: list[str],
+    snapshot_branch: str | None = None,
+    harvest_subrun_id: str | None = None,
+) -> GraphInterpSubmitResult:
+    """Submit graph interpretation to SLURM.
+
+    Args:
+        decomposition_id: ID of the target decomposition.
+        config: Graph interp SLURM configuration.
+        dependency_job_ids: Jobs to wait for (harvest merge + attribution merge).
+        snapshot_branch: Git snapshot branch to use.
+        harvest_subrun_id: Specific harvest subrun to use.
+    """
+    cmd = run.get_command(
+        decomposition_id=decomposition_id,
+        config=config.config,
+        harvest_subrun_id=harvest_subrun_id,
+    )
+
+    dependency_str = ":".join(dependency_job_ids) if dependency_job_ids else None
+
+    slurm_config = SlurmConfig(
+        job_name="spd-graph-interp",
+        partition=config.partition,
+        n_gpus=0,
+        cpus_per_task=16,
+        mem="240G",
+        time=config.time,
+        snapshot_branch=snapshot_branch,
+        dependency_job_id=dependency_str,
+        comment=decomposition_id,
+    )
+    script_content = generate_script(slurm_config, cmd)
+    result = submit_slurm_job(script_content, "spd-graph-interp")
+
+    logger.section("Graph interp job submitted")
+    logger.values(
+        {
+            "Job ID": result.job_id,
+            "Decomposition ID": decomposition_id,
+            "Model": config.config.model,
+            "Depends on": ", ".join(dependency_job_ids),
+            "Log": result.log_pattern,
+        }
+    )
+
+    return GraphInterpSubmitResult(result=result)

--- a/spd/graph_interp/scripts/run_slurm_cli.py
+++ b/spd/graph_interp/scripts/run_slurm_cli.py
@@ -1,0 +1,27 @@
+"""CLI entry point for graph interp SLURM launcher.
+
+Thin wrapper for fast --help. Heavy imports deferred to run_slurm.py.
+
+Usage:
+    spd-graph-interp <decomposition_id> --config graph_interp_config.yaml
+"""
+
+import fire
+
+
+def main(decomposition_id: str, config: str) -> None:
+    """Submit graph interpretation pipeline to SLURM.
+
+    Args:
+        decomposition_id: ID of the target decomposition run.
+        config: Path to GraphInterpSlurmConfig YAML/JSON.
+    """
+    from spd.graph_interp.config import GraphInterpSlurmConfig
+    from spd.graph_interp.scripts.run_slurm import submit_graph_interp
+
+    slurm_config = GraphInterpSlurmConfig.from_file(config)
+    submit_graph_interp(decomposition_id, slurm_config, dependency_job_ids=[])
+
+
+def cli() -> None:
+    fire.Fire(main)

--- a/spd/investigate/CLAUDE.md
+++ b/spd/investigate/CLAUDE.md
@@ -1,0 +1,118 @@
+# Investigation Module
+
+Launch a Claude Code agent to investigate a specific research question about an SPD model decomposition.
+
+## Usage
+
+```bash
+spd-investigate <wandb_path> "How does the model handle gendered pronouns?"
+spd-investigate <wandb_path> "What circuit handles verb agreement?" --max_turns 30 --time 4:00:00
+```
+
+For parallel investigations, run the command multiple times with different prompts.
+
+## Architecture
+
+```
+spd/investigate/
+├── __init__.py           # Public exports
+├── CLAUDE.md             # This file
+├── schemas.py            # Pydantic models for outputs (BehaviorExplanation, InvestigationEvent)
+├── agent_prompt.py       # System prompt template with model info injection
+└── scripts/
+    ├── __init__.py
+    ├── run_slurm_cli.py  # CLI entry point (spd-investigate)
+    ├── run_slurm.py      # SLURM submission logic
+    └── run_agent.py      # Worker script (runs in SLURM job)
+```
+
+## How It Works
+
+1. `spd-investigate` creates output dir, metadata, git snapshot, and submits a single SLURM job
+2. The SLURM job runs `run_agent.py` which:
+   - Starts an isolated FastAPI backend with MCP support
+   - Loads the SPD run onto GPU
+   - Fetches model architecture info
+   - Generates the agent prompt (research question + model context + methodology)
+   - Launches Claude Code with MCP tools
+3. The agent investigates using MCP tools and writes findings to the output directory
+
+## MCP Tools
+
+The agent accesses all SPD functionality via MCP at `/mcp`:
+
+**Circuit Discovery:**
+- `optimize_graph` — Find minimal circuit for a behavior (streams progress)
+- `create_prompt` — Tokenize text and get next-token probabilities
+
+**Component Analysis:**
+- `get_component_info` — Interpretation, token stats, correlations
+- `probe_component` — Fast CI probing on custom text
+- `get_component_activation_examples` — Training examples where a component fires
+- `get_component_attributions` — Dataset-level component dependencies
+- `get_attribution_strength` — Attribution between specific component pairs
+
+**Testing:**
+- `run_ablation` — Test circuit with only selected components
+- `search_dataset` — Search training data
+
+**Metadata:**
+- `get_model_info` — Architecture details
+
+**Output:**
+- `update_research_log` — Append to research log (PRIMARY OUTPUT)
+- `save_graph_artifact` — Save graph for inline visualization
+- `save_explanation` — Save complete behavior explanation
+- `set_investigation_summary` — Set title/summary for UI
+
+## Output Structure
+
+```
+SPD_OUT_DIR/investigations/<inv_id>/
+├── metadata.json          # Investigation config (wandb_path, prompt, etc.)
+├── research_log.md        # Human-readable progress log (PRIMARY OUTPUT)
+├── events.jsonl           # Structured progress events
+├── explanations.jsonl     # Complete behavior explanations
+├── summary.json           # Agent-provided title/summary for UI
+├── artifacts/             # Graph artifacts for visualization
+│   └── graph_001.json
+├── app.db                 # Isolated SQLite database
+├── backend.log            # Backend subprocess output
+├── claude_output.jsonl    # Raw Claude Code output
+├── agent_prompt.md        # The prompt given to the agent
+└── mcp_config.json        # MCP server configuration
+```
+
+## Environment
+
+The backend runs with `SPD_INVESTIGATION_DIR` set to the investigation directory. This controls:
+- Database location: `<dir>/app.db`
+- Events log: `<dir>/events.jsonl`
+- Research log: `<dir>/research_log.md`
+
+## Configuration
+
+CLI arguments:
+- `wandb_path` — Required. WandB run path for the SPD decomposition.
+- `prompt` — Required. Research question or investigation directive.
+- `--context_length` — Token context length (default: 128)
+- `--max_turns` — Max Claude turns (default: 50, prevents runaway)
+- `--partition` — SLURM partition (default: h200-reserved)
+- `--time` — Job time limit (default: 8:00:00)
+- `--job_suffix` — Optional suffix for job names
+
+## Monitoring
+
+```bash
+# Watch research log
+tail -f SPD_OUT_DIR/investigations/<inv_id>/research_log.md
+
+# Watch events
+tail -f SPD_OUT_DIR/investigations/<inv_id>/events.jsonl
+
+# View explanations
+cat SPD_OUT_DIR/investigations/<inv_id>/explanations.jsonl | jq .
+
+# Check SLURM job status
+squeue --me
+```

--- a/spd/investigate/__init__.py
+++ b/spd/investigate/__init__.py
@@ -1,0 +1,22 @@
+"""Investigation: SLURM-based agent investigation of model behaviors.
+
+This module provides infrastructure for launching a Claude Code agent to investigate
+behaviors in an SPD model decomposition. Each investigation:
+1. Starts an isolated app backend instance (separate database, unique port)
+2. Receives a specific research question and detailed instructions
+3. Investigates behaviors and writes findings to append-only JSONL files
+"""
+
+from spd.investigate.schemas import (
+    BehaviorExplanation,
+    ComponentInfo,
+    Evidence,
+    InvestigationEvent,
+)
+
+__all__ = [
+    "BehaviorExplanation",
+    "ComponentInfo",
+    "Evidence",
+    "InvestigationEvent",
+]

--- a/spd/investigate/agent_prompt.py
+++ b/spd/investigate/agent_prompt.py
@@ -1,0 +1,211 @@
+"""System prompt for SPD investigation agents.
+
+This module contains the detailed instructions given to the investigation agent.
+The agent has access to SPD tools via MCP - tools are self-documenting.
+"""
+
+from typing import Any
+
+AGENT_SYSTEM_PROMPT = """
+# SPD Behavior Investigation Agent
+
+You are a research agent investigating behaviors in a neural network model decomposition.
+A researcher has given you a specific question to investigate. Your job is to answer it
+thoroughly using the SPD analysis tools available to you.
+
+## Your Mission
+
+{prompt}
+
+## Available Tools (via MCP)
+
+You have access to SPD analysis tools. Use them directly - they have full documentation.
+
+**Circuit Discovery:**
+- **optimize_graph**: Find the minimal circuit for a behavior (e.g., "boy" → "he")
+- **create_prompt**: Tokenize text and get next-token probabilities
+
+**Component Analysis:**
+- **get_component_info**: Get interpretation and token stats for a component
+- **probe_component**: Fast CI probing - test if a component activates on specific text
+- **get_component_activation_examples**: See training examples where a component fires
+- **get_component_attributions**: Dataset-level component dependencies (sources and targets)
+- **get_attribution_strength**: Query attribution strength between two specific components
+
+**Testing:**
+- **run_ablation**: Test a circuit by running with only selected components
+- **search_dataset**: Find examples in the training data
+
+**Metadata:**
+- **get_model_info**: Get model architecture details
+- **get_stored_graphs**: Retrieve previously computed graphs
+
+**Output:**
+- **update_research_log**: Append to your research log (PRIMARY OUTPUT - use frequently!)
+- **save_graph_artifact**: Save a graph for inline visualization in your research log
+- **save_explanation**: Save a complete, validated behavior explanation
+- **set_investigation_summary**: Set a title and summary for your investigation
+
+## Investigation Methodology
+
+### Step 1: Understand the Question
+
+Read the research question carefully. Think about what behaviors, components, or mechanisms
+might be relevant. Use `get_model_info` if you need to understand the model architecture.
+
+### Step 2: Explore and Hypothesize
+
+- Use `create_prompt` to test prompts and see what the model predicts
+- Use `search_dataset` to find relevant examples in the training data
+- Use `probe_component` to quickly test whether specific components respond to your prompts
+- Use `get_component_info` to understand what components do
+
+### Step 3: Find Circuits
+
+- Use `optimize_graph` to find the minimal circuit for specific behaviors
+- Examine which components have high CI values
+- Note the circuit size (fewer active components = cleaner mechanism)
+
+### Step 4: Understand Component Roles
+
+For each important component in a circuit:
+1. Use `get_component_info` for interpretation and token associations
+2. Use `probe_component` to test activation on different inputs
+3. Use `get_component_activation_examples` to see training examples
+4. Use `get_component_attributions` to understand information flow
+5. Check correlated components for related functions
+
+### Step 5: Test with Ablations
+
+Form hypotheses and test them:
+1. Use `run_ablation` with the circuit's components
+2. Verify predictions match expectations
+3. Try removing individual components to find critical ones
+
+### Step 6: Document Your Findings
+
+Use `update_research_log` frequently - this is how humans monitor your work!
+When you have a complete explanation, use `save_explanation` to create a structured record.
+
+## Scientific Principles
+
+- **Be skeptical**: Your first hypothesis is probably incomplete
+- **Triangulate**: Don't rely on a single type of evidence
+- **Document uncertainty**: Note what you're confident in vs. uncertain about
+- **Consider alternatives**: What else could explain the behavior?
+
+## Output Format
+
+### Research Log (PRIMARY OUTPUT - Update frequently!)
+
+Use `update_research_log` with markdown content. Call it every few minutes to show progress:
+
+Example calls:
+```
+update_research_log("## Hypothesis: Gendered Pronoun Circuit\\n\\nTesting prompt: 'The boy said that' → expecting ' he'\\n\\n")
+
+update_research_log("## Ablation Test\\n\\nResult: P(he) = 0.89 (vs 0.22 baseline)\\n\\nThis confirms the circuit is sufficient!\\n\\n")
+```
+
+### Including Graph Visualizations
+
+After running `optimize_graph`, embed the circuit visualization in your research log:
+
+1. Call `save_graph_artifact` with the graph_id returned by optimize_graph
+2. Reference it in your research log using the `spd:graph` code block
+
+Example:
+```
+save_graph_artifact(graph_id=42, caption="Circuit predicting 'he' after 'The boy'")
+
+update_research_log('''## Circuit Visualization
+
+```spd:graph
+artifact: graph_001
+```
+
+This circuit shows the key components involved in predicting "he"...
+''')
+```
+
+### Saving Explanations
+
+When you have a complete explanation, use `save_explanation`:
+
+```
+save_explanation(
+  subject_prompt="The boy said that",
+  behavior_description="Predicts masculine pronoun 'he' after male subject",
+  components_involved=[
+    {{"component_key": "h.0.mlp.c_fc:407", "role": "Male subject detector"}},
+    {{"component_key": "h.3.attn.o_proj:262", "role": "Masculine pronoun promoter"}}
+  ],
+  explanation="Component h.0.mlp.c_fc:407 activates on male subjects...",
+  confidence="medium",
+  limitations=["Only tested on simple sentences"]
+)
+```
+
+## Getting Started
+
+1. **Create your research log** with `update_research_log`
+2. Understand the research question and plan your approach
+3. Use analysis tools to explore the model
+4. **Call `update_research_log` frequently** - humans are watching!
+5. Use `save_explanation` for complete findings
+6. **Call `set_investigation_summary`** with a title and summary when done
+
+Document what you learn, even if it's "this was more complicated than expected."
+"""
+
+
+def _format_model_info(model_info: dict[str, Any]) -> str:
+    """Format model architecture info for inclusion in the agent prompt."""
+    parts = [f"- **Architecture**: {model_info.get('summary', 'Unknown')}"]
+
+    target_config = model_info.get("target_model_config")
+    if target_config:
+        if "n_layer" in target_config:
+            parts.append(f"- **Layers**: {target_config['n_layer']}")
+        if "n_embd" in target_config:
+            parts.append(f"- **Hidden dim**: {target_config['n_embd']}")
+        if "vocab_size" in target_config:
+            parts.append(f"- **Vocab size**: {target_config['vocab_size']}")
+        if "n_ctx" in target_config:
+            parts.append(f"- **Context length**: {target_config['n_ctx']}")
+
+    topology = model_info.get("topology")
+    if topology and topology.get("block_structure"):
+        block = topology["block_structure"][0]
+        attn = ", ".join(block.get("attn_projections", []))
+        ffn = ", ".join(block.get("ffn_projections", []))
+        parts.append(f"- **Attention projections**: {attn}")
+        parts.append(f"- **FFN projections**: {ffn}")
+
+    return "\n".join(parts)
+
+
+def get_agent_prompt(
+    wandb_path: str,
+    prompt: str,
+    model_info: dict[str, Any],
+) -> str:
+    """Generate the full agent prompt with runtime parameters filled in."""
+    formatted_prompt = AGENT_SYSTEM_PROMPT.format(prompt=prompt)
+
+    model_section = f"""
+## Model Architecture
+
+{_format_model_info(model_info)}
+
+## Runtime Context
+
+- **Model Run**: {wandb_path}
+
+Use the MCP tools for ALL output:
+- `update_research_log` → **PRIMARY OUTPUT** - Update frequently with your progress!
+- `save_explanation` → Save complete, validated behavior explanations
+
+**Start by calling update_research_log to create your log, then investigate!**
+"""
+    return formatted_prompt + model_section

--- a/spd/investigate/schemas.py
+++ b/spd/investigate/schemas.py
@@ -1,0 +1,104 @@
+"""Schemas for investigation outputs.
+
+All agent outputs are append-only JSONL files. Each line is a JSON object
+conforming to one of the schemas defined here.
+"""
+
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+
+class ComponentInfo(BaseModel):
+    """Information about a component involved in a behavior."""
+
+    component_key: str = Field(
+        ...,
+        description="Component key in format 'layer:component_idx' (e.g., 'h.0.mlp.c_fc:5')",
+    )
+    role: str = Field(
+        ...,
+        description="The role this component plays in the behavior (e.g., 'stores subject gender')",
+    )
+    interpretation: str | None = Field(
+        default=None,
+        description="Auto-interp label for this component if available",
+    )
+
+
+class Evidence(BaseModel):
+    """A piece of supporting evidence for an explanation."""
+
+    evidence_type: Literal["ablation", "attribution", "activation_pattern", "correlation", "other"]
+    description: str = Field(
+        ...,
+        description="Description of the evidence",
+    )
+    details: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional structured details (e.g., ablation results, attribution values)",
+    )
+
+
+class BehaviorExplanation(BaseModel):
+    """A candidate explanation for a behavior discovered by an agent.
+
+    This is the primary output schema for agent investigations. Each explanation
+    describes a behavior (demonstrated by a subject prompt), the components involved,
+    and supporting evidence.
+    """
+
+    subject_prompt: str = Field(
+        ...,
+        description="A prompt that demonstrates the behavior being explained",
+    )
+    behavior_description: str = Field(
+        ...,
+        description="Clear description of the behavior (e.g., 'correctly predicts gendered pronoun')",
+    )
+    components_involved: list[ComponentInfo] = Field(
+        ...,
+        description="List of components involved in this behavior and their roles",
+    )
+    explanation: str = Field(
+        ...,
+        description="Explanation of how the components work together to produce the behavior",
+    )
+    supporting_evidence: list[Evidence] = Field(
+        default_factory=list,
+        description="Evidence supporting this explanation (ablations, attributions, etc.)",
+    )
+    confidence: Literal["high", "medium", "low"] = Field(
+        ...,
+        description="Agent's confidence in this explanation",
+    )
+    alternative_hypotheses: list[str] = Field(
+        default_factory=list,
+        description="Alternative hypotheses that were considered but not fully supported",
+    )
+    limitations: list[str] = Field(
+        default_factory=list,
+        description="Known limitations of this explanation",
+    )
+
+
+class InvestigationEvent(BaseModel):
+    """A generic event logged by an agent during investigation.
+
+    Used for logging progress, observations, and other non-explanation events.
+    """
+
+    event_type: Literal[
+        "start",
+        "progress",
+        "observation",
+        "hypothesis",
+        "test_result",
+        "explanation",
+        "error",
+        "complete",
+    ]
+    timestamp: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    message: str
+    details: dict[str, Any] = Field(default_factory=dict)

--- a/spd/investigate/scripts/__init__.py
+++ b/spd/investigate/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Investigation SLURM scripts."""

--- a/spd/investigate/scripts/run_agent.py
+++ b/spd/investigate/scripts/run_agent.py
@@ -1,0 +1,306 @@
+"""Worker script that runs inside each SLURM job.
+
+This script:
+1. Reads the research question from the investigation metadata
+2. Starts the app backend with an isolated database
+3. Loads the SPD run and fetches model architecture info
+4. Configures MCP server for Claude Code
+5. Launches Claude Code with the investigation question
+6. Handles cleanup on exit
+"""
+
+import json
+import os
+import signal
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from types import FrameType
+from typing import Any
+
+import fire
+import requests
+
+from spd.investigate.agent_prompt import get_agent_prompt
+from spd.investigate.schemas import InvestigationEvent
+from spd.investigate.scripts.run_slurm import get_investigation_output_dir
+from spd.log import logger
+
+
+def write_mcp_config(inv_dir: Path, port: int) -> Path:
+    """Write MCP configuration file for Claude Code."""
+    mcp_config = {
+        "mcpServers": {
+            "spd": {
+                "type": "http",
+                "url": f"http://localhost:{port}/mcp",
+            }
+        }
+    }
+    config_path = inv_dir / "mcp_config.json"
+    config_path.write_text(json.dumps(mcp_config, indent=2))
+    return config_path
+
+
+def write_claude_settings(inv_dir: Path) -> None:
+    """Write Claude Code settings to pre-grant MCP tool permissions."""
+    claude_dir = inv_dir / ".claude"
+    claude_dir.mkdir(exist_ok=True)
+    settings = {"permissions": {"allow": ["mcp__spd__*"]}}
+    (claude_dir / "settings.json").write_text(json.dumps(settings, indent=2))
+
+
+def find_available_port(start_port: int = 8000, max_attempts: int = 100) -> int:
+    """Find an available port starting from start_port."""
+    for offset in range(max_attempts):
+        port = start_port + offset
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("localhost", port))
+                return port
+            except OSError:
+                continue
+    raise RuntimeError(
+        f"Could not find available port in range {start_port}-{start_port + max_attempts}"
+    )
+
+
+def wait_for_backend(port: int, timeout: float = 120.0) -> bool:
+    """Wait for the backend to become healthy."""
+    url = f"http://localhost:{port}/api/health"
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            resp = requests.get(url, timeout=5)
+            if resp.status_code == 200:
+                return True
+        except requests.exceptions.ConnectionError:
+            pass
+        time.sleep(1)
+    return False
+
+
+def load_run(port: int, wandb_path: str, context_length: int) -> None:
+    """Load the SPD run into the backend. Raises on failure."""
+    url = f"http://localhost:{port}/api/runs/load"
+    params = {"wandb_path": wandb_path, "context_length": context_length}
+    resp = requests.post(url, params=params, timeout=300)
+    assert resp.status_code == 200, (
+        f"Failed to load run {wandb_path}: {resp.status_code} {resp.text}"
+    )
+
+
+def fetch_model_info(port: int) -> dict[str, Any]:
+    """Fetch model architecture info from the backend."""
+    resp = requests.get(f"http://localhost:{port}/api/pretrain_info/loaded", timeout=30)
+    assert resp.status_code == 200, f"Failed to fetch model info: {resp.status_code} {resp.text}"
+    result: dict[str, Any] = resp.json()
+    return result
+
+
+def log_event(events_path: Path, event: InvestigationEvent) -> None:
+    """Append an event to the events log."""
+    with open(events_path, "a") as f:
+        f.write(event.model_dump_json() + "\n")
+
+
+def run_agent(
+    wandb_path: str,
+    inv_id: str,
+    context_length: int = 128,
+    max_turns: int = 50,
+) -> None:
+    """Run a single investigation agent.
+
+    Args:
+        wandb_path: WandB path of the SPD run.
+        inv_id: Unique identifier for this investigation.
+        context_length: Context length for prompts.
+        max_turns: Maximum agentic turns before stopping (prevents runaway agents).
+    """
+    inv_dir = get_investigation_output_dir(inv_id)
+    assert inv_dir.exists(), f"Investigation directory does not exist: {inv_dir}"
+
+    # Read prompt from metadata
+    metadata: dict[str, Any] = json.loads((inv_dir / "metadata.json").read_text())
+    prompt = metadata["prompt"]
+
+    write_claude_settings(inv_dir)
+
+    events_path = inv_dir / "events.jsonl"
+    (inv_dir / "explanations.jsonl").touch()
+
+    log_event(
+        events_path,
+        InvestigationEvent(
+            event_type="start",
+            message=f"Investigation {inv_id} starting",
+            details={"wandb_path": wandb_path, "inv_id": inv_id, "prompt": prompt},
+        ),
+    )
+
+    port = find_available_port()
+    logger.info(f"[{inv_id}] Using port {port}")
+
+    log_event(
+        events_path,
+        InvestigationEvent(
+            event_type="progress",
+            message=f"Starting backend on port {port}",
+            details={"port": port},
+        ),
+    )
+
+    # Start backend with investigation configuration
+    env = os.environ.copy()
+    env["SPD_INVESTIGATION_DIR"] = str(inv_dir)
+
+    backend_cmd = [
+        sys.executable,
+        "-m",
+        "spd.app.backend.server",
+        "--port",
+        str(port),
+    ]
+
+    backend_log_path = inv_dir / "backend.log"
+    backend_log = open(backend_log_path, "w")  # noqa: SIM115 - managed manually
+    backend_proc = subprocess.Popen(
+        backend_cmd,
+        env=env,
+        stdout=backend_log,
+        stderr=subprocess.STDOUT,
+    )
+
+    def cleanup(signum: int | None = None, frame: FrameType | None = None) -> None:
+        _ = frame
+        logger.info(f"[{inv_id}] Cleaning up...")
+        if backend_proc.poll() is None:
+            backend_proc.terminate()
+            try:
+                backend_proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                backend_proc.kill()
+        backend_log.close()
+        if signum is not None:
+            sys.exit(1)
+
+    signal.signal(signal.SIGTERM, cleanup)
+    signal.signal(signal.SIGINT, cleanup)
+
+    try:
+        logger.info(f"[{inv_id}] Waiting for backend...")
+        if not wait_for_backend(port):
+            log_event(
+                events_path,
+                InvestigationEvent(event_type="error", message="Backend failed to start"),
+            )
+            raise RuntimeError("Backend failed to start")
+
+        logger.info(f"[{inv_id}] Backend ready, loading run...")
+        log_event(
+            events_path,
+            InvestigationEvent(event_type="progress", message="Backend ready, loading run"),
+        )
+
+        load_run(port, wandb_path, context_length)
+
+        logger.info(f"[{inv_id}] Run loaded, fetching model info...")
+        model_info = fetch_model_info(port)
+
+        logger.info(f"[{inv_id}] Launching Claude Code...")
+        log_event(
+            events_path,
+            InvestigationEvent(
+                event_type="progress", message="Run loaded, launching Claude Code agent"
+            ),
+        )
+
+        agent_prompt = get_agent_prompt(
+            wandb_path=wandb_path,
+            prompt=prompt,
+            model_info=model_info,
+        )
+
+        (inv_dir / "agent_prompt.md").write_text(agent_prompt)
+
+        mcp_config_path = write_mcp_config(inv_dir, port)
+        logger.info(f"[{inv_id}] MCP config written to {mcp_config_path}")
+
+        claude_output_path = inv_dir / "claude_output.jsonl"
+        claude_cmd = [
+            "claude",
+            "--print",
+            "--verbose",
+            "--output-format",
+            "stream-json",
+            "--max-turns",
+            str(max_turns),
+            # MCP: only our backend, no inherited servers
+            "--mcp-config",
+            str(mcp_config_path),
+            # Permissions: only MCP tools, deny everything else
+            "--permission-mode",
+            "dontAsk",
+            "--allowedTools",
+            "mcp__spd__*",
+            # Isolation: skip all user/project settings (no plugins, no inherited config)
+            "--setting-sources",
+            "",
+            "--model",
+            "opus",
+        ]
+
+        logger.info(f"[{inv_id}] Starting Claude Code (max_turns={max_turns})...")
+        logger.info(f"[{inv_id}] Monitor with: tail -f {claude_output_path}")
+
+        with open(claude_output_path, "w") as output_file:
+            claude_proc = subprocess.Popen(
+                claude_cmd,
+                stdin=subprocess.PIPE,
+                stdout=output_file,
+                stderr=subprocess.STDOUT,
+                text=True,
+                cwd=str(inv_dir),
+            )
+
+            assert claude_proc.stdin is not None
+            claude_proc.stdin.write(agent_prompt)
+            claude_proc.stdin.close()
+
+            claude_proc.wait()
+
+        log_event(
+            events_path,
+            InvestigationEvent(
+                event_type="complete",
+                message="Investigation complete",
+                details={"exit_code": claude_proc.returncode},
+            ),
+        )
+
+        logger.info(f"[{inv_id}] Investigation complete")
+
+    except Exception as e:
+        log_event(
+            events_path,
+            InvestigationEvent(
+                event_type="error",
+                message=f"Agent failed: {e}",
+                details={"error_type": type(e).__name__},
+            ),
+        )
+        logger.error(f"[{inv_id}] Failed: {e}")
+        raise
+    finally:
+        cleanup()
+
+
+def cli() -> None:
+    fire.Fire(run_agent)
+
+
+if __name__ == "__main__":
+    cli()

--- a/spd/investigate/scripts/run_slurm.py
+++ b/spd/investigate/scripts/run_slurm.py
@@ -1,0 +1,95 @@
+"""SLURM submission logic for investigation jobs."""
+
+import json
+import secrets
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+from spd.log import logger
+from spd.settings import SPD_OUT_DIR
+from spd.utils.git_utils import create_git_snapshot
+from spd.utils.slurm import SlurmConfig, generate_script, submit_slurm_job
+from spd.utils.wandb_utils import parse_wandb_run_path
+
+
+@dataclass
+class InvestigationResult:
+    inv_id: str
+    job_id: str
+    output_dir: Path
+
+
+def get_investigation_output_dir(inv_id: str) -> Path:
+    return SPD_OUT_DIR / "investigations" / inv_id
+
+
+def launch_investigation(
+    wandb_path: str,
+    prompt: str,
+    context_length: int,
+    max_turns: int,
+    partition: str,
+    time: str,
+    job_suffix: str | None,
+) -> InvestigationResult:
+    """Launch a single investigation agent via SLURM.
+
+    Creates a SLURM job that starts an isolated app backend, loads the SPD run,
+    and launches a Claude Code agent with the given research question.
+    """
+    # Normalize wandb_path to canonical form (entity/project/run_id)
+    entity, project, run_id = parse_wandb_run_path(wandb_path)
+    canonical_wandb_path = f"{entity}/{project}/{run_id}"
+
+    inv_id = f"inv-{secrets.token_hex(4)}"
+    output_dir = get_investigation_output_dir(inv_id)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    snapshot_branch, commit_hash = create_git_snapshot(inv_id)
+
+    suffix = f"-{job_suffix}" if job_suffix else ""
+    job_name = f"spd-investigate{suffix}"
+
+    metadata = {
+        "inv_id": inv_id,
+        "wandb_path": canonical_wandb_path,
+        "prompt": prompt,
+        "context_length": context_length,
+        "max_turns": max_turns,
+        "snapshot_branch": snapshot_branch,
+        "commit_hash": commit_hash,
+    }
+    (output_dir / "metadata.json").write_text(json.dumps(metadata, indent=2))
+
+    cmd = (
+        f"{sys.executable} -m spd.investigate.scripts.run_agent "
+        f'"{wandb_path}" '
+        f"--inv_id {inv_id} "
+        f"--context_length {context_length} "
+        f"--max_turns {max_turns}"
+    )
+
+    slurm_config = SlurmConfig(
+        job_name=job_name,
+        partition=partition,
+        n_gpus=1,
+        time=time,
+        snapshot_branch=snapshot_branch,
+    )
+    script = generate_script(slurm_config, cmd)
+    result = submit_slurm_job(script, "investigate")
+
+    logger.section("Investigation submitted")
+    logger.values(
+        {
+            "Investigation ID": inv_id,
+            "Job ID": result.job_id,
+            "WandB path": canonical_wandb_path,
+            "Prompt": prompt[:100] + ("..." if len(prompt) > 100 else ""),
+            "Output directory": str(output_dir),
+            "Logs": result.log_pattern,
+        }
+    )
+
+    return InvestigationResult(inv_id=inv_id, job_id=result.job_id, output_dir=output_dir)

--- a/spd/investigate/scripts/run_slurm_cli.py
+++ b/spd/investigate/scripts/run_slurm_cli.py
@@ -1,0 +1,59 @@
+"""CLI entry point for investigation SLURM launcher.
+
+Usage:
+    spd-investigate <wandb_path> "<prompt>"
+    spd-investigate <wandb_path> @prompt.txt
+    spd-investigate <wandb_path> "<prompt>" --max_turns 30
+"""
+
+from pathlib import Path
+
+import fire
+
+from spd.settings import DEFAULT_PARTITION_NAME
+
+
+def _resolve_prompt(prompt: str) -> str:
+    """If prompt starts with @, read from that file path. Otherwise return as-is."""
+    if prompt.startswith("@"):
+        path = Path(prompt[1:])
+        assert path.exists(), f"Prompt file not found: {path}"
+        return path.read_text().strip()
+    return prompt
+
+
+def main(
+    wandb_path: str,
+    prompt: str,
+    context_length: int = 128,
+    max_turns: int = 50,
+    partition: str = DEFAULT_PARTITION_NAME,
+    time: str = "8:00:00",
+    job_suffix: str | None = None,
+) -> None:
+    """Launch a single investigation agent for a specific question.
+
+    Args:
+        wandb_path: WandB run path for the SPD decomposition to investigate.
+        prompt: The research question, or @filepath to read from a file.
+        context_length: Context length for prompts (default 128).
+        max_turns: Maximum agentic turns (default 50, prevents runaway).
+        partition: SLURM partition name.
+        time: Job time limit (default 8 hours).
+        job_suffix: Optional suffix for SLURM job names.
+    """
+    from spd.investigate.scripts.run_slurm import launch_investigation
+
+    launch_investigation(
+        wandb_path=wandb_path,
+        prompt=_resolve_prompt(prompt),
+        context_length=context_length,
+        max_turns=max_turns,
+        partition=partition,
+        time=time,
+        job_suffix=job_suffix,
+    )
+
+
+def cli() -> None:
+    fire.Fire(main)

--- a/spd/postprocess/cli.py
+++ b/spd/postprocess/cli.py
@@ -3,35 +3,39 @@
 Thin wrapper for fast --help. Heavy imports deferred to postprocess.py.
 
 Usage:
-    spd-postprocess <wandb_path>
-    spd-postprocess <wandb_path> --config my_config.yaml
+    spd-postprocess config.yaml
+    spd-postprocess config.yaml --dependency 311644_1
 """
 
-import fire
+import argparse
 
 
-def main(config: str, dry_run: bool = False) -> None:
-    """Submit all postprocessing jobs for an SPD run.
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Submit all postprocessing jobs for an SPD run.")
+    parser.add_argument("config", help="Path to PostprocessConfig YAML.")
+    parser.add_argument(
+        "--dependency",
+        help="SLURM job ID to wait for before starting (e.g. a training job).",
+    )
+    parser.add_argument("--dry_run", action="store_true")
+    args = parser.parse_args()
 
-    Args:
-        config: Path to PostprocessConfig YAML.
-    """
     import yaml
 
     from spd.log import logger
     from spd.postprocess import postprocess
     from spd.postprocess.config import PostprocessConfig
 
-    cfg = PostprocessConfig.from_file(config)
+    cfg = PostprocessConfig.from_file(args.config)
 
-    if dry_run:
+    if args.dry_run:
         logger.info("Dry run: skipping submission\n\nConfig:\n")
         logger.info(yaml.dump(cfg.model_dump(), indent=2, sort_keys=False))
         return
 
-    manifest_path = postprocess(config=cfg)
+    manifest_path = postprocess(config=cfg, dependency_job_id=args.dependency)
     logger.info(f"Manifest: {manifest_path}")
 
 
 def cli() -> None:
-    fire.Fire(main)
+    main()

--- a/spd/postprocess/config.py
+++ b/spd/postprocess/config.py
@@ -9,6 +9,7 @@ from typing import Any, override
 from spd.autointerp.config import AutointerpSlurmConfig
 from spd.base_config import BaseConfig
 from spd.dataset_attributions.config import AttributionsSlurmConfig
+from spd.graph_interp.config import GraphInterpSlurmConfig
 from spd.harvest.config import HarvestSlurmConfig, IntruderSlurmConfig, SPDHarvestConfig
 
 
@@ -32,6 +33,7 @@ class PostprocessConfig(BaseConfig):
     autointerp: AutointerpSlurmConfig | None
     intruder: IntruderSlurmConfig | None
     attributions: AttributionsSlurmConfig | None
+    graph_interp: GraphInterpSlurmConfig | None
 
     @override
     def model_post_init(self, __context: Any) -> None:
@@ -39,3 +41,12 @@ class PostprocessConfig(BaseConfig):
         is_not_spd = not isinstance(self.harvest.config.method_config, SPDHarvestConfig)
         if expects_attributions and is_not_spd:
             raise ValueError("Attributions only work for SPD decompositions")
+        if self.graph_interp is not None and self.attributions is None:
+            raise ValueError("Graph interp requires attributions")
+
+
+if __name__ == "__main__":
+    import json
+
+    with open("spd/postprocess/postprocess.schema.json", "w") as f:
+        json.dump(PostprocessConfig.model_json_schema(), f, indent=2)

--- a/spd/postprocess/s-55ea3f9b.yaml
+++ b/spd/postprocess/s-55ea3f9b.yaml
@@ -1,0 +1,32 @@
+harvest:
+  n_gpus: 16
+  time: "24:00:00"
+  merge_time: "24:00:00"
+  config:
+    method_config:
+      type: SPDHarvestConfig
+      wandb_path: "wandb:goodfire/spd/s-55ea3f9b"
+
+autointerp:
+  time: "24:00:00"
+  config:
+    template_strategy:
+      type: compact_skeptical
+      forbidden_words: []
+    cost_limit_usd: 400
+  evals: null
+
+intruder: null
+
+attributions:
+  n_gpus: 16
+  time: "24:00:00"
+  merge_time: "24:00:00"
+  config:
+    spd_run_wandb_path: "wandb:goodfire/spd/s-55ea3f9b"
+    n_batches: 640
+
+graph_interp:
+  time: "24:00:00"
+  config:
+    cost_limit_usd: 400

--- a/spd/postprocess/s-82ffb969.yaml
+++ b/spd/postprocess/s-82ffb969.yaml
@@ -1,0 +1,71 @@
+# yaml-language-server: $schema=postprocess.schema.json
+
+harvest:
+  n_gpus: 32
+  time: "24:00:00"
+  merge_time: "24:00:00"
+  config:
+    method_config:
+      type: SPDHarvestConfig
+      wandb_path: "wandb:goodfire/spd/s-82ffb969"
+    n_batches: 20000
+    batch_size: 32
+    activation_examples_per_component: 400
+    activation_context_tokens_per_side: 20
+    pmi_token_top_k: 40
+    max_examples_per_batch_per_component: 5
+
+autointerp:
+  time: "24:00:00"
+  config:
+    model: "google/gemini-3-flash-preview"
+    reasoning_effort: "low"
+    # model: "google/gemini-3.1-pro-preview"
+    # reasoning_effort: "low"
+    template_strategy:
+      type: dual_view
+    cost_limit_usd: 2000
+  evals:
+    model: "google/gemini-3-flash-preview"
+    reasoning_effort: "low"
+    detection_config:
+      type: detection
+      n_activating: 5
+      n_non_activating: 5
+      n_trials: 5
+    fuzzing_config:
+      type: fuzzing
+      n_correct: 5
+      n_incorrect: 2
+      n_trials: 5
+    cost_limit_usd: 1000
+
+
+intruder:
+  config:
+    model: google/gemini-3-flash-preview
+    reasoning_effort: "none"
+    n_real: 4
+    n_trials: 10
+    density_tolerance: 0.05
+    max_concurrent: 50
+    max_requests_per_minute: 200
+    cost_limit_usd: 1000
+
+attributions:
+  n_gpus: 32
+  time: "24:00:00"
+  merge_time: "24:00:00"
+  config:
+    spd_run_wandb_path: "wandb:goodfire/spd/s-82ffb969"
+    n_batches: 1280
+
+graph_interp:
+  time: "24:00:00"
+  config:
+    model: "google/gemini-3-flash-preview"
+    reasoning_effort: "low"
+    # model: "google/gemini-3.1-pro-preview"
+    # reasoning_effort: "low"
+    cost_limit_usd: 2000
+


### PR DESCRIPTION
## Summary

**Stack: [#421](https://github.com/goodfire-ai/spd/pull/421) (merged) → this → PR3 (pending)**

Adds four new modules. Won't pass type-checking alone (cross-PR deps with PR3's app changes).

### graph_interp (`spd/graph_interp/`)
- Context-aware component labeling using attribution graph structure
- Three-phase pipeline: output pass (late→early), input pass (early→late), unification
- `GraphInterpDB` (SQLite via `open_nfs_sqlite`), `GraphInterpRepo`, CLI (`spd-graph-interp`)
- **Bug fix**: replaced WAL with NFS-safe DELETE journal (same bug fixed for HarvestDB/InterpDB in PR1)

### investigate (`spd/investigate/`)
- Claude Code agent for model investigation via MCP
- SLURM-launched, isolated from global config
- Research log system (append-only JSONL + markdown)

### editing (`spd/editing/`)
- `EditableModel`: component ablation, permanent weight editing, circuit analysis
- `optimize_circuit`, `find_components_by_examples`, token divergence

### postprocess (`spd/postprocess/`)
- Unified `spd-postprocess` CLI with SLURM dependency chains
- Orchestrates: harvest → intruder + autointerp → evals, attributions (parallel)

## Test plan
- [ ] `make check` passes on full stack (PR3)
- [ ] `spd-graph-interp`, `spd-investigate`, `spd-postprocess` CLIs importable

---

Review and bug fix by Claude Code (Opus 4.6).