### PR TITLE
Add paper_vis module for VPD paper dashboards

### DIFF
--- a/spd/paper_vis/build_dashboard.py
+++ b/spd/paper_vis/build_dashboard.py
@@ -1,0 +1,115 @@
+"""Build a dashboard with per-component JSON files for incremental loading.
+
+Outputs:
+  <out_dir>/
+    index.html          — self-contained dashboard shell
+    vpd/manifest.json   — VPD metadata (no heavy component data)
+    vpd/components/     — per-component JSON files
+    tc/manifest.json    — transcoder metadata
+    tc/components/      — per-component JSON files
+
+Usage:
+    python -m spd.paper_vis.build_dashboard \
+        --vpd_id s-55ea3f9b --tc_id tc-3f297233 \
+        --out_dir dashboard_out --limit 50
+"""
+
+from pathlib import Path
+
+import fire
+import orjson
+
+from spd.paper_vis.data import DecompositionData
+from spd.paper_vis.generate import build_decomposition_data
+
+
+def _component_index(data: DecompositionData) -> list[dict[str, object]]:
+    """Extract lightweight component index from full data (for inline embedding)."""
+    return [
+        {
+            "component_key": c.component_key,
+            "layer": c.layer,
+            "layer_display": c.layer_display,
+            "component_idx": c.component_idx,
+            "firing_density": c.firing_density,
+            "mean_activation": c.mean_activation,
+            "label": c.label,
+            "confidence": c.confidence,
+            "detection_score": c.detection_score.model_dump() if c.detection_score else None,
+            "fuzzing_score": c.fuzzing_score.model_dump() if c.fuzzing_score else None,
+        }
+        for c in data.components
+    ]
+
+
+def build(
+    out_dir: str = "dashboard_out",
+    vpd_id: str | None = None,
+    tc_id: str | None = None,
+    limit: int | None = None,
+) -> None:
+    assert vpd_id or tc_id, "Provide at least one of --vpd_id or --tc_id"
+
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+
+    manifest: dict[str, object] = {"vpd": None, "transcoder": None}
+
+    if vpd_id:
+        print(f"Loading VPD data: {vpd_id}")
+        vpd_data = build_decomposition_data(vpd_id, "vpd", limit, out / "vpd")
+        manifest["vpd"] = {
+            **vpd_data.model_dump(exclude={"components"}),
+            "component_index": _component_index(vpd_data),
+            "components_path": "vpd/components",
+        }
+
+    if tc_id:
+        print(f"Loading transcoder data: {tc_id}")
+        tc_data = build_decomposition_data(tc_id, "transcoder", limit, out / "tc")
+        manifest["transcoder"] = {
+            **tc_data.model_dump(exclude={"components"}),
+            "component_index": _component_index(tc_data),
+            "components_path": "tc/components",
+        }
+
+    manifest_json = orjson.dumps(manifest).decode()
+
+    # Standalone dashboard
+    dashboard_template = Path(__file__).parent / "dashboard.html"
+    dashboard_html = dashboard_template.read_text()
+    dashboard_html = dashboard_html.replace("/*DATA_JSON*/null", manifest_json)
+    (out / "index.html").write_text(dashboard_html)
+    print(f"Wrote dashboard to {out}/index.html")
+
+    # Research post with dashboard inlined (no iframe)
+    post_template = Path(__file__).parent / "research_post.html"
+    if post_template.exists():
+        post_html = post_template.read_text()
+
+        # Extract dashboard body content (between <body> tags), style, and script
+        import re
+
+        style_match = re.search(r"<style>(.*?)</style>", dashboard_html, re.DOTALL)
+        script_match = re.search(r"<script>(.*?)</script>", dashboard_html, re.DOTALL)
+        body_match = re.search(r"<body>(.*?)</body>", dashboard_html, re.DOTALL)
+
+        assert style_match and script_match and body_match
+
+        dashboard_inline = (
+            f"<style>{style_match.group(1)}</style>\n"
+            f"{body_match.group(1)}\n"
+            f"<script>{script_match.group(1)}</script>"
+        )
+
+        post_html = post_html.replace(
+            '<div class="component-embed">\n    <iframe src="index.html"></iframe>\n  </div>',
+            f'<div class="component-embed">\n{dashboard_inline}\n  </div>',
+        )
+
+        (out / "research_post.html").write_text(post_html)
+        print(f"Wrote research post to {out}/research_post.html")
+
+
+if __name__ == "__main__":
+    fire.Fire(build)

