### PR TITLE
Improve autointerp prompt context and metric explanations

### DIFF
--- a/spd/adapters/spd.py
+++ b/spd/adapters/spd.py
@@ -70,4 +70,5 @@ class SPDAdapter(DecompositionAdapter):
                 for path in self.component_model.target_module_paths
             },
             seq_len=task_cfg.max_seq_len,
+            decomposition_method="spd",
         )

--- a/spd/app/backend/routers/correlations.py
+++ b/spd/app/backend/routers/correlations.py
@@ -220,6 +220,7 @@ async def request_component_interpretation(
             path: loaded.topology.target_to_canon(path) for path in loaded.model.target_module_paths
         },
         seq_len=task_config.max_seq_len,
+        decomposition_method="spd",
     )
 
     harvest_config = loaded.harvest.get_config()

--- a/spd/autointerp/config.py
+++ b/spd/autointerp/config.py
@@ -31,7 +31,6 @@ class CompactSkepticalConfig(BaseConfig):
     type: Literal["compact_skeptical"] = "compact_skeptical"
     max_examples: int = 30
     include_pmi: bool = True
-    include_spd_context: bool = True
     include_dataset_description: bool = True
     label_max_words: int = 8
     forbidden_words: list[str] | None = None

--- a/spd/autointerp/prompt_helpers.py
+++ b/spd/autointerp/prompt_helpers.py
@@ -7,6 +7,7 @@ import re
 
 from spd.app.backend.app_tokenizer import AppTokenizer
 from spd.app.backend.utils import delimit_tokens
+from spd.autointerp.schemas import DECOMPOSITION_DESCRIPTIONS, DecompositionMethod
 from spd.harvest.analysis import TokenPRLift
 from spd.harvest.schemas import ComponentData
 from spd.utils.markdown import Md
@@ -83,9 +84,18 @@ def density_note(firing_density: float) -> str:
     return ""
 
 
-def build_data_presentation(seq_len: int, context_tokens_per_side: int) -> Md:
+def build_data_presentation(
+    seq_len: int,
+    context_tokens_per_side: int,
+    decomposition_method: DecompositionMethod,
+) -> Md:
     window_size = 2 * context_tokens_per_side + 1
     md = Md()
