### PR TITLE
Improve rich_examples autointerp prompt

### DIFF
--- a/spd/app/backend/app_tokenizer.py
+++ b/spd/app/backend/app_tokenizer.py
@@ -101,6 +101,39 @@ class AppTokenizer:
         assert "".join(spans) == text, f"span concat mismatch: {''.join(spans)!r} != {text!r}"
         return [escape_for_display(span) for span in spans]
 
+    def get_raw_spans(self, token_ids: list[int]) -> list[str]:
+        """Like get_spans but without control-character escaping.
+
+        Returns per-token strings preserving literal whitespace (newlines, tabs, etc.).
+        Intended for LLM prompt rendering where actual whitespace is meaningful.
+        """
+        if not token_ids:
+            return []
+
+        if not self._is_fast:
+            return self._fallback_raw_spans(token_ids)
+
+        text = self._tok.decode(token_ids, skip_special_tokens=False)
+        re_encoded = self._tok(text, return_offsets_mapping=True, add_special_tokens=False)
+
+        if re_encoded.input_ids != token_ids:
+            return self._fallback_raw_spans(token_ids)
+
+        offsets: list[tuple[int, int]] = re_encoded.offset_mapping
+        assert len(offsets) == len(token_ids)
+
+        spans: list[str] = []
+        prev_end = 0
+        for start, end in offsets:
+            if start >= prev_end:
+                spans.append(text[prev_end:end])
+                prev_end = end
+            else:
+                spans.append("")
+
+        assert "".join(spans) == text
+        return spans
+
     def get_tok_display(self, token_id: int) -> str:
         """Single token -> display string for vocab browsers and hover labels."""
         return escape_for_display(self._tok.decode([token_id], skip_special_tokens=False))
@@ -115,5 +148,14 @@ class AppTokenizer:
         for i in range(len(token_ids)):
             current = self._tok.decode(token_ids[: i + 1], skip_special_tokens=False)
             spans.append(escape_for_display(current[len(prev) :]))
+            prev = current
+        return spans
+
+    def _fallback_raw_spans(self, token_ids: list[int]) -> list[str]:
+        spans: list[str] = []
+        prev = ""
+        for i in range(len(token_ids)):
+            current = self._tok.decode(token_ids[: i + 1], skip_special_tokens=False)
+            spans.append(current[len(prev) :])
             prev = current
         return spans

--- a/spd/app/backend/routers/autointerp_compare.py
+++ b/spd/app/backend/routers/autointerp_compare.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 
 from spd.app.backend.dependencies import DepLoadedRun
 from spd.app.backend.utils import log_errors
-from spd.autointerp.db import DONE_MARKER, InterpDB
+from spd.autointerp.db import InterpDB
 from spd.autointerp.schemas import get_autointerp_dir
 from spd.topology import TransformerTopology
 
@@ -101,8 +101,6 @@ def list_subruns(loaded: DepLoadedRun) -> list[SubrunSummary]:
     results: list[SubrunSummary] = []
     for d in sorted(autointerp_dir.iterdir(), key=lambda d: d.name):
         if not d.is_dir() or not d.name.startswith("a-"):
-            continue
-        if not (d / DONE_MARKER).exists():
             continue
         db_path = d / "interp.db"
         if not db_path.exists():

--- a/spd/autointerp/prompt_helpers.py
+++ b/spd/autointerp/prompt_helpers.py
@@ -233,17 +233,19 @@ def build_annotated_examples(
     app_tok: AppTokenizer,
     max_examples: int,
 ) -> Md:
-    """Build activation examples with per-token CI and activation annotations."""
+    """Build activation examples with raw text followed by annotated version."""
     items: list[str] = []
     for ex in component.activation_examples[:max_examples]:
         if not any(ex.firings):
             continue
         spans = app_tok.get_spans(ex.token_ids)
+        raw = "".join(spans)
         act_keys = list(ex.activations.keys())
         per_token_acts = [
             {k: ex.activations[k][i] for k in act_keys} for i in range(len(ex.token_ids))
         ]
-        items.append(_delimit_annotated(spans, ex.firings, per_token_acts))
+        annotated = _delimit_annotated(spans, ex.firings, per_token_acts)
+        items.append(f"{raw}\n  → {annotated}")
     md = Md()
     if items:
         md.numbered(items)

--- a/spd/autointerp/prompt_helpers.py
+++ b/spd/autointerp/prompt_helpers.py
@@ -233,20 +233,22 @@ def build_annotated_examples(
     app_tok: AppTokenizer,
     max_examples: int,
 ) -> Md:
