### PR TITLE
Add rich_examples autointerp strategy + compare tab

### DIFF
--- a/spd/app/backend/routers/__init__.py
+++ b/spd/app/backend/routers/__init__.py
@@ -2,6 +2,7 @@
 
 from spd.app.backend.routers.activation_contexts import router as activation_contexts_router
 from spd.app.backend.routers.agents import router as agents_router
+from spd.app.backend.routers.autointerp_compare import router as autointerp_compare_router
 from spd.app.backend.routers.clusters import router as clusters_router
 from spd.app.backend.routers.correlations import router as correlations_router
 from spd.app.backend.routers.data_sources import router as data_sources_router
@@ -20,6 +21,7 @@ from spd.app.backend.routers.runs import router as runs_router
 __all__ = [
     "activation_contexts_router",
     "agents_router",
+    "autointerp_compare_router",
     "clusters_router",
     "correlations_router",
     "data_sources_router",

--- a/spd/app/backend/routers/autointerp_compare.py
+++ b/spd/app/backend/routers/autointerp_compare.py
@@ -1,0 +1,198 @@
+"""Autointerp comparison endpoints.
+
+Lists all completed autointerp subruns for a decomposition and serves
+interpretations from each, enabling side-by-side comparison of different
+strategies/models.
+"""
+
+from datetime import datetime
+from pathlib import Path
+
+import yaml
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from spd.app.backend.dependencies import DepLoadedRun
+from spd.app.backend.utils import log_errors
+from spd.autointerp.db import DONE_MARKER, InterpDB
+from spd.autointerp.schemas import get_autointerp_dir
+from spd.topology import TransformerTopology
+
+router = APIRouter(prefix="/api/autointerp_compare", tags=["autointerp_compare"])
+
+
+class SubrunSummary(BaseModel):
+    subrun_id: str
+    strategy: str
+    llm_model: str
+    timestamp: str
+    n_completed: int
+    mean_detection_score: float | None
+    mean_fuzzing_score: float | None
+
+
+class InterpretationHeadline(BaseModel):
+    label: str
+    confidence: str
+    detection_score: float | None = None
+    fuzzing_score: float | None = None
+
+
+class InterpretationDetail(BaseModel):
+    reasoning: str
+    prompt: str
+
+
+def _concrete_to_canonical_key(concrete_key: str, topology: TransformerTopology) -> str:
+    layer, idx = concrete_key.rsplit(":", 1)
+    canonical = topology.target_to_canon(layer)
+    return f"{canonical}:{idx}"
+
+
+def _canonical_to_concrete_key(
+    canonical_layer: str, component_idx: int, topology: TransformerTopology
+) -> str:
+    concrete = topology.canon_to_target(canonical_layer)
+    return f"{concrete}:{component_idx}"
+
+
+def _parse_subrun_timestamp(subrun_id: str) -> str:
+    """Parse 'a-YYYYMMDD_HHMMSS' into a readable timestamp."""
+    raw = subrun_id.removeprefix("a-")
+    try:
+        dt = datetime.strptime(raw, "%Y%m%d_%H%M%S")
+        return dt.strftime("%Y-%m-%d %H:%M:%S")
+    except ValueError:
+        return raw
+
+
+def _parse_config(config_path: Path) -> tuple[str, str]:
+    """Extract strategy type and LLM model from a subrun's config.yaml."""
+    if not config_path.exists():
+        return "unknown", "unknown"
+    with open(config_path) as f:
+        cfg = yaml.safe_load(f)
+    strategy = cfg.get("template_strategy", {}).get("type", "unknown")
+    llm = cfg.get("llm", {})
+    llm_model = llm.get("model", "unknown")
+    return strategy, llm_model
+
+
+def _mean_score(db: InterpDB, score_type: str) -> float | None:
+    scores = db.get_scores(score_type)
+    if not scores:
+        return None
+    return sum(scores.values()) / len(scores)
+
+
+def _get_run_id(loaded: DepLoadedRun) -> str:
+    return loaded.run.wandb_path.split("/")[-1]
+
+
+@router.get("/subruns")
+@log_errors
+def list_subruns(loaded: DepLoadedRun) -> list[SubrunSummary]:
+    """List all completed autointerp subruns with metadata."""
+    run_id = _get_run_id(loaded)
+    autointerp_dir = get_autointerp_dir(run_id)
+    if not autointerp_dir.exists():
+        return []
+
+    results: list[SubrunSummary] = []
+    for d in sorted(autointerp_dir.iterdir(), key=lambda d: d.name):
+        if not d.is_dir() or not d.name.startswith("a-"):
+            continue
+        if not (d / DONE_MARKER).exists():
+            continue
+        db_path = d / "interp.db"
+        if not db_path.exists():
+            continue
+
+        strategy, llm_model = _parse_config(d / "config.yaml")
+        db = InterpDB(db_path, readonly=True)
+        try:
+            if not db.has_interpretations_table():
+                continue
+            n_completed = db.get_interpretation_count()
+            if n_completed == 0:
+                continue
+            mean_detection = _mean_score(db, "detection")
+            mean_fuzzing = _mean_score(db, "fuzzing")
+        finally:
+            db.close()
+
+        results.append(
+            SubrunSummary(
+                subrun_id=d.name,
+                strategy=strategy,
+                llm_model=llm_model,
+                timestamp=_parse_subrun_timestamp(d.name),
+                n_completed=n_completed,
+                mean_detection_score=mean_detection,
+                mean_fuzzing_score=mean_fuzzing,
+            )
+        )
+
+    return results
+
+
+@router.get("/subruns/{subrun_id}/interpretations")
+@log_errors
+def get_subrun_interpretations(
+    subrun_id: str,
+    loaded: DepLoadedRun,
+) -> dict[str, InterpretationHeadline]:
+    """Get all interpretation headlines for a subrun (canonical keys)."""
+    run_id = _get_run_id(loaded)
+    subrun_dir = get_autointerp_dir(run_id) / subrun_id
+    db_path = subrun_dir / "interp.db"
+    assert db_path.exists(), f"No interp.db at {subrun_dir}"
+
+    db = InterpDB(db_path, readonly=True)
+    try:
+        interpretations = db.get_all_interpretations()
+        detection_scores = db.get_scores("detection")
+        fuzzing_scores = db.get_scores("fuzzing")
+    finally:
+        db.close()
+
+    return {
+        _concrete_to_canonical_key(key, loaded.topology): InterpretationHeadline(
+            label=result.label,
+            confidence=result.confidence,
+            detection_score=detection_scores.get(key),
+            fuzzing_score=fuzzing_scores.get(key),
+        )
+        for key, result in interpretations.items()
+    }
+
+
+@router.get("/subruns/{subrun_id}/interpretations/{layer}/{c_idx}")
+@log_errors
+def get_subrun_interpretation_detail(
+    subrun_id: str,
+    layer: str,
+    c_idx: int,
+    loaded: DepLoadedRun,
+) -> InterpretationDetail:
+    """Get full interpretation detail (reasoning + prompt) for one component in a subrun."""
+    run_id = _get_run_id(loaded)
+    subrun_dir = get_autointerp_dir(run_id) / subrun_id
+    db_path = subrun_dir / "interp.db"
+    assert db_path.exists(), f"No interp.db at {subrun_dir}"
+
+    concrete_key = _canonical_to_concrete_key(layer, c_idx, loaded.topology)
+
+    db = InterpDB(db_path, readonly=True)
+    try:
+        result = db.get_interpretation(concrete_key)
+    finally:
+        db.close()
+
+    if result is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"No interpretation for {layer}:{c_idx} in subrun {subrun_id}",
+        )
+
+    return InterpretationDetail(reasoning=result.reasoning, prompt=result.prompt)

