### PR TITLE
Add data presentation context to autointerp prompt

### DIFF
--- a/spd/app/backend/routers/correlations.py
+++ b/spd/app/backend/routers/correlations.py
@@ -170,8 +170,11 @@ async def request_component_interpretation(
             detail="OPENROUTER_API_KEY environment variable not set",
         )
 
+    from spd.harvest.schemas import get_activation_contexts_dir
+
     # Get architecture info and tokenizer
-    arch = get_architecture_info(loaded.run.wandb_path)
+    activation_contexts_dir = get_activation_contexts_dir(loaded.harvest.run_id)
+    arch = get_architecture_info(loaded.run.wandb_path, activation_contexts_dir)
 
     # Get token stats
     token_stats = loaded.harvest.token_stats

--- a/spd/app/backend/routers/correlations.py
+++ b/spd/app/backend/routers/correlations.py
@@ -144,7 +144,7 @@ async def request_component_interpretation(
 
     from spd.autointerp.interpret import (
         OpenRouterModelName,
-        get_architecture_info,
+        get_interp_context,
         interpret_component,
     )
     from spd.autointerp.schemas import get_autointerp_dir
@@ -174,7 +174,7 @@ async def request_component_interpretation(
 
     # Get architecture info and tokenizer
     activation_contexts_dir = get_activation_contexts_dir(loaded.harvest.run_id)
-    arch = get_architecture_info(loaded.run.wandb_path, activation_contexts_dir)
+    arch = get_interp_context(loaded.run.wandb_path, activation_contexts_dir)
 
     # Get token stats
     token_stats = loaded.harvest.token_stats

--- a/spd/autointerp/interpret.py
+++ b/spd/autointerp/interpret.py
@@ -24,7 +24,7 @@ from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 from spd.app.backend.compute import get_model_n_blocks
 from spd.autointerp.prompt_template import INTERPRETATION_SCHEMA, format_prompt_template
-from spd.autointerp.schemas import ArchitectureInfo, InterpretationResult
+from spd.autointerp.schemas import InterpContext, InterpretationResult
 from spd.configs import LMTaskConfig
 from spd.harvest.analysis import TokenPRLift, get_input_token_stats, get_output_token_stats
 from spd.harvest.harvest import HarvestResult
@@ -162,7 +162,7 @@ async def interpret_component(
     client: OpenRouter,
     model: str,
     component: ComponentData,
-    arch: ArchitectureInfo,
+    arch: InterpContext,
     tokenizer: PreTrainedTokenizerBase,
     input_token_stats: TokenPRLift,
     output_token_stats: TokenPRLift,
@@ -223,7 +223,7 @@ async def interpret_component(
 
 async def interpret_all(
     components: list[ComponentData],
-    arch: ArchitectureInfo,
+    arch: InterpContext,
     openrouter_api_key: str,
     interpreter_model: str,
     output_path: Path,
@@ -332,7 +332,7 @@ async def interpret_all(
     return results
 
 
-def get_architecture_info(wandb_path: str, activation_contexts_dir: Path) -> ArchitectureInfo:
+def get_interp_context(wandb_path: str, activation_contexts_dir: Path) -> InterpContext:
     run_info = SPDRunInfo.from_path(wandb_path)
     model = ComponentModel.from_run_info(run_info)
     n_blocks = get_model_n_blocks(model.target_model)
@@ -345,7 +345,7 @@ def get_architecture_info(wandb_path: str, activation_contexts_dir: Path) -> Arc
     assert harvest_config_path.exists(), f"harvest config not found: {harvest_config_path}"
     harvest_config = json.loads(harvest_config_path.read_text())
 
-    return ArchitectureInfo(
+    return InterpContext(
         n_blocks=n_blocks,
         c_per_layer=model.module_to_c,
         model_class=config.pretrained_model_class,
@@ -365,7 +365,7 @@ def run_interpret(
     autointerp_dir: Path,
     limit: int | None = None,
 ) -> list[InterpretationResult]:
-    arch = get_architecture_info(wandb_path, activation_contexts_dir)
+    arch = get_interp_context(wandb_path, activation_contexts_dir)
     components = HarvestResult.load_components(activation_contexts_dir)
     output_path = autointerp_dir / "results.jsonl"
 

--- a/spd/autointerp/interpret.py
+++ b/spd/autointerp/interpret.py
@@ -332,7 +332,7 @@ async def interpret_all(
     return results
 
 
-def get_architecture_info(wandb_path: str) -> ArchitectureInfo:
+def get_architecture_info(wandb_path: str, activation_contexts_dir: Path) -> ArchitectureInfo:
     run_info = SPDRunInfo.from_path(wandb_path)
     model = ComponentModel.from_run_info(run_info)
     n_blocks = get_model_n_blocks(model.target_model)
@@ -340,12 +340,19 @@ def get_architecture_info(wandb_path: str) -> ArchitectureInfo:
     task_config = config.task_config
     assert isinstance(task_config, LMTaskConfig)
     assert config.tokenizer_name is not None
+
+    harvest_config_path = activation_contexts_dir / "config.json"
+    assert harvest_config_path.exists(), f"harvest config not found: {harvest_config_path}"
+    harvest_config = json.loads(harvest_config_path.read_text())
+
     return ArchitectureInfo(
         n_blocks=n_blocks,
         c_per_layer=model.module_to_c,
         model_class=config.pretrained_model_class,
         dataset_name=task_config.dataset_name,
         tokenizer_name=config.tokenizer_name,
+        seq_len=task_config.max_seq_len,
+        context_tokens_per_side=harvest_config["activation_context_tokens_per_side"],
     )
 
 
@@ -358,7 +365,7 @@ def run_interpret(
     autointerp_dir: Path,
     limit: int | None = None,
 ) -> list[InterpretationResult]:
-    arch = get_architecture_info(wandb_path)
+    arch = get_architecture_info(wandb_path, activation_contexts_dir)
     components = HarvestResult.load_components(activation_contexts_dir)
     output_path = autointerp_dir / "results.jsonl"
 

--- a/spd/autointerp/prompt_template.py
+++ b/spd/autointerp/prompt_template.py
@@ -75,6 +75,20 @@ at that position: high CI (close to 1) means the component is essential and cann
 sparsity: as few components as possible should have high CI for any given input."""
 
 
+def _build_data_presentation_section(arch: ArchitectureInfo) -> str:
+    """Explain how the model sees data and how activation examples are constructed."""
+    k = arch.context_tokens_per_side
+    window_size = 2 * k + 1
+    return f"""\
+## Data Presentation
+
+The model processes sequences of {arch.seq_len} tokens. Each activation example below shows a \
+{window_size}-token window centered on the token where the component fired, with up to {k} tokens \
+of context on each side. If a firing occurs near the start or end of a sequence, the window will \
+be shorter on that side (there are no tokens beyond the sequence boundary). A short or absent \
+left context therefore indicates the component fired near the beginning of a sequence."""
+
+
 def format_prompt_template(
     component: ComponentData,
     arch: ArchitectureInfo,
@@ -134,6 +148,8 @@ def format_prompt_template(
 
     layer_desc = _parse_layer_description(component.layer, arch.n_blocks)
 
+    data_presentation = _build_data_presentation_section(arch)
+
     return f"""\
 Label this neural network component from a Stochastic Parameter Decomposition.
 
@@ -145,6 +161,8 @@ Label this neural network component from a Stochastic Parameter Decomposition.
 
 **Model**: {arch.model_class} ({arch.n_blocks} layers)
 **Dataset**: {dataset_description}
+
+{data_presentation}
 
 ## Component Context
 

--- a/spd/autointerp/prompt_template.py
+++ b/spd/autointerp/prompt_template.py
@@ -84,9 +84,7 @@ def _build_data_presentation_section(arch: InterpContext) -> str:
 
 The model processes sequences of {arch.seq_len} tokens. Each activation example below shows a \
 {window_size}-token window centered on the token where the component fired, with up to {k} tokens \
-of context on each side. If a firing occurs near the start or end of a sequence, the window will \
-be shorter on that side (there are no tokens beyond the sequence boundary). A short or absent \
-left context therefore indicates the component fired near the beginning of a sequence."""
+of context on each side. Windows are truncated at sequence boundaries."""
 
 
 def format_prompt_template(

--- a/spd/autointerp/prompt_template.py
+++ b/spd/autointerp/prompt_template.py
@@ -6,7 +6,7 @@ from transformers.tokenization_utils_base import PreTrainedTokenizerBase
 
 from spd.app.backend.utils import build_token_lookup
 from spd.autointerp import MAX_EXAMPLES_PER_COMPONENT
-from spd.autointerp.schemas import ArchitectureInfo
+from spd.autointerp.schemas import InterpContext
 from spd.harvest.analysis import TokenPRLift
 from spd.harvest.schemas import ComponentData
 
@@ -75,7 +75,7 @@ at that position: high CI (close to 1) means the component is essential and cann
 sparsity: as few components as possible should have high CI for any given input."""
 
 
-def _build_data_presentation_section(arch: ArchitectureInfo) -> str:
+def _build_data_presentation_section(arch: InterpContext) -> str:
     """Explain how the model sees data and how activation examples are constructed."""
     k = arch.context_tokens_per_side
     window_size = 2 * k + 1
@@ -91,7 +91,7 @@ left context therefore indicates the component fired near the beginning of a seq
 
 def format_prompt_template(
     component: ComponentData,
-    arch: ArchitectureInfo,
+    arch: InterpContext,
     tokenizer: PreTrainedTokenizerBase,
     input_token_stats: TokenPRLift,
     output_token_stats: TokenPRLift,

--- a/spd/autointerp/schemas.py
+++ b/spd/autointerp/schemas.py
@@ -21,6 +21,8 @@ class ArchitectureInfo:
     model_class: str
     dataset_name: str
     tokenizer_name: str
+    seq_len: int
+    context_tokens_per_side: int
 
 
 @dataclass

--- a/spd/autointerp/schemas.py
+++ b/spd/autointerp/schemas.py
@@ -15,7 +15,7 @@ def get_autointerp_dir(wandb_run_id: str) -> Path:
 
 
 @dataclass
-class ArchitectureInfo:
+class InterpContext:
     n_blocks: int
     c_per_layer: dict[str, int]  # Maps layer name -> number of components
     model_class: str


### PR DESCRIPTION
## Description

Adds a "Data Presentation" section to the autointerp prompt template that explains how activation examples are constructed — specifically that they are fixed-size token windows extracted from longer sequences, with boundary behavior at sequence edges.

## Motivation and Context

The autointerp LLM had no context about how the data it was analyzing was generated. For example, when a component consistently fired at early token positions, the interpreter couldn't recognize this because it didn't know that a short left context in an example implies the firing was near the start of a sequence. This led to missed positional patterns in labels.

## How Has This Been Tested?

Type-checked with basedpyright (0 errors). Ruff clean.

## Does this PR introduce a breaking change?

No — `ArchitectureInfo` gains two new required fields (`seq_len`, `context_tokens_per_side`) but all construction sites are updated. Existing harvest data is compatible (reads `context_tokens_per_side` from the already-saved `config.json`).