### PR TITLE
Add n_samples to PPGD config

### DIFF
--- a/spd/configs.py
+++ b/spd/configs.py
@@ -568,6 +568,7 @@ class _PersistentPGDBaseConfig(LossMetricConfig):
         ),
     ] = 0
     start_frac: Probability = 0.0
+    n_samples: PositiveInt = 1
 
     @model_validator(mode="before")
     @classmethod

--- a/spd/persistent_pgd.py
+++ b/spd/persistent_pgd.py
@@ -138,6 +138,7 @@ class PersistentPGDState:
         self._use_sigmoid_parameterization = cfg.use_sigmoid_parameterization
         self._router = _get_router_for_ppgd_config(cfg, device)
         self._n_warmup_steps = cfg.n_warmup_steps
+        self._n_samples = cfg.n_samples
         self._output_loss_type: Literal["mse", "kl"] = output_loss_type
         self._lr_schedule = cfg.optimizer.lr_schedule
 
@@ -238,20 +239,28 @@ class PersistentPGDState:
     ) -> Float[Tensor, ""]:
         """Pure forward pass that returns the PPGD reconstruction loss. No source mutation."""
         batch_dims = next(iter(ci.values())).shape[:-1]
-        routing_masks = (router or self._router).get_masks(
-            module_names=model.target_module_paths, mask_shape=batch_dims
-        )
+        router = router or self._router
         ppgd_sources = self.get_effective_sources()
-        sum_loss, n_examples = _compute_ppgd_recon_loss(
-            model=model,
-            ppgd_sources=ppgd_sources,
-            output_loss_type=self._output_loss_type,
-            batch=batch,
-            target_out=target_out,
-            ci=ci,
-            weight_deltas=weight_deltas,
-            routing_masks=routing_masks,
-        )
+
+        device = next(iter(ci.values())).device
+        sum_loss = torch.tensor(0.0, device=device)
+        n_examples = 0
+        for _ in range(self._n_samples):
+            routing_masks = router.get_masks(
+                module_names=model.target_module_paths, mask_shape=batch_dims
+            )
+            loss, n = _compute_ppgd_recon_loss(
+                model=model,
+                ppgd_sources=ppgd_sources,
+                output_loss_type=self._output_loss_type,
+                batch=batch,
+                target_out=target_out,
+                ci=ci,
+                weight_deltas=weight_deltas,
+                routing_masks=routing_masks,
+            )
+            sum_loss = sum_loss + loss
+            n_examples += n
         return sum_loss / n_examples
 
 


### PR DESCRIPTION
## Description
Adds `n_samples: PositiveInt = 1` to PPGD config. When `n_samples > 1`, `compute_recon_loss` draws multiple routing mask samples per step and averages the loss, reducing variance from stochastic routing.

Also includes the AllLayers warmup change from #$(gh pr list --head feature/allayers-ppgd-warmup --json number -q '.[0].number') as a prerequisite.

## Motivation and Context
With `uniform_k_subset` routing, a single mask sample per step is noisy. Multiple samples give a better gradient signal for source optimization.

## How Has This Been Tested?
Tested in pre-holiday SPD training runs on `pile_llama_simple_mlp-4L`.

## Does this PR introduce a breaking change?
No — defaults to `n_samples=1` which preserves existing behavior.