-    """Build activation examples with raw text followed by annotated version."""
-    items: list[str] = []
+    """Build activation examples as XML blocks with raw and annotated versions."""
+    blocks: list[str] = []
     for ex in component.activation_examples[:max_examples]:
         if not any(ex.firings):
             continue
-        spans = app_tok.get_spans(ex.token_ids)
+        spans = app_tok.get_raw_spans(ex.token_ids)
         raw = "".join(spans)
         act_keys = list(ex.activations.keys())
         per_token_acts = [
             {k: ex.activations[k][i] for k in act_keys} for i in range(len(ex.token_ids))
         ]
-        annotated = _delimit_annotated(spans, ex.firings, per_token_acts)
-        items.append(f"{raw}\n  → {annotated}")
+        highlighted = _delimit_annotated(spans, ex.firings, per_token_acts)
+        blocks.append(
+            f"<example>\n<raw>\n{raw}\n</raw>\n<highlighted>\n{highlighted}\n</highlighted>\n</example>"
+        )
     md = Md()
-    if items:
-        md.numbered(items)
+    for block in blocks:
+        md.p(block)
     return md

--- a/spd/autointerp/scripts/render_prompt.py
+++ b/spd/autointerp/scripts/render_prompt.py
@@ -1,0 +1,200 @@
+"""Render a prompt from dummy data for prompt engineering iteration.
+
+Usage:
+    python -m spd.autointerp.scripts.render_prompt
+"""
+
+from spd.app.backend.app_tokenizer import AppTokenizer
+from spd.autointerp.config import RichExamplesConfig
+from spd.autointerp.schemas import ModelMetadata
+from spd.autointerp.strategies.rich_examples import format_prompt
+from spd.harvest.schemas import ActivationExample, ComponentData, ComponentTokenPMI
+
+TOKENIZER_NAME = "openai-community/gpt2"
+
+# Dummy data with negative component_activation values to exercise the suppression
+# misinterpretation failure mode.
+DUMMY_COMPONENT = ComponentData(
+    component_key="h.2.attn.v_proj:52",
+    layer="h.2.attn.v_proj",
+    component_idx=52,
+    mean_activations={"causal_importance": 0.04, "component_activation": -0.31},
+    firing_density=0.04,
+    activation_examples=[
+        ActivationExample(
+            token_ids=[1026, 547, 257, 3217, 290, 6792, 1110, 13, 383, 1200, 373, 1016, 284, 1057],
+            firings=[
+                False,
+                False,
+                False,
+                False,
+                False,
+                True,
+                True,
+                False,
+                False,
+                True,
+                True,
+                False,
+                False,
+                False,
+            ],
+            activations={
+                "causal_importance": [
+                    0.02,
+                    0.03,
+                    0.01,
+                    0.05,
+                    0.02,
+                    0.45,
+                    0.82,
+                    0.03,
+                    0.04,
+                    0.38,
+                    0.71,
+                    0.03,
+                    0.02,
+                    0.05,
+                ],
+                "component_activation": [
+                    0.12,
+                    0.08,
+                    -0.05,
+                    0.11,
+                    -0.09,
+                    -0.63,
+                    -1.21,
+                    -0.03,
+                    0.07,
+                    -0.54,
+                    -0.98,
+                    -0.14,
+                    0.06,
+                    0.03,
+                ],
+            },
+        ),
+        ActivationExample(
+            token_ids=[383, 1200, 2540, 284, 262, 4571, 13, 366, 1639, 460, 466, 340, 553],
+            firings=[
+                False,
+                True,
+                False,
+                False,
+                False,
+                True,
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                True,
+            ],
+            activations={
+                "causal_importance": [
+                    0.03,
+                    0.74,
+                    0.02,
+                    0.01,
+                    0.03,
+                    0.68,
+                    0.02,
+                    0.04,
+                    0.03,
+                    0.02,
+                    0.04,
+                    0.78,
+                    0.02,
+                ],
+                "component_activation": [
+                    0.09,
+                    -1.04,
+                    0.03,
+                    -0.07,
+                    0.11,
+                    -0.91,
+                    0.04,
+                    -0.02,
+                    0.08,
+                    -0.06,
+                    0.03,
+                    -1.15,
+                    0.01,
+                ],
+            },
+        ),
+        ActivationExample(
+            token_ids=[679, 2486, 284, 534, 2563, 13, 366, 1212, 318, 407, 625],
+            firings=[False, False, False, False, True, False, False, False, False, False, True],
+            activations={
+                "causal_importance": [
+                    0.02,
+                    0.03,
+                    0.02,
+                    0.04,
+                    0.79,
+                    0.03,
+                    0.05,
+                    0.02,
+                    0.04,
+                    0.03,
+                    0.67,
+                ],
+                "component_activation": [
+                    0.04,
+                    0.06,
+                    -0.02,
+                    0.09,
+                    -0.87,
+                    -0.05,
+                    0.03,
+                    0.07,
+                    -0.11,
+                    0.04,
+                    -0.72,
+                ],
+            },
+        ),
+    ],
+    input_token_pmi=ComponentTokenPMI(
+        top=[(13, 2.1), (366, 1.8), (553, 1.6), (625, 1.5)],
+        bottom=[(257, -1.2), (290, -0.9)],
+    ),
+    output_token_pmi=ComponentTokenPMI(
+        top=[(679, 2.4), (1212, 2.0), (1639, 1.9)],
+        bottom=[(257, -1.1)],
+    ),
+)
+
+DUMMY_MODEL_METADATA = ModelMetadata(
+    n_blocks=4,
+    model_class="pile_llama_simple_mlp",
+    dataset_name="danbraunai/pile-uncopyrighted-tok-shuffled",
+    layer_descriptions={"h.2.attn.v_proj": "2.attn.v"},
+    seq_len=512,
+    decomposition_method="spd",
+)
+
+DUMMY_CONFIG = RichExamplesConfig(
+    max_examples=30,
+    include_dataset_description=True,
+    label_max_words=8,
+    forbidden_words=None,
+)
+
+
+def main() -> None:
+    app_tok = AppTokenizer.from_pretrained(TOKENIZER_NAME)
+    prompt = format_prompt(
+        config=DUMMY_CONFIG,
+        component=DUMMY_COMPONENT,
+        model_metadata=DUMMY_MODEL_METADATA,
+        app_tok=app_tok,
+        context_tokens_per_side=10,
+    )
+    print(prompt)
+
+
+if __name__ == "__main__":
+    main()

