### PR TITLE
Fix formatting and type errors on dev

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,7 @@ dev = [
     "ruff",
     "basedpyright<1.32.0", # pyright and wandb issues, see https://github.com/goodfire-ai/spd/pull/232
     "pre-commit",
+    "scikit-learn",
 ]
 
 [project.scripts]

--- a/scripts/export_blog_data.py
+++ b/scripts/export_blog_data.py
@@ -130,10 +130,9 @@ def convert_examples(
 
 
 def convert_pmi(raw_pmi: dict[str, Any], tokenizer: AppTokenizer, top_k: int = 8) -> dict[str, Any]:
-    return {"top": [
-        [tokenizer.get_tok_display(tid), score]
-        for tid, score in raw_pmi["top"][:top_k]
-    ]}
+    return {
+        "top": [[tokenizer.get_tok_display(tid), score] for tid, score in raw_pmi["top"][:top_k]]
+    }
 
 
 def build_dataset_attributions(
@@ -170,11 +169,13 @@ def build_dataset_attributions(
         for entry in entries:
             graph_key = find_graph_key(entry.layer, entry.component_idx)
             label = resolve_label(entry.layer, entry.component_idx)
-            result.append({
-                "key": graph_key,
-                "label": label,
-                "value": round(entry.value, 4),
-            })
+            result.append(
+                {
+                    "key": graph_key,
+                    "label": label,
+                    "value": round(entry.value, 4),
+                }
+            )
         return result
 
     pos_sources = storage.get_top_sources(storage_key, top_k, "positive", "attr_abs")
@@ -211,9 +212,7 @@ def build_graph(
     assert row, f"Graph {graph_id} not found"
     prompt_id, raw_edges, raw_ci, raw_acts = row
 
-    prompt_row = app_db.execute(
-        "SELECT token_ids FROM prompts WHERE id=?", (prompt_id,)
-    ).fetchone()
+    prompt_row = app_db.execute("SELECT token_ids FROM prompts WHERE id=?", (prompt_id,)).fetchone()
     assert prompt_row
     token_ids = json.loads(prompt_row[0])
     all_tokens = tokenizer.get_spans(token_ids)
@@ -242,7 +241,9 @@ def build_graph(
                     key = f"output:{t['seq_pos']}:{t['component_idx']}"
                     if seq_allowed(key):
                         output_strength[key] = output_strength.get(key, 0) + abs(e["strength"])
-            top_keys = sorted(output_strength, key=lambda k: output_strength[k], reverse=True)[:output_filter]
+            top_keys = sorted(output_strength, key=lambda k: output_strength[k], reverse=True)[
+                :output_filter
+            ]
             allowed_outputs = set(top_keys)
         case None:
             pass
@@ -264,12 +265,14 @@ def build_graph(
             continue
 
         if is_allowed(src, e["source"]["layer"]) and is_allowed(tgt, e["target"]["layer"]):
-            edges.append({
-                "src": src,
-                "tgt": tgt,
-                "val": e["strength"],
-                "is_cross_seq": e["is_cross_seq"],
-            })
+            edges.append(
+                {
+                    "src": src,
+                    "tgt": tgt,
+                    "val": e["strength"],
+                    "is_cross_seq": e["is_cross_seq"],
+                }
+            )
             active_keys.add(src)
             active_keys.add(tgt)
 
@@ -318,8 +321,12 @@ def build_graph(
                 }
                 if attr_repo:
                     details["dataset_attributions"] = build_dataset_attributions(
-                        node_key, active_keys, interp_by_key,
-                        canonical_to_concrete, attr_repo, tokenizer,
+                        node_key,
+                        active_keys,
+                        interp_by_key,
+                        canonical_to_concrete,
+                        attr_repo,
+                        tokenizer,
                     )
                 else:
                     details["input_token_pmi"] = convert_pmi(json.loads(raw_in_pmi), tokenizer)
@@ -328,12 +335,26 @@ def build_graph(
 
             components[node_key] = comp
 
-    topology_layers = ["embed"] + [
-        f"{b}.{sub}.{proj}"
-        for b in range(max(int(k.split(".")[0]) for k in canonical_to_concrete.values() if k[0].isdigit()) + 1)
-        for sub, proj in [("attn", "q"), ("attn", "k"), ("attn", "v"), ("attn", "o"), ("mlp", "up"), ("mlp", "down")]
-        if f"{b}.{sub}.{proj}" in {v for v in canonical_to_concrete.values()}
-    ] + ["output"]
+    topology_layers = (
+        ["embed"]
+        + [
+            f"{b}.{sub}.{proj}"
+            for b in range(
+                max(int(k.split(".")[0]) for k in canonical_to_concrete.values() if k[0].isdigit())
+                + 1
+            )
+            for sub, proj in [
+                ("attn", "q"),
+                ("attn", "k"),
+                ("attn", "v"),
+                ("attn", "o"),
+                ("mlp", "up"),
+                ("mlp", "down"),
+            ]
+            if f"{b}.{sub}.{proj}" in {v for v in canonical_to_concrete.values()}
+        ]
+        + ["output"]
+    )
 
     graph: dict[str, Any] = {
         "tokens": tokens,
@@ -352,7 +373,9 @@ def build_graph(
 def main() -> None:
     parser = argparse.ArgumentParser(description="Export blog graph data from SPD databases")
     parser.add_argument("run_id", help="SPD run ID (e.g. s-55ea3f9b)")
-    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR, help="Output directory for JSON files")
+    parser.add_argument(
+        "--out-dir", type=Path, default=DEFAULT_OUT_DIR, help="Output directory for JSON files"
+    )
     args = parser.parse_args()
 
     out_dir: Path = args.out_dir
@@ -381,7 +404,9 @@ def main() -> None:
 
     # Find latest harvest DB
     harvest_dir = get_harvest_dir(run_id)
-    harvest_subdirs = sorted(d for d in harvest_dir.iterdir() if d.is_dir() and d.name.startswith("h-"))
+    harvest_subdirs = sorted(
+        d for d in harvest_dir.iterdir() if d.is_dir() and d.name.startswith("h-")
+    )
     assert harvest_subdirs, f"No harvest data in {harvest_dir}"
     harvest_db_path = harvest_subdirs[-1] / "harvest.db"
     assert harvest_db_path.exists(), f"No harvest.db in {harvest_subdirs[-1]}"
@@ -408,7 +433,9 @@ def main() -> None:
     else:
         print("WARNING: No dataset attributions found, falling back to PMI")
 
-    print(f"Loaded {len(harvest_by_key)} harvest + {len(interp_by_key)} interp entries (from {interp_repo.subrun_id})")
+    print(
+        f"Loaded {len(harvest_by_key)} harvest + {len(interp_by_key)} interp entries (from {interp_repo.subrun_id})"
+    )
 
     cluster_mapping = None
     if CLUSTER_MAPPING_PATH and CLUSTER_MAPPING_PATH.exists():
@@ -420,8 +447,15 @@ def main() -> None:
     def write_graph(name: str, graph_id: int, **kwargs: Any) -> None:
         print(f"Building {name} (graph {graph_id})...")
         graph, details = build_graph(
-            graph_id, tokenizer, harvest_by_key, interp_by_key,
-            canonical_to_concrete, app_db, attr_repo, cluster_mapping, **kwargs
+            graph_id,
+            tokenizer,
+            harvest_by_key,
+            interp_by_key,
+            canonical_to_concrete,
+            app_db,
+            attr_repo,
+            cluster_mapping,
+            **kwargs,
         )
         graph_path = out_dir / f"{name}.json"
         details_path = out_dir / f"{name}-details.json"

--- a/scripts/export_component_data.py
+++ b/scripts/export_component_data.py
@@ -81,7 +81,9 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Export component data for blog post")
     parser.add_argument("run_id", help="SPD run ID (e.g. s-55ea3f9b)")
     parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR, help="Output directory")
-    parser.add_argument("--n-examples", type=int, default=30, help="Activation examples per component")
+    parser.add_argument(
+        "--n-examples", type=int, default=30, help="Activation examples per component"
+    )
     args = parser.parse_args()
 
     args.out_dir.mkdir(parents=True, exist_ok=True)
@@ -98,7 +100,9 @@ def main() -> None:
 
     # Find latest harvest DB
     harvest_dir = get_harvest_dir(run_id)
-    harvest_subdirs = sorted(d for d in harvest_dir.iterdir() if d.is_dir() and d.name.startswith("h-"))
+    harvest_subdirs = sorted(
+        d for d in harvest_dir.iterdir() if d.is_dir() and d.name.startswith("h-")
+    )
     assert harvest_subdirs, f"No harvest data in {harvest_dir}"
     harvest_db_path = harvest_subdirs[-1] / "harvest.db"
     assert harvest_db_path.exists(), f"No harvest.db in {harvest_subdirs[-1]}"
@@ -134,14 +138,16 @@ def main() -> None:
             json.loads(raw_examples), tokenizer, n_examples=args.n_examples
         )
 
-        components.append({
-            "key": canonical_key,
-            "label": interp_by_key[component_key],
-            "layer_display": canonical_display_name(canonical_layer),
-            "firing_density": firing_density,
-            "activation_examples": examples,
-            "max_act": max_act,
-        })
+        components.append(
+            {
+                "key": canonical_key,
+                "label": interp_by_key[component_key],
+                "layer_display": canonical_display_name(canonical_layer),
+                "firing_density": firing_density,
+                "activation_examples": examples,
+                "max_act": max_act,
+            }
+        )
 
     out_path = args.out_dir / "components.json"
     out_path.write_text(json.dumps(components))

--- a/uv.lock
+++ b/uv.lock
@@ -801,6 +801,15 @@ wheels = [
 ]
 
 [[package]]
+name = "joblib"
+version = "1.5.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/41/f2/d34e8b3a08a9cc79a50b2208a93dce981fe615b64d5a4d4abee421d898df/joblib-1.5.3.tar.gz", hash = "sha256:8561a3269e6801106863fd0d6d84bb737be9e7631e33aaed3fb9ce5953688da3", size = 331603, upload-time = "2025-12-15T08:41:46.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/91/984aca2ec129e2757d1e4e3c81c3fcda9d0f85b74670a094cc443d9ee949/joblib-1.5.3-py3-none-any.whl", hash = "sha256:5fc3c5039fc5ca8c0276333a188bbd59d6b7ab37fe6632daa76bc7f9ec18e713", size = 309071, upload-time = "2025-12-15T08:41:44.973Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.25.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1912,6 +1921,32 @@ wheels = [
 ]
 
 [[package]]
+name = "scikit-learn"
+version = "1.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "joblib" },
+    { name = "numpy" },
+    { name = "scipy" },
+    { name = "threadpoolctl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/d4/40988bf3b8e34feec1d0e6a051446b1f66225f8529b9309becaeef62b6c4/scikit_learn-1.8.0.tar.gz", hash = "sha256:9bccbb3b40e3de10351f8f5068e105d0f4083b1a65fa07b6634fbc401a6287fd", size = 7335585, upload-time = "2025-12-10T07:08:53.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/aa/e22e0768512ce9255eba34775be2e85c2048da73da1193e841707f8f039c/scikit_learn-1.8.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d6ae97234d5d7079dc0040990a6f7aeb97cb7fa7e8945f1999a429b23569e0a", size = 8513770, upload-time = "2025-12-10T07:08:03.251Z" },
+    { url = "https://files.pythonhosted.org/packages/58/37/31b83b2594105f61a381fc74ca19e8780ee923be2d496fcd8d2e1147bd99/scikit_learn-1.8.0-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:edec98c5e7c128328124a029bceb09eda2d526997780fef8d65e9a69eead963e", size = 8044458, upload-time = "2025-12-10T07:08:05.336Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/5a/3f1caed8765f33eabb723596666da4ebbf43d11e96550fb18bdec42b467b/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:74b66d8689d52ed04c271e1329f0c61635bcaf5b926db9b12d58914cdc01fe57", size = 8610341, upload-time = "2025-12-10T07:08:07.732Z" },
+    { url = "https://files.pythonhosted.org/packages/38/cf/06896db3f71c75902a8e9943b444a56e727418f6b4b4a90c98c934f51ed4/scikit_learn-1.8.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8fdf95767f989b0cfedb85f7ed8ca215d4be728031f56ff5a519ee1e3276dc2e", size = 8900022, upload-time = "2025-12-10T07:08:09.862Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/f9/9b7563caf3ec8873e17a31401858efab6b39a882daf6c1bfa88879c0aa11/scikit_learn-1.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:2de443b9373b3b615aec1bb57f9baa6bb3a9bd093f1269ba95c17d870422b271", size = 7989409, upload-time = "2025-12-10T07:08:12.028Z" },
+    { url = "https://files.pythonhosted.org/packages/49/bd/1f4001503650e72c4f6009ac0c4413cb17d2d601cef6f71c0453da2732fc/scikit_learn-1.8.0-cp313-cp313-win_arm64.whl", hash = "sha256:eddde82a035681427cbedded4e6eff5e57fa59216c2e3e90b10b19ab1d0a65c3", size = 7619760, upload-time = "2025-12-10T07:08:13.688Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/7d/a630359fc9dcc95496588c8d8e3245cc8fd81980251079bc09c70d41d951/scikit_learn-1.8.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:7cc267b6108f0a1499a734167282c00c4ebf61328566b55ef262d48e9849c735", size = 8826045, upload-time = "2025-12-10T07:08:15.215Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/56/a0c86f6930cfcd1c7054a2bc417e26960bb88d32444fe7f71d5c2cfae891/scikit_learn-1.8.0-cp313-cp313t-macosx_12_0_arm64.whl", hash = "sha256:fe1c011a640a9f0791146011dfd3c7d9669785f9fed2b2a5f9e207536cf5c2fd", size = 8420324, upload-time = "2025-12-10T07:08:17.561Z" },
+    { url = "https://files.pythonhosted.org/packages/46/1e/05962ea1cebc1cf3876667ecb14c283ef755bf409993c5946ade3b77e303/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72358cce49465d140cc4e7792015bb1f0296a9742d5622c67e31399b75468b9e", size = 8680651, upload-time = "2025-12-10T07:08:19.952Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/56/a85473cd75f200c9759e3a5f0bcab2d116c92a8a02ee08ccd73b870f8bb4/scikit_learn-1.8.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:80832434a6cc114f5219211eec13dcbc16c2bac0e31ef64c6d346cde3cf054cb", size = 8925045, upload-time = "2025-12-10T07:08:22.11Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/b7/64d8cfa896c64435ae57f4917a548d7ac7a44762ff9802f75a79b77cb633/scikit_learn-1.8.0-cp313-cp313t-win_amd64.whl", hash = "sha256:ee787491dbfe082d9c3013f01f5991658b0f38aa8177e4cd4bf434c58f551702", size = 8507994, upload-time = "2025-12-10T07:08:23.943Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/37/e192ea709551799379958b4c4771ec507347027bb7c942662c7fbeba31cb/scikit_learn-1.8.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bf97c10a3f5a7543f9b88cbf488d33d175e9146115a451ae34568597ba33dcde", size = 7869518, upload-time = "2025-12-10T07:08:25.71Z" },
+]
+
+[[package]]
 name = "scipy"
 version = "1.16.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2026,6 +2061,7 @@ dev = [
     { name = "pytest-testmon" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "scikit-learn" },
 ]
 
 [package.metadata]
@@ -2069,6 +2105,7 @@ dev = [
     { name = "pytest-testmon" },
     { name = "pytest-xdist" },
     { name = "ruff" },
+    { name = "scikit-learn" },
 ]
 
 [[package]]
@@ -2165,6 +2202,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/87/56/ab275c2b56a5e2342568838f0d5e3e66a32354adcc159b495e374cda43f5/termcolor-3.2.0.tar.gz", hash = "sha256:610e6456feec42c4bcd28934a8c87a06c3fa28b01561d46aa09a9881b8622c58", size = 14423, upload-time = "2025-10-25T19:11:42.586Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/d5/141f53d7c1eb2a80e6d3e9a390228c3222c27705cbe7f048d3623053f3ca/termcolor-3.2.0-py3-none-any.whl", hash = "sha256:a10343879eba4da819353c55cb8049b0933890c2ebf9ad5d3ecd2bb32ea96ea6", size = 7698, upload-time = "2025-10-25T19:11:41.536Z" },
+]
+
+[[package]]
+name = "threadpoolctl"
+version = "3.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b7/4d/08c89e34946fce2aec4fbb45c9016efd5f4d7f24af8e5d93296e935631d8/threadpoolctl-3.6.0.tar.gz", hash = "sha256:8ab8b4aa3491d812b623328249fab5302a68d2d71745c8a4c719a2fcaba9f44e", size = 21274, upload-time = "2025-03-13T13:49:23.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/d5/f9a850d79b0851d1d4ef6456097579a9005b31fea68726a4ae5f2d82ddd9/threadpoolctl-3.6.0-py3-none-any.whl", hash = "sha256:43a0b8fd5a2928500110039e43a5eed8480b918967083ea48dc3ab9f13c4a7fb", size = 18638, upload-time = "2025-03-13T13:49:21.846Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Format `scripts/export_blog_data.py` and `scripts/export_component_data.py` (ruff)
- Fix `sklearn` import errors in `geometric_interaction/statistical_analysis.py` by adding it

Pre-commit hooks were failing on dev because of these. Fixes it so other PRs don't pick up unrelated formatting diffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)