### PR TITLE
Add data presentation context to autointerp prompts

### DIFF
--- a/spd/adapters/spd.py
+++ b/spd/adapters/spd.py
@@ -69,4 +69,5 @@ class SPDAdapter(DecompositionAdapter):
                 path: self._topology.target_to_canon(path)
                 for path in self.component_model.target_module_paths
             },
+            seq_len=task_cfg.max_seq_len,
         )

--- a/spd/app/backend/routers/correlations.py
+++ b/spd/app/backend/routers/correlations.py
@@ -211,14 +211,21 @@ async def request_component_interpretation(
             detail=f"Token stats not available for component {component_key}",
         )
 
+    task_config = runtime_cast(LMTaskConfig, loaded.config.task_config)
     model_metadata = ModelMetadata(
         n_blocks=loaded.topology.n_blocks,
         model_class=loaded.model.__class__.__name__,
-        dataset_name=runtime_cast(LMTaskConfig, loaded.config.task_config).dataset_name,
+        dataset_name=task_config.dataset_name,
         layer_descriptions={
             path: loaded.topology.target_to_canon(path) for path in loaded.model.target_module_paths
         },
+        seq_len=task_config.max_seq_len,
     )
+
+    harvest_config = loaded.harvest.get_config()
+    raw_ctx = harvest_config["activation_context_tokens_per_side"]
+    assert isinstance(raw_ctx, int), f"expected int, got {type(raw_ctx)}"
+    context_tokens_per_side = raw_ctx
 
     async with OpenRouter(api_key=api_key) as api:
         try:
