### PR TITLE
Option to enable PPGD late during training

### DIFF
--- a/spd/configs.py
+++ b/spd/configs.py
@@ -567,6 +567,7 @@ class _PersistentPGDBaseConfig(LossMetricConfig):
             "source refinement iterations on the same batch in an inner loop beforehand."
         ),
     ] = 0
+    start_frac: Probability = 0.0
 
     @model_validator(mode="before")
     @classmethod

--- a/spd/losses.py
+++ b/spd/losses.py
@@ -183,6 +183,8 @@ def compute_losses(
                     weight_deltas=weight_deltas if use_delta_component else None,
                 )
             case PersistentPGDReconLossConfig() | PersistentPGDReconSubsetLossConfig():
+                if current_frac_of_training < cfg.start_frac:
+                    continue
                 loss = ppgd_states[cfg].compute_recon_loss(
                     model=model,
                     batch=batch,

--- a/spd/run_spd.py
+++ b/spd/run_spd.py
@@ -258,7 +258,10 @@ def optimize(
         for group in optimizer.param_groups:
             group["lr"] = step_lr
 
-        for ppgd_cfg in persistent_pgd_configs:
+        frac = step / config.steps
+        active_ppgd_configs = [c for c in persistent_pgd_configs if frac >= c.start_frac]
+
+        for ppgd_cfg in active_ppgd_configs:
             ppgd_states[ppgd_cfg].update_lr(step, config.steps)
 
         weight_deltas = component_model.calc_weight_deltas()
@@ -280,7 +283,7 @@ def optimize(
                 sampling=config.sampling,
             )
 
-            for ppgd_cfg in persistent_pgd_configs:
+            for ppgd_cfg in active_ppgd_configs:
                 ppgd_states[ppgd_cfg].warmup(
                     model=component_model,
                     batch=batch,
@@ -314,12 +317,12 @@ def optimize(
 
         ppgd_grads = {
             cfg: ppgd_states[cfg].get_grads(losses[cfg], retain_graph=True)
-            for cfg in persistent_pgd_configs
+            for cfg in active_ppgd_configs
         }
 
         total_loss.backward()
 
-        for ppgd_cfg in persistent_pgd_configs:
+        for ppgd_cfg in active_ppgd_configs:
             ppgd_states[ppgd_cfg].step(ppgd_grads[ppgd_cfg])
 
         for layer_name, layer_ci in ci.lower_leaky.items():


### PR DESCRIPTION
## Description
Add a `start_frac` option to the Persistent PGD loss configs, allowing PPGD to be enabled late during training rather than from the start. It determines the fraction of training at which the loss is enabled.

## Related Issue
NA

## Motivation and Context
Adversarial reconstruction losses require a lot of compute. Enabling them late during decomposition (e.g. during the last 20% of training) can make training faster while still reaching similar end results.

## How Has This Been Tested?
Tested on a pile_llamma model with 4 layers in targeted mode.

## Does this PR introduce a breaking change?
No, `start_frac` defaults to 0, preserving existing behavior.