+
+    md.h(3, "Decomposition method")
+    md.p(DECOMPOSITION_DESCRIPTIONS[decomposition_method])
+
+    md.h(3, "Data")
     md.p(
         f"The model processes sequences of {seq_len} tokens. "
         f"Each activation example below shows a {window_size}-token window centered on the "
@@ -98,16 +108,10 @@ def build_data_presentation(seq_len: int, context_tokens_per_side: int) -> Md:
     md.p("The token statistics below use these metrics:")
     md.bullets(
         [
-            "**Recall**: P(token | component fires). What fraction of this component's "
-            "firings occurred on token X? High recall means the component fires on this "
-            "token often, but says nothing about selectivity.",
             "**Precision**: P(component fires | token). Of all occurrences of token X in "
-            "the dataset, what fraction had this component firing? Low precision with high "
-            "recall means the component fires on this token, but only in specific contexts "
-            "— the token alone is not sufficient.",
+            "the dataset, what fraction had this component firing?",
             "**PMI** (pointwise mutual information, in nats): How much more likely is "
-            "co-occurrence than chance? Combines recall and precision into a single "
-            "association strength. 0 = no association, 1 ≈ 3x, 2 ≈ 7x, 3 ≈ 20x.",
+            "co-occurrence than chance? 0 = no association, 1 ≈ 3x, 2 ≈ 7x, 3 ≈ 20x.",
         ]
     )
     md.p(

--- a/spd/autointerp/prompt_helpers.py
+++ b/spd/autointerp/prompt_helpers.py
@@ -93,9 +93,27 @@ def build_data_presentation(seq_len: int, context_tokens_per_side: int) -> Md:
         f"Windows are truncated at sequence boundaries. "
         f"Examples are sampled uniformly at random from all firings across the dataset."
     )
+
+    md.h(3, "Metric definitions")
+    md.p("The token statistics below use these metrics:")
+    md.bullets(
+        [
+            "**Recall**: P(token | component fires). What fraction of this component's "
+            "firings occurred on token X? High recall means the component fires on this "
+            "token often, but says nothing about selectivity.",
+            "**Precision**: P(component fires | token). Of all occurrences of token X in "
+            "the dataset, what fraction had this component firing? Low precision with high "
+            "recall means the component fires on this token, but only in specific contexts "
+            "— the token alone is not sufficient.",
+            "**PMI** (pointwise mutual information, in nats): How much more likely is "
+            "co-occurrence than chance? Combines recall and precision into a single "
+            "association strength. 0 = no association, 1 ≈ 3x, 2 ≈ 7x, 3 ≈ 20x.",
+        ]
+    )
     md.p(
-        "Output token correlations measure what the model predicts (at its final logits) "
-        "at positions where the component fires, not the component's direct output."
+        "**Input** metrics concern the token at the position where the component fires. "
+        "**Output** metrics concern what the model predicts (at its final logits) at "
+        "those positions — not the component's direct output."
     )
     return md
 
@@ -107,15 +125,12 @@ def build_output_section(
     md = Md()
     if output_pmi:
         md.labeled_list(
-            "**Output PMI (pointwise mutual information, in nats: how much more likely "
-            "a token is to be produced when this component fires, vs its base rate. "
-            "0 = no association, 1 = ~3x more likely, 2 = ~7x, 3 = ~20x):**",
+            "**Output PMI:**",
             [f"{repr(tok)}: {pmi:.2f}" for tok, pmi in output_pmi[:10]],
         )
     if output_stats.top_precision:
         md.labeled_list(
-            "**Output precision — of all probability mass for token X, what fraction "
-            "is at positions where this component fires?**",
+            "**Output precision:**",
             [f"{repr(tok)}: {prec * 100:.0f}%" for tok, prec in output_stats.top_precision[:10]],
         )
     return md
@@ -128,12 +143,12 @@ def build_input_section(
     md = Md()
     if input_pmi:
         md.labeled_list(
-            "**Input PMI (same metric as above, for input tokens):**",
+            "**Input PMI:**",
             [f"{repr(tok)}: {pmi:.2f}" for tok, pmi in input_pmi[:6]],
         )
     if input_stats.top_precision:
         md.labeled_list(
-            "**Input precision — probability the component fires given the current token is X:**",
+            "**Input precision:**",
             [f"{repr(tok)}: {prec * 100:.0f}%" for tok, prec in input_stats.top_precision[:8]],
         )
     return md

--- a/spd/autointerp/schemas.py
+++ b/spd/autointerp/schemas.py
@@ -2,6 +2,7 @@
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Literal
 
 from spd.settings import SPD_OUT_DIR
 
@@ -19,6 +20,30 @@ def get_autointerp_subrun_dir(decomposition_id: str, autointerp_run_id: str) -> 
     return get_autointerp_dir(decomposition_id) / autointerp_run_id
 
 
+DecompositionMethod = Literal["spd", "clt", "molt"]
+
+DECOMPOSITION_DESCRIPTIONS: dict[DecompositionMethod, str] = {
+    "spd": (
+        "Each component is a rank-1 parameter vector learned by Stochastic Parameter "
+        "Decomposition (SPD). A weight matrix W is decomposed as a sum of outer products "
+        "W ≈ Σ u_i v_i^T. Each component has a causal importance (CI) value predicted per "
+        "token position: CI near 1 means the component is essential at that position, CI near "
+        "0 means it can be ablated without affecting output. A component 'fires' when its CI "
+        "is high."
+    ),
+    "clt": (
+        "Each component is a feature from a Cross-Layer Transcoder (CLT). CLTs learn sparse, "
+        "interpretable features that map activations at one layer to contributions at another. "
+        "A component 'fires' when its activation magnitude is high."
+    ),
+    "molt": (
+        "Each component is a feature from a Multi-Output Learned Transcoder (MOLT). MOLTs "
+        "extend transcoders to produce outputs at multiple layers simultaneously. A component "
+        "'fires' when its activation magnitude is high."
+    ),
+}
+
+
 @dataclass
 class ModelMetadata:
     n_blocks: int
@@ -26,6 +51,7 @@ class ModelMetadata:
     dataset_name: str
     layer_descriptions: dict[str, str]
     seq_len: int
+    decomposition_method: DecompositionMethod
 
 
 @dataclass

--- a/spd/autointerp/strategies/compact_skeptical.py
+++ b/spd/autointerp/strategies/compact_skeptical.py
@@ -116,17 +116,17 @@ def _build_input_section(
     md = Md()
     if input_stats.top_recall:
         md.labeled_list(
-            "**Input tokens with highest recall (most common current tokens when the component is firing)**",
+            "**Input recall:**",
             [f"{repr(tok)}: {recall * 100:.0f}%" for tok, recall in input_stats.top_recall[:8]],
         )
     if input_stats.top_precision:
         md.labeled_list(
-            "**Input tokens with highest precision (probability the component fires given the current token is X)**",
+            "**Input precision:**",
             [f"{repr(tok)}: {prec * 100:.0f}%" for tok, prec in input_stats.top_precision[:8]],
         )
     if input_pmi:
         md.labeled_list(
-            "**Input tokens with highest PMI (pointwise mutual information. Tokens with higher-than-base-rate likelihood of co-occurrence with the component firing)**",
+            "**Input PMI:**",
             [f"{repr(tok)}: {pmi:.2f}" for tok, pmi in input_pmi[:6]],
         )
     return md
@@ -139,12 +139,12 @@ def _build_output_section(
     md = Md()
     if output_stats.top_precision:
         md.labeled_list(
-            "**Output precision — of all predicted probability for token X, what fraction is at positions where this component fires?**",
+            "**Output precision:**",
             [f"{repr(tok)}: {prec * 100:.0f}%" for tok, prec in output_stats.top_precision[:10]],
         )
     if output_pmi:
         md.labeled_list(
-            "**Output PMI — tokens the model predicts at higher-than-base-rate when this component fires:**",
+            "**Output PMI:**",
             [f"{repr(tok)}: {pmi:.2f}" for tok, pmi in output_pmi[:6]],
         )
     return md

--- a/spd/autointerp/strategies/compact_skeptical.py
+++ b/spd/autointerp/strategies/compact_skeptical.py
@@ -16,11 +16,6 @@ from spd.harvest.analysis import TokenPRLift
 from spd.harvest.schemas import ComponentData
 from spd.utils.markdown import Md
 
-SPD_CONTEXT = (
-    "Each component has a causal importance (CI) value per token position. "
-    "High CI (near 1) = essential, cannot be ablated. Low CI (near 0) = ablatable."
-)
-
 
 def format_prompt(
     config: CompactSkepticalConfig,
@@ -64,9 +59,6 @@ def format_prompt(
     md = Md()
     md.p("Label this neural network component.")
 
-    if config.include_spd_context:
-        md.p(SPD_CONTEXT)
-
     md.h(2, "Context").bullets(
         [
             f"Model: {model_metadata.model_class} ({model_metadata.n_blocks} blocks){dataset_line}",
@@ -76,7 +68,11 @@ def format_prompt(
     )
 
     md.h(2, "Data presentation")
-    md.extend(build_data_presentation(model_metadata.seq_len, context_tokens_per_side))
+    md.extend(
+        build_data_presentation(
+            model_metadata.seq_len, context_tokens_per_side, model_metadata.decomposition_method
+        )
+    )
 
     md.h(2, "Token correlations")
     md.extend(input_section).extend(output_section)
@@ -114,11 +110,6 @@ def _build_input_section(
     input_pmi: list[tuple[str, float]] | None,
 ) -> Md:
     md = Md()
-    if input_stats.top_recall:
-        md.labeled_list(
-            "**Input recall:**",
-            [f"{repr(tok)}: {recall * 100:.0f}%" for tok, recall in input_stats.top_recall[:8]],
-        )
     if input_stats.top_precision:
         md.labeled_list(
             "**Input precision:**",

--- a/spd/autointerp/strategies/dual_view.py
+++ b/spd/autointerp/strategies/dual_view.py
@@ -78,19 +78,22 @@ def format_prompt(
     )
 
     md = Md()
+    md.p("Describe what this neural network component does.")
     md.p(
-        "Describe what this neural network component does.\n\n"
         "Each component has an input function (what causes it to fire) and an output "
         "function (what tokens it causes the model to produce). These are often different "
         "— a component might fire on periods but produce sentence-opening words, or "
-        "fire on prepositions but produce abstract nouns.\n\n"
+        "fire on prepositions but produce abstract nouns."
+    )
+    md.p(
         "Consider all of the evidence below critically. Token statistics can be noisy, "
         "especially for high-density components. The activation examples are sampled "
         "and may not be representative. Look for patterns that are consistent across "
         "multiple sources of evidence."
     )
 
-    md.h(2, "Context").bullets(
+    md.h(2, "Context")
+    md.bullets(
         [
             f"Model: {model_metadata.model_class} ({model_metadata.n_blocks} blocks){dataset_line}",
             f"Component location: {layer_desc}",

--- a/spd/autointerp/strategies/dual_view.py
+++ b/spd/autointerp/strategies/dual_view.py
@@ -80,10 +80,9 @@ def format_prompt(
     md = Md()
     md.p(
         "Describe what this neural network component does.\n\n"
-        "Each component is a learned linear transformation inside a weight matrix. "
-        "It has an input function (what causes it to fire) and an output function "
-        "(what tokens it causes the model to produce). These are often different — "
-        "a component might fire on periods but produce sentence-opening words, or "
+        "Each component has an input function (what causes it to fire) and an output "
+        "function (what tokens it causes the model to produce). These are often different "
+        "— a component might fire on periods but produce sentence-opening words, or "
         "fire on prepositions but produce abstract nouns.\n\n"
         "Consider all of the evidence below critically. Token statistics can be noisy, "
         "especially for high-density components. The activation examples are sampled "
@@ -102,7 +101,11 @@ def format_prompt(
         md.p(context_notes)
 
     md.h(2, "Data presentation")
-    md.extend(build_data_presentation(model_metadata.seq_len, context_tokens_per_side))
+    md.extend(
+        build_data_presentation(
+            model_metadata.seq_len, context_tokens_per_side, model_metadata.decomposition_method
+        )
+    )
 
     md.h(2, "Output tokens (what the model produces when this component fires)")
     md.extend(output_section)

--- a/spd/graph_interp/prompts.py
+++ b/spd/graph_interp/prompts.py
@@ -171,7 +171,9 @@ def format_unification_prompt(
     md.h(2, "Two-perspective analysis")
     md.p(
         f'OUTPUT FUNCTION: "{output_label.label}" (confidence: {output_label.confidence})\n'
-        f"  Reasoning: {output_label.reasoning}\n\n"
+        f"  Reasoning: {output_label.reasoning}"
+    )
+    md.p(
         f'INPUT FUNCTION: "{input_label.label}" (confidence: {input_label.confidence})\n'
         f"  Reasoning: {input_label.reasoning}"
     )


### PR DESCRIPTION
## Description

Improves the autointerp prompts with better context and cleaner metric explanations. Changes span both strategies (`compact_skeptical` and `dual_view`) and shared helpers.

### What changed

**Centralized metric definitions** — Moved metric explanations (precision, PMI) out of inline per-section labels into a shared "Metric definitions" block in the data presentation section. Both strategies now use short labels (e.g. "**Input PMI:**") since definitions are explained upfront.

**Decomposition method descriptions** — Added `decomposition_method` field to `ModelMetadata` with method-specific descriptions for SPD, CLT, and MOLT. Replaces the hardcoded SPD-specific text that was baked into each strategy ("each component is a learned linear transformation...", `SPD_CONTEXT`).

**Removed recall** — Recall was redundant with PMI + examples and confusing alongside precision. Removed from `compact_skeptical` (was never in `dual_view`'s shared helper).

**Clarified input vs output distinction** — The data presentation section now explicitly states that output metrics measure the model's final predicted logits, not the component's direct output.

**Removed `include_spd_context` config option** — Now covered by the decomposition method description.

**Fixed Md() usage** — Separated `\n\n`-joined text into separate `.p()` calls (Md already adds paragraph breaks). Unchained `.bullets()` from `.h()` for clarity. Applied to both `dual_view.py` and `graph_interp/prompts.py`.

## How Has This Been Tested?

Type-checked with basedpyright (0 errors). Ruff clean.

## Does this PR introduce a breaking change?

`ModelMetadata` gains a required `decomposition_method` field — both construction sites updated. `include_spd_context` removed from `CompactSkepticalConfig`.