### PR TITLE
Fix ss_llama_simple_mlp-2L decomp config

### DIFF
--- a/param_decomp/experiments/lm/ss_llama_simple_mlp-2L.yaml
+++ b/param_decomp/experiments/lm/ss_llama_simple_mlp-2L.yaml
@@ -109,10 +109,10 @@ eval_metric_configs:
   mask_scope: shared_across_batch
   classname: PGDReconLoss
 ci_alive_threshold: 0.0
-pretrained_model_class: simple_stories_train.models.llama_simple_mlp.LlamaSimpleMLP
+pretrained_model_class: param_decomp.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
 pretrained_model_path: null
 pretrained_model_name: wandb:goodfire/spd/runs/gf6rbga0
-pretrained_model_output_attr: idx_0
+output_extract: 0
 tokenizer_name: SimpleStories/test-SimpleStories-gpt2-1.25M
 task_config:
   task_name: lm


### PR DESCRIPTION
## Description
Update `param_decomp/experiments/lm/ss_llama_simple_mlp-2L.yaml`:
- Add `output_extract: 0`
- Remove the legacy `pretrained_model_output_attr: idx_0`
- Update `pretrained_model_class` from `simple_stories_train.models.llama_simple_mlp.LlamaSimpleMLP` to `param_decomp.pretrain.models.llama_simple_mlp.LlamaSimpleMLP`

## Motivation and Context
`LlamaSimpleMLP.forward` returns `(logits, loss)`. Without `output_extract`, `make_run_batch` falls back to passthrough and `run_batch_passthrough` calls `runtime_cast(Tensor, model(batch))` on the tuple, raising `TypeError: Expected <class 'torch.Tensor'>, got <class 'tuple'>` right after the faithfulness warmup. The previously-loaded `pretrained_model_output_attr: idx_0` got auto-migrated to `output_extract: 0` by the config loader, but that key is no longer in the schema; the YAML in `main` still has the stale field name and the now-removed `simple_stories_train` class path.

## How Has This Been Tested?
Ran `python param_decomp/experiments/lm/lm_decomposition.py` on a copy of the config with `faithfulness_warmup_steps=2`, `steps=3`, `batch_size=4`. Exit 0 — passes the previously failing point in `optimize` (first `model(next(train_iterator))` after warmup) and completes warmup, three optimization steps, and an eval pass with no errors.

## Does this PR introduce a breaking change?
No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)