@@ -232,6 +239,7 @@ async def request_component_interpretation(
                 app_tok=loaded.tokenizer,
                 input_token_stats=input_token_stats,
                 output_token_stats=output_token_stats,
+                context_tokens_per_side=context_tokens_per_side,
             )
         except Exception as e:
             raise HTTPException(

--- a/spd/autointerp/interpret.py
+++ b/spd/autointerp/interpret.py
@@ -36,6 +36,7 @@ async def interpret_component(
     app_tok: AppTokenizer,
     input_token_stats: TokenPRLift,
     output_token_stats: TokenPRLift,
+    context_tokens_per_side: int,
 ) -> InterpretationResult:
     """Interpret a single component. Used by the app for on-demand interpretation."""
     prompt = format_prompt(
@@ -45,6 +46,7 @@ async def interpret_component(
         app_tok=app_tok,
         input_token_stats=input_token_stats,
         output_token_stats=output_token_stats,
+        context_tokens_per_side=context_tokens_per_side,
     )
 
     schema = INTERPRETATION_SCHEMA
@@ -101,6 +103,11 @@ def run_interpret(
     token_stats = harvest.get_token_stats()
     assert token_stats is not None, "token_stats.pt not found. Run harvest first."
 
+    harvest_config = harvest.get_config()
+    raw = harvest_config["activation_context_tokens_per_side"]
+    assert isinstance(raw, int), f"expected int, got {type(raw)}"
+    context_tokens_per_side = raw
+
     app_tok = AppTokenizer.from_pretrained(tokenizer_name)
 
     eligible_keys = sorted(summary, key=lambda k: summary[k].firing_density, reverse=True)
@@ -136,6 +143,7 @@ def run_interpret(
                         app_tok=app_tok,
                         input_token_stats=input_stats,
                         output_token_stats=output_stats,
+                        context_tokens_per_side=context_tokens_per_side,
                     )
                     yield LLMJob(prompt=prompt, schema=schema, key=key)
 

--- a/spd/autointerp/prompt_helpers.py
+++ b/spd/autointerp/prompt_helpers.py
@@ -90,7 +90,8 @@ def build_data_presentation(seq_len: int, context_tokens_per_side: int) -> Md:
         f"The model processes sequences of {seq_len} tokens. "
         f"Each activation example below shows a {window_size}-token window centered on the "
         f"firing token, with up to {context_tokens_per_side} tokens of context on each side. "
-        f"Windows are truncated at sequence boundaries."
+        f"Windows are truncated at sequence boundaries. "
+        f"Examples are sampled uniformly at random from all firings across the dataset."
     )
     md.p(
         "Output token correlations measure what the model predicts (at its final logits) "

--- a/spd/autointerp/prompt_helpers.py
+++ b/spd/autointerp/prompt_helpers.py
@@ -83,6 +83,23 @@ def density_note(firing_density: float) -> str:
     return ""
 
 
+def build_data_presentation(seq_len: int, context_tokens_per_side: int) -> Md:
+    window_size = 2 * context_tokens_per_side + 1
+    md = Md()
+    md.p(
+        f"The model processes sequences of {seq_len} tokens. "
+        f"Each activation example below shows a {window_size}-token window centered on the "
+        f"firing token, with up to {context_tokens_per_side} tokens of context on each side. "
+        f"Windows are truncated at sequence boundaries."
+    )
+    md.p(
+        "All token correlations (input/output PMI, precision, recall) are measured "
+        "at the model's final output logits, not at the component's layer. "
+        "For components in early layers, the causal path to output is indirect."
+    )
+    return md
+
+
 def build_output_section(
     output_stats: TokenPRLift,
     output_pmi: list[tuple[str, float]] | None,

--- a/spd/autointerp/prompt_helpers.py
+++ b/spd/autointerp/prompt_helpers.py
@@ -93,9 +93,8 @@ def build_data_presentation(seq_len: int, context_tokens_per_side: int) -> Md:
         f"Windows are truncated at sequence boundaries."
     )
     md.p(
-        "All token correlations (input/output PMI, precision, recall) are measured "
-        "at the model's final output logits, not at the component's layer. "
-        "For components in early layers, the causal path to output is indirect."
+        "Output token correlations measure what the model predicts (at its final logits) "
+        "at positions where the component fires, not the component's direct output."
     )
     return md
 

--- a/spd/autointerp/schemas.py
+++ b/spd/autointerp/schemas.py
@@ -25,6 +25,7 @@ class ModelMetadata:
     model_class: str
     dataset_name: str
     layer_descriptions: dict[str, str]
+    seq_len: int
 
 
 @dataclass

--- a/spd/autointerp/strategies/compact_skeptical.py
+++ b/spd/autointerp/strategies/compact_skeptical.py
@@ -8,6 +8,7 @@ from spd.app.backend.app_tokenizer import AppTokenizer
 from spd.autointerp.config import CompactSkepticalConfig
 from spd.autointerp.prompt_helpers import (
     DATASET_DESCRIPTIONS,
+    build_data_presentation,
     build_fires_on_examples,
 )
 from spd.autointerp.schemas import ModelMetadata
@@ -28,6 +29,7 @@ def format_prompt(
     app_tok: AppTokenizer,
     input_token_stats: TokenPRLift,
     output_token_stats: TokenPRLift,
+    context_tokens_per_side: int,
 ) -> str:
     input_pmi: list[tuple[str, float]] | None = None
     output_pmi: list[tuple[str, float]] | None = None
@@ -72,6 +74,9 @@ def format_prompt(
             f"Component firing rate: {component.firing_density * 100:.2f}% ({rate_str})",
         ]
     )
+
+    md.h(2, "Data presentation")
+    md.extend(build_data_presentation(model_metadata.seq_len, context_tokens_per_side))
 
     md.h(2, "Token correlations")
     md.extend(input_section).extend(output_section)

--- a/spd/autointerp/strategies/dispatch.py
+++ b/spd/autointerp/strategies/dispatch.py
@@ -31,6 +31,7 @@ def format_prompt(
     app_tok: AppTokenizer,
     input_token_stats: TokenPRLift,
     output_token_stats: TokenPRLift,
+    context_tokens_per_side: int,
 ) -> str:
     match strategy:
         case CompactSkepticalConfig():
@@ -41,6 +42,7 @@ def format_prompt(
                 app_tok,
                 input_token_stats,
                 output_token_stats,
+                context_tokens_per_side,
             )
         case DualViewConfig():
             return dual_view_prompt(
@@ -50,4 +52,5 @@ def format_prompt(
                 app_tok,
                 input_token_stats,
                 output_token_stats,
+                context_tokens_per_side,
             )

--- a/spd/autointerp/strategies/dual_view.py
+++ b/spd/autointerp/strategies/dual_view.py
@@ -11,6 +11,7 @@ from spd.app.backend.app_tokenizer import AppTokenizer
 from spd.autointerp.config import DualViewConfig
 from spd.autointerp.prompt_helpers import (
     DATASET_DESCRIPTIONS,
+    build_data_presentation,
     build_fires_on_examples,
     build_input_section,
     build_output_section,
@@ -32,6 +33,7 @@ def format_prompt(
     app_tok: AppTokenizer,
     input_token_stats: TokenPRLift,
     output_token_stats: TokenPRLift,
+    context_tokens_per_side: int,
 ) -> str:
     input_pmi: list[tuple[str, float]] | None = None
     output_pmi: list[tuple[str, float]] | None = None
@@ -98,6 +100,9 @@ def format_prompt(
     )
     if context_notes:
         md.p(context_notes)
+
+    md.h(2, "Data presentation")
+    md.extend(build_data_presentation(model_metadata.seq_len, context_tokens_per_side))
 
     md.h(2, "Output tokens (what the model produces when this component fires)")
     md.extend(output_section)

--- a/spd/autointerp/strategies/dual_view.py
+++ b/spd/autointerp/strategies/dual_view.py
@@ -127,17 +127,6 @@ def format_prompt(
         "function. The label should read like a short description of the job this component "
         "does in the network. Use both the input and output evidence."
     )
-    md.p("Examples of good labels across different component types:")
-    md.bullets(
-        [
-            '"word stem completion (stems → suffixes)"',
-            '"closes dialogue with quotation marks"',
-            '"object pronouns after verbs"',
-            '"story-ending moral resolution vocabulary"',
-            '"aquatic scene vocabulary (frog, river, pond)"',
-            "\"'of course' and abstract nouns after prepositions\"",
-        ]
-    )
     md.p(
         f'Say "unclear" if the evidence is too weak or diffuse. {forbidden_sentence}Lowercase only.'
     )

--- a/spd/autointerp/strategies/dual_view.py
+++ b/spd/autointerp/strategies/dual_view.py
@@ -128,7 +128,8 @@ def format_prompt(
         "does in the network. Use both the input and output evidence."
     )
     md.p(
-        f'Say "unclear" if the evidence is too weak or diffuse. {forbidden_sentence}Lowercase only.'
+        f"Be epistemically honest — express uncertainty in the label and confidence "
+        f"field when the evidence is weak or ambiguous. {forbidden_sentence}Lowercase only."
     )
 
     return md.build()


### PR DESCRIPTION
## Description

Adds a "Data presentation" section to both autointerp prompt strategies (`compact_skeptical` and `dual_view`) explaining how the data the interpreter sees was generated.

Two things are clarified:
1. **Activation examples are windows** — the model processes N-token sequences, but examples show a fixed-size window centered on the firing token, truncated at sequence boundaries
2. **Output correlations are at the final logits** — not at the component's layer output

Also adds `seq_len` to `ModelMetadata` and threads `context_tokens_per_side` from harvest config through to the prompt builders.

## Motivation and Context

A blind evaluation of a baked prompt revealed the interpreter LLM had no way to reason about positional context (e.g. short left context = near sequence start) or know where output tokens were measured. Supersedes #441 which was against main.

## How Has This Been Tested?

Type-checked with basedpyright (0 errors). Ruff clean.

## Does this PR introduce a breaking change?

`ModelMetadata` gains a required `seq_len` field — both construction sites (adapter + app router) are updated. `format_prompt` and `interpret_component` gain a required `context_tokens_per_side` parameter — all call sites updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)