--- a/spd/autointerp/scripts/run_slurm_cli.py
+++ b/spd/autointerp/scripts/run_slurm_cli.py
@@ -10,19 +10,30 @@ Usage:
 import fire
 
 
-def main(decomposition_id: str, config: str, harvest_subrun_id: str) -> None:
+def main(
+    decomposition_id: str,
+    config: str,
+    harvest_subrun_id: str,
+    snapshot_branch: str | None = None,
+) -> None:
     """Submit autointerp pipeline (interpret + evals) to SLURM.
 
     Args:
         decomposition_id: ID of the target decomposition run.
         config: Path to AutointerpSlurmConfig YAML/JSON.
         harvest_subrun_id: Harvest subrun to use (e.g. "h-20260306_120000").
+        snapshot_branch: Git branch to run from (default: current REPO_ROOT checkout).
     """
     from spd.autointerp.config import AutointerpSlurmConfig
     from spd.autointerp.scripts.run_slurm import submit_autointerp
 
     slurm_config = AutointerpSlurmConfig.from_file(config)
-    submit_autointerp(decomposition_id, slurm_config, harvest_subrun_id=harvest_subrun_id)
+    submit_autointerp(
+        decomposition_id,
+        slurm_config,
+        harvest_subrun_id=harvest_subrun_id,
+        snapshot_branch=snapshot_branch,
+    )
 
 
 def cli() -> None:

