### PR TITLE
Always use AllLayers mask for PPGD warmup

### DIFF
--- a/spd/persistent_pgd.py
+++ b/spd/persistent_pgd.py
@@ -219,8 +219,11 @@ class PersistentPGDState:
         Each step computes the recon loss, extracts gradients, and updates sources in-place.
         When n_warmup_steps=0 (default), this is a no-op.
         """
+        all_layers = AllLayersRouter()
         for _ in range(self._n_warmup_steps):
-            loss = self.compute_recon_loss(model, batch, target_out, ci, weight_deltas)
+            loss = self.compute_recon_loss(
+                model, batch, target_out, ci, weight_deltas, router=all_layers
+            )
             grads = self.get_grads(loss, retain_graph=False)
             self.step(grads)
 
@@ -231,10 +234,11 @@ class PersistentPGDState:
         target_out: Float[Tensor, "... vocab"],
         ci: dict[str, Float[Tensor, "... C"]],
         weight_deltas: dict[str, Float[Tensor, "d_out d_in"]] | None,
+        router: Router | None = None,
     ) -> Float[Tensor, ""]:
         """Pure forward pass that returns the PPGD reconstruction loss. No source mutation."""
         batch_dims = next(iter(ci.values())).shape[:-1]
-        routing_masks = self._router.get_masks(
+        routing_masks = (router or self._router).get_masks(
             module_names=model.target_module_paths, mask_shape=batch_dims
         )
         ppgd_sources = self.get_effective_sources()


### PR DESCRIPTION
## Description
Forces PPGD warmup steps to use `AllLayersRouter` regardless of the configured router, ensuring warmup optimizes sources against all layers rather than a subset.

## Motivation and Context
During warmup, sources should be refined against all layers to get a good initialization. The configured router (e.g., `uniform_k_subset`) may mask out layers, making warmup less effective.

## How Has This Been Tested?
Tested in pre-holiday SPD training runs on `pile_llama_simple_mlp-4L`.

## Does this PR introduce a breaking change?
No — warmup behavior changes but the default `n_warmup_steps=0` means this is a no-op unless warmup is explicitly enabled.