--- a/spd/paper_vis/dashboard.html
+++ b/spd/paper_vis/dashboard.html
@@ -1,0 +1,746 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Component Interpretability — VPD vs Transcoder</title>
+  <style>
+    @font-face {
+      font-family: "Suisse Works";
+      font-weight: 400;
+      font-style: normal;
+      src: url("https://cdn.prod.website-files.com/67b4608695ee3b31a669d3a9/67b467edbcb831d14ec80a21_SuisseWorks-Book.otf") format("opentype");
+    }
+
+    @font-face {
+      font-family: "Suisse Intl";
+      font-weight: 400;
+      font-style: normal;
+      src: url("https://cdn.prod.website-files.com/67b4608695ee3b31a669d3a9/67b467b49a4db65259fafd97_SuisseIntl-Book.otf") format("opentype");
+    }
+
+    @font-face {
+      font-family: "Suisse Intl";
+      font-weight: 500;
+      font-style: normal;
+      src: url("https://cdn.prod.website-files.com/67b4608695ee3b31a669d3a9/67b46cade89f4c1805e64f62_SuisseIntl-Medium.otf") format("opentype");
+    }
+
+    @font-face {
+      font-family: "Suisse Intl";
+      font-weight: 600;
+      font-style: normal;
+      src: url("https://cdn.prod.website-files.com/67b4608695ee3b31a669d3a9/67b46cad70cd51d153f47310_SuisseIntl-SemiBold.otf") format("opentype");
+    }
+
+    @font-face {
+      font-family: "Suisse Intl";
+      font-weight: 700;
+      font-style: normal;
+      src: url("https://cdn.prod.website-files.com/67b4608695ee3b31a669d3a9/67b467b4e049d5ad5b175424_SuisseIntl-Bold.otf") format("opentype");
+    }
+
+    @font-face {
+      font-family: "IBM Plex Mono";
+      font-weight: 400;
+      font-style: normal;
+      src: url("https://cdn.prod.website-files.com/67b4608695ee3b31a669d3a9/67b4723df5335ccd8bcf5a36_IBMPlexMono-Regular.ttf") format("truetype");
+    }
+
+    :root {
+      --font-display: "Suisse Works", Georgia, serif;
+      --font-body: "Suisse Intl", -apple-system, sans-serif;
+      --font-mono: "IBM Plex Mono", "SF Mono", monospace;
+
+      --bg: #faf8f5;
+      --bg-card: #fff;
+      --bg-warm: #f5f0ea;
+      --bg-code: #f7f4f0;
+
+      --text: #1d272a;
+      --text-secondary: #5a6266;
+      --text-muted: #8c9196;
+      --border: #e5dfd8;
+
+      --accent-vpd: #c45d3e;
+      --accent-vpd-light: #faf0ec;
+      --accent-tc: #5e8a6e;
+      --accent-tc-light: #eef5f0;
+
+      --fire: #c45d3e;
+      --fire-bg: rgba(196, 93, 62, 0.10);
+      --fire-border: rgba(196, 93, 62, 0.50);
+
+      --conf-high: #3d7a52;
+      --conf-high-bg: #eef5f0;
+      --conf-med: #8a7340;
+      --conf-med-bg: #f8f3e8;
+      --conf-low: #8a5040;
+      --conf-low-bg: #f8eee8;
+    }
+
+    *,
+    *::before,
+    *::after {
+      margin: 0;
+      padding: 0;
+      box-sizing: border-box;
+    }
+
+    body {
+      font-family: var(--font-body);
+      color: var(--text);
+      background: var(--bg);
+      line-height: 1.55;
+      -webkit-font-smoothing: antialiased;
+      font-size: 15px;
+    }
+
+    /* ── Controls ── */
+
+    .controls-bar {
+      max-width: 1280px;
+      margin: 1.25rem auto 0;
+      padding: 0 2rem;
+      display: flex;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .controls-bar select,
+    .controls-bar input {
+      font-family: var(--font-body);
+      font-size: 0.8rem;
+      padding: 0.35rem 0.5rem;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      background: var(--bg-card);
+      color: var(--text);
+    }
+
+    .controls-bar label {
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      font-weight: 500;
+      display: flex;
+      align-items: center;
+      gap: 0.35rem;
+    }
+
+    .controls-bar input[type="text"] {
+      width: 140px;
+    }
+
+    /* ── Carousel layout ── */
+
+    .carousel-container {
+      max-width: 1280px;
+      margin: 1.5rem auto 3rem;
+      padding: 0 2rem;
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1.5rem;
+      align-items: start;
+    }
+
+    .carousel-pane {
+      min-width: 0;
+    }
+
+    .pane-header {
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .pane-title {
+      font-family: var(--font-mono);
+      font-size: 0.7rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      font-weight: 500;
+    }
+
+    .pane-title.vpd {
+      color: var(--accent-vpd);
+    }
+
+    .pane-title.tc {
+      color: var(--accent-tc);
+    }
+
+    .pane-nav {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+
+    .pane-counter {
+      font-family: var(--font-mono);
+      font-size: 0.75rem;
+      color: var(--text-muted);
+      min-width: 4em;
+      text-align: center;
+    }
+
+    .nav-btn {
+      background: none;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      width: 28px;
+      height: 28px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      color: var(--text-secondary);
+      font-size: 0.85rem;
+      transition: background 0.1s, border-color 0.1s;
+    }
+
+    .nav-btn:hover {
+      background: var(--bg-warm);
+      border-color: var(--text-muted);
+    }
+
+    .nav-btn:disabled {
+      opacity: 0.3;
+      cursor: default;
+    }
+
+    .nav-btn:disabled:hover {
+      background: none;
+      border-color: var(--border);
+    }
+
+    /* ── Component card ── */
+
+    .component-card {
+      background: var(--bg-card);
+      border-radius: 8px;
+      border: 1px solid var(--border);
+      overflow: hidden;
+      opacity: 0;
+      transform: translateY(4px);
+      animation: cardIn 0.2s ease forwards;
+    }
+
+    @keyframes cardIn {
+      to {
+        opacity: 1;
+        transform: translateY(0);
+      }
+    }
+
+    .card-top {
+      padding: 1rem 1.25rem 0.75rem;
+    }
+
+    .card-label {
+      font-family: var(--font-display);
+      font-size: 1.15rem;
+      font-weight: 400;
+      line-height: 1.3;
+    }
+
+    .card-label-missing {
+      color: var(--text-muted);
+      font-style: italic;
+    }
+
+    .card-confidence {
+      font-family: var(--font-mono);
+      font-size: 0.65rem;
+      margin-left: 0.4rem;
+      padding: 0.1rem 0.4rem;
+      border-radius: 3px;
+      vertical-align: middle;
+      letter-spacing: 0.02em;
+    }
+
+    .card-confidence.high {
+      background: var(--conf-high-bg);
+      color: var(--conf-high);
+    }
+
+    .card-confidence.medium {
+      background: var(--conf-med-bg);
+      color: var(--conf-med);
+    }
+
+    .card-confidence.low {
+      background: var(--conf-low-bg);
+      color: var(--conf-low);
+    }
+
+    .card-meta-row {
+      display: flex;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      margin-top: 0.5rem;
+      align-items: center;
+    }
+
+    .meta-chip {
+      font-family: var(--font-mono);
+      font-size: 0.68rem;
+      padding: 0.15rem 0.45rem;
+      border-radius: 3px;
+      background: var(--bg-warm);
+      color: var(--text-secondary);
+      letter-spacing: 0.01em;
+      white-space: nowrap;
+    }
+
+
+    /* ── Sections inside card ── */
+
+    .card-section {
+      padding: 0 1.25rem;
+      margin-top: 0.75rem;
+    }
+
+    .card-section:last-child {
+      padding-bottom: 1.25rem;
+    }
+
+    .section-label {
+      font-family: var(--font-mono);
+      font-size: 0.6rem;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: var(--text-muted);
+      margin-bottom: 0.4rem;
+      font-weight: 500;
+    }
+
+    /* Activation examples */
+
+    .example-block {
+      background: var(--bg-code);
+      border-radius: 4px;
+      padding: 0.6rem 0.75rem;
+      overflow-x: auto;
+    }
+
+    .example-line {
+      font-family: var(--font-mono);
+      font-size: 0.78rem;
+      line-height: 1.9;
+      white-space: pre;
+      /* TODO: add "center on highlighted token" scroll behavior like the app */
+    }
+
+    .example-line+.example-line {
+      border-top: 1px solid var(--border);
+      padding-top: 0.35rem;
+      margin-top: 0.35rem;
+    }
+
+    .tok {
+      transition: background 0.1s;
+    }
+
+    .tok.fire {
+      background: var(--fire-bg);
+      border-bottom: 1.5px solid var(--fire-border);
+      border-radius: 1px;
+      font-weight: 500;
+    }
+
+    /* PMI tokens */
+
+    .pmi-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.3rem;
+    }
+
+    .pmi-chip {
+      font-family: var(--font-mono);
+      font-size: 0.72rem;
+      padding: 0.15rem 0.4rem;
+      background: var(--bg-code);
+      border-radius: 3px;
+      display: inline-flex;
+      align-items: baseline;
+      gap: 0.3rem;
+    }
+
+    .pmi-chip .pmi-score {
+      font-size: 0.62rem;
+      color: var(--text-muted);
+    }
+
+    /* Scores */
+
+    .scores-row {
+      display: flex;
+      gap: 1rem;
+    }
+
+    .score-item {
+      display: flex;
+      align-items: baseline;
+      gap: 0.35rem;
+    }
+
+    .score-item .score-label {
+      font-family: var(--font-mono);
+      font-size: 0.62rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--text-muted);
+    }
+
+    .score-item .score-value {
+      font-family: var(--font-mono);
+      font-size: 0.85rem;
+      font-weight: 500;
+      color: var(--text);
+    }
+
+    /* Reasoning (collapsible) */
+
+    .reasoning-toggle {
+      font-family: var(--font-mono);
+      font-size: 0.65rem;
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+      color: var(--text-muted);
+      background: none;
+      border: none;
+      cursor: pointer;
+      padding: 0;
+      display: flex;
+      align-items: center;
+      gap: 0.3rem;
+    }
+
+    .reasoning-toggle:hover {
+      color: var(--text-secondary);
+    }
+
+    .reasoning-toggle .arrow {
+      display: inline-block;
+      transition: transform 0.15s ease;
+      font-size: 0.55rem;
+    }
+
+    .reasoning-toggle.open .arrow {
+      transform: rotate(90deg);
+    }
+
+    .reasoning-body {
+      overflow: hidden;
+      max-height: 0;
+      transition: max-height 0.2s ease;
+    }
+
+    .reasoning-body.open {
+      max-height: 20rem;
+    }
+
+    .reasoning-text {
+      font-size: 0.82rem;
+      color: var(--text-secondary);
+      line-height: 1.5;
+      font-style: italic;
+      border-left: 2px solid var(--border);
+      padding-left: 0.75rem;
+      margin-top: 0.35rem;
+    }
+
+    /* Loading state */
+
+    .card-loading {
+      padding: 3rem;
+      text-align: center;
+      color: var(--text-muted);
+      font-size: 0.85rem;
+    }
+
+    .card-empty {
+      padding: 2rem;
+      text-align: center;
+      color: var(--text-muted);
+      font-size: 0.85rem;
+    }
+
+    /* Divider between sections */
+
+    .card-divider {
+      height: 1px;
+      background: var(--border);
+      margin: 0.75rem 1.25rem 0;
+    }
+  </style>
+</head>
+
+<body>
+
+  <div class="controls-bar">
+    <label>Layer
+      <select id="filter-layer">
+        <option value="all">All</option>
+      </select>
+    </label>
+    <label>Sort
+      <select id="sort-by">
+        <option value="detection">Detection</option>
+        <option value="fuzzing">Fuzzing</option>
+        <option value="density">Density</option>
+        <option value="label">Label</option>
+      </select>
+    </label>
+    <label>Search
+      <input id="search" type="text" placeholder="filter...">
+    </label>
+  </div>
+
+  <div class="carousel-container">
+    <div class="carousel-pane" id="vpd-pane"></div>
+    <div class="carousel-pane" id="tc-pane"></div>
+  </div>
+
+  <script>
+    (function () {
+      const DATA = /*DATA_JSON*/null;
+      const componentCache = {};
+
+      function esc(s) {
+        if (!s) return "";
+        const d = document.createElement("div");
+        d.textContent = s;
+        return d.innerHTML;
+      }
+
+      /* ── Component card renderer ── */
+
+      function renderComponentCard(comp) {
+        // 1. Label + confidence (inline)
+        const confBadge = comp.confidence
+          ? `<span class="card-confidence ${comp.confidence}">confidence: ${comp.confidence}</span>`
+          : "";
+        const labelHtml = comp.label && comp.label !== "unclear"
+          ? `<div class="card-label">${esc(comp.label)}${confBadge}</div>`
+          : `<div class="card-label card-label-missing">unlabeled</div>`;
+
+        // 2. Layer + density
+        const chips = [];
+        chips.push(`<span class="meta-chip">${esc(comp.layer_display || comp.layer)}</span>`);
+        const density = comp.firing_density;
+        const densityStr = density > 0
+          ? `${(density * 100).toFixed(density < 0.01 ? 2 : 1)}%`
+          : "0%";
+        chips.push(`<span class="meta-chip">${densityStr} density</span>`);
+
+        // 3. Scores
+        let scoresHtml = "";
+        if (comp.detection_score || comp.fuzzing_score) {
+          let inner = "";
+          if (comp.detection_score) {
+            inner += `<div class="score-item"><span class="score-label">Detection</span><span class="score-value">${comp.detection_score.score.toFixed(2)}</span></div>`;
+          }
+          if (comp.fuzzing_score) {
+            inner += `<div class="score-item"><span class="score-label">Fuzzing</span><span class="score-value">${comp.fuzzing_score.score.toFixed(2)}</span></div>`;
+          }
+          scoresHtml = `<div class="card-section"><div class="section-label">Scores</div><div class="scores-row">${inner}</div></div>`;
+        }
+
+        // 4. Reasoning (collapsible)
+        const uid = "r" + Math.random().toString(36).slice(2, 8);
+        let reasoningHtml = "";
+        if (comp.reasoning) {
+          reasoningHtml = `<div class="card-section">
+      <button class="reasoning-toggle" onclick="this.classList.toggle('open');document.getElementById('${uid}').classList.toggle('open')">
+        <span class="arrow">\u25B6</span> Reasoning
+      </button>
+      <div class="reasoning-body" id="${uid}">
+        <div class="reasoning-text">${esc(comp.reasoning)}</div>
+      </div>
+    </div>`;
+        }
+
+        // 5. Activation examples (no-wrap, scrollable)
+        let examplesHtml = "";
+        if (comp.activation_examples && comp.activation_examples.length) {
+          const lines = comp.activation_examples.slice(0, 5).map(ex =>
+            `<div class="example-line">${ex.tokens.map(t =>
+              `<span class="tok${t.is_firing ? " fire" : ""}">${esc(t.token)}</span>`
+            ).join("")}</div>`
+          ).join("");
+          examplesHtml = `<div class="card-section">
+      <div class="section-label">Activation examples</div>
+      <div class="example-block">${lines}</div>
+    </div>`;
+        }
+
+        // 6. PMI tokens (below examples)
+        function pmiSection(label, pmi) {
+          if (!pmi || !pmi.top || !pmi.top.length) return "";
+          const tags = pmi.top.slice(0, 8).map(([tok, val]) =>
+            `<span class="pmi-chip">${esc(tok)}<span class="pmi-score">${val.toFixed(1)}</span></span>`
+          ).join("");
+          return `<div class="card-section">
+      <div class="section-label">${label}</div>
+      <div class="pmi-row">${tags}</div>
+    </div>`;
+        }
+
+        return `<div class="component-card">
+    <div class="card-top">
+      ${labelHtml}
+      <div class="card-meta-row">${chips.join("")}</div>
+    </div>
+    ${scoresHtml}
+    ${reasoningHtml}
+    <div class="card-divider"></div>
+    ${examplesHtml}
+    ${pmiSection("Input token correlations", comp.input_token_pmi)}
+    ${pmiSection("Output token correlations", comp.output_token_pmi)}
+  </div>`;
+      }
+
+      /* ── Carousel pane ── */
+
+      class CarouselPane {
+        constructor(el, methodKey, methodLabel, decomp) {
+          this.el = el;
+          this.methodKey = methodKey;
+          this.methodLabel = methodLabel;
+          this.decomp = decomp;
+          this.filtered = decomp ? [...decomp.component_index] : [];
+          this.idx = 0;
+          this.loading = false;
+        }
+
+        applyFilters(layerFilter, sortBy, search) {
+          if (!this.decomp) { this.filtered = []; return; }
+          let list = this.decomp.component_index.filter(c => {
+            if (layerFilter !== "all" && c.layer !== layerFilter) return false;
+            if (search && !(c.label || "").toLowerCase().includes(search)) return false;
+            return true;
+          });
+          list.sort((a, b) => {
+            switch (sortBy) {
+              case "detection": return (b.detection_score?.score ?? -1) - (a.detection_score?.score ?? -1);
+              case "fuzzing": return (b.fuzzing_score?.score ?? -1) - (a.fuzzing_score?.score ?? -1);
+              case "density": return b.firing_density - a.firing_density;
+              case "label": return (a.label || "zzz").localeCompare(b.label || "zzz");
+              default: return 0;
+            }
+          });
+          this.filtered = list;
+          this.idx = Math.min(this.idx, Math.max(0, list.length - 1));
+        }
+
+        async render() {
+          if (!this.decomp || this.filtered.length === 0) {
+            this.el.innerHTML = `<div class="pane-header">
+        <span class="pane-title ${this.methodKey === "vpd" ? "vpd" : "tc"}">${this.methodLabel}</span>
+      </div><div class="card-empty">No components match filters</div>`;
+            return;
+          }
+
+          const cls = this.methodKey === "vpd" ? "vpd" : "tc";
+          const c = this.filtered[this.idx];
+          const safeKey = c.component_key.replace(/:/g, "_").replace(/\//g, "_");
+
+          this.el.innerHTML = `<div class="pane-header">
+      <span class="pane-title ${cls}">${this.methodLabel}</span>
+      <div class="pane-nav">
+        <button class="nav-btn" id="prev-${this.methodKey}" ${this.idx <= 0 ? "disabled" : ""}>\u2190</button>
+        <span class="pane-counter">${this.idx + 1} / ${this.filtered.length}</span>
+        <button class="nav-btn" id="next-${this.methodKey}" ${this.idx >= this.filtered.length - 1 ? "disabled" : ""}>\u2192</button>
+      </div>
+    </div>
+    <div id="card-slot-${this.methodKey}"><div class="component-card"><div class="card-loading">Loading\u2026</div></div></div>`;
+
+          document.getElementById(`prev-${this.methodKey}`).addEventListener("click", () => this.go(-1));
+          document.getElementById(`next-${this.methodKey}`).addEventListener("click", () => this.go(1));
+
+          const cacheKey = `${this.methodKey}:${c.component_key}`;
+          let comp = componentCache[cacheKey];
+          if (!comp) {
+            const resp = await fetch(`${this.decomp.components_path}/${safeKey}.json`);
+            comp = await resp.json();
+            componentCache[cacheKey] = comp;
+          }
+
+          document.getElementById(`card-slot-${this.methodKey}`).innerHTML = renderComponentCard(comp);
+        }
+
+        async go(delta) {
+          if (this.loading) return;
+          const next = this.idx + delta;
+          if (next < 0 || next >= this.filtered.length) return;
+          this.idx = next;
+          this.loading = true;
+          await this.render();
+          this.loading = false;
+        }
+      }
+
+      /* ── Init ── */
+
+      function render() {
+        if (!DATA) return;
+
+        const layers = new Set();
+        for (const key of ["vpd", "transcoder"]) {
+          if (DATA[key]) DATA[key].component_index.forEach(c => layers.add(c.layer));
+        }
+        const layerSelect = document.getElementById("filter-layer");
+        for (const l of [...layers].sort()) {
+          const opt = document.createElement("option");
+          opt.value = l; opt.textContent = l;
+          layerSelect.appendChild(opt);
+        }
+
+        const vpdPane = new CarouselPane(
+          document.getElementById("vpd-pane"), "vpd", "VPD", DATA.vpd
+        );
+        const tcPane = new CarouselPane(
+          document.getElementById("tc-pane"), "transcoder", "Transcoder", DATA.transcoder
+        );
+
+        function update() {
+          const lf = document.getElementById("filter-layer").value;
+          const sb = document.getElementById("sort-by").value;
+          const q = document.getElementById("search").value.toLowerCase();
+          vpdPane.applyFilters(lf, sb, q);
+          tcPane.applyFilters(lf, sb, q);
+          vpdPane.render();
+          tcPane.render();
+        }
+
+        for (const id of ["filter-layer", "sort-by"]) {
+          document.getElementById(id).addEventListener("change", update);
+        }
+        document.getElementById("search").addEventListener("input", update);
+
+        // Keyboard nav
+        document.addEventListener("keydown", (e) => {
+          if (e.target.tagName === "INPUT") return;
+          if (e.key === "ArrowLeft") { vpdPane.go(-1); tcPane.go(-1); }
+          if (e.key === "ArrowRight") { vpdPane.go(1); tcPane.go(1); }
+          if (e.key === "j") { vpdPane.go(1); tcPane.go(1); }
+          if (e.key === "k") { vpdPane.go(-1); tcPane.go(-1); }
+        });
+
+        update();
+      }
+
+      document.addEventListener("DOMContentLoaded", render);
+    })();
+  </script>
+</body>
+
+</html>

--- a/spd/paper_vis/data.py
+++ b/spd/paper_vis/data.py
@@ -1,0 +1,80 @@
+"""Data types for paper visualisation dashboards.
+
+JSON-serializable types that bridge the harvest/autointerp pipeline outputs
+into static dashboard data. Each DecompositionData bundles everything needed
+to render a component-level comparison dashboard for one decomposition method.
+"""
+
+from pydantic import BaseModel
+
+
+class TokenSpan(BaseModel):
+    """A token with its firing/activation state in context."""
+
+    token: str
+    is_firing: bool
+    activation: float
+
+
+class ActivationExampleData(BaseModel):
+    """One activation example: a window of tokens around a firing."""
+
+    tokens: list[TokenSpan]
+    center_idx: int
+
+
+class TokenPMIData(BaseModel):
+    """Top tokens by PMI for a component."""
+
+    top: list[tuple[str, float]]
+    bottom: list[tuple[str, float]]
+
+
+class ScoreData(BaseModel):
+    """Autointerp eval score for a component."""
+
+    score: float
+    n_trials: int
+
+
+class ComponentDashboardData(BaseModel):
+    """Everything we know about a single component, ready for the dashboard."""
+
+    component_key: str
+    layer: str
+    layer_display: str
+    component_idx: int
+
+    # Harvest data
+    firing_density: float
+    mean_activation: float
+    activation_examples: list[ActivationExampleData]
+    input_token_pmi: TokenPMIData
+    output_token_pmi: TokenPMIData
+
+    # Autointerp data (None if not yet interpreted)
+    label: str | None
+    confidence: str | None
+    reasoning: str | None
+
+    # Scoring data (None if not yet scored)
+    detection_score: ScoreData | None
+    fuzzing_score: ScoreData | None
+
+
+class DecompositionData(BaseModel):
+    """All dashboard data for one decomposition method."""
+
+    decomposition_id: str
+    method: str  # "vpd" or "transcoder"
+    base_model: str
+    n_components: int
+    n_layers: int
+    components: list[ComponentDashboardData]
+
+
+class ComparisonDashboardData(BaseModel):
+    """Top-level data for a VPD-vs-transcoder comparison dashboard."""
+
+    vpd: DecompositionData
+    transcoder: DecompositionData

--- a/spd/paper_vis/generate.py
+++ b/spd/paper_vis/generate.py
@@ -1,0 +1,212 @@
+"""Generate dashboard JSON from harvest + autointerp data.
+
+Outputs:
+  - manifest.json: lightweight metadata + component list (inline in HTML)
+  - components/{component_key}.json: per-component full data (loaded on demand)
+
+Usage:
+    python -m spd.paper_vis.generate --decomposition_id s-55ea3f9b --method vpd --out_dir out/vpd
+"""
+
+import contextlib
+import json
+from pathlib import Path
+
+import fire
+import orjson
+
+from spd.adapters import adapter_from_id
+from spd.app.backend.app_tokenizer import AppTokenizer
+from spd.autointerp.prompt_helpers import human_layer_desc
+from spd.autointerp.repo import InterpRepo
+from spd.harvest.repo import HarvestRepo
+from spd.harvest.schemas import ActivationExample, ComponentData
+from spd.paper_vis.data import (
+    ActivationExampleData,
+    ComponentDashboardData,
+    DecompositionData,
+    ScoreData,
+    TokenPMIData,
+    TokenSpan,
+)
+
+
+def _convert_pmi(pmi_data: list[tuple[int, float]], tok: AppTokenizer) -> list[tuple[str, float]]:
+    return [(tok.get_tok_display(tid), score) for tid, score in pmi_data]
+
+
+def _convert_example(
+    example: "ActivationExample", tok: AppTokenizer, act_type: str
+) -> ActivationExampleData:
+    activations = example.activations.get(act_type, [0.0] * len(example.token_ids))
+    tokens = [
+        TokenSpan(
+            token=tok.get_tok_display(tid),
+            is_firing=f,
+            activation=a,
+        )
+        for tid, f, a in zip(example.token_ids, example.firings, activations, strict=True)
+    ]
+    center_idx = len(tokens) // 2
+    return ActivationExampleData(tokens=tokens, center_idx=center_idx)
+
+
+def _primary_activation_type(component: ComponentData) -> str:
+    if not component.activation_examples:
+        return "activation"
+    act_types = list(component.activation_examples[0].activations.keys())
+    if "causal_importance" in act_types:
+        return "causal_importance"
+    return act_types[0] if act_types else "activation"
+
+
+def _build_component(
+    comp: ComponentData,
+    tok: AppTokenizer,
+    interp_repo: InterpRepo | None,
+    detection_scores: dict[str, float],
+    fuzzing_scores: dict[str, float],
+    layer_descriptions: dict[str, str],
+    n_blocks: int,
+) -> ComponentDashboardData:
+    act_type = _primary_activation_type(comp)
+    mean_act = comp.mean_activations.get(act_type, 0.0)
+
+    examples = [_convert_example(ex, tok, act_type) for ex in comp.activation_examples[:20]]
+
+    input_pmi = TokenPMIData(
+        top=_convert_pmi(comp.input_token_pmi.top, tok),
+        bottom=_convert_pmi(comp.input_token_pmi.bottom, tok),
+    )
+    output_pmi = TokenPMIData(
+        top=_convert_pmi(comp.output_token_pmi.top, tok),
+        bottom=_convert_pmi(comp.output_token_pmi.bottom, tok),
+    )
+
+    label = None
+    confidence = None
+    reasoning = None
+    detection_score = None
+    fuzzing_score = None
+
+    if interp_repo is not None:
+        interp = interp_repo.get_interpretation(comp.component_key)
+        if interp is not None:
+            label = interp.label
+            confidence = interp.confidence
+            reasoning = interp.reasoning
+
+        det_val = detection_scores.get(comp.component_key)
+        if det_val is not None:
+            detection_score = ScoreData(score=det_val, n_trials=0)
+
+        fuz_val = fuzzing_scores.get(comp.component_key)
+        if fuz_val is not None:
+            fuzzing_score = ScoreData(score=fuz_val, n_trials=0)
+
+    canonical = layer_descriptions.get(comp.layer, comp.layer)
+    layer_display = human_layer_desc(canonical, n_blocks)
+
+    return ComponentDashboardData(
+        component_key=comp.component_key,
+        layer=comp.layer,
+        layer_display=layer_display,
+        component_idx=comp.component_idx,
+        firing_density=comp.firing_density,
+        mean_activation=mean_act,
+        activation_examples=examples,
+        input_token_pmi=input_pmi,
+        output_token_pmi=output_pmi,
+        label=label,
+        confidence=confidence,
+        reasoning=reasoning,
+        detection_score=detection_score,
+        fuzzing_score=fuzzing_score,
+    )
+
+
+def build_decomposition_data(
+    decomposition_id: str,
+    method: str,
+    limit: int | None,
+    out_dir: Path,
+) -> DecompositionData:
+    adapter = adapter_from_id(decomposition_id)
+
+    harvest = HarvestRepo.open_most_recent(decomposition_id)
+    assert harvest is not None, f"No harvest data for {decomposition_id}"
+
+    tok = AppTokenizer.from_pretrained(adapter.tokenizer_name)
+
+    interp_repo: InterpRepo | None = None
+    with contextlib.suppress(Exception):
+        interp_repo = InterpRepo.open(decomposition_id)
+
+    detection_scores: dict[str, float] = {}
+    fuzzing_scores: dict[str, float] = {}
+    if interp_repo is not None:
+        detection_scores = interp_repo.get_scores("detection")
+        fuzzing_scores = interp_repo.get_scores("fuzzing")
+
+    metadata = adapter.model_metadata
+    layer_descriptions = metadata.layer_descriptions
+    n_blocks = metadata.n_blocks
+
+    summaries = harvest.get_summary()
+    keys = list(summaries.keys())
+    if limit is not None:
+        keys = keys[:limit]
+
+    comp_dir = out_dir / "components"
+    comp_dir.mkdir(parents=True, exist_ok=True)
+
+    dashboard_components: list[ComponentDashboardData] = []
+    for i, key in enumerate(keys):
+        comp = harvest.get_component(key)
+        assert comp is not None
+        dash_comp = _build_component(
+            comp,
+            tok,
+            interp_repo,
+            detection_scores,
+            fuzzing_scores,
+            layer_descriptions,
+            n_blocks,
+        )
+        dashboard_components.append(dash_comp)
+
+        safe_key = key.replace(":", "_").replace("/", "_")
+        comp_path = comp_dir / f"{safe_key}.json"
+        comp_path.write_bytes(orjson.dumps(dash_comp.model_dump()))
+
+        if (i + 1) % 50 == 0:
+            print(f"  {i + 1}/{len(keys)} components", flush=True)
+
+    print(f"  {len(keys)}/{len(keys)} components done", flush=True)
+
+    layers = adapter.layer_activation_sizes
+    return DecompositionData(
+        decomposition_id=decomposition_id,
+        method=method,
+        base_model=adapter.tokenizer_name,
+        n_components=sum(n for _, n in layers),
+        n_layers=len(layers),
+        components=dashboard_components,
+    )
+
+
+def main(
+    decomposition_id: str,
+    method: str,
+    out_dir: str,
+    limit: int | None = None,
+) -> None:
+    out_path = Path(out_dir)
+    data = build_decomposition_data(decomposition_id, method, limit, out_path)
+    manifest = out_path / "manifest.json"
+    manifest.write_text(json.dumps(data.model_dump(exclude={"components"}), indent=2))
+    print(f"Wrote {len(data.components)} components to {out_path}/")
+
+
+if __name__ == "__main__":
+    fire.Fire(main)

--- a/spd/paper_vis/research_post.html
+++ b/spd/paper_vis/research_post.html
@@ -1,0 +1,322 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Interpreting Language Model Parameters — Goodfire Research</title>
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.css">
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js"></script>
+<script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/contrib/auto-render.min.js"
+  onload="renderMathInElement(document.body, {delimiters: [{left: '$$', right: '$$', display: true}, {left: '$', right: '$', display: false}]});"></script>
+<style>
+@font-face { font-family: "Suisse Works"; font-weight: 400;
+  src: url("https://cdn.prod.website-files.com/67b4608695ee3b31a669d3a9/67b467edbcb831d14ec80a21_SuisseWorks-Book.otf") format("opentype"); }
+@font-face { font-family: "Suisse Intl"; font-weight: 400;
+  src: url("https://cdn.prod.website-files.com/67b4608695ee3b31a669d3a9/67b467b49a4db65259fafd97_SuisseIntl-Book.otf") format("opentype"); }
+@font-face { font-family: "Suisse Intl"; font-weight: 500;
+  src: url("https://cdn.prod.website-files.com/67b4608695ee3b31a669d3a9/67b46cade89f4c1805e64f62_SuisseIntl-Medium.otf") format("opentype"); }
+@font-face { font-family: "Suisse Intl"; font-weight: 600;
+  src: url("https://cdn.prod.website-files.com/67b4608695ee3b31a669d3a9/67b46cad70cd51d153f47310_SuisseIntl-SemiBold.otf") format("opentype"); }
+@font-face { font-family: "IBM Plex Mono"; font-weight: 400;
+  src: url("https://cdn.prod.website-files.com/67b4608695ee3b31a669d3a9/67b4723df5335ccd8bcf5a36_IBMPlexMono-Regular.ttf") format("truetype"); }
+
+:root {
+  --serif: "Suisse Works", Georgia, serif;
+  --sans: "Suisse Intl", -apple-system, sans-serif;
+  --mono: "IBM Plex Mono", monospace;
+  --text: #1d272a;
+  --text-secondary: #646464;
+  --text-muted: #8c9196;
+  --border: #b4b4b4;
+  --bg: #fff;
+  --bg-code: #f5f5f5;
+  --link: #1d272a;
+  --col-width: 740px;
+}
+
+* { margin: 0; padding: 0; box-sizing: border-box; }
+
+body {
+  font-family: var(--sans);
+  color: var(--text);
+  background: var(--bg);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Nav */
+nav {
+  max-width: 1200px; margin: 0 auto; padding: 1.25rem 2rem;
+  display: flex; justify-content: space-between; align-items: center;
+  border-bottom: 1px solid #e5e5e5;
+}
+.nav-logo { font-family: var(--sans); font-weight: 600; font-size: 1.1rem; color: var(--text); text-decoration: none; }
+.nav-links { display: flex; gap: 1.5rem; list-style: none; }
+.nav-links a { font-size: 0.85rem; color: var(--text-secondary); text-decoration: none; }
+.nav-links a:hover { color: var(--text); }
+
+/* Article */
+article { max-width: var(--col-width); margin: 0 auto; padding: 3rem 1.5rem 5rem; }
+
+article h1 {
+  font-family: var(--serif); font-size: 2.5rem; font-weight: 400;
+  line-height: 1.2; margin-bottom: 0.75rem; color: var(--text);
+}
+
+.byline {
+  font-family: var(--mono); font-size: 0.75rem; text-transform: uppercase;
+  letter-spacing: 0.06em; color: var(--text-muted); margin-bottom: 2.5rem;
+}
+
+article h2 {
+  font-family: var(--serif); font-size: 1.625rem; font-weight: 400;
+  margin: 2.5rem 0 1rem; padding-top: 1.5rem; border-top: 1px solid #e5e5e5;
+  color: var(--text);
+}
+
+article h3 {
+  font-family: var(--sans); font-size: 1.1rem; font-weight: 600;
+  margin: 1.5rem 0 0.5rem; color: var(--text);
+}
+
+article p {
+  font-family: var(--serif); font-size: 1.0625rem; line-height: 1.65;
+  color: var(--text-secondary); margin-bottom: 1rem;
+}
+
+article ul, article ol {
+  font-family: var(--serif); font-size: 1.0625rem; line-height: 1.65;
+  color: var(--text-secondary); margin: 0.5rem 0 1rem 1.5rem;
+}
+
+article li { margin-bottom: 0.5rem; }
+
+code {
+  font-family: var(--mono); font-size: 0.9em;
+  background: var(--bg-code); padding: 0.1em 0.35em; border-radius: 3px;
+}
+
+.equation {
+  font-family: var(--serif); font-size: 1rem;
+  text-align: center; margin: 1.5rem 0; padding: 1rem;
+  background: #fafafa; border-radius: 4px; overflow-x: auto;
+}
+
+figure {
+  margin: 2rem 0;
+}
+
+figure img {
+  width: 100%; border-radius: 8px;
+}
+
+figcaption {
+  font-family: var(--sans); font-size: 0.85rem; color: var(--text-muted);
+  margin-top: 0.5rem; text-align: center; line-height: 1.4;
+}
+
+/* TOC */
+.toc {
+  margin: 0 0 2rem; padding: 1.25rem 1.5rem;
+  background: #fafafa; border-radius: 6px;
+}
+.toc-title {
+  font-family: var(--mono); font-size: 0.7rem; text-transform: uppercase;
+  letter-spacing: 0.06em; color: var(--text-muted); margin-bottom: 0.5rem;
+}
+.toc a {
+  display: block; font-size: 0.9rem; color: var(--text-secondary);
+  text-decoration: none; padding: 0.2rem 0;
+}
+.toc a:hover { color: var(--text); }
+.toc .indent { padding-left: 1.25rem; }
+
+/* Component demo embed */
+.component-embed {
+  margin: 2rem 0;
+  border-top: 1px solid #e5e5e5;
+  border-bottom: 1px solid #e5e5e5;
+  width: 100vw;
+  position: relative;
+  left: 50%;
+  transform: translateX(-50%);
+}
+.embed-caption {
+  font-family: var(--sans); font-size: 0.85rem; color: var(--text-muted);
+  padding: 0.75rem 1rem; background: #fafafa; border-top: 1px solid #e5e5e5;
+}
+
+/* Highlight box */
+.callout {
+  border-left: 3px solid var(--text);
+  padding: 1rem 1.25rem; margin: 1.5rem 0;
+  background: #fafafa;
+}
+.callout p { margin-bottom: 0.5rem; }
+.callout p:last-child { margin-bottom: 0; }
+
+/* Table */
+table { width: 100%; border-collapse: collapse; margin: 1rem 0; font-size: 0.95rem; }
+th { font-family: var(--sans); font-weight: 600; text-align: left; padding: 0.5rem; border-bottom: 2px solid var(--text); }
+td { font-family: var(--serif); padding: 0.5rem; border-bottom: 1px solid #e5e5e5; color: var(--text-secondary); }
+
+.draft-badge {
+  display: inline-block; font-family: var(--mono); font-size: 0.65rem;
+  text-transform: uppercase; letter-spacing: 0.06em;
+  background: #fff3cd; color: #856404; padding: 0.2rem 0.6rem;
+  border-radius: 3px; margin-left: 0.5rem; vertical-align: middle;
+}
+</style>
+</head>
+<body>
+
+<nav>
+  <a href="https://goodfire.ai" class="nav-logo">Goodfire</a>
+  <ul class="nav-links">
+    <li><a href="https://goodfire.ai/company">Company</a></li>
+    <li><a href="https://goodfire.ai/research">Research</a></li>
+    <li><a href="https://goodfire.ai/blog">Blog</a></li>
+  </ul>
+</nav>
+
+<article>
+  <h1>Interpreting Language Model Parameters <span class="draft-badge">Draft</span></h1>
+  <div class="byline">Goodfire Research &middot; 2025</div>
+
+  <div class="toc">
+    <div class="toc-title">Contents</div>
+    <a href="#intro">Introduction</a>
+    <a href="#method">Method &mdash; Adversarial Parameter Decomposition</a>
+    <a class="indent" href="#components">Parameter components</a>
+    <a class="indent" href="#minimality">Optimizing for minimality</a>
+    <a class="indent" href="#faithfulness">Optimizing for mechanistic faithfulness</a>
+    <a class="indent" href="#simplicity">Optimizing for simplicity</a>
+    <a href="#results">Results</a>
+    <a class="indent" href="#pareto">Comparison with activation-based decompositions</a>
+    <a class="indent" href="#interp">Parameter components are highly interpretable</a>
+    <a class="indent" href="#examples">Example components</a>
+    <a class="indent" href="#case-studies">Case studies</a>
+  </div>
+
+  <h2 id="intro">Introduction</h2>
+
+  <p>Structure in the parameters of language models is responsible for their remarkable intelligence. The trainable parameters of these neural networks, in interaction with the architecture and dataset, learn to implement algorithms that we do not know how to design directly. On the one hand, deep learning thus affords us the ability to build machines to solve tasks that otherwise resist engineering solutions, and incidentally creates objects that are of great scientific interest in their own right. On the other hand, it means that an increasing portion of our daily lives depend on systems that we do not deeply understand.</p>
+
+  <p>A key barrier to understanding the computations that these systems perform is how best to decompose them into simpler parts that we can study in relative isolation. Naive choices of these parts&mdash;such as neurons, attention heads, or whole layers&mdash;don't always map to individual, interpretable computations.</p>
+
+  <p>Alternative approaches, such as transcoders or mixtures of linear transforms (MOLTs), typically involve fitting a set of simple functions to the transitions between activations at different layers in the network, and linearly combining the outputs of these simple functions. The idea is to approximate the complex, nonlinear function implemented by the network's layers using a simpler, easier to understand function. Unfortunately, because these simpler functions are of a different functional form to the original network, it is hard to relate their accounts of network function to the actual objects that are doing the computations&mdash;the network's parameters and its nonlinearities.</p>
+
+  <p>These issues motivate <em>parameter decomposition methods</em>, which give accounts of network function in terms of the components of the network's parameters that are used by the network on a given datapoint. <em>Ablation-based parameter decomposition methods</em> identify a set of parameter components where as few components as possible are necessary to perform the same computations as the original network on any datapoint, while the set of components sums to the parameters of the target network and are as computationally simple as possible.</p>
+
+  <div class="callout">
+    <p>In this work, we introduce <strong>Adversarial Parameter Decomposition (VPD)</strong>, which builds on SPD but with several important modifications that make it more mechanistically faithful and scalable. We decompose a small language model (67M parameters) trained on The Pile and find parameter components that are highly interpretable, compare favorably to transcoder and CLT latents, and enable novel circuit analysis.</p>
+  </div>
+
+  <h2 id="method">Method &mdash; Adversarial Parameter Decomposition</h2>
+
+  <p>Our method, VPD, builds heavily on SPD, but we do not assume familiarity with that work. Our goal is to decompose a neural network's parameters into the mechanisms that it uses to compute its behavior. Networks appear not to use all of their parameters simultaneously on every datapoint. If particular parameters are unused by the network on a particular datapoint, then we should be able to ablate them without adversely affecting the network's output.</p>
+
+  <p>Ablation-based parameter decomposition methods thus aim to decompose network parameters into a set of vectors in parameter space called <em>parameter components</em> that sum to the network's total parameter vector and are:</p>
+  <ul>
+    <li><strong>Minimal</strong> &mdash; as few components as possible are causally important on any particular input</li>
+    <li><strong>Mechanistically faithful</strong> &mdash; every subset of components that includes the causally important ones suffices to compute the output</li>
+    <li><strong>Simple</strong> &mdash; components should each involve as little computational machinery as possible</li>
+  </ul>
+
+  <h3 id="components">Parameter components are vectors in parameter space</h3>
+
+  <p>We decompose individual weight matrices into sums of rank-one matrices called <em>subcomponents</em>, each parametrized as an outer product of two vectors. Although a single subcomponent parameterizes only a single weight matrix, it implicitly parametrises a full parameter vector if we assume it takes values of 0 in every other weight matrix. It is therefore possible to combine these subcomponents into full parameter components by clustering them together.</p>
+
+  <h3 id="minimality">Optimizing for minimality</h3>
+
+  <p>We train a <em>causal importance function</em> to predict how ablatable each subcomponent is on a given datapoint. We want causal importance values to take minimal values, leading to the importance minimality loss:</p>
+
+  <div class="equation">
+    $$\mathcal{L}_{\text{importance-minimality}} = \sum_{l=1}^{L} \sum_{c=1}^{C} |g^l_c(x)|^p$$
+  </div>
+
+  <h3 id="faithfulness">Optimizing for mechanistic faithfulness</h3>
+
+  <p>We create stochastic masks $m^l_c(x, r) := g^l_c(x) + (1 - g^l_c(x))r^l_c(x)$ where $r \sim \mathcal{U}(0,1)$, and minimize:</p>
+
+  <div class="equation">
+    $$\mathcal{L}_{\text{stochastic-recon}} = \frac{1}{S}\sum_{s=1}^{S} D\!\left(f(x \mid W'(x, r^{(s)})),\; f(x \mid W)\right)$$
+  </div>
+
+  <p>VPD optimizes for a stricter criterion than SPD: adversarial ablatability. The stochastic reconstruction loss approximates our desired condition on average, but not for worst-case values. VPD therefore introduces an adversarial loss:</p>
+
+  <div class="equation">
+    $$\mathcal{L}_{\text{adversarial-recon}} = \frac{1}{S} \max_{r^{(s)}(x)} D\!\left(f(x \mid W'(x, r^{(s)}(x))),\; f(x \mid W)\right)$$
+  </div>
+
+  <h3 id="simplicity">Optimizing for simplicity</h3>
+
+  <p>VPD introduces a frequency-minimality loss that encourages subcomponents to activate on as few datapoints as possible, complementing the importance minimality loss which encourages datapoints to activate as few subcomponents as possible:</p>
+
+  <div class="equation">
+    $$\mathcal{L}_{\text{frequency-minimality}} = \sum_{l=1}^{L}\sum_{c=1}^{C} |g^l_c(x)|^p \log_2\!\left(1 + \sum_{x'} |g^l_c(x')|^p\right)$$
+  </div>
+
+  <p>Where importance minimality encourages each datapoint to activate few components, frequency minimality encourages each component to activate on few datapoints. This creates a useful tradeoff during training.</p>
+
+  <h2 id="results">Results</h2>
+
+  <h3>The target language model</h3>
+
+  <p>We trained a four-layer, 67M parameter decoder-only transformer model on an uncopyrighted subset of The Pile. It uses standard multihead attention with RoPE positional encoding and MLPs with GELU activation. The model achieves a final validation cross-entropy loss of approximately 2.71.</p>
+
+  <table>
+    <tr><th>Property</th><th>Value</th></tr>
+    <tr><td>Layers</td><td>4</td></tr>
+    <tr><td>Residual stream d<sub>model</sub></td><td>768</td></tr>
+    <tr><td>MLP intermediate dimension</td><td>3,072</td></tr>
+    <tr><td>Attention heads</td><td>6</td></tr>
+    <tr><td>Context length</td><td>512</td></tr>
+    <tr><td>Vocabulary size</td><td>50,277</td></tr>
+    <tr><td>Total parameters</td><td>~67M</td></tr>
+  </table>
+
+  <h3 id="pareto">VPD achieves a better sparsity&ndash;accuracy tradeoff</h3>
+
+  <p>We compare VPD's reconstruction quality against transcoders and cross-layer transcoders (CLTs). VPD achieves lower CE degradation than both at comparable sparsity levels, consistent across multiple normalizations of component count.</p>
+
+  <p>End-to-end trained activation-based methods exhibit severe brittleness to evaluation mode mismatch. When evaluated in a mismatched setting (cascading vs parallel), performance degrades by 5&ndash;20&times;. VPD's CE degradation, by contrast, is relatively consistent across all evaluation protocols, because its stochastic and adversarial masking during training naturally covers both patterns.</p>
+
+  <h3 id="interp">Parameter components are highly interpretable</h3>
+
+  <p>Automated interpretation of VPD's parameter components shows that they correspond to recognizable linguistic and computational functions. Below, we show example components from our decomposition alongside transcoder latents trained on the same architecture, demonstrating that VPD components are at least as interpretable as transcoder features.</p>
+
+  <h3 id="examples">Example components</h3>
+
+  <p>The interactive viewer below shows VPD parameter components (left) and transcoder latents (right) from the same model architecture. Each card displays the component's automatically generated label, activation examples (tokens where the component fires are highlighted), and token correlation statistics. Use the arrow keys or navigation buttons to browse.</p>
+
+  <div class="component-embed">
+    <iframe src="index.html"></iframe>
+  </div>
+
+  <h3 id="case-studies">Case studies</h3>
+
+  <h3>Case study 1: Gender for possessive pronouns</h3>
+
+  <p>On the prompt <code>The princess lost her crown.</code> the target model correctly predicts that <code>her</code> follows <code>lost</code>, assigning probability 0.586. This requires recognizing that a possessive pronoun is coming up, remembering that the previous token was <code>princess</code>, and realizing that princesses use feminine-gendered pronouns.</p>
+
+  <p>The attribution graph reveals two core mechanisms: one which moves the femaleness attribute of "princess" over to the next token in attention layer 3, and another which suggests that a possessive pronoun might follow the verb "lost". A subset of just six components proves sufficient to predict "her" under causal importance masking&mdash;but fails under adversarial masking, revealing that many more components play important computational roles.</p>
+
+  <h3>Case study 2: Distributed attention behaviors</h3>
+
+  <p>Previous token behavior&mdash;attention from timestep <em>t</em> to <em>t</em>&minus;1&mdash;is typically associated with "previous token heads." We find that in our model, a single pair of VPD rank-one components, whose weight spans all heads in that layer, is responsible for a greater amount of previous token behavior than the model's dedicated previous token head (L1H1). This demonstrates VPD's ability to identify attention computations distributed across heads&mdash;something activation-based methods struggle with.</p>
+
+  <h3>Case study 3: Bracket closing</h3>
+
+  <p>On the prompt <code>&lt;u,v&gt;</code>, the model predicts the closing bracket <code>&gt;</code>. The attribution graph reveals a rich multi-layer computation: layer 1 attention carries forward general delimiter information from <code>&lt;</code>, layer 2 attention distinguishes which specific bracket type was opened, and layer 3 MLPs produce the final output. Ablation experiments confirm that each layer's contribution is necessary&mdash;but only adversarial evaluation reveals this, as standard causal masking dramatically underestimates the number of components involved.</p>
+
+  <h2>Discussion</h2>
+
+  <p>VPD and other ablation-based parameter decomposition methods obey a principle of correspondence: ablations in the decomposed model have exactly corresponding ablations in the original model, making it straightforward to use insights from the decomposition for model editing. For example, we can remove any component from the original model by subtracting it from the total parameter vector.</p>
+
+  <p>Our results suggest that parameter decomposition methods offer a promising alternative to activation-based approaches. VPD components are more mechanistically faithful, exhibit less feature splitting, and are comparably or more interpretable than transcoder and SAE latents. The rarity of complex nonlinear interactions between components further suggests an underlying computational simplicity in the target model itself.</p>
+
+</article>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Static HTML dashboard pipeline comparing VPD components with transcoder/CLT latents
- Side-by-side carousel, per-component JSON loading, research post template
- Reads from harvest + autointerp DBs via existing repos

Stacked on #419.

🤖 Generated with [Claude Code](https://claude.com/claude-code)