--- a/spd/app/backend/server.py
+++ b/spd/app/backend/server.py
@@ -29,6 +29,7 @@ from spd.app.backend.database import PromptAttrDB
 from spd.app.backend.routers import (
     activation_contexts_router,
     agents_router,
+    autointerp_compare_router,
     clusters_router,
     correlations_router,
     data_sources_router,
@@ -175,6 +176,7 @@ async def global_exception_handler(request: Request, exc: Exception) -> JSONResp
 
 # Routers
 app.include_router(runs_router)
+app.include_router(autointerp_compare_router)
 app.include_router(prompts_router)
 app.include_router(graphs_router)
 app.include_router(activation_contexts_router)

--- a/spd/app/frontend/src/components/AutointerpCompareTab.svelte
+++ b/spd/app/frontend/src/components/AutointerpCompareTab.svelte
@@ -1,0 +1,114 @@
+<script lang="ts">
+    import { getContext, onMount } from "svelte";
+    import { SvelteMap, SvelteSet } from "svelte/reactivity";
+    import type { Loadable } from "../lib";
+    import {
+        getSubruns,
+        getSubrunInterpretations,
+        type CompareInterpretationHeadline,
+        type SubrunSummary,
+    } from "../lib/api";
+    import { RUN_KEY, type RunContext } from "../lib/useRun.svelte";
+    import AutointerpComparer from "./AutointerpComparer.svelte";
+    import SubrunSelector from "./SubrunSelector.svelte";
+    import StatusText from "./ui/StatusText.svelte";
+
+    const runState = getContext<RunContext>(RUN_KEY);
+
+    let subrunsState = $state<Loadable<SubrunSummary[]>>({ status: "uninitialized" });
+    let selectedIds = new SvelteSet<string>();
+
+    // Headline cache: subrunId → Record<componentKey, headline>
+    let headlinesCache = new SvelteMap<string, Record<string, CompareInterpretationHeadline>>();
+    let headlinesLoading = new SvelteSet<string>();
+
+    onMount(() => {
+        subrunsState = { status: "loading" };
+        getSubruns()
+            .then((data) => {
+                subrunsState = { status: "loaded", data };
+            })
+            .catch((error) => {
+                subrunsState = { status: "error", error };
+            });
+
+        // Load activation contexts summary if not already loaded
+        runState.loadActivationContextsSummary();
+    });
+
+    // When selection changes, fetch headlines for newly selected subruns
+    $effect(() => {
+        for (const id of selectedIds) {
+            if (headlinesCache.has(id) || headlinesLoading.has(id)) continue;
+            headlinesLoading.add(id);
+            getSubrunInterpretations(id)
+                .then((data) => {
+                    headlinesCache.set(id, data);
+                })
+                .catch((error) => {
+                    console.error(`Failed to load headlines for ${id}:`, error);
+                })
+                .finally(() => {
+                    headlinesLoading.delete(id);
+                });
+        }
+    });
+
+    const summary = $derived(runState.activationContextsSummary);
+
+    const selectedSubruns = $derived.by(() => {
+        if (subrunsState.status !== "loaded") return [];
+        return subrunsState.data.filter((s) => selectedIds.has(s.subrun_id));
+    });
+</script>
+
+<div class="tab-wrapper">
+    {#if subrunsState.status === "uninitialized" || subrunsState.status === "loading"}
+        <div class="loading">Loading subruns...</div>
+    {:else if subrunsState.status === "error"}
+        <StatusText>Error loading subruns: {String(subrunsState.error)}</StatusText>
+    {:else if subrunsState.data.length === 0}
+        <StatusText>No completed autointerp subruns found.</StatusText>
+    {:else}
+        <SubrunSelector subruns={subrunsState.data} {selectedIds} />
+
+        {#if selectedSubruns.length > 0}
+            {#if summary.status === "loaded" && summary.data !== null}
+                <AutointerpComparer activationContextsSummary={summary.data} {selectedSubruns} {headlinesCache} />
+            {:else if summary.status === "loading" || summary.status === "uninitialized"}
+                <div class="loading">Loading component data...</div>
+            {:else if summary.status === "error"}
+                <StatusText>Error loading component data: {String(summary.error)}</StatusText>
+            {:else}
+                <StatusText>No harvest data available. Run postprocessing first.</StatusText>
+            {/if}
+        {:else}
+            <div class="empty-hint">Select one or more subruns to compare interpretations.</div>
+        {/if}
+    {/if}
+</div>
+
+<style>
+    .tab-wrapper {
+        height: 100%;
+        padding: var(--space-6);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-4);
+    }
+
+    .loading {
+        text-align: center;
+        font-size: var(--text-sm);
+        font-family: var(--font-sans);
+        color: var(--text-muted);
+    }
+
+    .empty-hint {
+        text-align: center;
+        font-size: var(--text-sm);
+        font-family: var(--font-sans);
+        color: var(--text-muted);
+        padding: var(--space-6);
+    }
+</style>

--- a/spd/app/frontend/src/components/AutointerpComparer.svelte
+++ b/spd/app/frontend/src/components/AutointerpComparer.svelte
@@ -1,0 +1,566 @@
+<script lang="ts">
+    import { onMount } from "svelte";
+    import { SvelteMap } from "svelte/reactivity";
+    import type { Loadable } from "../lib";
+    import { computeMaxAbsComponentAct } from "../lib/colors";
+    import { mapLoadable } from "../lib/index";
+    import { COMPONENT_CARD_CONSTANTS } from "../lib/componentCardConstants";
+    import { anyCorrelationStatsEnabled, displaySettings } from "../lib/displaySettings.svelte";
+    import type { ActivationContextsSummary, SubcomponentMetadata } from "../lib/promptAttributionsTypes";
+    import { useComponentData } from "../lib/useComponentData.svelte";
+    import {
+        getSubrunInterpretationDetail,
+        type CompareInterpretationDetail,
+        type CompareInterpretationHeadline,
+        type SubrunSummary,
+    } from "../lib/api";
+    import ActivationContextsPagedTable, { type ActivationExamplesData } from "./ActivationContextsPagedTable.svelte";
+    import ComponentProbeInput from "./ComponentProbeInput.svelte";
+    import ComponentCorrelationMetrics from "./ui/ComponentCorrelationMetrics.svelte";
+    import SectionHeader from "./ui/SectionHeader.svelte";
+    import StatusText from "./ui/StatusText.svelte";
+    import SubrunInterpCard from "./ui/SubrunInterpCard.svelte";
+    import TokenStatsSection from "./ui/TokenStatsSection.svelte";
+    import DatasetAttributionsSection from "./ui/DatasetAttributionsSection.svelte";
+
+    interface Props {
+        activationContextsSummary: ActivationContextsSummary;
+        selectedSubruns: SubrunSummary[];
+        headlinesCache: Map<string, Record<string, CompareInterpretationHeadline>>;
+    }
+
+    let { activationContextsSummary, selectedSubruns, headlinesCache }: Props = $props();
+
+    let availableLayers = $derived(Object.keys(activationContextsSummary).sort());
+    let currentPage = $state(0);
+    let selectedLayer = $state<string>(Object.keys(activationContextsSummary)[0]);
+
+    let currentLayerMetadata = $derived(
+        activationContextsSummary[selectedLayer].filter((m) => m.mean_ci >= displaySettings.meanCiCutoff),
+    );
+    let totalPages = $derived(currentLayerMetadata.length);
+    let currentMetadata = $derived<SubcomponentMetadata | undefined>(currentLayerMetadata[currentPage]);
+
+    // Component data hook for right panel
+    const componentData = useComponentData();
+    const DEBOUNCE_MS = 250;
+    let loadTimeout: ReturnType<typeof setTimeout> | null = null;
+
+    // Detail cache: subrunId → (componentKey → Loadable<detail>)
+    let detailCache = new SvelteMap<string, SvelteMap<string, Loadable<CompareInterpretationDetail | null>>>();
+
+    function currentComponentKey(): string | null {
+        if (!currentMetadata) return null;
+        return `${selectedLayer}:${currentMetadata.subcomponent_idx}`;
+    }
+
+    function loadCurrentComponent() {
+        if (loadTimeout) clearTimeout(loadTimeout);
+        componentData.reset();
+        loadTimeout = setTimeout(() => {
+            if (!currentMetadata) return;
+            componentData.load(selectedLayer, currentMetadata.subcomponent_idx);
+            loadDetails();
+        }, DEBOUNCE_MS);
+    }
+
+    function loadDetails() {
+        const key = currentComponentKey();
+        if (!key || !currentMetadata) return;
+        for (const subrun of selectedSubruns) {
+            let subrunDetails = detailCache.get(subrun.subrun_id);
+            if (!subrunDetails) {
+                subrunDetails = new SvelteMap();
+                detailCache.set(subrun.subrun_id, subrunDetails);
+            }
+            if (subrunDetails.has(key)) continue;
+            subrunDetails.set(key, { status: "loading" });
+
+            getSubrunInterpretationDetail(subrun.subrun_id, selectedLayer, currentMetadata.subcomponent_idx).then(
+                (data) => {
+                    detailCache.get(subrun.subrun_id)?.set(key!, { status: "loaded", data });
+                },
+                (error) => {
+                    detailCache.get(subrun.subrun_id)?.set(key!, { status: "error", error });
+                },
+            );
+        }
+    }
+
+    onMount(() => {
+        loadCurrentComponent();
+        return () => {
+            if (loadTimeout) clearTimeout(loadTimeout);
+        };
+    });
+
+    $effect(() => {
+        if (currentPage >= totalPages && totalPages > 0) {
+            currentPage = 0;
+            loadCurrentComponent();
+        }
+    });
+
+    // Reload details when selectedSubruns change
+    $effect(() => {
+        // read selectedSubruns to establish reactive dependency
+        void selectedSubruns.length;
+        if (currentMetadata) {
+            loadDetails();
+        }
+    });
+
+    function handlePageInput(event: Event) {
+        const target = event.target as HTMLInputElement;
+        if (target.value === "") return;
+        const value = parseInt(target.value);
+        if (!isNaN(value) && value >= 1 && value <= totalPages) {
+            currentPage = value - 1;
+            loadCurrentComponent();
+        }
+    }
+
+    let searchValue = $state("");
+    let searchError = $state<string | null>(null);
+
+    function handleSearchInput(event: Event) {
+        const target = event.target as HTMLInputElement;
+        searchValue = target.value;
+        searchError = null;
+
+        if (searchValue === "") return;
+
+        const targetIdx = parseInt(searchValue);
+        if (isNaN(targetIdx)) {
+            searchError = "Invalid number";
+            return;
+        }
+
+        const fullMetadata = activationContextsSummary[selectedLayer];
+        const component = fullMetadata.find((m) => m.subcomponent_idx === targetIdx);
+        if (!component) {
+            searchError = "Not found";
+            return;
+        }
+
+        const pageIndex = currentLayerMetadata.findIndex((m) => m.subcomponent_idx === targetIdx);
+        if (pageIndex === -1) {
+            searchError = `Below cutoff (${component.mean_ci.toExponential(2)})`;
+            return;
+        }
+
+        currentPage = pageIndex;
+        loadCurrentComponent();
+    }
+
+    function previousPage() {
+        if (currentPage > 0) {
+            currentPage--;
+            loadCurrentComponent();
+        }
+    }
+
+    function nextPage() {
+        if (currentPage < totalPages - 1) {
+            currentPage++;
+            loadCurrentComponent();
+        }
+    }
+
+    function handleLayerChange(event: Event) {
+        selectedLayer = (event.target as HTMLSelectElement).value;
+        currentPage = 0;
+        loadCurrentComponent();
+    }
+
+    function getHeadline(subrunId: string): CompareInterpretationHeadline | null {
+        const key = currentComponentKey();
+        if (!key) return null;
+        const headlines = headlinesCache.get(subrunId);
+        if (!headlines) return null;
+        return headlines[key] ?? null;
+    }
+
+    function getDetail(subrunId: string): Loadable<CompareInterpretationDetail | null> {
+        const key = currentComponentKey();
+        if (!key) return { status: "uninitialized" };
+        return detailCache.get(subrunId)?.get(key) ?? { status: "uninitialized" };
+    }
+
+    function formatMeanCi(ci: number): string {
+        return ci < 0.001 ? ci.toExponential(2) : ci.toFixed(3);
+    }
+
+    // Activation examples data
+    const maxAbsComponentAct = $derived.by(() => {
+        if (componentData.componentDetail.status !== "loaded") return 1;
+        return computeMaxAbsComponentAct(componentData.componentDetail.data.example_component_acts);
+    });
+
+    const activationExamples = $derived(
+        mapLoadable(
+            componentData.componentDetail,
+            (d): ActivationExamplesData => ({
+                tokens: d.example_tokens,
+                ci: d.example_ci,
+                componentActs: d.example_component_acts,
+                maxAbsComponentAct,
+            }),
+        ),
+    );
+
+    // Token stats
+    const inputTokenLists = $derived.by(() => {
+        const ts = componentData.tokenStats;
+        if (ts.status !== "loaded" || ts.data === null) return null;
+        return [
+            {
+                title: "Top Precision",
+                mathNotation: "P(component fires | token)",
+                items: ts.data.input.top_precision.map(([token, value]) => ({ token, value })),
+                maxScale: 1,
+            },
+        ];
+    });
+
+    const outputTokenLists = $derived.by(() => {
+        const ts = componentData.tokenStats;
+        if (ts.status !== "loaded" || ts.data === null) return null;
+        const maxAbsPmi = Math.max(
+            ts.data.output.top_pmi[0]?.[1] ?? 0,
+            Math.abs(ts.data.output.bottom_pmi?.[0]?.[1] ?? 0),
+        );
+        return [
+            {
+                title: "Top PMI",
+                mathNotation: "positive association with predictions",
+                items: ts.data.output.top_pmi.map(([token, value]) => ({ token, value })),
+                maxScale: maxAbsPmi,
+            },
+            {
+                title: "Bottom PMI",
+                mathNotation: "negative association with predictions",
+                items: ts.data.output.bottom_pmi.map(([token, value]) => ({ token, value })),
+                maxScale: maxAbsPmi,
+            },
+        ];
+    });
+</script>
+
+{#if currentMetadata}
+    <div class="comparer">
+        <div class="controls-row">
+            <div class="layer-select">
+                <label for="compare-layer-select">Layer:</label>
+                <select id="compare-layer-select" value={selectedLayer} onchange={handleLayerChange}>
+                    {#each availableLayers as layer (layer)}
+                        <option value={layer}>{layer}</option>
+                    {/each}
+                </select>
+            </div>
+
+            <div class="pagination">
+                <label for="compare-page-input">Subcomponent:</label>
+                <button onclick={previousPage} disabled={currentPage === 0}>&lt;</button>
+                <input
+                    id="compare-page-input"
+                    type="number"
+                    min="1"
+                    max={totalPages}
+                    value={currentPage + 1}
+                    oninput={handlePageInput}
+                    class="page-input"
+                />
+                <span>of {totalPages}</span>
+                <button onclick={nextPage} disabled={currentPage === totalPages - 1}>&gt;</button>
+            </div>
+
+            <div class="search-box">
+                <label for="compare-search-input">Go to index:</label>
+                <input
+                    id="compare-search-input"
+                    type="number"
+                    placeholder="e.g. 42"
+                    value={searchValue}
+                    oninput={handleSearchInput}
+                    class="search-input"
+                />
+                {#if searchError}
+                    <span class="search-error">{searchError}</span>
+                {/if}
+            </div>
+        </div>
+
+        <div class="two-panel">
+            <div class="left-panel">
+                <SectionHeader title="Subcomponent {currentMetadata.subcomponent_idx}" level="h4">
+                    <span class="mean-ci">Mean CI: {formatMeanCi(currentMetadata.mean_ci)}</span>
+                </SectionHeader>
+
+                <div class="interp-cards">
+                    {#each selectedSubruns as subrun (subrun.subrun_id)}
+                        <SubrunInterpCard
+                            subrunId={subrun.subrun_id}
+                            strategy={subrun.strategy}
+                            llmModel={subrun.llm_model}
+                            headline={getHeadline(subrun.subrun_id)}
+                            detail={getDetail(subrun.subrun_id)}
+                        />
+                    {/each}
+                </div>
+            </div>
+
+            <div class="right-panel">
+                {#if activationExamples.status === "error"}
+                    <StatusText>Error loading component data: {String(activationExamples.error)}</StatusText>
+                {:else}
+                    <ActivationContextsPagedTable data={activationExamples} />
+                {/if}
+
+                <ComponentProbeInput
+                    layer={selectedLayer}
+                    componentIdx={currentMetadata.subcomponent_idx}
+                    {maxAbsComponentAct}
+                />
+
+                {#if componentData.datasetAttributions?.status === "loaded" && componentData.datasetAttributions.data}
+                    <DatasetAttributionsSection attributions={componentData.datasetAttributions.data} />
+                {:else if componentData.datasetAttributions?.status === "loading"}
+                    <div class="section-loading">
+                        <SectionHeader title="Dataset Attributions" />
+                        <StatusText>Loading...</StatusText>
+                    </div>
+                {/if}
+
+                <div class="token-stats-row">
+                    {#if componentData.tokenStats.status === "uninitialized" || componentData.tokenStats.status === "loading"}
+                        <StatusText>Loading token stats...</StatusText>
+                    {:else if componentData.tokenStats.status === "error"}
+                        <StatusText>Error: {String(componentData.tokenStats.error)}</StatusText>
+                    {:else}
+                        <TokenStatsSection
+                            sectionTitle="Input Tokens"
+                            sectionSubtitle="(what activates this component)"
+                            lists={inputTokenLists}
+                        />
+                        <TokenStatsSection
+                            sectionTitle="Output Tokens"
+                            sectionSubtitle="(what this component predicts)"
+                            lists={outputTokenLists}
+                        />
+                    {/if}
+                </div>
+
+                {#if anyCorrelationStatsEnabled()}
+                    <div class="correlations-section">
+                        <SectionHeader title="Correlated Components" />
+                        {#if componentData.correlations.status === "uninitialized" || componentData.correlations.status === "loading"}
+                            <StatusText>Loading...</StatusText>
+                        {:else if componentData.correlations.status === "error"}
+                            <StatusText>Error loading correlations</StatusText>
+                        {:else if componentData.correlations.data === null}
+                            <StatusText>No correlations data.</StatusText>
+                        {:else}
+                            <ComponentCorrelationMetrics
+                                correlations={componentData.correlations.data}
+                                pageSize={COMPONENT_CARD_CONSTANTS.CORRELATIONS_PAGE_SIZE}
+                            />
+                        {/if}
+                    </div>
+                {/if}
+            </div>
+        </div>
+    </div>
+{:else}
+    <StatusText>No components above CI cutoff</StatusText>
+{/if}
+
+<style>
+    .comparer {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+    }
+
+    .controls-row {
+        display: flex;
+        align-items: center;
+        gap: var(--space-4);
+        flex-wrap: wrap;
+    }
+
+    .layer-select {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+    }
+
+    .comparer label {
+        font-size: var(--text-sm);
+        font-family: var(--font-sans);
+        color: var(--text-secondary);
+        font-weight: 500;
+    }
+
+    #compare-layer-select {
+        border: 1px solid var(--border-default);
+        padding: var(--space-1) var(--space-2);
+        font-size: var(--text-sm);
+        font-family: var(--font-mono);
+        background: var(--bg-elevated);
+        color: var(--text-primary);
+        cursor: pointer;
+        min-width: 180px;
+    }
+
+    #compare-layer-select:focus {
+        outline: none;
+        border-color: var(--accent-primary-dim);
+    }
+
+    .pagination {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+    }
+
+    .pagination button {
+        padding: var(--space-1) var(--space-2);
+        border: 1px solid var(--border-default);
+        background: var(--bg-elevated);
+        color: var(--text-secondary);
+    }
+
+    .pagination button:hover:not(:disabled) {
+        background: var(--bg-surface);
+        color: var(--text-primary);
+        border-color: var(--border-strong);
+    }
+
+    .pagination button:disabled {
+        opacity: 0.5;
+    }
+
+    .pagination span {
+        font-size: var(--text-sm);
+        font-family: var(--font-sans);
+        color: var(--text-muted);
+        white-space: nowrap;
+    }
+
+    .search-box {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+    }
+
+    .search-input {
+        width: 80px;
+        padding: var(--space-1) var(--space-2);
+        border: 1px solid var(--border-default);
+        font-size: var(--text-sm);
+        font-family: var(--font-mono);
+        background: var(--bg-elevated);
+        color: var(--text-primary);
+        appearance: textfield;
+    }
+
+    .search-input:focus {
+        outline: none;
+        border-color: var(--accent-primary-dim);
+    }
+
+    .search-input::-webkit-inner-spin-button,
+    .search-input::-webkit-outer-spin-button {
+        appearance: none;
+        margin: 0;
+    }
+
+    .search-error {
+        font-size: var(--text-xs);
+        color: var(--semantic-error);
+        white-space: nowrap;
+    }
+
+    .page-input {
+        width: 50px;
+        padding: var(--space-1) var(--space-2);
+        border: 1px solid var(--border-default);
+        text-align: center;
+        font-size: var(--text-sm);
+        font-family: var(--font-mono);
+        background: var(--bg-elevated);
+        color: var(--text-primary);
+        appearance: textfield;
+    }
+
+    .page-input:focus {
+        outline: none;
+        border-color: var(--accent-primary-dim);
+    }
+
+    .page-input::-webkit-inner-spin-button,
+    .page-input::-webkit-outer-spin-button {
+        appearance: none;
+        margin: 0;
+    }
+
+    .two-panel {
+        display: flex;
+        gap: var(--space-4);
+        min-height: 0;
+    }
+
+    .left-panel {
+        flex: 2;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        overflow-y: auto;
+    }
+
+    .right-panel {
+        flex: 3;
+        min-width: 0;
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        overflow-y: auto;
+    }
+
+    .interp-cards {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+    }
+
+    .mean-ci {
+        font-weight: 400;
+        color: var(--text-muted);
+        font-family: var(--font-mono);
+        margin-left: var(--space-2);
+    }
+
+    .token-stats-row {
+        display: flex;
+        gap: var(--space-4);
+    }
+
+    .token-stats-row > :global(*) {
+        flex: 1;
+        min-width: 0;
+    }
+
+    .correlations-section {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+    }
+
+    .section-loading {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+    }
+</style>

--- a/spd/app/frontend/src/components/RunView.svelte
+++ b/spd/app/frontend/src/components/RunView.svelte
@@ -2,6 +2,7 @@
     import { getContext } from "svelte";
     import { RUN_KEY, type RunContext } from "../lib/useRun.svelte";
     import ActivationContextsTab from "./ActivationContextsTab.svelte";
+    import AutointerpCompareTab from "./AutointerpCompareTab.svelte";
     import ClusterPathInput from "./ClusterPathInput.svelte";
     import ClustersTab from "./ClustersTab.svelte";
     import DatasetExplorerTab from "./DatasetExplorerTab.svelte";
@@ -19,6 +20,7 @@
     let activeTab = $state<
         | "prompts"
         | "components"
+        | "autointerp-compare"
         | "dataset-search"
         | "model-graph"
         | "data-sources"
@@ -82,6 +84,16 @@
                 >
                     Components
                 </button>
+                {#if runState.run.data.autointerp_available}
+                    <button
+                        type="button"
+                        class="tab-button"
+                        class:active={activeTab === "autointerp-compare"}
+                        onclick={() => (activeTab = "autointerp-compare")}
+                    >
+                        Autointerp Compare
+                    </button>
+                {/if}
                 {#if datasetSearchEnabled}
                     <button
                         type="button"
@@ -139,6 +151,9 @@
             </div>
             <div class="tab-content" class:hidden={activeTab !== "components"}>
                 <ActivationContextsTab />
+            </div>
+            <div class="tab-content" class:hidden={activeTab !== "autointerp-compare"}>
+                <AutointerpCompareTab />
             </div>
             {#if datasetSearchEnabled}
                 <div class="tab-content" class:hidden={activeTab !== "dataset-search"}>

--- a/spd/app/frontend/src/components/SubrunSelector.svelte
+++ b/spd/app/frontend/src/components/SubrunSelector.svelte
@@ -1,0 +1,124 @@
+<script lang="ts">
+    import type { SubrunSummary } from "../lib/api";
+    import { SvelteSet } from "svelte/reactivity";
+
+    interface Props {
+        subruns: SubrunSummary[];
+        selectedIds: SvelteSet<string>;
+    }
+
+    let { subruns, selectedIds }: Props = $props();
+
+    function toggle(id: string) {
+        if (selectedIds.has(id)) {
+            selectedIds.delete(id);
+        } else {
+            selectedIds.add(id);
+        }
+    }
+
+    function formatScore(score: number | null): string {
+        if (score === null) return "-";
+        return `${Math.round(score * 100)}%`;
+    }
+
+    function shortModel(model: string): string {
+        return model.split("/").pop() ?? model;
+    }
+</script>
+
+<div class="selector">
+    <div class="selector-label">Subruns</div>
+    <div class="chips">
+        {#each subruns as subrun (subrun.subrun_id)}
+            <button
+                type="button"
+                class="chip"
+                class:selected={selectedIds.has(subrun.subrun_id)}
+                onclick={() => toggle(subrun.subrun_id)}
+            >
+                <span class="chip-strategy">{subrun.strategy}</span>
+                <span class="chip-model">{shortModel(subrun.llm_model)}</span>
+                <span class="chip-meta">
+                    {subrun.n_completed} interps
+                    {#if subrun.mean_detection_score !== null}
+                        &middot; Det {formatScore(subrun.mean_detection_score)}
+                    {/if}
+                    {#if subrun.mean_fuzzing_score !== null}
+                        &middot; Fuz {formatScore(subrun.mean_fuzzing_score)}
+                    {/if}
+                </span>
+                <span class="chip-time">{subrun.timestamp}</span>
+            </button>
+        {/each}
+    </div>
+</div>
+
+<style>
+    .selector {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+    }
+
+    .selector-label {
+        font-size: var(--text-sm);
+        font-weight: 500;
+        font-family: var(--font-sans);
+        color: var(--text-secondary);
+    }
+
+    .chips {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-2);
+    }
+
+    .chip {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        padding: var(--space-2) var(--space-3);
+        border: 1px solid var(--border-default);
+        border-radius: var(--radius-md);
+        background: var(--bg-surface);
+        cursor: pointer;
+        text-align: left;
+        transition:
+            border-color var(--transition-normal),
+            background var(--transition-normal);
+    }
+
+    .chip:hover {
+        border-color: var(--border-strong);
+        background: var(--bg-elevated);
+    }
+
+    .chip.selected {
+        border-color: var(--accent-primary);
+        background: color-mix(in srgb, var(--accent-primary) 10%, var(--bg-surface));
+    }
+
+    .chip-strategy {
+        font-size: var(--text-sm);
+        font-weight: 600;
+        color: var(--text-primary);
+    }
+
+    .chip-model {
+        font-size: var(--text-xs);
+        font-family: var(--font-mono);
+        color: var(--text-secondary);
+    }
+
+    .chip-meta {
+        font-size: var(--text-xs);
+        color: var(--text-muted);
+    }
+
+    .chip-time {
+        font-size: var(--text-xs);
+        font-family: var(--font-mono);
+        color: var(--text-muted);
+    }
+</style>

--- a/spd/app/frontend/src/components/ui/SubrunInterpCard.svelte
+++ b/spd/app/frontend/src/components/ui/SubrunInterpCard.svelte
@@ -1,0 +1,232 @@
+<script lang="ts">
+    import type { Loadable } from "../../lib";
+    import type { CompareInterpretationDetail, CompareInterpretationHeadline } from "../../lib/api";
+
+    interface Props {
+        subrunId: string;
+        strategy: string;
+        llmModel: string;
+        headline: CompareInterpretationHeadline | null;
+        detail: Loadable<CompareInterpretationDetail | null>;
+    }
+
+    let { subrunId, strategy, llmModel, headline, detail }: Props = $props();
+
+    let showPrompt = $state(false);
+
+    function scoreClass(score: number): string {
+        if (score >= 0.7) return "score-high";
+        if (score >= 0.5) return "score-medium";
+        return "score-low";
+    }
+
+    const shortModel = $derived(llmModel.split("/").pop() ?? llmModel);
+</script>
+
+<div class="subrun-card">
+    <div class="card-header">
+        <span class="strategy-tag">{strategy}</span>
+        <span class="model-tag">{shortModel}</span>
+        <span class="subrun-id">{subrunId}</span>
+    </div>
+
+    {#if headline === null}
+        <div class="no-interp">No interpretation for this component</div>
+    {:else}
+        <div class="card-body">
+            <div class="label-row">
+                <span class="label">{headline.label}</span>
+                <span class="confidence confidence-{headline.confidence}">{headline.confidence}</span>
+                {#if headline.detection_score !== null}
+                    <span class="score-pill {scoreClass(headline.detection_score)}"
+                        >Det {Math.round(headline.detection_score * 100)}%</span
+                    >
+                {/if}
+                {#if headline.fuzzing_score !== null}
+                    <span class="score-pill {scoreClass(headline.fuzzing_score)}"
+                        >Fuz {Math.round(headline.fuzzing_score * 100)}%</span
+                    >
+                {/if}
+            </div>
+
+            {#if detail.status === "loaded" && detail.data}
+                <div class="reasoning">{detail.data.reasoning}</div>
+                <button class="prompt-toggle" onclick={() => (showPrompt = !showPrompt)}>
+                    {showPrompt ? "Hide" : "Show"} Prompt
+                </button>
+                {#if showPrompt}
+                    <div class="prompt-display">
+                        <pre>{detail.data.prompt}</pre>
+                    </div>
+                {/if}
+            {:else if detail.status === "loading"}
+                <div class="reasoning loading-text">Loading...</div>
+            {:else if detail.status === "error"}
+                <div class="reasoning error-text">Error loading detail</div>
+            {/if}
+        </div>
+    {/if}
+</div>
+
+<style>
+    .subrun-card {
+        border: 1px solid var(--border-default);
+        border-radius: var(--radius-md);
+        background: var(--bg-surface);
+        overflow: hidden;
+    }
+
+    .card-header {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        padding: var(--space-2) var(--space-3);
+        background: var(--bg-elevated);
+        border-bottom: 1px solid var(--border-default);
+    }
+
+    .strategy-tag {
+        font-size: var(--text-xs);
+        font-weight: 600;
+        padding: var(--space-1) var(--space-2);
+        border-radius: var(--radius-sm);
+        background: color-mix(in srgb, var(--accent-primary) 20%, transparent);
+        color: var(--accent-primary);
+    }
+
+    .model-tag {
+        font-size: var(--text-xs);
+        font-family: var(--font-mono);
+        color: var(--text-secondary);
+    }
+
+    .subrun-id {
+        margin-left: auto;
+        font-size: var(--text-xs);
+        font-family: var(--font-mono);
+        color: var(--text-muted);
+    }
+
+    .card-body {
+        padding: var(--space-3);
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+    }
+
+    .no-interp {
+        padding: var(--space-3);
+        font-size: var(--text-sm);
+        color: var(--text-muted);
+        font-style: italic;
+    }
+
+    .label-row {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        flex-wrap: wrap;
+    }
+
+    .label {
+        font-weight: 500;
+        font-size: var(--text-sm);
+        color: var(--text-primary);
+    }
+
+    .confidence {
+        font-size: var(--text-xs);
+        padding: var(--space-1) var(--space-2);
+        border-radius: var(--radius-sm);
+        text-transform: uppercase;
+        font-weight: 600;
+    }
+
+    .confidence-high {
+        background: color-mix(in srgb, var(--status-positive-bright) 20%, transparent);
+        color: var(--status-positive-bright);
+    }
+
+    .confidence-medium {
+        background: color-mix(in srgb, var(--status-warning) 20%, transparent);
+        color: var(--status-warning);
+    }
+
+    .confidence-low {
+        background: color-mix(in srgb, var(--text-muted) 20%, transparent);
+        color: var(--text-muted);
+    }
+
+    .score-pill {
+        font-size: var(--text-xs);
+        padding: var(--space-1) var(--space-2);
+        border-radius: var(--radius-sm);
+        font-weight: 600;
+        white-space: nowrap;
+    }
+
+    .score-high {
+        background: color-mix(in srgb, var(--status-positive-bright) 20%, transparent);
+        color: var(--status-positive-bright);
+    }
+
+    .score-medium {
+        background: color-mix(in srgb, var(--status-warning) 20%, transparent);
+        color: var(--status-warning);
+    }
+
+    .score-low {
+        background: color-mix(in srgb, var(--text-muted) 20%, transparent);
+        color: var(--text-muted);
+    }
+
+    .reasoning {
+        font-size: var(--text-xs);
+        color: var(--text-secondary);
+        line-height: 1.4;
+    }
+
+    .loading-text {
+        color: var(--text-muted);
+        font-style: italic;
+    }
+
+    .error-text {
+        color: var(--status-negative);
+    }
+
+    .prompt-toggle {
+        align-self: flex-start;
+        padding: var(--space-1) var(--space-2);
+        font-size: var(--text-xs);
+        background: var(--bg-elevated);
+        color: var(--text-secondary);
+        border: 1px solid var(--border-default);
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        font-weight: 500;
+    }
+
+    .prompt-toggle:hover {
+        background: var(--bg-surface);
+        border-color: var(--border-strong);
+    }
+
+    .prompt-display {
+        background: var(--bg-inset);
+        border: 1px solid var(--border-default);
+        border-radius: var(--radius-md);
+        padding: var(--space-3);
+        max-height: 400px;
+        overflow: auto;
+    }
+
+    .prompt-display pre {
+        margin: 0;
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        white-space: pre-wrap;
+        word-break: break-word;
+        color: var(--text-secondary);
+    }
+</style>

--- a/spd/app/frontend/src/lib/api/autointerpCompare.ts
+++ b/spd/app/frontend/src/lib/api/autointerpCompare.ts
@@ -1,0 +1,54 @@
+/**
+ * API client for /api/autointerp_compare endpoints.
+ */
+
+import { ApiError, fetchJson } from "./index";
+
+export type SubrunSummary = {
+    subrun_id: string;
+    strategy: string;
+    llm_model: string;
+    timestamp: string;
+    n_completed: number;
+    mean_detection_score: number | null;
+    mean_fuzzing_score: number | null;
+};
+
+export type CompareInterpretationHeadline = {
+    label: string;
+    confidence: string;
+    detection_score: number | null;
+    fuzzing_score: number | null;
+};
+
+export type CompareInterpretationDetail = {
+    reasoning: string;
+    prompt: string;
+};
+
+export async function getSubruns(): Promise<SubrunSummary[]> {
+    return fetchJson<SubrunSummary[]>("/api/autointerp_compare/subruns");
+}
+
+export async function getSubrunInterpretations(
+    subrunId: string,
+): Promise<Record<string, CompareInterpretationHeadline>> {
+    return fetchJson<Record<string, CompareInterpretationHeadline>>(
+        `/api/autointerp_compare/subruns/${encodeURIComponent(subrunId)}/interpretations`,
+    );
+}
+
+export async function getSubrunInterpretationDetail(
+    subrunId: string,
+    layer: string,
+    componentIdx: number,
+): Promise<CompareInterpretationDetail | null> {
+    try {
+        return await fetchJson<CompareInterpretationDetail>(
+            `/api/autointerp_compare/subruns/${encodeURIComponent(subrunId)}/interpretations/${encodeURIComponent(layer)}/${componentIdx}`,
+        );
+    } catch (e) {
+        if (e instanceof ApiError && e.status === 404) return null;
+        throw e;
+    }
+}

--- a/spd/app/frontend/src/lib/api/index.ts
+++ b/spd/app/frontend/src/lib/api/index.ts
@@ -42,6 +42,7 @@ export async function fetchJson<T>(url: string, options?: RequestInit): Promise<
 }
 
 // Re-export all API modules
+export * from "./autointerpCompare";
 export * from "./runs";
 export * from "./graphs";
 export * from "./prompts";

--- a/spd/autointerp/config.py
+++ b/spd/autointerp/config.py
@@ -53,7 +53,21 @@ class DualViewConfig(BaseConfig):
     forbidden_words: list[str] | None = None
 
 
-StrategyConfig = CompactSkepticalConfig | DualViewConfig
+class RichExamplesConfig(BaseConfig):
+    """Rich examples strategy: drops token statistics, shows per-token CI and activation values.
+
+    Renders firing tokens with inline annotations like <<<token (ci:0.8, act:0.12)>>>
+    so the LLM can judge evidence quality directly from the examples.
+    """
+
+    type: Literal["rich_examples"] = "rich_examples"
+    max_examples: int = 30
+    include_dataset_description: bool = True
+    label_max_words: int = 8
+    forbidden_words: list[str] | None = None
+
+
+StrategyConfig = CompactSkepticalConfig | DualViewConfig | RichExamplesConfig
 
 
 class AutointerpConfig(BaseConfig):

--- a/spd/autointerp/db.py
+++ b/spd/autointerp/db.py
@@ -132,6 +132,13 @@ class InterpDB:
         )
         self._conn.commit()
 
+    def has_interpretations_table(self) -> bool:
+        row = self._conn.execute(
+            "SELECT EXISTS(SELECT 1 FROM sqlite_master WHERE type='table' AND name='interpretations')"
+        ).fetchone()
+        assert row is not None
+        return bool(row[0])
+
     def has_interpretations(self) -> bool:
         row = self._conn.execute("SELECT EXISTS(SELECT 1 FROM interpretations LIMIT 1)").fetchone()
         assert row is not None

--- a/spd/autointerp/interpret.py
+++ b/spd/autointerp/interpret.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 from pathlib import Path
 
 from spd.app.backend.app_tokenizer import AppTokenizer
-from spd.autointerp.config import StrategyConfig
+from spd.autointerp.config import RichExamplesConfig, StrategyConfig
 from spd.autointerp.db import InterpDB
 from spd.autointerp.llm_api import (
     LLMError,
@@ -29,8 +29,8 @@ async def interpret_component(
     component: ComponentData,
     model_metadata: ModelMetadata,
     app_tok: AppTokenizer,
-    input_token_stats: TokenPRLift,
-    output_token_stats: TokenPRLift,
+    input_token_stats: TokenPRLift | None,
+    output_token_stats: TokenPRLift | None,
     context_tokens_per_side: int,
 ) -> InterpretationResult:
     """Interpret a single component. Used by the app for on-demand interpretation."""
@@ -87,8 +87,10 @@ def run_interpret(
     summary = harvest.get_summary()
     logger.info(f"Loaded summary for {len(summary)} components")
 
-    token_stats = harvest.get_token_stats()
-    assert token_stats is not None, "token_stats.pt not found. Run harvest first."
+    needs_token_stats = not isinstance(template_strategy, RichExamplesConfig)
+    token_stats = harvest.get_token_stats() if needs_token_stats else None
+    if needs_token_stats:
+        assert token_stats is not None, "token_stats.pt not found. Run harvest first."
 
     harvest_config = harvest.get_config()
     raw = harvest_config["activation_context_tokens_per_side"]
@@ -116,14 +118,16 @@ def run_interpret(
             schema = INTERPRETATION_SCHEMA
 
             def build_jobs() -> Iterable[LLMJob]:
-                assert token_stats is not None, "token_stats required for interpretation"
                 for key in remaining_keys:
                     component = harvest.get_component(key)
                     assert component is not None, f"Component {key} not found in harvest"
-                    input_stats = get_input_token_stats(token_stats, key, app_tok, top_k=20)
-                    output_stats = get_output_token_stats(token_stats, key, app_tok, top_k=50)
-                    assert input_stats is not None
-                    assert output_stats is not None
+                    input_stats: TokenPRLift | None = None
+                    output_stats: TokenPRLift | None = None
+                    if token_stats is not None:
+                        input_stats = get_input_token_stats(token_stats, key, app_tok, top_k=20)
+                        output_stats = get_output_token_stats(token_stats, key, app_tok, top_k=50)
+                        assert input_stats is not None
+                        assert output_stats is not None
                     prompt = format_prompt(
                         strategy=template_strategy,
                         component=component,

--- a/spd/autointerp/prompt_helpers.py
+++ b/spd/autointerp/prompt_helpers.py
@@ -192,3 +192,59 @@ def build_says_examples(
     max_examples: int,
 ) -> Md:
     return _build_examples(component, app_tok, max_examples, shift_firings=True)
+
+
+def _fmt_ann(activations: dict[str, float]) -> str:
+    """Format activation annotations for a single firing token.
+
+    For SPD: (ci:0.82, act:-0.05)
+    For other methods: just the activation value, e.g. (act:3.21)
+    """
+    parts: list[str] = []
+    if "causal_importance" in activations:
+        parts.append(f"ci:{activations['causal_importance']:.2g}")
+    if "component_activation" in activations:
+        parts.append(f"act:{activations['component_activation']:.2g}")
+    if "activation" in activations:
+        parts.append(f"act:{activations['activation']:.2g}")
+    return f"({', '.join(parts)})"
+
+
+def _delimit_annotated(
+    spans: list[str],
+    firings: list[bool],
+    per_token_activations: list[dict[str, float]],
+) -> str:
+    """Join token strings, wrapping active tokens with <<<token (ci, act)>>>."""
+    parts: list[str] = []
+    for span, active, acts in zip(spans, firings, per_token_activations, strict=True):
+        if active:
+            stripped = span.lstrip()
+            whitespace = span[: len(span) - len(stripped)]
+            ann = _fmt_ann(acts)
+            parts.append(f"{whitespace}<<<{stripped} {ann}>>>")
+        else:
+            parts.append(span)
+    return "".join(parts)
+
+
+def build_annotated_examples(
+    component: ComponentData,
+    app_tok: AppTokenizer,
+    max_examples: int,
+) -> Md:
+    """Build activation examples with per-token CI and activation annotations."""
+    items: list[str] = []
+    for ex in component.activation_examples[:max_examples]:
+        if not any(ex.firings):
+            continue
+        spans = app_tok.get_spans(ex.token_ids)
+        act_keys = list(ex.activations.keys())
+        per_token_acts = [
+            {k: ex.activations[k][i] for k in act_keys} for i in range(len(ex.token_ids))
+        ]
+        items.append(_delimit_annotated(spans, ex.firings, per_token_acts))
+    md = Md()
+    if items:
+        md.numbered(items)
+    return md

--- a/spd/autointerp/providers.py
+++ b/spd/autointerp/providers.py
@@ -33,10 +33,14 @@ class OpenRouterLLMConfig(BaseConfig):
     reasoning_effort: ReasoningEffort = "low"
 
 
+EffortLevel = Literal["low", "medium", "high", "max"]
+
+
 class AnthropicLLMConfig(BaseConfig):
     type: Literal["anthropic"] = "anthropic"
     model: str = "claude-sonnet-4-20250514"
     thinking_budget: int | None = None
+    effort: EffortLevel | None = None
 
 
 class OpenAILLMConfig(BaseConfig):
@@ -63,7 +67,9 @@ _PROVIDER_ENV_VARS: dict[ProviderName, str] = {
 
 _ANTHROPIC_PRICING: dict[str, tuple[float, float]] = {
     "claude-sonnet-4-20250514": (3.0 / 1_000_000, 15.0 / 1_000_000),
+    "claude-sonnet-4-6": (3.0 / 1_000_000, 15.0 / 1_000_000),
     "claude-opus-4-20250514": (15.0 / 1_000_000, 75.0 / 1_000_000),
+    "claude-opus-4-6": (15.0 / 1_000_000, 75.0 / 1_000_000),
     "claude-haiku-4-5-20251001": (0.80 / 1_000_000, 4.0 / 1_000_000),
 }
 
@@ -202,9 +208,12 @@ class OpenRouterProvider(LLMProvider):
 
 
 class AnthropicProvider(LLMProvider):
-    def __init__(self, api_key: str, model: str, thinking_budget: int | None):
+    def __init__(
+        self, api_key: str, model: str, thinking_budget: int | None, effort: EffortLevel | None
+    ):
         self.model = model
         self._thinking_budget = thinking_budget
+        self._effort = effort
         self._client = httpx.AsyncClient(
             base_url="https://api.anthropic.com",
             headers={
@@ -226,6 +235,8 @@ class AnthropicProvider(LLMProvider):
         if self._thinking_budget is not None:
             effective_max_tokens = max_tokens + self._thinking_budget
 
+        uses_thinking = self._thinking_budget is not None or self._effort is not None
+
         body: dict[str, Any] = {
             "model": self.model,
             "max_tokens": effective_max_tokens,
@@ -237,9 +248,14 @@ class AnthropicProvider(LLMProvider):
                     "input_schema": response_schema,
                 }
             ],
-            "tool_choice": {"type": "tool", "name": "respond"},
+            "tool_choice": {"type": "auto"}
+            if uses_thinking
+            else {"type": "tool", "name": "respond"},
         }
-        if self._thinking_budget is not None:
+        if self._effort is not None:
+            body["thinking"] = {"type": "adaptive"}
+            body["output_config"] = {"effort": self._effort}
+        elif self._thinking_budget is not None:
             body["thinking"] = {"type": "enabled", "budget_tokens": self._thinking_budget}
 
         try:
@@ -368,7 +384,7 @@ def create_provider(
             return OpenRouterProvider(api_key, config.model, config.reasoning_effort)
         case AnthropicLLMConfig():
             api_key = _get_api_key("anthropic")
-            return AnthropicProvider(api_key, config.model, config.thinking_budget)
+            return AnthropicProvider(api_key, config.model, config.thinking_budget, config.effort)
         case OpenAILLMConfig():
             api_key = _get_api_key("openai")
             return OpenAIProvider(api_key, config.model, config.reasoning_effort)

--- a/spd/autointerp/providers.py
+++ b/spd/autointerp/providers.py
@@ -2,7 +2,7 @@
 
 LLMConfig discriminated union determines which API to call:
   - OpenRouterLLMConfig → OpenRouter API (any model via vendor/model ID)
-  - AnthropicLLMConfig → first-party Anthropic API (tool_use for structured output)
+  - AnthropicLLMConfig → first-party Anthropic API (structured outputs)
   - OpenAILLMConfig → first-party OpenAI API (json_schema response format)
 """
 
@@ -36,11 +36,28 @@ class OpenRouterLLMConfig(BaseConfig):
 EffortLevel = Literal["low", "medium", "high", "max"]
 
 
-class AnthropicLLMConfig(BaseConfig):
+class AnthropicSonnet46LLMConfig(BaseConfig):
     type: Literal["anthropic"] = "anthropic"
-    model: str = "claude-sonnet-4-20250514"
-    thinking_budget: int | None = None
+    model: Literal["claude-sonnet-4-6"] = "claude-sonnet-4-6"
+    effort: Literal["low", "medium", "high"] | None = None
+
+
+class AnthropicOpus46LLMConfig(BaseConfig):
+    type: Literal["anthropic"] = "anthropic"
+    model: Literal["claude-opus-4-6"] = "claude-opus-4-6"
     effort: EffortLevel | None = None
+
+
+class AnthropicHaiku45LLMConfig(BaseConfig):
+    type: Literal["anthropic"] = "anthropic"
+    model: Literal["claude-haiku-4-5-20251001"] = "claude-haiku-4-5-20251001"
+    thinking_budget: int | None = Field(default=None, ge=1024)
+
+
+AnthropicLLMConfig = Annotated[
+    AnthropicSonnet46LLMConfig | AnthropicOpus46LLMConfig | AnthropicHaiku45LLMConfig,
+    Field(discriminator="model"),
+]
 
 
 class OpenAILLMConfig(BaseConfig):
@@ -208,12 +225,9 @@ class OpenRouterProvider(LLMProvider):
 
 
 class AnthropicProvider(LLMProvider):
-    def __init__(
-        self, api_key: str, model: str, thinking_budget: int | None, effort: EffortLevel | None
-    ):
-        self.model = model
-        self._thinking_budget = thinking_budget
-        self._effort = effort
+    def __init__(self, api_key: str, config: AnthropicLLMConfig):
+        self.model = config.model
+        self._config = config
         self._client = httpx.AsyncClient(
             base_url="https://api.anthropic.com",
             headers={
@@ -232,31 +246,38 @@ class AnthropicProvider(LLMProvider):
         timeout_ms: int,
     ) -> ChatResponse:
         effective_max_tokens = max_tokens
-        if self._thinking_budget is not None:
-            effective_max_tokens = max_tokens + self._thinking_budget
-
-        uses_thinking = self._thinking_budget is not None or self._effort is not None
+        match self._config:
+            case AnthropicHaiku45LLMConfig(thinking_budget=thinking_budget):
+                if thinking_budget is not None:
+                    effective_max_tokens = max_tokens + thinking_budget
+            case AnthropicSonnet46LLMConfig(effort=effort):
+                pass
+            case AnthropicOpus46LLMConfig(effort=effort):
+                pass
 
         body: dict[str, Any] = {
             "model": self.model,
             "max_tokens": effective_max_tokens,
             "messages": [{"role": "user", "content": prompt}],
-            "tools": [
-                {
-                    "name": "respond",
-                    "description": "Respond with the structured output",
-                    "input_schema": response_schema,
+            "output_config": {
+                "format": {
+                    "type": "json_schema",
+                    "schema": {**response_schema, "additionalProperties": False},
                 }
-            ],
-            "tool_choice": {"type": "auto"}
-            if uses_thinking
-            else {"type": "tool", "name": "respond"},
+            },
         }
-        if self._effort is not None:
-            body["thinking"] = {"type": "adaptive"}
-            body["output_config"] = {"effort": self._effort}
-        elif self._thinking_budget is not None:
-            body["thinking"] = {"type": "enabled", "budget_tokens": self._thinking_budget}
+        match self._config:
+            case AnthropicHaiku45LLMConfig(thinking_budget=thinking_budget):
+                if thinking_budget is not None:
+                    body["thinking"] = {"type": "enabled", "budget_tokens": thinking_budget}
+            case AnthropicSonnet46LLMConfig(effort=effort):
+                if effort is not None:
+                    body["thinking"] = {"type": "adaptive"}
+                    body["output_config"]["effort"] = effort
+            case AnthropicOpus46LLMConfig(effort=effort):
+                if effort is not None:
+                    body["thinking"] = {"type": "adaptive"}
+                    body["output_config"]["effort"] = effort
 
         try:
             resp = await self._client.post("/v1/messages", json=body, timeout=timeout_ms / 1000)
@@ -272,14 +293,17 @@ class AnthropicProvider(LLMProvider):
         resp.raise_for_status()
         data = resp.json()
 
-        tool_input = None
+        text_blocks: list[str] = []
         for block in data["content"]:
-            if block["type"] == "tool_use" and block["name"] == "respond":
-                tool_input = block["input"]
-                break
-        assert tool_input is not None, f"No tool_use response in: {data['content']}"
+            if block["type"] == "text":
+                text = block.get("text")
+                if isinstance(text, str):
+                    text_blocks.append(text)
 
-        content = json.dumps(tool_input)
+        content = "\n".join(text_blocks).strip()
+        assert content, f"No text response in: {data['content']}"
+        json.loads(content)
+
         usage = data["usage"]
         return ChatResponse(
             content=content,
@@ -382,9 +406,11 @@ def create_provider(
         case OpenRouterLLMConfig():
             api_key = _get_api_key("openrouter")
             return OpenRouterProvider(api_key, config.model, config.reasoning_effort)
-        case AnthropicLLMConfig():
+        case (
+            AnthropicSonnet46LLMConfig() | AnthropicOpus46LLMConfig() | AnthropicHaiku45LLMConfig()
+        ):
             api_key = _get_api_key("anthropic")
-            return AnthropicProvider(api_key, config.model, config.thinking_budget, config.effort)
+            return AnthropicProvider(api_key, config)
         case OpenAILLMConfig():
             api_key = _get_api_key("openai")
             return OpenAIProvider(api_key, config.model, config.reasoning_effort)

--- a/spd/autointerp/strategies/dispatch.py
+++ b/spd/autointerp/strategies/dispatch.py
@@ -1,13 +1,21 @@
 """Strategy dispatch: routes AutointerpConfig variants to their implementations."""
 
 from spd.app.backend.app_tokenizer import AppTokenizer
-from spd.autointerp.config import CompactSkepticalConfig, DualViewConfig, StrategyConfig
+from spd.autointerp.config import (
+    CompactSkepticalConfig,
+    DualViewConfig,
+    RichExamplesConfig,
+    StrategyConfig,
+)
 from spd.autointerp.schemas import ModelMetadata
 from spd.autointerp.strategies.compact_skeptical import (
     format_prompt as compact_skeptical_prompt,
 )
 from spd.autointerp.strategies.dual_view import (
     format_prompt as dual_view_prompt,
+)
+from spd.autointerp.strategies.rich_examples import (
+    format_prompt as rich_examples_prompt,
 )
 from spd.harvest.analysis import TokenPRLift
 from spd.harvest.schemas import ComponentData
@@ -29,12 +37,13 @@ def format_prompt(
     component: ComponentData,
     model_metadata: ModelMetadata,
     app_tok: AppTokenizer,
-    input_token_stats: TokenPRLift,
-    output_token_stats: TokenPRLift,
+    input_token_stats: TokenPRLift | None,
+    output_token_stats: TokenPRLift | None,
     context_tokens_per_side: int,
 ) -> str:
     match strategy:
         case CompactSkepticalConfig():
+            assert input_token_stats is not None and output_token_stats is not None
             return compact_skeptical_prompt(
                 strategy,
                 component,
@@ -45,6 +54,7 @@ def format_prompt(
                 context_tokens_per_side,
             )
         case DualViewConfig():
+            assert input_token_stats is not None and output_token_stats is not None
             return dual_view_prompt(
                 strategy,
                 component,
@@ -52,5 +62,13 @@ def format_prompt(
                 app_tok,
                 input_token_stats,
                 output_token_stats,
+                context_tokens_per_side,
+            )
+        case RichExamplesConfig():
+            return rich_examples_prompt(
+                strategy,
+                component,
+                model_metadata,
+                app_tok,
                 context_tokens_per_side,
             )

--- a/spd/autointerp/strategies/rich_examples.py
+++ b/spd/autointerp/strategies/rich_examples.py
@@ -1,0 +1,154 @@
+"""Rich examples interpretation strategy.
+
+Drops token statistics entirely. Shows per-token CI and activation values inline
+in the examples so the LLM can judge evidence quality directly.
+"""
+
+from spd.app.backend.app_tokenizer import AppTokenizer
+from spd.autointerp.config import RichExamplesConfig
+from spd.autointerp.prompt_helpers import (
+    DATASET_DESCRIPTIONS,
+    build_annotated_examples,
+    density_note,
+    human_layer_desc,
+    layer_position_note,
+)
+from spd.autointerp.schemas import DECOMPOSITION_DESCRIPTIONS, DecompositionMethod, ModelMetadata
+from spd.harvest.schemas import ComponentData
+from spd.utils.markdown import Md
+
+
+def format_prompt(
+    config: RichExamplesConfig,
+    component: ComponentData,
+    model_metadata: ModelMetadata,
+    app_tok: AppTokenizer,
+    context_tokens_per_side: int,
+) -> str:
+    fires_on = build_annotated_examples(component, app_tok, config.max_examples)
+
+    rate_str = (
+        f"~1 in {int(1 / component.firing_density)} tokens"
+        if component.firing_density > 0.0
+        else "extremely rare"
+    )
+
+    canonical = model_metadata.layer_descriptions.get(component.layer, component.layer)
+    layer_desc = human_layer_desc(canonical, model_metadata.n_blocks)
+    position_note = layer_position_note(canonical, model_metadata.n_blocks)
+    dens_note = density_note(component.firing_density)
+
+    context_notes = " ".join(filter(None, [position_note, dens_note]))
+
+    dataset_line = ""
+    if config.include_dataset_description:
+        dataset_desc = DATASET_DESCRIPTIONS.get(
+            model_metadata.dataset_name, model_metadata.dataset_name
+        )
+        dataset_line = f", dataset: {dataset_desc}"
+
+    forbidden_sentence = (
+        "FORBIDDEN vague words: " + ", ".join(config.forbidden_words) + ". "
+        if config.forbidden_words
+        else ""
+    )
+
+    md = Md()
+    md.p("Describe what this neural network component does.")
+    md.p(
+        "Each component has an input function (what causes it to fire) and an output "
+        "function (what tokens it causes the model to produce). These are often different "
+        "— a component might fire on periods but produce sentence-opening words, or "
+        "fire on prepositions but produce abstract nouns."
+    )
+
+    md.h(2, "Context")
+    md.bullets(
+        [
+            f"Model: {model_metadata.model_class} ({model_metadata.n_blocks} blocks){dataset_line}",
+            f"Component location: {layer_desc}",
+            f"Component firing rate: {component.firing_density * 100:.2f}% ({rate_str})",
+        ]
+    )
+    if context_notes:
+        md.p(context_notes)
+
+    md.h(2, "Data presentation")
+    md.extend(
+        _build_data_section(
+            model_metadata.seq_len, context_tokens_per_side, model_metadata.decomposition_method
+        )
+    )
+
+    md.h(3, "Example annotation format")
+    md.p(
+        "Firing tokens are wrapped in <<<triple angle brackets>>> with their activation "
+        "values. Non-firing tokens appear as plain text."
+    )
+    _build_annotation_legend(md, component)
+
+    md.h(2, "Activation examples — where the component fires")
+    md.p(
+        "Each firing token shows its activation values inline. "
+        "Use these to judge how strongly the component responds at each position."
+    )
+    md.extend(fires_on)
+
+    md.h(2, "Task")
+    md.p(
+        f"Give a {config.label_max_words}-word-or-fewer label describing this component's "
+        "function. The label should read like a short description of the job this component "
+        "does in the network. Use both the input and output evidence."
+    )
+    md.p(
+        f"Be epistemically honest — express uncertainty in the label and confidence "
+        f"field when the evidence is weak or ambiguous. {forbidden_sentence}Lowercase only."
+    )
+
+    return md.build()
+
+
+def _build_data_section(
+    seq_len: int,
+    context_tokens_per_side: int,
+    decomposition_method: DecompositionMethod,
+) -> Md:
+    window_size = 2 * context_tokens_per_side + 1
+    md = Md()
+    md.h(3, "Decomposition method")
+    md.p(DECOMPOSITION_DESCRIPTIONS[decomposition_method])
+    md.h(3, "Data")
+    md.p(
+        f"The model processes sequences of {seq_len} tokens. "
+        f"Each activation example below shows a {window_size}-token window centered on the "
+        f"firing token, with up to {context_tokens_per_side} tokens of context on each side. "
+        f"Windows are truncated at sequence boundaries. "
+        f"Examples are sampled uniformly at random from all firings across the dataset."
+    )
+    return md
+
+
+def _build_annotation_legend(md: Md, component: ComponentData) -> None:
+    first_ex = next((ex for ex in component.activation_examples if any(ex.firings)), None)
+    if first_ex is None:
+        return
+    act_keys = list(first_ex.activations.keys())
+    legend_items: list[str] = []
+    if "causal_importance" in act_keys:
+        legend_items.append(
+            "**ci** (causal importance): 0–1. How essential this component is at this position. "
+            "ci near 1 = component is critical here; ci near 0 = component could be ablated."
+        )
+    if "component_activation" in act_keys:
+        legend_items.append(
+            "**act** (component activation): The component's pre-mask activation magnitude. "
+            "Can be positive or negative. Larger absolute values mean stronger signal."
+        )
+    if "activation" in act_keys:
+        legend_items.append(
+            "**act** (activation): The component's activation magnitude. "
+            "Larger values mean stronger signal."
+        )
+    if legend_items:
+        md.bullets(legend_items)
+    md.p("Example: `the <<<cat (ci:0.92, act:0.45)>>> sat` — 'cat' is a firing token.")

--- a/tests/autointerp/test_providers.py
+++ b/tests/autointerp/test_providers.py
@@ -1,0 +1,156 @@
+import asyncio
+from typing import Any
+
+import httpx
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from spd.autointerp.providers import (
+    AnthropicHaiku45LLMConfig,
+    AnthropicOpus46LLMConfig,
+    AnthropicProvider,
+    AnthropicSonnet46LLMConfig,
+    LLMConfig,
+)
+
+
+def test_anthropic_llm_config_accepts_only_valid_model_specific_shapes() -> None:
+    adapter = TypeAdapter(LLMConfig)
+
+    sonnet = adapter.validate_python(
+        {"type": "anthropic", "model": "claude-sonnet-4-6", "effort": "high"}
+    )
+    assert isinstance(sonnet, AnthropicSonnet46LLMConfig)
+
+    opus = adapter.validate_python(
+        {"type": "anthropic", "model": "claude-opus-4-6", "effort": "max"}
+    )
+    assert isinstance(opus, AnthropicOpus46LLMConfig)
+
+    haiku = adapter.validate_python(
+        {
+            "type": "anthropic",
+            "model": "claude-haiku-4-5-20251001",
+            "thinking_budget": 2048,
+        }
+    )
+    assert isinstance(haiku, AnthropicHaiku45LLMConfig)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        {"type": "anthropic", "model": "claude-sonnet-4-6", "thinking_budget": 1024},
+        {"type": "anthropic", "model": "claude-sonnet-4-6", "effort": "max"},
+        {"type": "anthropic", "model": "claude-opus-4-6", "thinking_budget": 1024},
+        {"type": "anthropic", "model": "claude-haiku-4-5-20251001", "effort": "low"},
+    ],
+)
+def test_anthropic_llm_config_rejects_invalid_model_specific_shapes(data: dict[str, Any]) -> None:
+    adapter = TypeAdapter(LLMConfig)
+    with pytest.raises(ValidationError):
+        adapter.validate_python(data)
+
+
+def test_anthropic_provider_uses_structured_outputs_for_46_models() -> None:
+    provider = AnthropicProvider(
+        api_key="test-key",
+        config=AnthropicSonnet46LLMConfig(effort="medium"),
+    )
+
+    captured_json: dict[str, Any] = {}
+
+    class DummyClient:
+        async def post(self, url: str, json: dict[str, Any], timeout: float) -> httpx.Response:
+            nonlocal captured_json
+            _ = timeout
+            captured_json = json
+            request = httpx.Request("POST", f"https://api.anthropic.com{url}")
+            return httpx.Response(
+                200,
+                request=request,
+                json={
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": '{"label":"foo","confidence":"high","reasoning":"bar"}',
+                        }
+                    ],
+                    "usage": {"input_tokens": 12, "output_tokens": 34},
+                },
+            )
+
+        async def aclose(self) -> None:
+            return None
+
+    provider._client = DummyClient()  # pyright: ignore[reportAttributeAccessIssue]
+
+    response = asyncio.run(
+        provider.chat(
+            prompt="prompt",
+            max_tokens=100,
+            response_schema={"type": "object"},
+            timeout_ms=1000,
+        )
+    )
+
+    assert captured_json["thinking"] == {"type": "adaptive"}
+    assert captured_json["output_config"] == {
+        "format": {
+            "type": "json_schema",
+            "schema": {"type": "object", "additionalProperties": False},
+        },
+        "effort": "medium",
+    }
+    assert response.content == '{"label":"foo","confidence":"high","reasoning":"bar"}'
+
+
+def test_anthropic_provider_uses_manual_thinking_for_haiku() -> None:
+    provider = AnthropicProvider(
+        api_key="test-key",
+        config=AnthropicHaiku45LLMConfig(thinking_budget=1024),
+    )
+
+    captured_json: dict[str, Any] = {}
+
+    class DummyClient:
+        async def post(self, url: str, json: dict[str, Any], timeout: float) -> httpx.Response:
+            nonlocal captured_json
+            _ = timeout
+            captured_json = json
+            request = httpx.Request("POST", f"https://api.anthropic.com{url}")
+            return httpx.Response(
+                200,
+                request=request,
+                json={
+                    "content": [
+                        {
+                            "type": "text",
+                            "text": '{"label":"foo","confidence":"medium","reasoning":"bar"}',
+                        }
+                    ],
+                    "usage": {"input_tokens": 1, "output_tokens": 2},
+                },
+            )
+
+        async def aclose(self) -> None:
+            return None
+
+    provider._client = DummyClient()  # pyright: ignore[reportAttributeAccessIssue]
+
+    asyncio.run(
+        provider.chat(
+            prompt="prompt",
+            max_tokens=100,
+            response_schema={"type": "object"},
+            timeout_ms=1000,
+        )
+    )
+
+    assert captured_json["thinking"] == {"type": "enabled", "budget_tokens": 1024}
+    assert captured_json["output_config"] == {
+        "format": {
+            "type": "json_schema",
+            "schema": {"type": "object", "additionalProperties": False},
+        }
+    }


### PR DESCRIPTION
## Description

Two features:

1. **Rich examples autointerp strategy** (`rich_examples`): New interpretation strategy that shows per-token CI and activation values inline (e.g. `<<<token (ci:0.8, act:0.12)>>>`), letting the LLM judge evidence quality directly from examples rather than relying on aggregate token statistics.

2. **Autointerp Compare tab**: New app tab for side-by-side comparison of interpretation results across different autointerp subruns (different strategies, models, etc.) for the same component.

### Compare tab layout
- **Subrun selector**: Multiselect chips showing strategy, model, timestamp, completion count, and eval scores
- **Two-panel view**: Stacked interpretation cards (left) + full component data (right: activation examples, token stats, correlations, dataset attributions)
- Navigation: Layer dropdown, pagination, go-to-index search

### Backend
- `GET /api/autointerp_compare/subruns` — lists all completed subruns with metadata
- `GET /api/autointerp_compare/subruns/{id}/interpretations` — bulk headlines for a subrun
- `GET /api/autointerp_compare/subruns/{id}/interpretations/{layer}/{idx}` — reasoning + prompt detail
- Robustly handles corrupted/empty DBs from cancelled jobs

### Other changes
- `InterpDB.has_interpretations_table()` for safe schema validation
- Multi-provider LLM config support (Anthropic, OpenAI, OpenRouter)
- `RichExamplesConfig` added to strategy discriminated union

## Motivation and Context

We're running the new `rich_examples` strategy against existing `dual_view` and `compact_skeptical` runs on Jose (`s-55ea3f9b`) and need an easy way to compare results side-by-side in the app.

## How Has This Been Tested?

- `basedpyright` — 0 errors on all modified Python files
- `svelte-check` — 0 errors, 0 warnings
- `eslint` — clean
- `prettier` — clean
- Manual testing with Jose run in the app

## Does this PR introduce a breaking change?

No.