--- a/spd/autointerp/strategies/rich_examples.py
+++ b/spd/autointerp/strategies/rich_examples.py
@@ -112,10 +112,10 @@ def format_prompt(
 
     md.h(3, "Example annotation format")
     md.p(
-        "Each example shows the raw text first, then an annotated version. "
-        "In the annotated version, each firing token is wrapped as "
-        "`<<<token (ci:X, act:Y)>>>` where ci is the causal importance and act is the "
-        "component's inner activation at that position. Non-firing tokens appear as plain text."
+        "Each example is an XML block with a `<raw>` section (the unmodified text) and a "
+        "`<highlighted>` section where firing tokens are wrapped as "
+        "`<<<token (ci:X, act:Y)>>>` — ci is the causal importance, act is the component's "
+        "inner activation at that position. Non-firing tokens appear as plain text."
     )
     _build_annotation_legend(md, component)
 

--- a/spd/autointerp/strategies/rich_examples.py
+++ b/spd/autointerp/strategies/rich_examples.py
@@ -86,6 +86,11 @@ def format_prompt(
         "— a component might fire on periods but produce sentence-opening words, or "
         "fire on prepositions but produce abstract nouns."
     )
+    md.p(
+        "The activation examples are sampled and may not be fully representative. "
+        "Look for patterns that are consistent across multiple examples, and express "
+        "uncertainty when the evidence is weak or noisy."
+    )
 
     md.h(2, "Context")
     md.bullets(
@@ -107,8 +112,10 @@ def format_prompt(
 
     md.h(3, "Example annotation format")
     md.p(
-        "Firing tokens are wrapped in <<<triple angle brackets>>> with their activation "
-        "values. Non-firing tokens appear as plain text."
+        "Each example shows the raw text first, then an annotated version. "
+        "In the annotated version, each firing token is wrapped as "
+        "`<<<token (ci:X, act:Y)>>>` where ci is the causal importance and act is the "
+        "component's inner activation at that position. Non-firing tokens appear as plain text."
     )
     _build_annotation_legend(md, component)
 

--- a/spd/autointerp/strategies/rich_examples.py
+++ b/spd/autointerp/strategies/rich_examples.py
@@ -13,9 +13,34 @@ from spd.autointerp.prompt_helpers import (
     human_layer_desc,
     layer_position_note,
 )
-from spd.autointerp.schemas import DECOMPOSITION_DESCRIPTIONS, DecompositionMethod, ModelMetadata
+from spd.autointerp.schemas import DecompositionMethod, ModelMetadata
 from spd.harvest.schemas import ComponentData
 from spd.utils.markdown import Md
+
+_DECOMPOSITION_DESCRIPTIONS: dict[DecompositionMethod, str] = {
+    "spd": (
+        "Each component is a rank-1 parameter matrix learned by Stochastic Parameter "
+        "Decomposition (SPD). A weight matrix W is decomposed as W ≈ Σ u_i v_i^T. "
+        "When the model processes a token, each component computes an activation: the inner "
+        "product of the residual stream with its read direction v_i. This value can be "
+        "positive or negative depending on how the input aligns with v_i — the sign is an "
+        "arbitrary consequence of how the vectors were initialised and does not indicate "
+        "suppression. What matters is the magnitude. "
+        "Each component also has a causal importance (CI) value per token position: CI near 1 "
+        "means the component is essential at that position, CI near 0 means it can be ablated "
+        "without affecting output. A component 'fires' when its CI is high."
+    ),
+    "clt": (
+        "Each component is a feature from a Cross-Layer Transcoder (CLT). CLTs learn sparse, "
+        "interpretable features that map activations at one layer to contributions at another. "
+        "A component 'fires' when its activation magnitude is high."
+    ),
+    "transcoder": (
+        "Each component is a feature from a Transcoder, which learns a sparse dictionary of "
+        "linear transformations mapping MLP inputs to MLP outputs. A component 'fires' when "
+        "its encoder activation is above threshold."
+    ),
+}
 
 
 def format_prompt(
@@ -116,7 +141,7 @@ def _build_data_section(
     window_size = 2 * context_tokens_per_side + 1
     md = Md()
     md.h(3, "Decomposition method")
-    md.p(DECOMPOSITION_DESCRIPTIONS[decomposition_method])
+    md.p(_DECOMPOSITION_DESCRIPTIONS[decomposition_method])
     md.h(3, "Data")
     md.p(
         f"The model processes sequences of {seq_len} tokens. "
@@ -141,8 +166,8 @@ def _build_annotation_legend(md: Md, component: ComponentData) -> None:
         )
     if "component_activation" in act_keys:
         legend_items.append(
-            "**act** (component activation): The component's pre-mask activation magnitude. "
-            "Can be positive or negative. Larger absolute values mean stronger signal."
+            "**act** (component activation): Inner product with the component's read direction. "
+            "Sign is arbitrary; magnitude indicates response strength."
         )
     if "activation" in act_keys:
         legend_items.append(


### PR DESCRIPTION
## Summary

- Fix signed activation misinterpretation: adds local `_DECOMPOSITION_DESCRIPTIONS` in `rich_examples.py` explaining that `component_activation` sign is arbitrary (inner product with read direction) and does not indicate suppression
- Show raw + highlighted XML example format so dense token sequences (code, LaTeX, multilingual) are readable
- Add "consider evidence critically" paragraph and clearer `<<<token (ci:X, act:Y)>>>` format description
- Add `AppTokenizer.get_raw_spans` for LLM prompt rendering with literal whitespace
- Expose `--snapshot_branch` on `spd-autointerp` CLI
- Autointerp compare tab now lists all subruns regardless of `.done` marker
- Add `render_prompt.py` script for iterating on prompt templates without loading a full run

## Test plan

- [ ] `python -m spd.autointerp.scripts.render_prompt` renders correctly
- [ ] `make check` passes
- [ ] Autointerp compare tab shows all subruns in app

🤖 Generated with [Claude Code](https://claude.com/claude-code)