### PR TITLE
Remove hardcoded goodfire entity from SPDAdapter

### DIFF
--- a/spd/adapters/__init__.py
+++ b/spd/adapters/__init__.py
@@ -23,7 +23,7 @@ def adapter_from_config(method_config: DecompositionMethodHarvestConfig) -> Deco
         case SPDHarvestConfig():
             from spd.adapters.spd import SPDAdapter
 
-            return SPDAdapter(method_config.id)
+            return SPDAdapter(method_config.wandb_path)
         case TranscoderHarvestConfig():
             from spd.adapters.transcoder import TranscoderAdapter
 
@@ -41,11 +41,6 @@ def adapter_from_id(decomposition_id: str) -> DecompositionAdapter:
     method config from the harvest DB (which is always populated before downstream
     steps like autointerp run).
     """
-    if decomposition_id.startswith("s-"):
-        from spd.adapters.spd import SPDAdapter
-
-        return SPDAdapter(decomposition_id)
-
     return adapter_from_config(_load_method_config(decomposition_id))
 
 

--- a/spd/adapters/spd.py
+++ b/spd/adapters/spd.py
@@ -11,15 +11,18 @@ from spd.data import train_loader_and_tokenizer
 from spd.models.component_model import ComponentModel, SPDRunInfo
 from spd.topology import TransformerTopology
 from spd.utils.general_utils import runtime_cast
+from spd.utils.wandb_utils import parse_wandb_run_path
 
 
 class SPDAdapter(DecompositionAdapter):
-    def __init__(self, run_id: str):
+    def __init__(self, wandb_path: str):
+        _, _, run_id = parse_wandb_run_path(wandb_path)
+        self._wandb_path = wandb_path
         self._run_id = run_id
 
     @cached_property
     def spd_run_info(self):
-        return SPDRunInfo.from_path(f"goodfire/spd/runs/{self._run_id}")
+        return SPDRunInfo.from_path(self._wandb_path)
 
     @cached_property
     def component_model(self):


### PR DESCRIPTION
## Description
`SPDAdapter` now accepts a full `wandb_path` instead of just a run ID, removing the hardcoded `goodfire/spd/runs/` prefix.

## Motivation and Context
The harvest pipeline was unusable for anyone with a different wandb entity because `SPDAdapter.__init__` only took a run ID and hardcoded `goodfire/spd/runs/{run_id}`. Now the full wandb path flows through from the harvest config.

## How Has This Been Tested?
- `make check` passes (basedpyright + ruff)
- Tested harvest submission on a non-goodfire wandb entity

## Does this PR introduce a breaking change?
No. `adapter_from_config` still works the same way (reads `wandb_path` from `SPDHarvestConfig`). `adapter_from_id` now always goes through `_load_method_config`, which reads the full config from the harvest DB. This requires harvest data to exist, but `adapter_from_id` is only called from downstream steps (autointerp, intruder eval, graph_interp) that already depend on harvest.