### PR TITLE
Add calc_distances toggle to clustering pipeline

### DIFF
--- a/spd/clustering/scripts/run_pipeline.py
+++ b/spd/clustering/scripts/run_pipeline.py
@@ -70,6 +70,9 @@ class ClusteringPipelineConfig(BaseConfig):
         description="Weights & Biases project name (set to None to disable WandB logging)",
     )
     wandb_entity: str = Field(default="goodfire", description="WandB entity (team/user) name")
+    calc_distances: bool = Field(
+        default=True, description="Whether to run distance calculations after clustering"
+    )
     create_git_snapshot: bool = Field(
         default=False, description="Create a git snapshot for the run"
     )
@@ -194,43 +197,41 @@ def main(
         for idx, run_id in enumerate(clustering_run_ids)
     ]
 
-    calc_distances_commands = [
-        distances_command(pipeline_run_id, clustering_run_ids, method)
-        for method in pipeline_config.distances_methods
-    ]
+    calc_distances_commands: list[str] = []
+    if pipeline_config.calc_distances:
+        calc_distances_commands = [
+            distances_command(pipeline_run_id, clustering_run_ids, method)
+            for method in pipeline_config.distances_methods
+        ]
 
     # Submit to SLURM
     if local:
-        # submit clustering array job
         run_locally(
             commands=clustering_commands,
             parallel=local_clustering_parallel,
         )
 
-        # submit calc_distances jobs in parallel
-        logger.info("Calculating distances...")
-        run_locally(
-            commands=calc_distances_commands,
-            parallel=local_calc_distances_parallel,
-            track_resources=track_resources_calc_distances,
-        )
+        if pipeline_config.calc_distances:
+            logger.info("Calculating distances...")
+            run_locally(
+                commands=calc_distances_commands,
+                parallel=local_calc_distances_parallel,
+                track_resources=track_resources_calc_distances,
+            )
 
         logger.section("complete!")
 
-        # Build distances plot paths dict
-        distances_plots = {
-            f"distances via {method}": str(pipeline_dir / "plots" / f"distances_{method}.png")
-            for method in pipeline_config.distances_methods
+        log_info: dict[str, str | int] = {
+            "Total clustering runs": len(clustering_commands),
+            "Pipeline run ID": pipeline_run_id,
+            "Pipeline output dir": str(pipeline_dir),
         }
-
-        logger.values(
-            {
-                "Total clustering runs": len(clustering_commands),
-                "Pipeline run ID": pipeline_run_id,
-                "Pipeline output dir": str(pipeline_dir),
-                **distances_plots,
-            }
-        )
+        if pipeline_config.calc_distances:
+            for method in pipeline_config.distances_methods:
+                log_info[f"distances via {method}"] = str(
+                    pipeline_dir / "plots" / f"distances_{method}.png"
+                )
+        logger.values(log_info)
 
     else:
         assert pipeline_config.slurm_job_name_prefix is not None, (
@@ -262,43 +263,40 @@ def main(
         calc_distances_job_ids: list[str] = []
         calc_distances_logs: list[str] = []
 
-        for method, cmd in zip(
-            pipeline_config.distances_methods, calc_distances_commands, strict=True
-        ):
-            dist_config = SlurmConfig(
-                job_name=f"{pipeline_config.slurm_job_name_prefix}_dist_{method}",
-                partition=pipeline_config.slurm_partition,
-                n_gpus=1,
-                snapshot_branch=snapshot_branch,
-                dependency_job_id=array_job_id,
-            )
-            dist_script = generate_script(dist_config, cmd)
-            dist_result = submit_slurm_job(dist_script, f"calc_distances_{method}")
-            calc_distances_job_ids.append(dist_result.job_id)
-            calc_distances_logs.append(dist_result.log_pattern)
+        if pipeline_config.calc_distances:
+            for method, cmd in zip(
+                pipeline_config.distances_methods, calc_distances_commands, strict=True
+            ):
+                dist_config = SlurmConfig(
+                    job_name=f"{pipeline_config.slurm_job_name_prefix}_dist_{method}",
+                    partition=pipeline_config.slurm_partition,
+                    n_gpus=1,
+                    snapshot_branch=snapshot_branch,
+                    dependency_job_id=array_job_id,
+                )
+                dist_script = generate_script(dist_config, cmd)
+                dist_result = submit_slurm_job(dist_script, f"calc_distances_{method}")
+                calc_distances_job_ids.append(dist_result.job_id)
+                calc_distances_logs.append(dist_result.log_pattern)
 
         logger.section("Jobs submitted successfully!")
 
-        # Build distances plot paths dict
-        distances_plots = {
-            method: str(pipeline_dir / "plots" / f"distances_{method}.png")
-            for method in pipeline_config.distances_methods
+        log_values: dict[str, str | int] = {
+            "Clustering Array Job ID": array_job_id,
+            "Total clustering runs": len(clustering_commands),
+            "Pipeline run ID": pipeline_run_id,
+            "Pipeline output dir": str(pipeline_dir),
+            "Clustering logs": clustering_result.log_pattern,
         }
+        if calc_distances_job_ids:
+            log_values["Calc Distances Job IDs"] = ", ".join(calc_distances_job_ids)
+            log_values["Calc Distances logs"] = ", ".join(calc_distances_logs)
+        logger.values(log_values)
 
-        logger.values(
-            {
-                "Clustering Array Job ID": array_job_id,
-                "Calc Distances Job IDs": ", ".join(calc_distances_job_ids),
-                "Total clustering runs": len(clustering_commands),
-                "Pipeline run ID": pipeline_run_id,
-                "Pipeline output dir": str(pipeline_dir),
-                "Clustering logs": clustering_result.log_pattern,
-                "Calc Distances logs": ", ".join(calc_distances_logs),
-            }
-        )
-        logger.info("Distances plots will be saved to:")
-        for method, path in distances_plots.items():
-            logger.info(f"  {method}: {path}")
+        if pipeline_config.calc_distances:
+            logger.info("Distances plots will be saved to:")
+            for method in pipeline_config.distances_methods:
+                logger.info(f"  {method}: {pipeline_dir / 'plots' / f'distances_{method}.png'}")
 
 
 def cli():
@@ -339,6 +337,12 @@ def cli():
         help="Comma-separated list of distance methods (e.g., 'perm_invariant_hamming,matching_dist')",
     )
     parser.add_argument(
+        "--calc-distances",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help="Whether to run distance calculations after clustering (overrides config value)",
+    )
+    parser.add_argument(
         "--local",
         action=argparse.BooleanOptionalAction,
         default=False,
@@ -367,6 +371,8 @@ def cli():
 
     if args.n_runs is not None:
         overrides["n_runs"] = args.n_runs
+    if args.calc_distances is not None:
+        overrides["calc_distances"] = args.calc_distances
     if args.wandb_project is not _NO_ARG_PARSSED_SENTINEL:
         overrides["wandb_project"] = args.wandb_project
     if args.wandb_entity is not None:


### PR DESCRIPTION
## Description
Adds a `calc_distances: bool` field to `ClusteringPipelineConfig` and a `--calc-distances` / `--no-calc-distances` CLI flag. When disabled, distance calculation jobs are skipped entirely (both locally and on SLURM).

Also refactors logging in both local and SLURM paths to conditionally include distance-related info.

## Motivation and Context
When running a single clustering run (`n_runs=1`), distance calculations are meaningless. This toggle avoids wasting compute.

## How Has This Been Tested?
Tested locally with `--local --no-calc-distances`.

## Does this PR introduce a breaking change?
No — `calc_distances` defaults to `True`, preserving existing behavior.