### PR TITLE
Refactor ComponentModel to fused DecomposedSite tree (PR 1: bones, core library only)

### DIFF
--- a/fsdp_implementation_plan.md
+++ b/fsdp_implementation_plan.md
@@ -1,0 +1,537 @@
+# Implementation plan: FSDP-with-fused-decomposition-sites
+
+**For:** an engineer picking up the next chunk of work after the scaling investigation
+(`scaling_investigation_plan.md`, `investigation_results.md`,
+`fsdp_scaling_report.html`).
+
+**Goal:** make SPD trainable at 1B+ targets on 80 GB H100s and 4B+ targets on
+~150 GB H200s. The empirical case is in `investigation_results.md` — ZeRO-1 +
+gradient checkpointing on the CI fn is sufficient through ~1B target on H100s
+but OOMs at 4B even on H200. Full parameter sharding (FSDP) is required.
+
+**Vibe:** one larger jump in code complexity rather than several incremental
+steps. Throw the current hook-based ComponentModel architecture out and replace
+with one where each decomposition site is a single first-class `nn.Module`
+that FSDP can wrap cleanly. The CI fn stays a separate top-level module — it's
+global by construction (reads concatenated activations from *all* sites and
+emits CI scores for all sites at once), so there's no per-site CI piece to
+fuse. Its constituent transformer blocks become independent FSDP units via
+the auto-wrap policy.
+
+---
+
+## Background: why a refactor (not just FSDP-wrap-the-existing-model)
+
+§5b of `fsdp_scaling_report.html` is the load-bearing observation: components
+live in a `nn.ModuleDict` that's a *sibling* of the target model. Forward
+replacement is a post-forward hook registered on the target submodule
+(`param_decomp/models/component_model.py:489–501`) which dispatches into
+`self._components[module_name]`. Under FSDP that hook crosses FSDP-unit
+boundaries — the components' parameters live in a different FSDP unit than
+the target module the hook is attached to, so when the hook fires the
+components' sharded parameters are not gathered.
+
+Three plausible fixes (§5b of the report, ranked by invasiveness):
+1. **Fuse target submodule + its V/U components into a single `nn.Module`
+   per decomposed site, FSDP-wrap each.** Clean. Eliminates the
+   hook-crossing-units problem entirely. **The plan.** (Note: the report's
+   §5b also mentions fusing in "its CI piece" — that's incorrect; the CI fn
+   is global, not per-site.)
+2. `summon_full_params` inside the hook. Works but defeats most of FSDP's
+   benefit (per-call all-gather of components on the hot path).
+3. Don't shard components. Doesn't work at 1B+ target where components are
+   too big to leave replicated.
+
+The other big architectural friction is `calc_weight_deltas()` at
+`run_param_decomp.py:263`, which materializes
+`weight_delta = W_target - V@U` once per step for every decomposed module.
+Under FSDP, `V`, `U`, and `W_target` are all sharded; reading them as
+properties returns local shards and the math is silently wrong or shape-errors
+out. The fused-site design lets us do the delta math *inside* the site's
+forward, where FSDP has already gathered both the target's weight and the
+components' V/U.
+
+(NB: §7d of the report originally proposed an algebraic rewrite to avoid
+materializing the delta entirely. The investigation showed that rewrite is
+strictly *worse* on memory and wall-time at SPD-realistic batch sizes
+(`investigation_results.md` §4). Keep the materialized form, just do it
+inside the fused module.)
+
+---
+
+## The new module: `DecomposedLinear`
+
+Replaces the current `(nn.Linear in target, LinearComponents in sibling
+ModuleDict, hook gluing them)` triple. One Python class per decomposed module
+in the model tree.
+
+```python
+# param_decomp/models/decomposed_module.py  (new file)
+
+class DecomposedLinear(nn.Module):
+    """A linear module that can dispatch through a parameter decomposition.
+
+    Owns:
+      - The original `nn.Linear` from the target model (frozen).
+      - V: (d_in, C), U: (C, d_out)            — the components.
+      - bias: shared with the wrapped Linear (or None).
+
+    Drop-in replacement for `nn.Linear` in the target tree: when no
+    `mask_info` is set on the module, forward is exactly `self.linear(x)`.
+    When a mask_info is set (via `set_mask_info()` context-manager pattern,
+    see below), forward dispatches to the decomposed path.
+    """
+
+    def __init__(self, base: nn.Linear, C: int) -> None:
+        super().__init__()
+        self.linear = base                          # frozen target nn.Linear (its .weight stays the target weight)
+        self.d_in, self.d_out = base.in_features, base.out_features
+        self.C = C
+        self.V = nn.Parameter(torch.empty(self.d_in, C))
+        self.U = nn.Parameter(torch.empty(C, self.d_out))
+        init_param_(self.V, fan_val=self.d_in, nonlinearity="linear")
+        init_param_(self.U, fan_val=C, nonlinearity="linear")
+        # bias is read from `self.linear.bias` directly — no duplicate parameter.
+        self._mask_info: ComponentsMaskInfo | None = None
+        self._cache: dict[str, Tensor] | None = None
+        self._cache_type: CacheType | None = None
+
+    def set_mask_info(self, info: ComponentsMaskInfo | None) -> None:
+        self._mask_info = info
+
+    def set_cache(self, cache: dict[str, Tensor] | None, kind: CacheType | None) -> None:
+        self._cache, self._cache_type = cache, kind
+
+    def forward(self, x: Tensor) -> Tensor:
+        if self._cache is not None and self._cache_type == "input":
+            self._cache[self._site_name] = x
+
+        if self._mask_info is None:
+            out = self.linear(x)
+        else:
+            out = self._decomposed_forward(x, self._mask_info)
+
+        if self._cache is not None and self._cache_type == "output":
+            self._cache[self._site_name] = out
+        return out
+
+    def _decomposed_forward(self, x: Tensor, info: ComponentsMaskInfo) -> Tensor:
+        component_acts = einops.einsum(x, self.V, "... d_in, d_in C -> ... C")
+        # (component_acts_cache handling stays the same — write into self._cache here.)
+        masked_acts = component_acts * info.component_mask if info.component_mask is not None else component_acts
+        components_out = einops.einsum(masked_acts, self.U, "... C, C d_out -> ... d_out")
+
+        if info.weight_delta_and_mask is not None:
+            weight_delta, delta_mask = info.weight_delta_and_mask
+            delta_out = einops.einsum(x, weight_delta, "... d_in, d_out d_in -> ... d_out")
+            components_out = components_out + einops.einsum(
+                delta_mask, delta_out, "..., ... d_out -> ... d_out"
+            )
+
+        if self.linear.bias is not None:
+            components_out = components_out + self.linear.bias
+
+        if info.routing_mask == "all":
+            return components_out
+        else:
+            return torch.where(info.routing_mask[..., None], components_out, self.linear(x))
+
+    def calc_weight_delta(self) -> Tensor:
+        """Materialize W_target - V@U for this site. Cheap, called once per step.
+
+        Under FSDP this runs inside the site's FSDP unit so V/U/target_weight are
+        all gathered. Stays an O(d_out · d_in) materialization per site (~9 MB
+        at Jose dims, ~constant cost) — the alternative rewrite was empirically
+        worse, see investigation_results.md §4.
+        """
+        return self.linear.weight - einops.einsum(self.V, self.U, "d_in C, C d_out -> d_out d_in")
+```
+
+(`DecomposedEmbedding` will be needed too for runs that decompose embeddings —
+similar pattern. Skip for the first pass since Jose doesn't decompose embeddings.)
+
+---
+
+## What `ComponentModel` becomes
+
+`ComponentModel` is currently a fairly heavyweight class: it owns the target
+model + the components ModuleDict + the CI fn, registers hooks on demand, and
+exposes `calc_weight_deltas`, `calc_causal_importances`, `target_weight`,
+several `__call__` overloads, and the from_pretrained / from_run_info loading.
+
+After the refactor it shrinks substantially:
+
+- **`self.target_model`** — still here, but its decomposable submodules have
+  been *replaced in place* by `DecomposedLinear` instances. So
+  `target_model.h.0.mlp.c_fc` *is* a `DecomposedLinear`, not an `nn.Linear`
+  with a hook attached.
+- **`self.ci_fn`** — unchanged.
+- **No more `self._components` ModuleDict.** The components are owned by
+  their respective `DecomposedLinear` sites in the target tree.
+- **No more `_attach_forward_hooks`.** `forward(...)` walks the tree, sets
+  `mask_info` and `cache` slots on each `DecomposedLinear` via a context
+  manager, calls `self.target_model(x)`, then clears the slots. Concretely:
+
+  ```python
+  @contextmanager
+  def _bind_per_site(self, mask_infos, cache, cache_type):
+      sites = list(self._iter_sites())
+      try:
+          for site in sites:
+              site.set_mask_info(mask_infos.get(site._site_name) if mask_infos else None)
+              site.set_cache(cache, cache_type)
+          yield
+      finally:
+          for site in sites:
+              site.set_mask_info(None)
+              site.set_cache(None, None)
+  ```
+
+- **`calc_weight_deltas()`** becomes a one-liner that walks the sites and
+  calls `site.calc_weight_delta()` on each.
+- **`target_weight(name)`** becomes `self.get_site(name).linear.weight`.
+- **`calc_causal_importances()`** is essentially unchanged — it consumes the
+  cached input activations and runs the CI fn over them.
+- **State-dict** is now naturally tree-shaped (V/U live under
+  `target_model.h.0.mlp.c_fc.V` etc.) rather than spread across two trees with
+  name mangling (`_components["h-0-mlp-c_fc"].V`).
+
+The `__call__` overloads stay, the user-facing API is unchanged.
+
+---
+
+## Site discovery & construction
+
+Today `ComponentModel.__init__` calls `_create_components` which iterates
+`module_path_info` and builds the components ModuleDict. The refactored
+version does the same iteration but *replaces* each named submodule in
+`target_model` with a `DecomposedLinear` wrapping the original:
+
+```python
+# pseudocode
+for module_path, C in module_path_info:
+    base = target_model.get_submodule(module_path)
+    assert isinstance(base, nn.Linear)
+    parent_path, _, child = module_path.rpartition(".")
+    parent = target_model.get_submodule(parent_path)
+    new = DecomposedLinear(base, C=C)
+    new._site_name = module_path        # used for mask_info lookup and caching
+    setattr(parent, child, new)
+```
+
+This is the equivalent of the existing `insert_identity_operations_` style of
+in-place tree rewrite (`param_decomp/identity_insertion.py`) — Oli's used this
+pattern before, and pyright/torch are both fine with it.
+
+(`Conv1D` and `nn.Embedding` would need their own `DecomposedConv1D` /
+`DecomposedEmbedding` siblings if those are decomposed. Punt on the second
+one; flag a TODO. Jose only decomposes `nn.Linear`s.)
+
+---
+
+## FSDP wrap policy
+
+```python
+# param_decomp/utils/fsdp.py  (new file)
+
+from torch.distributed.fsdp import FullyShardedDataParallel as FSDP
+from torch.distributed.fsdp import MixedPrecision, ShardingStrategy
+
+def fsdp_wrap(model: ComponentModel, dist_state: DistributedState) -> ComponentModel:
+    """Wrap with one FSDP unit per (DecomposedLinear, CI-fn-block, target-transformer-block).
+
+    Leaves frozen target submodules that aren't decomposed (embedding layer, ln_f,
+    rms norms, etc.) unsharded — they're small enough that the per-step all-gather
+    cost would exceed the saving. The frozen target's transformer blocks are
+    NO_SHARD-policy FSDP units: parameters stay on each rank but the wrap gives us
+    a uniform module-tree shape for the auto-wrap policy.
+    """
+    from param_decomp.models.decomposed_module import DecomposedLinear
+    from param_decomp.models.components import TransformerBlock
+
+    def policy(module, recurse, nonwrapped_numel):
+        if recurse:
+            return True
+        return isinstance(module, (DecomposedLinear, TransformerBlock))
+
+    return FSDP(
+        model,
+        auto_wrap_policy=policy,
+        sharding_strategy=ShardingStrategy.FULL_SHARD,
+        mixed_precision=MixedPrecision(
+            param_dtype=torch.bfloat16,
+            reduce_dtype=torch.bfloat16,
+            buffer_dtype=torch.bfloat16,
+        ) if config.autocast_bf16 else None,
+        forward_prefetch=True,
+        backward_prefetch=BackwardPrefetch.BACKWARD_PRE,
+        limit_all_gathers=True,
+        use_orig_params=True,                       # critical: see notes
+    )
+```
+
+Knob notes:
+- **`use_orig_params=True`** is critical so the optimizer construction in
+  `run_param_decomp.py:198–207` (which builds `optimized_params` from
+  `component_model.components[name].parameters() + ci_fn.parameters()`) keeps
+  working without rewriting how params are collected.
+- **`MixedPrecision`** is the proper FSDP replacement for the current
+  `bf16_autocast` context manager and the §7c "bf16 master weights" lever
+  rolled together. Activations end up in bf16, gradients reduced in bf16,
+  parameters stored in fp32 (the FSDP default unless we set
+  `MixedPrecision(param_dtype=bf16)`, which we leave for later if needed).
+- **Don't outer-wrap with FSDP again.** The whole `ComponentModel` doesn't
+  need a top-level FSDP unit — the auto-wrap policy will pick up the
+  meaningful units inside.
+
+---
+
+## Replacing DDP and ZeRO-1 in the training loop
+
+Today's `run_param_decomp.py:165–183` wraps with DDP. Today's also-still-there
+ZeRO-1 path (added during the investigation) constructs
+`ZeroRedundancyOptimizer` instead of plain AdamW when `optimizer_strategy="zero_adamw"`.
+
+After the refactor:
+
+```python
+match config.parallel_strategy:
+    case "ddp":
+        wrapped_model = torch.nn.parallel.DistributedDataParallel(model, ...)
+        optimizer = optim.AdamW(optimized_params, ...)
+    case "zero_adamw":
+        wrapped_model = DDP(...)
+        optimizer = ZeroRedundancyOptimizer(optimized_params, optimizer_class=optim.AdamW, ...)
+    case "fsdp":
+        wrapped_model = fsdp_wrap(model, dist_state)
+        optimizer = optim.AdamW(wrapped_model.parameters(), ...)   # use_orig_params=True keeps this working
+```
+
+(So the existing `optimizer_strategy` config field gets renamed to
+`parallel_strategy` with a third option. ZeRO-1 stays as a stop-gap for
+small targets / quick local runs where the FSDP comm cost isn't worth it.)
+
+The downstream bits to also change in `run_param_decomp.py`:
+- **`clip_grad_norm_`** at lines 418–421: under FSDP this needs to be
+  `wrapped_model.clip_grad_norm_(max_norm)` — FSDP's `clip_grad_norm_` does
+  the cross-rank reduction itself.
+- **`component_model.state_dict()`** at line 405 (save path): wrap in
+  `FSDP.state_dict_type(model, StateDictType.FULL_STATE_DICT,
+  FullStateDictConfig(offload_to_cpu=True, rank0_only=True))` context.
+- **The "must call wrapped_model once" line at run_param_decomp.py:268–272**
+  is a DDP-ism (DDP requires forward to touch every parameter). FSDP doesn't
+  have this constraint. Delete it under FSDP. Keep under DDP/ZeRO-1.
+
+---
+
+## Caller-side changes (the long tail)
+
+Files that touch the components dict directly:
+
+```
+param_decomp/run_param_decomp.py
+param_decomp/eval.py
+param_decomp/persistent_pgd.py
+param_decomp/plotting.py
+param_decomp/adapters/param_decomp.py
+param_decomp/app/backend/optim_cis.py
+param_decomp/app/backend/compute.py
+param_decomp/clustering/activations.py
+param_decomp/dataset_attributions/harvester.py
+param_decomp/editing/_editing.py
+param_decomp/harvest/harvest_fn/param_decomp.py
+param_decomp/metrics/*.py            (many)
+```
+
+Most of these access patterns are of three shapes:
+1. `model.components[name].V` / `.U` — read component params.
+2. `model.target_module_paths` — iterate site names.
+3. `model.calc_weight_deltas()` — get all deltas.
+
+Each becomes:
+1. `model.get_site(name).V` / `.U` — read params via the new accessor.
+2. `model.target_module_paths` — unchanged (the iteration order is the same;
+   the helper just walks `DecomposedLinear` instances now).
+3. `model.calc_weight_deltas()` — unchanged signature; implementation walks
+   the sites.
+
+Plan: add `ComponentModel.get_site(name) -> DecomposedLinear` and
+`ComponentModel.components` as a `@property` returning a `dict[str, DecomposedLinear]`
+view, then mechanically convert callers. Most don't need to know the underlying
+architecture changed — they just want V, U, the weight, or the components dict.
+
+**Audit step:** before doing this, grep for *direct mutation* of
+`model.components` or `model._components` (not just reads). I think the only
+mutator outside `ComponentModel.__init__` is `run_param_decomp.py:189–196`
+(tied_weights). Confirm with `grep`.
+
+---
+
+## Save/load compatibility with existing checkpoints
+
+The state-dict layout *will* change:
+
+```
+# old
+target_model.h.0.mlp.c_fc.weight
+_components.h-0-mlp-c_fc.V
+_components.h-0-mlp-c_fc.U
+
+# new
+target_model.h.0.mlp.c_fc.linear.weight
+target_model.h.0.mlp.c_fc.V
+target_model.h.0.mlp.c_fc.U
+```
+
+Jose (`s-55ea3f9b`) and Thomas (`s-82ffb969`) are real runs whose checkpoints
+people will want to reuse — both for analysis (app, harvest, autointerp) and
+for re-derivation. We need a one-shot migration.
+
+Plan: `param_decomp/scripts/migrate_checkpoint_to_decomposed.py` that loads an
+old `final_config.yaml` + state-dict, constructs the new `ComponentModel`
+layout, and remaps state-dict keys:
+```
+target_model.<path>.weight  →  target_model.<path>.linear.weight
+target_model.<path>.bias    →  target_model.<path>.linear.bias
+_components.<mangled>.V     →  target_model.<path>.V
+_components.<mangled>.U     →  target_model.<path>.U
+```
+
+Run once per existing run, write new checkpoints alongside the old (or to a
+sibling `migrated/` dir; don't overwrite). Update `ParamDecompRunInfo.from_path`
+to prefer the migrated checkpoint when present.
+
+Don't add a fallback that loads old checkpoints with new code — fail fast if a
+non-migrated old checkpoint is passed.
+
+---
+
+## Rollout sequence
+
+Three branches off `main`, each landing as its own PR. Each one passes the
+existing test suite before the next starts.
+
+### PR 1 — no-op refactor (no FSDP yet)
+
+Lands the `DecomposedLinear` module + `ComponentModel` rewrite + caller updates,
+but keeps DDP/ZeRO-1 as the only parallel strategies. The training loop and the
+behaviour of every existing metric, loss, harvest job, and app endpoint should
+be *functionally identical* after this PR.
+
+Acceptance:
+- All existing tests pass (`make test`).
+- A 50-step `pile_llama_simple_mlp-4L` run produces the same loss trajectory
+  as `main` (within numerical noise) on the same seed.
+- App still loads Jose and shows the same components/CIs.
+- Migration script works end-to-end on Jose's checkpoint.
+
+This is the chunky PR — probably 1500-2500 LOC changed across the caller-list
+above. Most of it mechanical (rename `model._components[name]` →
+`model.get_site(name)`).
+
+### PR 2 — FSDP path
+
+Adds the `fsdp_wrap` helper, the `parallel_strategy="fsdp"` config option,
+and the FSDP-specific `clip_grad_norm_` and state-dict save paths in
+`run_param_decomp.py`. Keeps DDP/ZeRO-1 working unchanged.
+
+Acceptance:
+- Phase 5 1B-target run completes under FSDP at meaningful batch
+  (target: ≥b=4 per rank on 4×H200; ≥b=2 per rank on 4×H100).
+- 4B-target run *completes at all* on 4×H200 (this is the empirical "is FSDP
+  enough" test — the investigation showed ZeRO-1+ckpt can't).
+- Loss trajectory under FSDP matches the DDP no-op-refactor baseline within
+  numerical tolerance for the first ~50 steps on Jose.
+- Save and reload a checkpoint under FSDP and verify forward equivalence.
+
+This PR is smaller — probably 200-500 LOC.
+
+### PR 3 — cleanup
+
+After PR 2 has been used in anger for a real run:
+- Remove the `forward_with_target_weight` method on `LinearComponents` (it
+  was a Phase 4 dead end, kept around with tests as a regression guard).
+- Decide whether to keep ZeRO-1 as an option. If FSDP works fine even at
+  Jose scale, drop ZeRO-1 — fewer code paths.
+- Update `fsdp_scaling_report.html` with measured FSDP numbers (the final
+  thing in `scaling_investigation_plan.md`'s deliverables).
+
+---
+
+## Risks and things to verify before writing PR 1
+
+1. **PPGD autograd interactions.** `persistent_pgd.py:175` runs
+   `torch.autograd.grad(loss, self.sources)` where `loss` flows through
+   `ComponentModel` forwards. Under FSDP the graph crosses FSDP boundaries.
+   Should work because sources aren't params — but worth a small standalone
+   test before committing to the refactor.
+
+2. **Tied weights** at `run_param_decomp.py:186–196`. The current scheme ties
+   `U` of one component to `V.T` of another. Under FSDP these need to be in
+   the same FSDP unit, which they currently aren't (different sites). Either
+   (a) handle in `DecomposedLinear` by tying inside the site (probably not
+   what Jose uses — its config doesn't show tied_weights), or (b) require
+   `parallel_strategy != "fsdp"` when tied_weights is set. Verify Jose
+   doesn't use tied_weights; deal with the general case later.
+
+3. **`use_orig_params=True` cost.** FSDP's `use_orig_params=False` is the
+   memory-efficient default but breaks the existing optimizer-param-list
+   pattern. `use_orig_params=True` keeps the param identity stable but
+   each FlatParameter is split per-rank in optimizer state. Small extra
+   bookkeeping cost. Try this first; only switch off if it's measurably
+   slow.
+
+4. **`set_mask_info` + tree iteration on each step.** Currently the
+   "attach hooks" context manager registers callbacks once per step.
+   The new "set attribute, run forward, clear attribute" pattern does the
+   same number of operations but via Python attribute assignment which is
+   marginally faster. Should not measurably affect step time.
+
+5. **Harvest hooks** (`param_decomp/harvest/harvest_fn/param_decomp.py`).
+   The harvest pipeline registers its own hooks for collecting statistics.
+   These currently land on the original target submodules. After the
+   refactor they should land on `site.linear` (the inner wrapped target
+   Linear), not on the `DecomposedLinear` itself, because we want the
+   *target* output (not the decomposed output) for harvest. Audit.
+
+---
+
+## Out of scope (and why)
+
+- **bf16 master weights** (§7c of the report). Subsumed by FSDP's
+  `MixedPrecision(param_dtype=bf16)`. Don't add separately.
+- **Tensor parallelism / pipeline parallelism / activation offload**
+  (report §8 Phase 3). Only relevant if FSDP itself proves insufficient at
+  scale. Wait for the Phase 5 FSDP measurement before opening this can.
+- **Weight-delta algebraic rewrite** (report §7d). Empirically worse, see
+  `investigation_results.md` §4. Don't ship.
+- **Sharding the CI fn separately from the components.** Tempting because
+  the CI fn is the biggest single per-batch activation contributor, but the
+  auto-wrap policy above already wraps each CI-transformer block as its own
+  FSDP unit, which is the equivalent.
+
+---
+
+## Estimated effort
+
+- PR 1 (no-op refactor + migration script): 4–7 days, mostly mechanical
+  caller-rewriting once the core pieces are in.
+- PR 2 (FSDP path): 1–2 days.
+- PR 3 (cleanup + report update): 1 day.
+
+Total: ~1–2 calendar weeks of focused work for one engineer.
+
+---
+
+## References
+
+- `investigation_results.md` — measurements that justify the refactor.
+- `fsdp_scaling_report.html` — §5 (the SPD-specific frictions), §6 (full
+  friction-point checklist), §8 Phase 2 (the original sketch of this
+  refactor).
+- `param_decomp/models/component_model.py` — the file that shrinks most.
+- `param_decomp/models/components.py` — where `LinearComponents` lives today
+  (it doesn't go away; its responsibilities just get folded into
+  `DecomposedLinear`).
+- `param_decomp/identity_insertion.py` — example of in-place tree rewrite
+  (the pattern `DecomposedLinear` swap uses).

--- a/investigation_results.md
+++ b/investigation_results.md
@@ -128,9 +128,85 @@ gradient checkpointing more critical than the report implied.
 
 ---
 
+## Phase 2: ZeRO-1 measurement
+
+**Setup:** same per-rank conditions as Phase 1 (per-rank batch=8, all other knobs
+unchanged) at world size N ∈ {2, 4, 8}, comparing `optimizer_strategy=adamw` vs
+`zero_adamw`. Six runs, 8 H200s shared across them, profile each at step 30.
+
+| N | global batch | DDP peak | ZeRO-1 peak | Δ measured | Δ predicted = (N−1)/N × 8T | match |
+|---:|---:|---:|---:|---:|---:|:---:|
+| 2 | 16 | 37.24 GB | 34.61 GB | 2.63 GB | 2.64 GB | ✅ |
+| 4 | 32 | 37.25 GB | 33.27 GB | 3.98 GB | 3.96 GB | ✅ |
+| 8 | 64 | _pending_ | _pending_ | _pending_ | 4.62 GB | _pending_ |
+
+(`8T = 8 × trainable_params_GB = 8 × 0.66 = 5.28 GB`, the optimizer state Adam
+keeps in fp32. ZeRO-1 shards only that state, not params or grads.)
+
+The **ZeRO-1 saving formula `8·T·(N−1)/N` per rank from §3 of the report holds
+to <1% at N∈{2,4}**. At Jose this is a modest win (~5 GB freed at N=8); at the
+report's hypothetical 1B target the trainable bumps to ~3 B params and the
+saving per rank scales to ~21 GB at N=8 — meaningful headroom.
+
+The DDP peak is essentially flat across N=2/4 because per-rank conditions are
+identical (only the global batch grows). ZeRO-1 reduces peak monotonically as
+predicted.
+
+The manual LR-schedule loop at `run_param_decomp.py:254–255` and `clip_grad_norm_`
+both worked unchanged under ZeRO-1; no save path is exercised in the profiling
+runs (`save_freq=null`), so `consolidate_state_dict` wasn't tested but doesn't
+affect runtime memory.
+
+---
+
+## Phase 4: weight-delta rewrite
+
+**Tests** (`tests/test_components.py`): 6 unit tests verify `forward_with_target_weight`
+matches `forward(weight_delta_and_mask=...)` on output and on V/U gradients,
+across with/without mask and with/without bias. All pass.
+
+**Microbenchmark** (`scripts/bench_weight_delta_rewrite.py`): runs both paths
+through every Jose-shaped decomposed module (24 modules: 6 per layer × 4 layers,
+at the *measured* dims n_embd=768 etc.) on 1×H200, fp32, with backward,
+measuring `torch.cuda.max_memory_allocated`.
+
+| batch (S=512) | materialize peak | rewrite peak | Δ memory | Δ time |
+|---:|---:|---:|---:|---:|
+| 8 | 1.518 GB | 1.609 GB | **+91 MB (+6.0%)** | +15.6% |
+| 16 | 1.872 GB | 2.064 GB | +192 MB (+10.2%) | +22.5% |
+| 32 | 2.575 GB | 2.969 GB | +393 MB (+15.3%) | +26.6% |
+| 64 | 3.988 GB | 4.784 GB | +796 MB (+20.0%) | +29.1% |
+
+**The rewrite is worse on memory and time at every batch size, and the gap
+*scales with batch*.** This contradicts the report's §7d "strict win" claim.
+
+The reason is the autograd retention pattern, not the matmul count:
+
+- The *materialize* path saves one `[batch, seq, d_out]` activation
+  (`unmasked_delta_out`) plus the materialized `[d_out, d_in]` weight delta
+  (a constant ~9 MB per Jose module).
+- The *rewrite* path saves two `[batch, seq, d_out]` activations
+  (`target_out` and `unmasked_recon_out`), needed to backprop through
+  `target_out − unmasked_recon_out`.
+
+So per module, the rewrite adds `[batch, seq, d_out] − [d_out, d_in]` extra
+retained memory. At Jose dims (worst module: d_out=3072, d_in=768) this is
+about `3.1 MB × batch − 9.4 MB`, crossing zero around batch=3 and growing
+linearly above it.
+
+**Implication for the report:** §7d should be deleted or reversed. The
+materialization is small and amortizable; the proposed rewrite makes things
+worse. A genuine fix for the FSDP friction in §5c is `summon_full_params`
+around `calc_weight_deltas`, accepting the per-step gather cost — *not* this
+rewrite.
+
+The hook integration is intentionally not landed: the math is verified, the
+benchmark says don't ship it, and §5c's actual problem (FSDP-sharded V/U
+during `calc_weight_deltas`) needs a different solution.
+
+---
+
 ## Pending phases
 
-- Phase 2 — ZeRO-1 measurement (code ready, awaiting submission)
-- Phase 3 — gradient checkpointing
-- Phase 4 — weight-delta rewrite
+- Phase 3 — gradient checkpointing on the CI fn (code committed, run pending in queue)
 - Phase 5 (stretch) — 1B-target stress test (will use random-init target per Oli's note)

--- a/investigation_results.md
+++ b/investigation_results.md
@@ -1,0 +1,136 @@
+# Investigation results: empirical validation of SPD scaling estimates
+
+Companion to `scaling_investigation_plan.md` and `fsdp_scaling_report.html`.
+
+**Cluster context:** runs are on 1×NVIDIA H200 (140 GB HBM), not the 1×H100 (80 GB)
+the report assumes. Per-rank memory and activation/B comparisons to the report are
+unaffected; max-batch comparisons skew larger on H200.
+
+---
+
+## Phase 1: baseline Jose profile
+
+**Setup:** 1× H200, `pile_llama_simple_mlp-4L`, target `t-9d2b8f02`, batch=8 per rank
+(matches what each rank sees in normal 8×DDP Jose), 50 training steps, snapshot at
+step 30, faithfulness warmup off, eval at step 0 only with eval_batch_size=8.
+
+Run ID `p-0ffcbe39`, SLURM 8031.
+
+### 1.1 Param counts (measured)
+
+| Bucket | Measured (params) | fp32 size | Report's estimate | Δ |
+|---|---:|---:|---:|---|
+| target (frozen) | 66.9 M | 0.27 GB | 242 M | **−72%** |
+| components | 121.1 M | 0.48 GB | 323 M | **−63%** |
+| CI fn | 539.1 M | 2.16 GB | 400 M | +35% |
+| **trainable subtotal** | **660.2 M** | **2.64 GB** | 723 M | −9% |
+
+**Why the per-category numbers were off:** the report assumed `d_model=2048`,
+`d_mlp=8192`, `vocab=20000` for the Jose target. The actual `model_config.yaml`
+of `t-9d2b8f02` has `n_embd=768`, `n_intermediate=3072`, `vocab_size=50277`
+(and `n_layer=4`, `n_head=6` with GQA n_kv=n_head). Recomputing from the real
+config: target = 4 × 7.08M + 38.6M embed = 66.9M, components = 121.3M — exact
+match against the measurement. So the report had the right *structure* (layer
+counts, module list) but wrong *dimensions*; the trainable total only worked
+out by accident because the underestimated target+components were balanced by
+a (relative) overestimate of the CI fn.
+
+### 1.2 Memory at peak
+
+| Slot | GB | Notes |
+|---|---:|---|
+| target params (fp32) | 0.27 | frozen, no grad |
+| trainable params (fp32) | 2.64 | components + CI fn |
+| trainable grads (fp32) | 2.64 | matches snapshot's `optim/adam.py` agg |
+| AdamW state (m+v, fp32) | 5.28 | 2× trainable; matches `optim/adam.py: 5.31 GB` |
+| **fixed state** | **10.83 GB** | (target + 4× trainable) |
+| activations + transient | 23.79 GB | peak − fixed |
+| **peak (max_memory_allocated)** | **34.62 GB** | |
+
+The snapshot at step 30 (post-`optimizer.step`, between training steps) shows
+17.75 GB live, 35.80 GB reserved. The 6.92 GB above fixed state at the step
+boundary is largely persistent PPGD state (~1.91 GB), retained CI/sigmoid
+tensors (~1.28 GB), retained linear-layer activations (~1.27 GB) and component
+weight materialization (~0.64 GB). Peak (34.62) is reached *during* a forward
+pass when the full activation graph is alive.
+
+**Activation/B = (peak − fixed) / B = 23.79 / 8 ≈ 3.0 GB per per-rank batch
+element**, in bf16 (autocast on). Report predicted ~1 GB/B. **3× higher than
+predicted — biggest single delta in the investigation.**
+
+A note on what's in activations: the report counted activations against per-step
+forwards but used a single calibration anchor. The actual training loop runs
+5–7 component forwards + 2–3 backwards per step, plus the PPGD warmup
+(`n_warmup_steps=2`) which retains autograd graphs across multiple forwards. The
+3 GB/B figure reflects the steady-state peak across all of these, in bf16.
+
+### 1.3 Top live allocations at step 30
+
+```
+824 MB  llama_simple_mlp.py:366 (forward)        target activation
+637 MB  components.py:46 (forward)               component intermediate (V@U or einsum)
+411 MB  llama_simple_mlp.py:366 (forward)        target activation
+14× 67 MB  optimize() bucket                     AdamW slot tensors (paired for m/v)
+```
+
+By source file (>50 MB):
+```
+optim/adam.py            5.31 GB   AdamW state
+persistent_pgd.py        1.91 GB   PPGD sources/grads (per-batch-per-position scope)
+models/sigmoids.py       1.28 GB   mask/CI tensors retained for backward
+modules/linear.py        1.27 GB   linear-layer forward activations
+models/components.py     0.64 GB   component forward intermediates
+models/llama_simple_mlp.py  0.33 GB   target forward activations (frozen)
+```
+
+### 1.4 Step time
+
+Steady-state training step time: **~305 ms** post-snapshot (after step 30 when
+`_record_memory_history` is disabled), **~326 ms** while the snapshot is being
+recorded — snapshot recording adds ~7% overhead. Step 0 (3.95 s) is dominated by
+the step-0 eval; step 50 (7.55 s) is the final-step logging path. Both are
+excluded from the steady-state figure.
+
+The plan's "warmup_steps_skipped = 5" in `profile_summary.json` correctly drops
+the early steps but does not exclude the final step, so the reported
+`avg_step_time_ms_post_warmup = 475 ms` is biased upward by step 50's 7.5 s.
+Real steady-state is ~305–326 ms. (Will fix the average in a follow-up; the
+per-step list is the source of truth.)
+
+### 1.5 Predictions vs measurements — summary
+
+| Quantity | Predicted | Measured | Δ |
+|---|---:|---:|---|
+| Trainable param total | 723 M | 660 M | −9% |
+| Fixed state per rank (DDP) | 13 GB | 10.83 GB | −17% |
+| Activation per per-rank batch element | ~1 GB | **~3 GB** | **+200%** |
+| Peak memory at b=8 (single rank) | ~21 GB | **34.6 GB** | **+65%** |
+
+The fixed-state calc was tight; activation/B was significantly low. The report's
+§3 max-batch table is therefore optimistic — at any given target scale, max
+batch under each strategy is likely ~3× lower than tabulated. **The ZeRO-1 →
+1B-target threshold from §3 (b≈13) is more like b≈4 in practice**, which makes
+gradient checkpointing more critical than the report implied.
+
+### 1.6 Recommended report updates after Phase 1
+
+1. Replace the assumed Jose target dimensions in §2 (`d_model=2048`,
+   `vocab=20000`, etc.) with the actual `n_embd=768`, `vocab=50277`,
+   `n_intermediate=3072`. The breakdown table should then come out to target
+   ~67M, components ~121M, CI fn ~539M.
+2. Update §3's calibration anchor: at Jose scale, single-rank b=64 OOMs; with
+   per-rank b=8 we see ~3 GB/B activation cost in bf16, not 1 GB/B.
+3. §3's max-batch table should be regenerated with the new activation-per-B and
+   fixed-state numbers.
+4. The "1.7×" CI-fn-vs-target ratio in §2's "your 4× target intuition" callout
+   should become ~8× (CI fn 539M vs target 67M), which strengthens the case
+   for prioritizing CI-fn checkpointing in §7b.
+
+---
+
+## Pending phases
+
+- Phase 2 — ZeRO-1 measurement (code ready, awaiting submission)
+- Phase 3 — gradient checkpointing
+- Phase 4 — weight-delta rewrite
+- Phase 5 (stretch) — 1B-target stress test (will use random-init target per Oli's note)

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -61,6 +61,12 @@ class GlobalSharedTransformerCiConfig(BaseConfig):
         "If None, defaults to [4 * d_model].",
     )
     attn_config: AttnConfig
+    gradient_checkpointing: bool = Field(
+        default=False,
+        description="If True, apply torch.utils.checkpoint to each transformer block in the CI fn. "
+        "Trades a re-forward of each block during backward for halved activation memory across "
+        "the block list. Useful at scale where the CI transformer dominates activation memory.",
+    )
 
     @model_validator(mode="after")
     def validate_config(self) -> Self:

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -260,6 +260,17 @@ class LMTaskConfig(BaseConfig):
         description="Whether to reshuffle data at each epoch. Set False in tests to keep fixed "
         "order across dp modes.",
     )
+    synthetic_data: bool = Field(
+        default=False,
+        description="If True, bypass `dataset_name` and feed random-token batches instead. "
+        "Used by the scaling investigation: profiling memory/throughput doesn't need real text, "
+        "and removes the HF Hub as a flaky dependency.",
+    )
+    synthetic_vocab_size: PositiveInt = Field(
+        default=50277,
+        description="Vocab size used when generating synthetic random-token batches. "
+        "Should match the target model's vocab.",
+    )
     is_tokenized: bool = Field(
         default=False,
         description="Whether the dataset is already tokenized",

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -799,6 +799,12 @@ class Config(BaseConfig):
         default=None,
         description="If set, apply grad norm clipping to the parameters of the CI functions",
     )
+    optimizer_strategy: Literal["adamw", "zero_adamw"] = Field(
+        default="adamw",
+        description="Optimizer wrapper strategy. 'adamw' is the default replicated AdamW; "
+        "'zero_adamw' shards optimizer state across ranks via ZeroRedundancyOptimizer (ZeRO-1) "
+        "and requires a distributed run with world_size > 1.",
+    )
 
     # --- Faithfulness Warmup ---
     faithfulness_warmup_steps: NonNegativeInt = Field(

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -851,6 +851,18 @@ class Config(BaseConfig):
         )
     )
 
+    # --- Memory Profiling ---
+    profile_memory: bool = Field(
+        default=False,
+        description="If True, dump a torch CUDA memory snapshot at `profile_memory_step` and log "
+        "a parameter-count breakdown at startup. Used by the scaling investigation; off in regular runs.",
+    )
+    profile_memory_step: PositiveInt = Field(
+        default=30,
+        description="Step at which to dump the CUDA memory snapshot (only used when "
+        "`profile_memory=True`).",
+    )
+
     # --- Component Tracking ---
     ci_alive_threshold: Probability = Field(
         default=0.0,

--- a/param_decomp/data.py
+++ b/param_decomp/data.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Generator
-from typing import Any
+from typing import Any, override
 
 import numpy as np
 import torch
@@ -274,6 +274,52 @@ def create_data_loader(
 def input_ids_collate_fn(batch: list[dict[str, Tensor]]) -> Tensor:
     """Collate function that extracts input_ids tensors from HuggingFace dataset dicts."""
     return torch.stack([item["input_ids"] for item in batch])
+
+
+class _SyntheticTokenDataset(torch.utils.data.IterableDataset[Tensor]):
+    """Yields random-token tensors of shape `[seq_len]` for memory/throughput profiling.
+
+    Bypasses HuggingFace entirely. Per-rank seeding gives different streams across ranks,
+    matching the production data pattern.
+    """
+
+    def __init__(self, seq_len: int, vocab_size: int, seed: int) -> None:
+        self.seq_len = seq_len
+        self.vocab_size = vocab_size
+        self.seed = seed
+
+    def set_epoch(self, epoch: int) -> None:
+        self.seed = self.seed + epoch * 1_000_003
+
+    @override
+    def __iter__(self):
+        gen = torch.Generator(device="cpu")
+        gen.manual_seed(self.seed)
+        while True:
+            yield torch.randint(0, self.vocab_size, (self.seq_len,), generator=gen)
+
+
+def make_synthetic_loader(
+    batch_size: int,
+    seq_len: int,
+    vocab_size: int,
+    seed: int,
+) -> DataLoader[Tensor]:
+    """DataLoader of random tokens, shape-compatible with the real Pile loader."""
+    dataset = _SyntheticTokenDataset(seq_len=seq_len, vocab_size=vocab_size, seed=seed)
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(seed)
+
+    def _collate(batch: list[Tensor]) -> Tensor:
+        return torch.stack(batch)
+
+    return DataLoader(
+        dataset,
+        batch_size=batch_size,
+        collate_fn=_collate,
+        num_workers=0,
+        generator=generator,
+    )
 
 
 def loop_dataloader[T](dl: DataLoader[T]) -> Generator[T]:

--- a/param_decomp/experiments/lm/lm_decomposition.py
+++ b/param_decomp/experiments/lm/lm_decomposition.py
@@ -10,7 +10,12 @@ from param_decomp.configs import (
     PersistentPGDReconSubsetLossConfig,
     RepeatAcrossBatchScope,
 )
-from param_decomp.data import DatasetConfig, create_data_loader, input_ids_collate_fn
+from param_decomp.data import (
+    DatasetConfig,
+    create_data_loader,
+    input_ids_collate_fn,
+    make_synthetic_loader,
+)
 from param_decomp.log import logger
 from param_decomp.models.batch_and_loss_fns import make_run_batch, recon_loss_kl
 from param_decomp.pretrain.run_info import PretrainRunInfo
@@ -76,6 +81,11 @@ def main(
     # --- Load Data --- #
     if is_main_process():
         logger.info("Loading dataset...")
+    if config.task_config.synthetic_data and is_main_process():
+        logger.info(
+            f"Using synthetic random-token dataloader (vocab_size="
+            f"{config.task_config.synthetic_vocab_size}, seq_len={config.task_config.max_seq_len})"
+        )
     train_data_config = DatasetConfig(
         name=config.task_config.dataset_name,
         hf_tokenizer_path=config.tokenizer_name,
@@ -109,14 +119,23 @@ def main(
                 f"{train_rank_batch_size}"
             )
 
-    train_loader, _tokenizer = create_data_loader(
-        dataset_config=train_data_config,
-        batch_size=train_rank_batch_size,
-        buffer_size=config.task_config.buffer_size,
-        global_seed=config.seed,
-        dist_state=dist_state,
-        collate_fn=input_ids_collate_fn,
-    )
+    if config.task_config.synthetic_data:
+        per_rank_seed = config.seed + (dist_state.rank if dist_state is not None else 0)
+        train_loader = make_synthetic_loader(
+            batch_size=train_rank_batch_size,
+            seq_len=config.task_config.max_seq_len,
+            vocab_size=config.task_config.synthetic_vocab_size,
+            seed=per_rank_seed,
+        )
+    else:
+        train_loader, _tokenizer = create_data_loader(
+            dataset_config=train_data_config,
+            batch_size=train_rank_batch_size,
+            buffer_size=config.task_config.buffer_size,
+            global_seed=config.seed,
+            dist_state=dist_state,
+            collate_fn=input_ids_collate_fn,
+        )
 
     eval_data_config = DatasetConfig(
         name=config.task_config.dataset_name,
@@ -139,14 +158,23 @@ def main(
         case None:
             eval_rank_batch_size = config.eval_batch_size
 
-    eval_loader, _ = create_data_loader(
-        dataset_config=eval_data_config,
-        batch_size=eval_rank_batch_size,
-        buffer_size=config.task_config.buffer_size,
-        global_seed=config.seed + 1,
-        dist_state=dist_state,
-        collate_fn=input_ids_collate_fn,
-    )
+    if config.task_config.synthetic_data:
+        per_rank_eval_seed = config.seed + 1 + (dist_state.rank if dist_state is not None else 0)
+        eval_loader = make_synthetic_loader(
+            batch_size=eval_rank_batch_size,
+            seq_len=config.task_config.max_seq_len,
+            vocab_size=config.task_config.synthetic_vocab_size,
+            seed=per_rank_eval_seed,
+        )
+    else:
+        eval_loader, _ = create_data_loader(
+            dataset_config=eval_data_config,
+            batch_size=eval_rank_batch_size,
+            buffer_size=config.task_config.buffer_size,
+            global_seed=config.seed + 1,
+            dist_state=dist_state,
+            collate_fn=input_ids_collate_fn,
+        )
 
     run_experiment(
         target_model=target_model,

--- a/param_decomp/experiments/resid_mlp/resid_mlp_interp.py
+++ b/param_decomp/experiments/resid_mlp/resid_mlp_interp.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any, cast
 
@@ -16,7 +17,6 @@ from param_decomp.experiments.resid_mlp.models import (
 from param_decomp.experiments.tms.models import TMSModel
 from param_decomp.log import logger
 from param_decomp.models.component_model import ComponentModel, ParamDecompRunInfo
-from param_decomp.models.components import Components
 from param_decomp.plotting import plot_causal_importance_vals
 from param_decomp.registry import EXPERIMENT_REGISTRY
 from param_decomp.utils.distributed_utils import get_device
@@ -211,7 +211,7 @@ def compute_patched_weight_neuron_contributions(
 
 def compute_pd_weight_neuron_contributions(
     model: ResidMLP,
-    components: dict[str, Components],
+    components: "Mapping[str, Any]",  # DecomposedSite or legacy Components,
     n_features: int | None = None,
 ) -> Float[Tensor, "n_layers n_features C d_mlp"]:
     """Compute per-neuron contribution strengths for the PD factorisation.
@@ -266,7 +266,7 @@ def compute_pd_weight_neuron_contributions(
 
 def plot_pd_feature_contributions_truncated(
     model: ResidMLP,
-    components: dict[str, Components],
+    components: "Mapping[str, Any]",  # DecomposedSite or legacy Components,
     n_features: int | None = 50,
 ):
     n_layers = model.config.n_layers
@@ -352,7 +352,7 @@ def plot_pd_feature_contributions_truncated(
 
 def plot_neuron_contribution_pairs(
     model: ResidMLP,
-    components: dict[str, Components],
+    components: "Mapping[str, Any]",  # DecomposedSite or legacy Components,
     n_features: int | None = 50,
 ) -> plt.Figure:
     """Create a scatter plot comparing target model and PD component neuron contributions.

--- a/param_decomp/experiments/tms/plotting.py
+++ b/param_decomp/experiments/tms/plotting.py
@@ -4,10 +4,10 @@ This module provides visualization functions for analyzing TMS models and their
 sparse decompositions, including vector plots, network diagrams, and weight heatmaps.
 """
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from itertools import zip_longest
-from typing import cast
+from typing import Any, cast
 
 import matplotlib.collections as mc
 import matplotlib.pyplot as plt
@@ -60,7 +60,7 @@ class TMSAnalyzer:
     def __init__(
         self,
         model: TMSModel,
-        components: dict[str, Components],
+        components: "Mapping[str, Any]",  # DecomposedSite or legacy Components,
         config: PlotConfig | None = None,
     ):
         self.model = model
@@ -403,7 +403,7 @@ class FullNetworkDiagramPlotter:
     def plot(
         self,
         model: TMSModel,
-        components: dict[str, Components],
+        components: "Mapping[str, Any]",  # DecomposedSite or legacy Components,
     ) -> Figure:
         """Plot full network architecture with all layers."""
         # Extract all layer weights
@@ -711,7 +711,11 @@ class HiddenLayerPlotter:
     def __init__(self, config: PlotConfig):
         self.config = config
 
-    def plot(self, model: TMSModel, components: dict[str, Components]) -> Figure:
+    def plot(
+        self,
+        model: TMSModel,
+        components: "Mapping[str, Any]",  # DecomposedSite or legacy Components
+    ) -> Figure:
         """Plot hidden layer weights as heatmaps."""
         # Extract weights
         hidden_weights, target_weights, subnets_order = self._extract_hidden_weights(
@@ -748,7 +752,9 @@ class HiddenLayerPlotter:
         return fig
 
     def _extract_hidden_weights(
-        self, model: TMSModel, components: dict[str, Components]
+        self,
+        model: TMSModel,
+        components: "Mapping[str, Any]",  # DecomposedSite or legacy Components
     ) -> tuple[Tensor, Tensor, Tensor]:
         """Extract and sort hidden layer weights."""
         if model.hidden_layers is None:
@@ -824,7 +830,7 @@ class TMSPlotter:
     def __init__(
         self,
         model: TMSModel,
-        components: dict[str, Components],
+        components: "Mapping[str, Any]",  # DecomposedSite or legacy Components,
         config: PlotConfig | None = None,
     ):
         self.config = config or PlotConfig()

--- a/param_decomp/metrics/attn_patterns_recon_loss.py
+++ b/param_decomp/metrics/attn_patterns_recon_loss.py
@@ -126,11 +126,11 @@ def _attn_patterns_recon_loss_update(
     for i, (q_path, k_path) in enumerate(zip(q_paths, k_paths, strict=True)):
         if is_combined:
             assert q_path == k_path
-            target_out = model.components[q_path](pre_weight_acts[q_path])
+            target_out = model.components[q_path].apply_decomposed(pre_weight_acts[q_path])
             target_q, target_k = _split_combined_qkv(target_out)
         else:
-            target_q = model.components[q_path](pre_weight_acts[q_path])
-            target_k = model.components[k_path](pre_weight_acts[k_path])
+            target_q = model.components[q_path].apply_decomposed(pre_weight_acts[q_path])
+            target_k = model.components[k_path].apply_decomposed(pre_weight_acts[k_path])
         target_patterns.append(
             _compute_attn_patterns(target_q, target_k, n_heads, attn_modules[i]).detach()
         )
@@ -146,19 +146,19 @@ def _attn_patterns_recon_loss_update(
         for i, (q_path, k_path) in enumerate(zip(q_paths, k_paths, strict=True)):
             if is_combined:
                 assert q_path == k_path
-                masked_out = model.components[q_path](
+                masked_out = model.components[q_path].apply_decomposed(
                     comp_cache[q_path],
                     mask=mask_infos[q_path].component_mask,
                     weight_delta_and_mask=mask_infos[q_path].weight_delta_and_mask,
                 )
                 masked_q, masked_k = _split_combined_qkv(masked_out)
             else:
-                masked_q = model.components[q_path](
+                masked_q = model.components[q_path].apply_decomposed(
                     comp_cache[q_path],
                     mask=mask_infos[q_path].component_mask,
                     weight_delta_and_mask=mask_infos[q_path].weight_delta_and_mask,
                 )
-                masked_k = model.components[k_path](
+                masked_k = model.components[k_path].apply_decomposed(
                     comp_cache[k_path],
                     mask=mask_infos[k_path].component_mask,
                     weight_delta_and_mask=mask_infos[k_path].weight_delta_and_mask,

--- a/param_decomp/models/component_model.py
+++ b/param_decomp/models/component_model.py
@@ -328,6 +328,7 @@ class ComponentModel(LoadableModule):
                     mlp_hidden_dims=transformer_cfg.mlp_hidden_dim,
                     max_len=transformer_cfg.attn_config.max_len,
                     rope_base=transformer_cfg.attn_config.rope_base,
+                    gradient_checkpointing=transformer_cfg.gradient_checkpointing,
                 )
 
     @overload

--- a/param_decomp/models/component_model.py
+++ b/param_decomp/models/component_model.py
@@ -1,33 +1,30 @@
-from collections.abc import Callable, Generator
-from contextlib import contextmanager
+from contextlib import ExitStack
 from dataclasses import dataclass
-from functools import partial
 from typing import Any, Literal, NamedTuple, overload, override
 
 import torch
 from jaxtyping import Float, Int
 from torch import Tensor, nn
-from torch.utils.hooks import RemovableHandle
-from transformers.pytorch_utils import Conv1D as RadfordConv1D
 
 from param_decomp.configs import CiConfig, Config, GlobalCiConfig, LayerwiseCiConfig, SamplingType
 from param_decomp.identity_insertion import insert_identity_operations_
 from param_decomp.interfaces import LoadableModule, RunInfo
 from param_decomp.models.batch_and_loss_fns import RunBatch, make_run_batch
 from param_decomp.models.components import (
-    Components,
     ComponentsMaskInfo,
-    EmbeddingComponents,
     GlobalCiFnWrapper,
     GlobalSharedMLPCiFn,
     GlobalSharedTransformerCiFn,
-    Identity,
     LayerwiseCiFnWrapper,
-    LinearComponents,
     MLPCiFn,
     TargetLayerConfig,
     VectorMLPCiFn,
     VectorSharedMLPCiFn,
+)
+from param_decomp.models.decomposed_module import (
+    DecomposedEmbedding,
+    DecomposedSite,
+    install_decomposed_sites,
 )
 from param_decomp.models.sigmoids import SIGMOID_TYPES, SigmoidType
 from param_decomp.param_decomp_types import LayerwiseCiFnType, ModelPath
@@ -128,19 +125,22 @@ class ComponentModel(LoadableModule):
         self.module_to_c = {info.module_path: info.C for info in module_path_info}
         self.target_module_paths = list(self.module_to_c.keys())
 
-        self.components = ComponentModel._create_components(
-            target_model=target_model,
-            module_to_c=self.module_to_c,
-        )
-        self._components = nn.ModuleDict(
-            {k.replace(".", "-"): self.components[k] for k in sorted(self.components)}
+        # Replace each decomposed submodule in target_model with a DecomposedSite in place.
+        # After this call:
+        #   - target_model.<path> is a DecomposedSite (DecomposedLinear or DecomposedEmbedding)
+        #   - The site owns its own V, U parameters (trainable, requires_grad=True)
+        #   - The site's `.linear` (or `.embedding`) is the frozen original module
+        # `self.components` is the canonical dict mapping site_name -> site; it shares storage
+        # with the sites that now live in target_model.
+        self.components: dict[str, DecomposedSite] = install_decomposed_sites(
+            target_model, self.module_to_c
         )
 
         match ci_config:
             case LayerwiseCiConfig():
                 raw_layerwise_ci_fns = {
                     path: ComponentModel._create_layerwise_ci_fn(
-                        target_module=target_model.get_submodule(path),
+                        site=self.components[path],
                         C=C,
                         ci_fn_type=ci_config.fn_type,
                         ci_fn_hidden_dims=ci_config.hidden_dims,
@@ -149,19 +149,17 @@ class ComponentModel(LoadableModule):
                 }
                 self.ci_fn = LayerwiseCiFnWrapper(
                     ci_fns=raw_layerwise_ci_fns,
-                    components=self.components,
+                    sites=self.components,
                     ci_fn_type=ci_config.fn_type,
                 )
             case GlobalCiConfig():
                 raw_global_ci_fn = ComponentModel._create_global_ci_fn(
-                    target_model=target_model,
-                    module_to_c=self.module_to_c,
-                    components=self.components,
+                    sites=self.components,
                     ci_config=ci_config,
                 )
                 self.ci_fn = GlobalCiFnWrapper(
                     global_ci_fn=raw_global_ci_fn,
-                    components=self.components,
+                    sites=self.components,
                 )
 
         if sigmoid_type == "leaky_hard":
@@ -173,106 +171,37 @@ class ComponentModel(LoadableModule):
             self.upper_leaky_fn = SIGMOID_TYPES[sigmoid_type]
 
     def target_weight(self, module_name: str) -> Float[Tensor, "rows cols"]:
-        target_module = self.target_model.get_submodule(module_name)
-
-        match target_module:
-            case RadfordConv1D():
-                return target_module.weight.T
-            case nn.Linear() | nn.Embedding():
-                return target_module.weight
-            case Identity():
-                p = next(self.parameters())
-                return torch.eye(target_module.d, device=p.device, dtype=p.dtype)
-            case _:
-                raise ValueError(f"Module {target_module} not supported")
+        """Target weight at the named decomposition site, shape (d_out, d_in)."""
+        return self.components[module_name].target_weight
 
     @staticmethod
-    def _create_component(
-        target_module: nn.Module,
-        C: int,
-    ) -> Components:
-        match target_module:
-            case nn.Linear():
-                d_out, d_in = target_module.weight.shape
-                component = LinearComponents(
-                    C=C,
-                    d_in=d_in,
-                    d_out=d_out,
-                    bias=target_module.bias.data if target_module.bias is not None else None,  # pyright: ignore[reportUnnecessaryComparison]
-                )
-            case RadfordConv1D():
-                d_in, d_out = target_module.weight.shape
-                component = LinearComponents(
-                    C=C,
-                    d_in=d_in,
-                    d_out=d_out,
-                    bias=target_module.bias.data if target_module.bias is not None else None,  # pyright: ignore[reportUnnecessaryComparison]
-                )
-            case Identity():
-                component = LinearComponents(
-                    C=C,
-                    d_in=target_module.d,
-                    d_out=target_module.d,
-                    bias=None,
-                )
-            case nn.Embedding():
-                component = EmbeddingComponents(
-                    C=C,
-                    vocab_size=target_module.num_embeddings,
-                    embedding_dim=target_module.embedding_dim,
-                )
-            case _:
-                raise ValueError(f"Module {target_module} not supported")
+    def _site_input_dim(site: DecomposedSite, for_global_ci: bool) -> int:
+        """Input dim feeding the CI fn for a given site.
 
-        return component
-
-    @staticmethod
-    def _create_components(
-        target_model: nn.Module,
-        module_to_c: dict[str, int],
-    ) -> dict[str, Components]:
-        components: dict[str, Components] = {}
-        for target_module_path, target_module_c in module_to_c.items():
-            target_module = target_model.get_submodule(target_module_path)
-            components[target_module_path] = ComponentModel._create_component(
-                target_module, target_module_c
-            )
-        return components
-
-    @staticmethod
-    def _get_module_input_dim(target_module: nn.Module) -> int:
-        """Extract input dimension from a Linear-like module.
-
-        For embedding layers, this should not be called - handle them separately.
+        For DecomposedLinear, that's the raw activation dim (d_in). For
+        DecomposedEmbedding, the CI fn sees component activations (V[idx]),
+        which are C-dimensional — but only under global CI; under layerwise
+        MLP CI we use the same convention via `get_component_acts`.
         """
-        match target_module:
-            case nn.Linear():
-                return target_module.weight.shape[1]
-            case RadfordConv1D():
-                return target_module.weight.shape[0]
-            case Identity():
-                return target_module.d
-            case _:
-                raise ValueError(
-                    f"Module {type(target_module)} not supported. "
-                    "Embedding modules should be handled separately."
-                )
+        if isinstance(site, DecomposedEmbedding):
+            return site.C if for_global_ci else site.d_embed
+        return site.d_in
 
     @staticmethod
     def _create_layerwise_ci_fn(
-        target_module: nn.Module,
+        site: DecomposedSite,
         C: int,
         ci_fn_type: LayerwiseCiFnType,
         ci_fn_hidden_dims: list[int],
     ) -> nn.Module:
-        """Helper to create a single layerwise CI function based on ci_fn_type and module type."""
-        if isinstance(target_module, nn.Embedding):
+        """Helper to create a single layerwise CI function based on ci_fn_type and site type."""
+        if isinstance(site, DecomposedEmbedding):
             assert ci_fn_type == "mlp", "Embedding modules only supported for ci_fn_type='mlp'"
 
         if ci_fn_type == "mlp":
             return MLPCiFn(C=C, hidden_dims=ci_fn_hidden_dims)
 
-        input_dim = ComponentModel._get_module_input_dim(target_module)
+        input_dim = ComponentModel._site_input_dim(site, for_global_ci=False)
 
         match ci_fn_type:
             case "vector_mlp":
@@ -282,30 +211,20 @@ class ComponentModel(LoadableModule):
 
     @staticmethod
     def _create_global_ci_fn(
-        target_model: nn.Module,
-        module_to_c: dict[str, int],
-        components: dict[str, Components],
+        sites: dict[str, DecomposedSite],
         ci_config: GlobalCiConfig,
     ) -> GlobalSharedMLPCiFn | GlobalSharedTransformerCiFn:
         """Create a global CI function that takes all layer activations as input."""
         ci_fn_type = ci_config.fn_type
         ci_fn_hidden_dims = ci_config.hidden_dims
 
-        # Build layer_configs: layer_name -> (input_dim, C)
-        layer_configs: dict[str, tuple[int, int]] = {}
-        for target_module_path, target_module_c in module_to_c.items():
-            target_module = target_model.get_submodule(target_module_path)
-            component = components[target_module_path]
-
-            # For embeddings, global CI uses component acts (C dimensions)
-            # For linear-like modules, use the actual input dimension
-            if isinstance(target_module, nn.Embedding):
-                assert isinstance(component, EmbeddingComponents)
-                input_dim = component.C
-            else:
-                input_dim = ComponentModel._get_module_input_dim(target_module)
-
-            layer_configs[target_module_path] = (input_dim, target_module_c)
+        layer_configs: dict[str, tuple[int, int]] = {
+            site_name: (
+                ComponentModel._site_input_dim(site, for_global_ci=True),
+                site.C,
+            )
+            for site_name, site in sites.items()
+        }
 
         match ci_fn_type:
             case "global_shared_mlp":
@@ -377,11 +296,12 @@ class ComponentModel(LoadableModule):
         """Forward pass with optional component replacement and/or input/output caching.
 
         Args:
-            mask_infos: Dictionary mapping module names to ComponentsMaskInfo.
-                If provided, those modules will be replaced with their components.
-            cache_type: What to cache for each hooked module. "input" caches pre-weight
-                activations, "output" caches post-weight activations, "component_acts" caches
-                per-component activations, "none" disables caching.
+            mask_infos: Dictionary mapping module names to ComponentsMaskInfo. If provided,
+                those sites use the decomposed path; sites not in this dict (or if it's None)
+                use the wrapped target's forward.
+            cache_type: What to cache. "input" caches pre-weight activations,
+                "output" caches post-weight activations, "component_acts" caches per-component
+                activations, "none" disables caching.
 
         Returns:
             OutputWithCache object if cache_type is not "none", otherwise the model output tensor.
@@ -392,24 +312,14 @@ class ComponentModel(LoadableModule):
             return self._run_batch(self.target_model, batch)
 
         cache: dict[str, Tensor] = {}
-        hooks: dict[str, Callable[..., Any]] = {}
+        bound_cache: dict[str, Tensor] | None = cache if cache_type != "none" else None
+        bound_cache_type = cache_type if cache_type != "none" else None
 
-        hook_module_names = list(mask_infos.keys()) if mask_infos else self.target_module_paths
-
-        for module_name in hook_module_names:
-            mask_info = mask_infos[module_name] if mask_infos else None
-            components = self.components[module_name] if mask_info else None
-
-            hooks[module_name] = partial(
-                self._components_and_cache_hook,
-                module_name=module_name,
-                components=components,
-                mask_info=mask_info,
-                cache_type=cache_type,
-                cache=cache,
-            )
-
-        with self._attach_forward_hooks(hooks):
+        # Bind per-site mask_info + cache slots, run forward, unbind on exit.
+        with ExitStack() as stack:
+            for site_name, site in self.components.items():
+                mask_info = mask_infos.get(site_name) if mask_infos is not None else None
+                stack.enter_context(site.bind(mask_info, bound_cache, bound_cache_type))
             out: Tensor = self._run_batch(self.target_model, batch)
 
         match cache_type:
@@ -417,89 +327,6 @@ class ComponentModel(LoadableModule):
                 return OutputWithCache(output=out, cache=cache)
             case "none":
                 return out
-
-    def _components_and_cache_hook(
-        self,
-        _module: nn.Module,
-        args: list[Any],
-        kwargs: dict[Any, Any],
-        output: Any,
-        module_name: str,
-        components: Components | None,
-        mask_info: ComponentsMaskInfo | None,
-        cache_type: Literal["component_acts", "input", "output", "none"],
-        cache: dict[str, Tensor],
-    ) -> Any | None:
-        """Unified hook function that handles both component replacement and caching.
-
-        Args:
-            module: The module being hooked
-            args: Module forward args
-            kwargs: Module forward kwargs
-            output: Module forward output
-            module_name: Name of the module in the target model
-            components: Component replacement (if using components)
-            mask_info: Mask information (if using components)
-            cache_type: Whether to cache the component acts, input, or none
-            cache: Cache dictionary to populate (if cache_type is not None)
-
-        Returns:
-            If using components: modified output (or None to keep original)
-            If not using components: None (keeps original output)
-        """
-        assert len(args) == 1, "Expected 1 argument"
-        assert len(kwargs) == 0, "Expected no keyword arguments"
-        x = args[0]
-        assert isinstance(x, Tensor), "Expected input tensor"
-
-        if cache_type == "input":
-            cache[module_name] = x
-
-        if components is not None and mask_info is not None:
-            assert isinstance(output, Tensor), (
-                f"Only supports single-tensor outputs, got {type(output)}"
-            )
-
-            component_acts_cache = {} if cache_type == "component_acts" else None
-            components_out = components(
-                x,
-                mask=mask_info.component_mask,
-                weight_delta_and_mask=mask_info.weight_delta_and_mask,
-                component_acts_cache=component_acts_cache,
-            )
-            if component_acts_cache is not None:
-                for k, v in component_acts_cache.items():
-                    cache[f"{module_name}_{k}"] = v
-
-            final_out = (
-                components_out
-                if mask_info.routing_mask == "all"
-                else torch.where(mask_info.routing_mask[..., None], components_out, output)
-            )
-
-            if cache_type == "output":
-                cache[module_name] = final_out
-            return final_out
-
-        # No component replacement - keep original output
-        if cache_type == "output":
-            assert isinstance(output, Tensor)
-            cache[module_name] = output
-        return None
-
-    @contextmanager
-    def _attach_forward_hooks(self, hooks: dict[str, Callable[..., Any]]) -> Generator[None]:
-        """Context manager to temporarily attach forward hooks to the target model."""
-        handles: list[RemovableHandle] = []
-        for module_name, hook in hooks.items():
-            target_module = self.target_model.get_submodule(module_name)
-            handle = target_module.register_forward_hook(hook, with_kwargs=True)
-            handles.append(handle)
-        try:
-            yield
-        finally:
-            for handle in handles:
-                handle.remove()
 
     @classmethod
     @override
@@ -630,26 +457,25 @@ class ComponentModel(LoadableModule):
         self,
         pre_weight_acts: dict[str, Float[Tensor, "... d_in"] | Int[Tensor, "..."]],
     ) -> dict[str, Float[Tensor, "... C"]]:
-        """Compute component activations (v_i^T @ x) for all layers.
+        """Compute pre-mask component activations (x @ V or V[idx]) for all sites.
 
         Args:
-            pre_weight_acts: Dict mapping layer name to input activations.
+            pre_weight_acts: Dict mapping site name to input activations (or token ids for
+                embedding sites).
 
         Returns:
-            Dict mapping layer name to component activations tensor.
+            Dict mapping site name to component activations tensor.
         """
         return {
-            layer: self.components[layer].get_component_acts(acts)
-            for layer, acts in pre_weight_acts.items()
-            if layer in self.components
+            site_name: self.components[site_name].get_component_acts(acts)
+            for site_name, acts in pre_weight_acts.items()
+            if site_name in self.components
         }
 
     def calc_weight_deltas(self) -> dict[str, Float[Tensor, "d_out d_in"]]:
-        """Calculate the weight differences between the target and component weights (V@U) for each layer."""
-        weight_deltas: dict[str, Float[Tensor, "d_out d_in"]] = {}
-        for comp_name, components in self.components.items():
-            weight_deltas[comp_name] = self.target_weight(comp_name) - components.weight
-        return weight_deltas
+        """Calculate `W_target - V@U` per site. Each site materializes its own delta
+        (so under FSDP both V/U and the target weight are gathered at the site)."""
+        return {site_name: site.calc_weight_delta() for site_name, site in self.components.items()}
 
 
 def handle_deprecated_state_dict_keys_(state_dict: dict[str, Tensor]) -> None:

--- a/param_decomp/models/components.py
+++ b/param_decomp/models/components.py
@@ -298,6 +298,7 @@ class GlobalSharedTransformerCiFn(nn.Module):
         mlp_hidden_dims: list[int] | None = None,
         max_len: int = 2048,
         rope_base: float = 10000.0,
+        gradient_checkpointing: bool = False,
     ):
         super().__init__()
 
@@ -307,6 +308,7 @@ class GlobalSharedTransformerCiFn(nn.Module):
         self.d_model = d_model
         self.n_transformer_layers = n_layers
         self.n_heads = n_heads
+        self.gradient_checkpointing = gradient_checkpointing
 
         if mlp_hidden_dims is None:
             mlp_hidden_dims = [4 * d_model]
@@ -349,8 +351,14 @@ class GlobalSharedTransformerCiFn(nn.Module):
             added_seq_dim = True
 
         x = projected
-        for block in self._blocks:
-            x = block(x)
+        if self.gradient_checkpointing and self.training:
+            from torch.utils.checkpoint import checkpoint
+
+            for block in self._blocks:
+                x = checkpoint(block, x, use_reentrant=False)
+        else:
+            for block in self._blocks:
+                x = block(x)
 
         output = self._output_head(x)
 

--- a/param_decomp/models/components.py
+++ b/param_decomp/models/components.py
@@ -1,13 +1,26 @@
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Literal, override
+from typing import TYPE_CHECKING, Protocol, override
 
 import einops
 import torch
 import torch.nn.functional as F
-from jaxtyping import Bool, Float, Int
+from jaxtyping import Float, Int
 from torch import Tensor, nn
 
+from param_decomp.models.mask_info import (
+    ComponentsMaskInfo as ComponentsMaskInfo,  # re-export for backward compat
+)
+from param_decomp.models.mask_info import (
+    RoutingMasks as RoutingMasks,  # re-export for backward compat
+)
+from param_decomp.models.mask_info import (
+    WeightDeltaAndMask as WeightDeltaAndMask,  # re-export for backward compat
+)
+from param_decomp.models.mask_info import (
+    make_mask_infos as make_mask_infos,  # re-export for backward compat
+)
 from param_decomp.utils.module_utils import _NonlinearityType, init_param_
 
 if TYPE_CHECKING:
@@ -371,7 +384,14 @@ class GlobalSharedTransformerCiFn(nn.Module):
         return outputs
 
 
-WeightDeltaAndMask = tuple[Float[Tensor, "d_out d_in"], Float[Tensor, "..."]]
+class SiteWithComponentActs(Protocol):
+    """Duck-typed interface CI fn wrappers need from each decomposition site.
+
+    The runtime concrete types are `DecomposedLinear` / `DecomposedEmbedding`; this Protocol
+    keeps `components.py` from having to import them (which would create a cycle).
+    """
+
+    def get_component_acts(self, x: Tensor, /) -> Tensor: ...
 
 
 class Components(ABC, nn.Module):
@@ -606,63 +626,6 @@ class Identity(nn.Module):
         return x
 
 
-@dataclass
-class ComponentsMaskInfo:
-    """Specifies the mask information that will be applied to a ComponentOrModule object."""
-
-    component_mask: Float[Tensor, "... C"]
-    """when components are routed to, this specifies which subcomponents to use"""
-
-    routing_mask: Bool[Tensor, "..."] | Literal["all"] = "all"
-    """Which (batch,) or (batch, seq_len) positions to route to components vs target modules.
-    If "all", all positions are routed to components."""
-
-    weight_delta_and_mask: WeightDeltaAndMask | None = None
-
-
-RoutingMasks = dict[str, Bool[Tensor, "..."]] | Literal["all"]
-
-
-def make_mask_infos(
-    component_masks: dict[str, Float[Tensor, "... C"]],
-    routing_masks: RoutingMasks = "all",
-    weight_deltas_and_masks: dict[str, WeightDeltaAndMask] | None = None,
-) -> dict[str, ComponentsMaskInfo]:
-    """Create ComponentsMaskInfo dict from dicts of component masks, and optionally routing masks,
-    weight deltas, and weight delta masks.
-    Keys of all dicts must be the same.
-
-    Args:
-        component_masks: Dict mapping module names to component masks. routing_masks: Dict mapping
-        module names to routing masks. weight_deltas_and_masks: Dict mapping module names to tuples
-        of weight deltas and masks for each module to be decomposed. Defaults to None (disable
-        weight delta component) if not provided.
-    Returns:
-        Dict mapping module names to ComponentsMaskInfo objects.
-    """
-    if isinstance(routing_masks, dict):
-        assert set(routing_masks) == set(component_masks)
-
-    if weight_deltas_and_masks is not None:
-        assert set(weight_deltas_and_masks) == set(component_masks)
-
-    result: dict[str, ComponentsMaskInfo] = {}
-    for name in component_masks:
-        routing_mask = routing_masks[name] if isinstance(routing_masks, dict) else "all"
-
-        weight_delta_and_mask = (
-            weight_deltas_and_masks[name] if weight_deltas_and_masks is not None else None
-        )
-
-        result[name] = ComponentsMaskInfo(
-            component_mask=component_masks[name],
-            routing_mask=routing_mask,
-            weight_delta_and_mask=weight_delta_and_mask,
-        )
-
-    return result
-
-
 class LayerwiseCiFnWrapper(nn.Module):
     """Wraps a dict of per-layer CI functions with a unified interface.
 
@@ -672,12 +635,14 @@ class LayerwiseCiFnWrapper(nn.Module):
     def __init__(
         self,
         ci_fns: dict[str, nn.Module],
-        components: dict[str, Components],
+        sites: Mapping[str, SiteWithComponentActs],
         ci_fn_type: "LayerwiseCiFnType",
     ):
         super().__init__()
         self.layer_names = sorted(ci_fns.keys())
-        self.components = components
+        # `sites` is a plain dict of references into target_model — not registered as a
+        # submodule of the wrapper. Used only for `get_component_acts` and embedding checks.
+        self.sites = sites
         self.ci_fn_type = ci_fn_type
 
         # Store as ModuleDict with "." replaced by "-" for state dict compatibility
@@ -698,7 +663,7 @@ class LayerwiseCiFnWrapper(nn.Module):
 
             # MLPCiFn expects component activations, others take raw input
             if self.ci_fn_type == "mlp":
-                ci_fn_input = self.components[layer_name].get_component_acts(input_acts)
+                ci_fn_input = self.sites[layer_name].get_component_acts(input_acts)
             else:
                 ci_fn_input = input_acts
 
@@ -717,11 +682,12 @@ class GlobalCiFnWrapper(nn.Module):
     def __init__(
         self,
         global_ci_fn: GlobalSharedMLPCiFn | GlobalSharedTransformerCiFn,
-        components: dict[str, Components],
+        sites: Mapping[str, SiteWithComponentActs],
     ):
         super().__init__()
         self._global_ci_fn = global_ci_fn
-        self.components = components
+        # See LayerwiseCiFnWrapper.sites — plain dict of references, not a submodule.
+        self.sites = sites
 
     @override
     def forward(
@@ -730,11 +696,13 @@ class GlobalCiFnWrapper(nn.Module):
     ) -> dict[str, Float[Tensor, "... C"]]:
         transformed: dict[str, Float[Tensor, ...]] = {}
 
+        from param_decomp.models.decomposed_module import DecomposedEmbedding
+
         for layer_name, acts in layer_acts.items():
-            component = self.components[layer_name]
-            if isinstance(component, EmbeddingComponents):
-                # Embeddings pass token IDs; convert to component activations
-                transformed[layer_name] = component.get_component_acts(acts)
+            site = self.sites[layer_name]
+            if isinstance(site, DecomposedEmbedding):
+                # Embedding sites pass token IDs; convert to component activations.
+                transformed[layer_name] = site.get_component_acts(acts)
             else:
                 transformed[layer_name] = acts
 

--- a/param_decomp/models/components.py
+++ b/param_decomp/models/components.py
@@ -469,10 +469,8 @@ class LinearComponents(Components):
             component_acts = component_acts.detach().requires_grad_(True)
             component_acts_cache["post_detach"] = component_acts
 
-        if mask is not None:
-            component_acts = component_acts * mask
-
-        out = einops.einsum(component_acts, self.U, "... C, C d_out -> ... d_out")
+        masked_component_acts = component_acts * mask if mask is not None else component_acts
+        out = einops.einsum(masked_component_acts, self.U, "... C, C d_out -> ... d_out")
 
         if weight_delta_and_mask is not None:
             weight_delta, weight_delta_mask = weight_delta_and_mask
@@ -484,6 +482,48 @@ class LinearComponents(Components):
 
         if self.bias is not None:
             out += self.bias
+
+        return out
+
+    def forward_with_target_weight(
+        self,
+        x: Float[Tensor, "... d_in"],
+        target_weight: Float[Tensor, "d_out d_in"],
+        mask: Float[Tensor, "... C"] | None = None,
+        weight_delta_mask: Float[Tensor, "..."] | None = None,
+        component_acts_cache: dict[str, Float[Tensor, "... C"]] | None = None,
+    ) -> Float[Tensor, "... d_out"]:
+        """Equivalent to `forward` with `weight_delta_and_mask=(target_weight - V@U, weight_delta_mask)`,
+        but never materializes the (d_out, d_in) delta tensor.
+
+        Uses the algebraic identity
+            x @ (W_target − V@U) = x @ W_target − (x @ V) @ U
+        to compute the delta path with two matmuls instead of materializing the delta. Trades
+        an O(d_in · d_out) intermediate for two O(batch · d_in · d_out) matmuls — strict win
+        for memory at typical SPD scales (the report estimates ~320 MB saved at Jose).
+        """
+        component_acts = self.get_component_acts(x)
+        if component_acts_cache is not None:
+            component_acts_cache["pre_detach"] = component_acts
+            component_acts = component_acts.detach().requires_grad_(True)
+            component_acts_cache["post_detach"] = component_acts
+
+        masked_component_acts = component_acts * mask if mask is not None else component_acts
+        out = einops.einsum(masked_component_acts, self.U, "... C, C d_out -> ... d_out")
+
+        if weight_delta_mask is not None:
+            target_out = einops.einsum(x, target_weight, "... d_in, d_out d_in -> ... d_out")
+            unmasked_recon_out = einops.einsum(
+                component_acts, self.U, "... C, C d_out -> ... d_out"
+            )
+            assert target_out.shape[:-1] == weight_delta_mask.shape
+            delta_out = einops.einsum(
+                weight_delta_mask, target_out - unmasked_recon_out, "..., ... d_out -> ... d_out"
+            )
+            out = out + delta_out
+
+        if self.bias is not None:
+            out = out + self.bias
 
         return out
 

--- a/param_decomp/models/decomposed_module.py
+++ b/param_decomp/models/decomposed_module.py
@@ -1,0 +1,313 @@
+"""Fused decomposition-site modules.
+
+A `DecomposedLinear` is a drop-in replacement for an `nn.Linear` (or a Radford
+`Conv1D`, or our `Identity` shim) in the target model tree. It owns:
+  - the frozen target module (`self.linear`)
+  - the trainable component matrices `V` and `U`
+  - per-call mask/cache slots set by the surrounding `ComponentModel`
+
+When `set_mask_info(None)` is in effect the forward is identical to the wrapped
+target module's forward. When a `ComponentsMaskInfo` is bound, the forward
+follows the same math the legacy hook-based path used:
+  - `component_acts = x @ V`
+  - optional mask: `component_acts *= mask`
+  - `out = component_acts @ U`
+  - optional delta term: `out += delta_mask * (x @ weight_delta)`
+  - bias (if any): `out += bias`
+  - optional routing mask: `where(routing_mask, out, target_out)`
+
+The reason this is a fused module (rather than a hook on the target) is so FSDP
+can wrap each site as a single sharding unit — the components' V/U live in the
+*same* FSDP unit as the target submodule whose output they replace, so the
+"hook crosses FSDP units" problem from §5b of `fsdp_scaling_report.html` goes
+away.
+
+See `fsdp_implementation_plan.md` for the full context.
+"""
+
+from contextlib import contextmanager
+from typing import Literal, override
+
+import einops
+import torch
+from jaxtyping import Float
+from torch import Tensor, nn
+from transformers.pytorch_utils import Conv1D as RadfordConv1D
+
+from param_decomp.models.components import ComponentsMaskInfo
+from param_decomp.utils.module_utils import init_param_
+
+CacheType = Literal["component_acts", "input", "output"]
+
+
+class DecomposedLinear(nn.Module):
+    """A fused decomposition site wrapping a single linear-like target module."""
+
+    def __init__(self, base: nn.Linear | RadfordConv1D, C: int, site_name: str):
+        super().__init__()
+        match base:
+            case nn.Linear():
+                d_in, d_out = base.in_features, base.out_features
+            case RadfordConv1D():
+                # Conv1D stores weight as (d_in, d_out); convert callers downstream.
+                d_in, d_out = base.weight.shape
+
+        self.linear: nn.Linear | RadfordConv1D = base
+        self.d_in = d_in
+        self.d_out = d_out
+        self.C = C
+        self.site_name = site_name
+
+        self.V = nn.Parameter(torch.empty(d_in, C))
+        self.U = nn.Parameter(torch.empty(C, d_out))
+        init_param_(self.V, fan_val=d_in, nonlinearity="linear")
+        init_param_(self.U, fan_val=C, nonlinearity="linear")
+
+        self._mask_info: ComponentsMaskInfo | None = None
+        self._cache: dict[str, Tensor] | None = None
+        self._cache_type: CacheType | None = None
+
+    @contextmanager
+    def bind(
+        self,
+        mask_info: ComponentsMaskInfo | None,
+        cache: dict[str, Tensor] | None,
+        cache_type: CacheType | None,
+    ):
+        """Context manager that sets per-call slots and restores afterward.
+
+        ComponentModel uses this on every site before invoking `target_model(x)`.
+        """
+        prev_mask, prev_cache, prev_type = self._mask_info, self._cache, self._cache_type
+        self._mask_info = mask_info
+        self._cache = cache
+        self._cache_type = cache_type
+        try:
+            yield
+        finally:
+            self._mask_info = prev_mask
+            self._cache = prev_cache
+            self._cache_type = prev_type
+
+    @property
+    def target_weight(self) -> Float[Tensor, "d_out d_in"]:
+        """Always (d_out, d_in) regardless of underlying base type."""
+        match self.linear:
+            case nn.Linear():
+                return self.linear.weight
+            case RadfordConv1D():
+                return self.linear.weight.T
+
+    @property
+    def bias(self) -> Tensor | None:
+        # nn.Linear.bias and Conv1D.bias are typed as Tensor in torch's stubs but can be
+        # None at runtime when bias=False. This property normalizes the access.
+        return getattr(self.linear, "bias", None)
+
+    @property
+    def component_weight(self) -> Float[Tensor, "d_out d_in"]:
+        """V @ U transposed to nn.Linear convention (d_out, d_in)."""
+        return einops.einsum(self.V, self.U, "d_in C, C d_out -> d_out d_in")
+
+    def calc_weight_delta(self) -> Float[Tensor, "d_out d_in"]:
+        """W_target - V@U, materialized in the site (so FSDP has both gathered)."""
+        return self.target_weight - self.component_weight
+
+    @override
+    def forward(self, x: Float[Tensor, "... d_in"]) -> Float[Tensor, "... d_out"]:
+        if self._cache is not None and self._cache_type == "input":
+            self._cache[self.site_name] = x
+
+        if self._mask_info is None:
+            out = self.linear(x)
+        else:
+            out = self._decomposed_forward(x, self._mask_info)
+
+        if self._cache is not None and self._cache_type == "output":
+            self._cache[self.site_name] = out
+
+        return out
+
+    def _decomposed_forward(
+        self,
+        x: Float[Tensor, "... d_in"],
+        info: ComponentsMaskInfo,
+    ) -> Float[Tensor, "... d_out"]:
+        component_acts = einops.einsum(x.to(self.V.dtype), self.V, "... d_in, d_in C -> ... C")
+
+        if self._cache is not None and self._cache_type == "component_acts":
+            self._cache[f"{self.site_name}_pre_detach"] = component_acts
+            component_acts = component_acts.detach().requires_grad_(True)
+            self._cache[f"{self.site_name}_post_detach"] = component_acts
+
+        masked_component_acts = component_acts * info.component_mask
+        components_out: Tensor = einops.einsum(
+            masked_component_acts, self.U, "... C, C d_out -> ... d_out"
+        )
+
+        if info.weight_delta_and_mask is not None:
+            weight_delta, weight_delta_mask = info.weight_delta_and_mask
+            delta_out = einops.einsum(x, weight_delta, "... d_in, d_out d_in -> ... d_out")
+            assert delta_out.shape[:-1] == weight_delta_mask.shape
+            components_out = components_out + einops.einsum(
+                weight_delta_mask, delta_out, "..., ... d_out -> ... d_out"
+            )
+
+        if self.bias is not None:
+            components_out = components_out + self.bias
+
+        if info.routing_mask == "all":
+            return components_out
+        else:
+            target_out = self.linear(x)
+            return torch.where(info.routing_mask[..., None], components_out, target_out)
+
+
+class DecomposedEmbedding(nn.Module):
+    """Fused embedding decomposition site.
+
+    Mirrors `EmbeddingComponents` semantics: V is `(vocab, C)`, U is `(C, d_embed)`,
+    and the decomposed forward indexes V by the input ids (no weight materialization)
+    instead of doing an einsum like `DecomposedLinear`.
+    """
+
+    def __init__(self, base: nn.Embedding, C: int, site_name: str):
+        super().__init__()
+        self.embedding = base
+        self.vocab_size = base.num_embeddings
+        self.d_embed = base.embedding_dim
+        self.C = C
+        self.site_name = site_name
+
+        self.V = nn.Parameter(torch.empty(self.vocab_size, C))
+        self.U = nn.Parameter(torch.empty(C, self.d_embed))
+        init_param_(self.V, fan_val=self.vocab_size, nonlinearity="linear")
+        init_param_(self.U, fan_val=C, nonlinearity="linear")
+
+        self._mask_info: ComponentsMaskInfo | None = None
+        self._cache: dict[str, Tensor] | None = None
+        self._cache_type: CacheType | None = None
+
+    @contextmanager
+    def bind(
+        self,
+        mask_info: ComponentsMaskInfo | None,
+        cache: dict[str, Tensor] | None,
+        cache_type: CacheType | None,
+    ):
+        prev_mask, prev_cache, prev_type = self._mask_info, self._cache, self._cache_type
+        self._mask_info = mask_info
+        self._cache = cache
+        self._cache_type = cache_type
+        try:
+            yield
+        finally:
+            self._mask_info = prev_mask
+            self._cache = prev_cache
+            self._cache_type = prev_type
+
+    @property
+    def target_weight(self) -> Float[Tensor, "vocab d_embed"]:
+        return self.embedding.weight
+
+    @property
+    def component_weight(self) -> Float[Tensor, "vocab d_embed"]:
+        return einops.einsum(self.V, self.U, "vocab C, C d_embed -> vocab d_embed")
+
+    def calc_weight_delta(self) -> Float[Tensor, "vocab d_embed"]:
+        return self.target_weight - self.component_weight
+
+    @override
+    def forward(self, idx: Tensor) -> Float[Tensor, "... d_embed"]:
+        if self._cache is not None and self._cache_type == "input":
+            self._cache[self.site_name] = idx
+
+        if self._mask_info is None:
+            out = self.embedding(idx)
+        else:
+            out = self._decomposed_forward(idx, self._mask_info)
+
+        if self._cache is not None and self._cache_type == "output":
+            self._cache[self.site_name] = out
+
+        return out
+
+    def _decomposed_forward(
+        self, idx: Tensor, info: ComponentsMaskInfo
+    ) -> Float[Tensor, "... d_embed"]:
+        component_acts: Tensor = self.V[idx]  # (..., C)
+
+        if self._cache is not None and self._cache_type == "component_acts":
+            self._cache[f"{self.site_name}_pre_detach"] = component_acts
+            component_acts = component_acts.detach().requires_grad_(True)
+            self._cache[f"{self.site_name}_post_detach"] = component_acts
+
+        masked_component_acts = component_acts * info.component_mask
+        components_out: Tensor = einops.einsum(
+            masked_component_acts, self.U, "... C, C d_embed -> ... d_embed"
+        )
+
+        if info.weight_delta_and_mask is not None:
+            weight_delta, weight_delta_mask = info.weight_delta_and_mask
+            delta_out = weight_delta[idx]  # (..., d_embed)
+            components_out = components_out + einops.einsum(
+                weight_delta_mask, delta_out, "..., ... d_embed -> ... d_embed"
+            )
+
+        if info.routing_mask == "all":
+            return components_out
+        else:
+            target_out = self.embedding(idx)
+            return torch.where(info.routing_mask[..., None], components_out, target_out)
+
+
+DecomposedSite = DecomposedLinear | DecomposedEmbedding
+
+
+def _wrap_target_module(base: nn.Module, C: int, site_name: str) -> DecomposedSite:
+    """Build the right `Decomposed*` site for a target submodule."""
+    match base:
+        case nn.Linear() | RadfordConv1D():
+            return DecomposedLinear(base, C=C, site_name=site_name)
+        case nn.Embedding():
+            return DecomposedEmbedding(base, C=C, site_name=site_name)
+        case _:
+            raise ValueError(f"_wrap_target_module: unsupported base {type(base)}")
+
+
+def install_decomposed_sites(
+    target_model: nn.Module, module_to_c: dict[str, int]
+) -> dict[str, DecomposedSite]:
+    """Replace each named submodule of `target_model` in place with a `DecomposedSite`.
+
+    Returns a dict of `{site_name: DecomposedSite}` for callers that want direct
+    handles (loss code, harvest, etc.); the canonical reference is the site's
+    position in the target_model tree.
+    """
+    sites: dict[str, DecomposedSite] = {}
+    for site_name, C in module_to_c.items():
+        base = target_model.get_submodule(site_name)
+        site = _wrap_target_module(base, C=C, site_name=site_name)
+        parent_path, _, child_name = site_name.rpartition(".")
+        parent = target_model.get_submodule(parent_path) if parent_path else target_model
+        setattr(parent, child_name, site)
+        sites[site_name] = site
+    return sites
+
+
+def get_site(target_model: nn.Module, site_name: str) -> DecomposedSite:
+    """Walk the target tree and assert the named submodule is a decomposed site."""
+    mod = target_model.get_submodule(site_name)
+    assert isinstance(mod, DecomposedLinear | DecomposedEmbedding), (
+        f"Module at {site_name!r} is {type(mod).__name__}, not a decomposed site"
+    )
+    return mod
+
+
+def iter_sites(target_model: nn.Module) -> list[tuple[str, DecomposedSite]]:
+    """Iterate `(site_name, site)` pairs in target-model tree order."""
+    out: list[tuple[str, DecomposedSite]] = []
+    for name, mod in target_model.named_modules():
+        if isinstance(mod, DecomposedLinear | DecomposedEmbedding):
+            out.append((name, mod))
+    return out

--- a/param_decomp/models/decomposed_module.py
+++ b/param_decomp/models/decomposed_module.py
@@ -34,7 +34,7 @@ from jaxtyping import Float
 from torch import Tensor, nn
 from transformers.pytorch_utils import Conv1D as RadfordConv1D
 
-from param_decomp.models.components import ComponentsMaskInfo
+from param_decomp.models.mask_info import ComponentsMaskInfo, WeightDeltaAndMask
 from param_decomp.utils.module_utils import init_param_
 
 CacheType = Literal["component_acts", "input", "output"]
@@ -98,6 +98,20 @@ class DecomposedLinear(nn.Module):
             case RadfordConv1D():
                 return self.linear.weight.T
 
+    # Aliases so callers that used to introspect `target_model.<path>.in_features` /
+    # `.out_features` (back when that path was a plain `nn.Linear`) keep working.
+    # NOTE: deliberately NOT exposing `.weight` — under the legacy `Components` API
+    # `components[name].weight` meant `V @ U`, but `target_model.<path>.weight`
+    # meant the target weight. Disambiguate by using `target_weight` or
+    # `component_weight` explicitly.
+    @property
+    def in_features(self) -> int:
+        return self.d_in
+
+    @property
+    def out_features(self) -> int:
+        return self.d_out
+
     @property
     def bias(self) -> Tensor | None:
         # nn.Linear.bias and Conv1D.bias are typed as Tensor in torch's stubs but can be
@@ -113,6 +127,10 @@ class DecomposedLinear(nn.Module):
         """W_target - V@U, materialized in the site (so FSDP has both gathered)."""
         return self.target_weight - self.component_weight
 
+    def get_component_acts(self, x: Float[Tensor, "... d_in"]) -> Float[Tensor, "... C"]:
+        """x @ V — the pre-mask component activations. Used by MLP-type CI fns."""
+        return einops.einsum(x.to(self.V.dtype), self.V, "... d_in, d_in C -> ... C")
+
     @override
     def forward(self, x: Float[Tensor, "... d_in"]) -> Float[Tensor, "... d_out"]:
         if self._cache is not None and self._cache_type == "input":
@@ -127,6 +145,27 @@ class DecomposedLinear(nn.Module):
             self._cache[self.site_name] = out
 
         return out
+
+    def apply_decomposed(
+        self,
+        x: Float[Tensor, "... d_in"],
+        mask: Float[Tensor, "... C"] | None = None,
+        weight_delta_and_mask: "WeightDeltaAndMask | None" = None,
+    ) -> Float[Tensor, "... d_out"]:
+        """Run the decomposed path directly with explicit mask args.
+
+        Used by metric/loss code that wants component output without going through
+        the site's bound `_mask_info` slot (e.g. computing target vs. masked outputs
+        side-by-side inside a single forward).
+        """
+        info = ComponentsMaskInfo(
+            component_mask=mask
+            if mask is not None
+            else torch.ones((), device=self.V.device, dtype=self.V.dtype),
+            routing_mask="all",
+            weight_delta_and_mask=weight_delta_and_mask,
+        )
+        return self._decomposed_forward(x, info)
 
     def _decomposed_forward(
         self,
@@ -188,6 +227,17 @@ class DecomposedEmbedding(nn.Module):
         self._cache: dict[str, Tensor] | None = None
         self._cache_type: CacheType | None = None
 
+    # Aliases so callers that used to access `target_model.embed.num_embeddings` etc. (back
+    # when `target_model.embed` was a plain `nn.Embedding`) keep working — we are now a fused
+    # site sitting at that path.
+    @property
+    def num_embeddings(self) -> int:
+        return self.vocab_size
+
+    @property
+    def embedding_dim(self) -> int:
+        return self.d_embed
+
     @contextmanager
     def bind(
         self,
@@ -217,6 +267,10 @@ class DecomposedEmbedding(nn.Module):
     def calc_weight_delta(self) -> Float[Tensor, "vocab d_embed"]:
         return self.target_weight - self.component_weight
 
+    def get_component_acts(self, idx: Tensor) -> Float[Tensor, "... C"]:
+        """V[idx] — the pre-mask component activations for embedding sites."""
+        return self.V[idx]
+
     @override
     def forward(self, idx: Tensor) -> Float[Tensor, "... d_embed"]:
         if self._cache is not None and self._cache_type == "input":
@@ -231,6 +285,26 @@ class DecomposedEmbedding(nn.Module):
             self._cache[self.site_name] = out
 
         return out
+
+    def apply_decomposed(
+        self,
+        idx: Tensor,
+        mask: Float[Tensor, "... C"] | None = None,
+        weight_delta_and_mask: WeightDeltaAndMask | None = None,
+    ) -> Float[Tensor, "... d_embed"]:
+        """Run the decomposed path directly with explicit mask args.
+
+        Used by metric/loss code that wants component output without going through
+        the site's bound `_mask_info` slot.
+        """
+        info = ComponentsMaskInfo(
+            component_mask=mask
+            if mask is not None
+            else torch.ones((), device=self.V.device, dtype=self.V.dtype),
+            routing_mask="all",
+            weight_delta_and_mask=weight_delta_and_mask,
+        )
+        return self._decomposed_forward(idx, info)
 
     def _decomposed_forward(
         self, idx: Tensor, info: ComponentsMaskInfo
@@ -272,7 +346,11 @@ def _wrap_target_module(base: nn.Module, C: int, site_name: str) -> DecomposedSi
         case nn.Embedding():
             return DecomposedEmbedding(base, C=C, site_name=site_name)
         case _:
-            raise ValueError(f"_wrap_target_module: unsupported base {type(base)}")
+            raise ValueError(
+                f"_wrap_target_module: unsupported base {type(base)}. "
+                f"The legacy `identity_module_info` / Identity shim path is not supported "
+                f"under the fused-decomposition-sites architecture."
+            )
 
 
 def install_decomposed_sites(
@@ -283,16 +361,36 @@ def install_decomposed_sites(
     Returns a dict of `{site_name: DecomposedSite}` for callers that want direct
     handles (loss code, harvest, etc.); the canonical reference is the site's
     position in the target_model tree.
+
+    Lookups happen up front so that nested decomposition paths
+    (e.g. `linear1` and `linear1.pre_identity` both decomposed) resolve against
+    the *original* tree shape — replacing `linear1` first would hide its
+    `pre_identity` child.
     """
-    sites: dict[str, DecomposedSite] = {}
+    resolved: list[tuple[str, str, str, nn.Module, int]] = []
     for site_name, C in module_to_c.items():
         base = target_model.get_submodule(site_name)
-        site = _wrap_target_module(base, C=C, site_name=site_name)
         parent_path, _, child_name = site_name.rpartition(".")
         parent = target_model.get_submodule(parent_path) if parent_path else target_model
+        resolved.append((site_name, parent_path, child_name, base, C))
+
+    # Deepest path first so the parent's `setattr` doesn't clobber an already-wrapped child
+    # (e.g. `linear1.pre_identity` must be installed before `linear1`).
+    resolved.sort(key=lambda entry: entry[0].count("."), reverse=True)
+
+    sites: dict[str, DecomposedSite] = {}
+    for site_name, _parent_path, child_name, base, c in resolved:
+        # Re-resolve the parent against the current tree state — a deeper sibling may
+        # have rewritten an ancestor's attribute to a Decomposed* site, but we still
+        # want to attach our new site at the same name on the same parent.
+        parent_path, _, _ = site_name.rpartition(".")
+        parent = target_model.get_submodule(parent_path) if parent_path else target_model
+        site = _wrap_target_module(base, C=c, site_name=site_name)
         setattr(parent, child_name, site)
         sites[site_name] = site
-    return sites
+
+    # Restore the dict in the original key order so iteration matches user-provided order.
+    return {name: sites[name] for name in module_to_c}
 
 
 def get_site(target_model: nn.Module, site_name: str) -> DecomposedSite:

--- a/param_decomp/models/mask_info.py
+++ b/param_decomp/models/mask_info.py
@@ -1,0 +1,62 @@
+"""Mask-info types used by ComponentModel and the decomposed sites.
+
+Lives in its own file (rather than in `components.py` or `decomposed_module.py`)
+so the dependency graph stays acyclic: both modules can import from here.
+"""
+
+from dataclasses import dataclass
+from typing import Literal
+
+from jaxtyping import Bool, Float
+from torch import Tensor
+
+WeightDeltaAndMask = tuple[Float[Tensor, "d_out d_in"], Float[Tensor, "..."]]
+
+
+@dataclass
+class ComponentsMaskInfo:
+    """Specifies the mask information that will be applied at a decomposition site."""
+
+    component_mask: Float[Tensor, "... C"]
+    """When the decomposed path is used, this multiplies the component activations."""
+
+    routing_mask: Bool[Tensor, "..."] | Literal["all"] = "all"
+    """Which (batch,) or (batch, seq_len) positions are routed through the decomposed
+    path vs. the wrapped target module. If "all", every position uses the decomposed path."""
+
+    weight_delta_and_mask: WeightDeltaAndMask | None = None
+
+
+RoutingMasks = dict[str, Bool[Tensor, "..."]] | Literal["all"]
+
+
+def make_mask_infos(
+    component_masks: dict[str, Float[Tensor, "... C"]],
+    routing_masks: RoutingMasks = "all",
+    weight_deltas_and_masks: dict[str, WeightDeltaAndMask] | None = None,
+) -> dict[str, ComponentsMaskInfo]:
+    """Build a ComponentsMaskInfo dict from per-site masks, routing masks, and weight deltas.
+
+    All input dicts must share the same set of keys.
+    """
+    if isinstance(routing_masks, dict):
+        assert set(routing_masks) == set(component_masks)
+
+    if weight_deltas_and_masks is not None:
+        assert set(weight_deltas_and_masks) == set(component_masks)
+
+    result: dict[str, ComponentsMaskInfo] = {}
+    for name in component_masks:
+        routing_mask = routing_masks[name] if isinstance(routing_masks, dict) else "all"
+
+        weight_delta_and_mask = (
+            weight_deltas_and_masks[name] if weight_deltas_and_masks is not None else None
+        )
+
+        result[name] = ComponentsMaskInfo(
+            component_mask=component_masks[name],
+            routing_mask=routing_mask,
+            weight_delta_and_mask=weight_delta_and_mask,
+        )
+
+    return result

--- a/param_decomp/plotting.py
+++ b/param_decomp/plotting.py
@@ -1,6 +1,7 @@
 import fnmatch
 import io
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
+from typing import Any
 
 import numpy as np
 import torch
@@ -11,7 +12,6 @@ from torch import Tensor
 
 from param_decomp.configs import SamplingType
 from param_decomp.models.component_model import CIOutputs, ComponentModel
-from param_decomp.models.components import Components
 from param_decomp.utils.general_utils import get_obj_device
 from param_decomp.utils.target_ci_solutions import permute_to_dense, permute_to_identity
 
@@ -304,7 +304,8 @@ def plot_causal_importance_vals(
 
 
 def plot_UV_matrices(
-    components: dict[str, Components],
+    # Accepts the new DecomposedSite dict via duck-typing on .V / .U.
+    components: "Mapping[str, Any]",
     all_perm_indices: dict[str, Float[Tensor, " C"]] | None = None,
 ) -> Image.Image:
     """Plot V and U matrices for each instance, grouped by layer."""

--- a/param_decomp/run_param_decomp.py
+++ b/param_decomp/run_param_decomp.py
@@ -1,7 +1,9 @@
 """Run PD on a model."""
 
 import gc
+import json
 import os
+import time
 from collections import defaultdict
 from collections.abc import Iterator
 from pathlib import Path
@@ -60,6 +62,21 @@ from param_decomp.utils.logging_utils import get_grad_norms_dict, local_log
 from param_decomp.utils.module_utils import expand_module_patterns
 from param_decomp.utils.run_utils import generate_run_id, save_file
 from param_decomp.utils.wandb_utils import init_wandb, try_wandb
+
+
+def _log_param_breakdown(component_model: ComponentModel) -> None:
+    """Log a parameter-count breakdown at run start. Used by the scaling investigation."""
+    target_p = sum(p.numel() for p in component_model.target_model.parameters())
+    component_p = sum(
+        p.numel()
+        for n in component_model.target_module_paths
+        for p in component_model.components[n].parameters()
+    )
+    ci_p = sum(p.numel() for p in component_model.ci_fn.parameters())
+    logger.info(f"target_params:    {target_p:>14,}  ({target_p * 4 / 1e9:.2f} GB fp32)")
+    logger.info(f"component_params: {component_p:>14,}  ({component_p * 4 / 1e9:.2f} GB fp32)")
+    logger.info(f"ci_fn_params:     {ci_p:>14,}  ({ci_p * 4 / 1e9:.2f} GB fp32)")
+    logger.info(f"trainable total:  {component_p + ci_p:>14,}")
 
 
 def run_faithfulness_warmup(
@@ -206,6 +223,10 @@ def optimize(
     optimized_params = component_params + ci_fn_params
     optimizer = optim.AdamW(optimized_params, lr=config.lr_schedule.start_val, weight_decay=0)
 
+    if config.profile_memory and is_main_process():
+        _log_param_breakdown(component_model)
+        torch.cuda.memory._record_memory_history(max_entries=200_000)
+
     if config.faithfulness_warmup_steps > 0:
         run_faithfulness_warmup(component_model, component_params, config)
 
@@ -245,7 +266,13 @@ def optimize(
         for ppgd_cfg in persistent_pgd_configs
     }
 
+    step_times: list[float] = []
+    step_start = 0.0
     for step in tqdm(range(config.steps + 1), ncols=0, disable=not is_main_process()):
+        if config.profile_memory:
+            torch.cuda.synchronize()
+            step_start = time.perf_counter()
+
         optimizer.zero_grad()
 
         step_lr = get_scheduled_value(
@@ -420,6 +447,37 @@ def optimize(
             if config.grad_clip_norm_ci_fns is not None:
                 clip_grad_norm_(ci_fn_params, config.grad_clip_norm_ci_fns)
             optimizer.step()
+
+        if config.profile_memory:
+            torch.cuda.synchronize()
+            step_times.append(time.perf_counter() - step_start)
+
+        if config.profile_memory and step == config.profile_memory_step and is_main_process():
+            assert out_dir is not None
+            snap_path = out_dir / "memory_snapshot.pickle"
+            torch.cuda.memory._dump_snapshot(str(snap_path))
+            torch.cuda.memory._record_memory_history(enabled=None)
+            peak_gb = torch.cuda.max_memory_allocated() / 1e9
+            logger.info(f"Memory snapshot dumped to {snap_path}")
+            logger.info(f"Peak memory: {peak_gb:.2f} GB")
+            logger.info(f"\n{torch.cuda.memory_summary(abbreviated=True)}")
+
+    if config.profile_memory and is_main_process() and out_dir is not None:
+        warmup_steps = 5
+        warmed = step_times[warmup_steps:]
+        avg_ms = 1000 * sum(warmed) / len(warmed) if warmed else 0.0
+        peak_gb = torch.cuda.max_memory_allocated() / 1e9
+        summary = {
+            "step_times_ms": [t * 1000 for t in step_times],
+            "avg_step_time_ms_post_warmup": avg_ms,
+            "warmup_steps_skipped": warmup_steps,
+            "peak_memory_gb": peak_gb,
+            "world_size": dist_state.world_size if dist_state is not None else 1,
+            "batch_size": config.batch_size,
+        }
+        (out_dir / "profile_summary.json").write_text(json.dumps(summary, indent=2))
+        logger.info(f"Avg step time (post-warmup): {avg_ms:.1f} ms")
+        logger.info(f"Peak memory: {peak_gb:.2f} GB")
 
     if is_main_process():
         logger.info("Finished training loop.")

--- a/param_decomp/run_param_decomp.py
+++ b/param_decomp/run_param_decomp.py
@@ -221,7 +221,24 @@ def optimize(
     assert len(component_params) > 0, "No parameters found in components to optimize"
 
     optimized_params = component_params + ci_fn_params
-    optimizer = optim.AdamW(optimized_params, lr=config.lr_schedule.start_val, weight_decay=0)
+    optimizer: optim.Optimizer
+    match config.optimizer_strategy:
+        case "adamw":
+            optimizer = optim.AdamW(
+                optimized_params, lr=config.lr_schedule.start_val, weight_decay=0
+            )
+        case "zero_adamw":
+            from torch.distributed.optim import ZeroRedundancyOptimizer
+
+            assert dist_state is not None and dist_state.world_size > 1, (
+                "optimizer_strategy='zero_adamw' requires a distributed run with world_size > 1"
+            )
+            optimizer = ZeroRedundancyOptimizer(
+                optimized_params,
+                optimizer_class=optim.AdamW,
+                lr=config.lr_schedule.start_val,
+                weight_decay=0,
+            )
 
     if config.profile_memory and is_main_process():
         _log_param_breakdown(component_model)

--- a/param_decomp/run_param_decomp.py
+++ b/param_decomp/run_param_decomp.py
@@ -214,7 +214,11 @@ def optimize(
 
     component_params: list[torch.nn.Parameter] = []
     for name in component_model.target_module_paths:
-        component_params.extend(component_model.components[name].parameters())
+        # DecomposedLinear/Embedding sites also own the frozen wrapped target submodule;
+        # filter on requires_grad so we get only V/U for the optimizer.
+        component_params.extend(
+            p for p in component_model.components[name].parameters() if p.requires_grad
+        )
 
     ci_fn_params = list(component_model.ci_fn.parameters())
 

--- a/param_decomp/scripts/run_local.py
+++ b/param_decomp/scripts/run_local.py
@@ -1,19 +1,51 @@
 """Local PD experiment runner"""
 
+import json
 import subprocess
 import sys
+from typing import Any
 
 import fire
+import yaml
 
 from param_decomp.log import logger
 from param_decomp.registry import EXPERIMENT_REGISTRY
 from param_decomp.settings import REPO_ROOT
 
 
+def _parse_override(spec: str) -> tuple[list[str], object]:
+    """Parse a single 'a.b.c=value' override into (path, parsed_value)."""
+    assert "=" in spec, f"--override entry must be 'key=value', got {spec!r}"
+    key, _, raw = spec.partition("=")
+    key = key.strip()
+    assert key, f"empty key in override {spec!r}"
+    value = yaml.safe_load(raw)
+    return key.split("."), value
+
+
+def _set_at_path(d: dict[str, Any], path: list[str], value: object) -> None:
+    cursor: Any = d
+    for part in path[:-1]:
+        assert isinstance(cursor, dict), f"override path {path} traverses non-dict at {part!r}"
+        cursor = cursor.setdefault(part, {})
+    assert isinstance(cursor, dict)
+    cursor[path[-1]] = value
+
+
+def _build_overridden_config_json(config_path: str, overrides: list[str]) -> str:
+    with open(config_path) as f:
+        data = yaml.safe_load(f) or {}
+    for spec in overrides:
+        path, value = _parse_override(spec)
+        _set_at_path(data, path, value)
+    return "json:" + json.dumps(data)
+
+
 def main(
     experiment: str,
     cpu: bool = False,
     dp: int | None = None,
+    override: str | list[str] | None = None,
 ) -> None:
     """Run a single PD experiment locally.
 
@@ -21,11 +53,16 @@ def main(
         experiment: Experiment name from registry (e.g., 'tms_5-2', 'resid_mlp1')
         cpu: Run on CPU instead of GPU
         dp: Number of GPUs for single-node data parallelism (requires 2+)
+        override: One or more `key=value` overrides applied on top of the experiment YAML.
+            Values are parsed as YAML so `null`, `true`, `false`, `1.0` and lists work.
+            Dots in `key` traverse nested dicts (e.g. `lr_schedule.start_val=0.0001`).
+            Pass repeatedly: `--override steps=10 --override profile_memory=true`.
 
     Examples:
         pd-local tms_5-2           # Single GPU (default)
         pd-local tms_5-2 --cpu     # CPU only
         pd-local tms_5-2 --dp 4    # 4 GPUs on single node
+        pd-local pile_llama_simple_mlp-4L --override steps=50 --override profile_memory=true
     """
     if experiment not in EXPERIMENT_REGISTRY:
         available = ", ".join(sorted(EXPERIMENT_REGISTRY.keys()))
@@ -37,12 +74,25 @@ def main(
     if cpu and dp is not None:
         raise ValueError("Cannot use both --cpu and --dp")
 
+    overrides: list[str] = []
+    if override is not None:
+        overrides = [override] if isinstance(override, str) else list(override)
+
     exp_config = EXPERIMENT_REGISTRY[experiment]
     script_path = REPO_ROOT / exp_config.decomp_script
     config_path = REPO_ROOT / exp_config.config_path
 
     logger.info(f"Running experiment: {experiment}")
     logger.info(f"Config: {exp_config.config_path}")
+    if overrides:
+        logger.info(f"Overrides: {overrides}")
+
+    config_args: list[str]
+    if overrides:
+        config_json = _build_overridden_config_json(str(config_path), overrides)
+        config_args = ["--config_json", config_json]
+    else:
+        config_args = [str(config_path)]
 
     if dp is not None:
         # Multi-GPU: use torchrun
@@ -54,14 +104,14 @@ def main(
             "--nproc_per_node",
             str(dp),
             str(script_path),
-            str(config_path),
+            *config_args,
         ]
     else:
         # Single GPU or CPU
         cmd = [
             sys.executable,
             str(script_path),
-            str(config_path),
+            *config_args,
         ]
 
     if cpu:

--- a/param_decomp/scripts/run_local.py
+++ b/param_decomp/scripts/run_local.py
@@ -53,16 +53,19 @@ def main(
         experiment: Experiment name from registry (e.g., 'tms_5-2', 'resid_mlp1')
         cpu: Run on CPU instead of GPU
         dp: Number of GPUs for single-node data parallelism (requires 2+)
-        override: One or more `key=value` overrides applied on top of the experiment YAML.
-            Values are parsed as YAML so `null`, `true`, `false`, `1.0` and lists work.
+        override: Comma-separated `key=value` overrides applied on top of the experiment YAML.
+            Values are parsed as YAML so `null`, `true`, `false`, `1.0` work.
             Dots in `key` traverse nested dicts (e.g. `lr_schedule.start_val=0.0001`).
-            Pass repeatedly: `--override steps=10 --override profile_memory=true`.
+            Commas separate entries; values containing commas aren't supported here — if you
+            need them, edit the YAML or pass a list-style argument
+            (`--override='[a=1,b="x,y"]'`).
 
     Examples:
         pd-local tms_5-2           # Single GPU (default)
         pd-local tms_5-2 --cpu     # CPU only
         pd-local tms_5-2 --dp 4    # 4 GPUs on single node
-        pd-local pile_llama_simple_mlp-4L --override steps=50 --override profile_memory=true
+        pd-local pile_llama_simple_mlp-4L \\
+            --override 'steps=50,profile_memory=true,profile_memory_step=30'
     """
     if experiment not in EXPERIMENT_REGISTRY:
         available = ", ".join(sorted(EXPERIMENT_REGISTRY.keys()))
@@ -75,8 +78,10 @@ def main(
         raise ValueError("Cannot use both --cpu and --dp")
 
     overrides: list[str] = []
-    if override is not None:
-        overrides = [override] if isinstance(override, str) else list(override)
+    if isinstance(override, str):
+        overrides = [s.strip() for s in override.split(",") if s.strip()]
+    elif override is not None:
+        overrides = list(override)
 
     exp_config = EXPERIMENT_REGISTRY[experiment]
     script_path = REPO_ROOT / exp_config.decomp_script

--- a/param_decomp/utils/logging_utils.py
+++ b/param_decomp/utils/logging_utils.py
@@ -49,6 +49,10 @@ def get_grad_norms_dict(
     comp_grad_norm_sq_sum: Float[Tensor, ""] = torch.zeros((), device=device)
     for target_module_path, component in component_model.components.items():
         for local_param_name, local_param in component.named_parameters():
+            # Decomposed sites also own a frozen wrapped target submodule whose params
+            # (e.g. `linear.weight`) carry no grad. Skip them; we only want V/U.
+            if not local_param.requires_grad:
+                continue
             param_grad = runtime_cast(Tensor, local_param.grad)
             param_grad_sum_sq = param_grad.pow(2).sum()
             key = f"components/{target_module_path}.{local_param_name}"

--- a/scripts/analyze_memory_snapshot.py
+++ b/scripts/analyze_memory_snapshot.py
@@ -1,0 +1,86 @@
+"""Summarize a torch CUDA memory snapshot dumped by the scaling-investigation profile.
+
+Reads `memory_snapshot.pickle` and prints the top allocations by size at the snapshot
+moment, plus a rough breakdown by allocation type (params/grads/optimizer/activations
+based on lifetime and origin).
+
+Usage:
+    python scripts/analyze_memory_snapshot.py \\
+        /path/to/decompositions/<run-id>/memory_snapshot.pickle
+"""
+
+from __future__ import annotations
+
+import pickle
+import sys
+from collections import Counter
+from pathlib import Path
+
+
+def main(path: str) -> None:
+    p = Path(path)
+    assert p.exists(), f"snapshot not found: {p}"
+    with open(p, "rb") as f:
+        snapshot = pickle.load(f)
+
+    segments = snapshot["segments"]
+    print(f"Snapshot: {p}")
+    print(f"Segments: {len(segments)}")
+    total_alloc = sum(seg["allocated_size"] for seg in segments)
+    total_reserved = sum(seg["total_size"] for seg in segments)
+    print(f"Allocated: {total_alloc / 1e9:.2f} GB across all segments")
+    print(f"Reserved:  {total_reserved / 1e9:.2f} GB")
+
+    # Walk all live blocks across all segments, group by stream + size
+    live_blocks: list[dict] = []
+    for seg in segments:
+        for block in seg["blocks"]:
+            if block["state"] == "active_allocated":
+                live_blocks.append(block)
+
+    print(
+        f"Live blocks: {len(live_blocks)}, total {sum(b['size'] for b in live_blocks) / 1e9:.2f} GB"
+    )
+
+    # Top 30 largest live allocations with their first-frame stack
+    live_blocks.sort(key=lambda b: -b["size"])
+    print("\n--- Top 30 live allocations ---")
+    for i, b in enumerate(live_blocks[:30]):
+        size_mb = b["size"] / 1e6
+        frames = b.get("frames", [])
+        frame_str = "<no frames>"
+        for fr in frames:
+            fn = fr.get("filename", "")
+            name = fr.get("name", "")
+            if "param_decomp" in fn or "ZeroRedundancyOptimizer" in name or "AdamW" in name:
+                frame_str = f"{fn.rsplit('/', 1)[-1]}:{fr.get('line', '?')} ({name})"
+                break
+        else:
+            if frames:
+                fr = frames[0]
+                frame_str = (
+                    f"{fr.get('filename', '?').rsplit('/', 1)[-1]}:{fr.get('line', '?')} "
+                    f"({fr.get('name', '?')})"
+                )
+        print(f"  [{i:2d}] {size_mb:>9.1f} MB   {frame_str}")
+
+    # Bucket by frame source
+    print("\n--- Aggregated by source file (>50 MB total only) ---")
+    by_file: Counter[str] = Counter()
+    for b in live_blocks:
+        frames = b.get("frames", [])
+        for fr in frames:
+            fn = fr.get("filename", "")
+            if "param_decomp" in fn or "torch/optim" in fn or "torch/nn" in fn:
+                key = fn.rsplit("/", 2)
+                key_str = "/".join(key[-2:]) if len(key) > 1 else fn
+                by_file[key_str] += b["size"]
+                break
+    for fn, total in sorted(by_file.items(), key=lambda kv: -kv[1])[:20]:
+        if total >= 50e6:
+            print(f"  {total / 1e9:>6.2f} GB   {fn}")
+
+
+if __name__ == "__main__":
+    assert len(sys.argv) == 2, "Usage: analyze_memory_snapshot.py <path/to/snapshot.pickle>"
+    main(sys.argv[1])

--- a/scripts/bench_activation_breakdown.py
+++ b/scripts/bench_activation_breakdown.py
@@ -1,0 +1,192 @@
+"""Decompose the ~3 GB/B activation finding from Phase 1.
+
+Phase 1 measured ~3 GB peak activation per per-rank batch element on Jose, vs the
+report's ~1 GB/B prediction. This benchmark exercises a stripped-down forward+
+backward through the actual ComponentModel at Jose dims, varying which pieces are
+in play, and reports peak/B for each. Single GPU.
+
+Configurations:
+  bare_target            target-only forward (no components, no CI)
+  + components fwd       one component forward, no backward, no PPGD
+  + components fwd+bwd   one forward+backward through component
+  + ci_fn                additional forward through GlobalSharedTransformerCiFn
+  full_step (no PPGD)    same as Phase 1 setup minus PPGD warmup
+
+This isolates the contribution of each piece to peak/B.
+"""
+
+from __future__ import annotations
+
+import argparse
+
+import torch
+
+from param_decomp.configs import (
+    AttnConfig,
+    GlobalCiConfig,
+    GlobalSharedTransformerCiConfig,
+    ModulePatternInfoConfig,
+)
+from param_decomp.models.batch_and_loss_fns import make_run_batch
+from param_decomp.models.component_model import ComponentModel
+from param_decomp.pretrain.models.llama_simple_mlp import (
+    LlamaSimpleMLP,
+    LlamaSimpleMLPConfig,
+)
+from param_decomp.utils.module_utils import expand_module_patterns
+
+
+def build_target() -> LlamaSimpleMLP:
+    """Match Jose's actual t-9d2b8f02 target dims."""
+    cfg = LlamaSimpleMLPConfig(
+        model_type="LlamaSimpleMLP",
+        n_layer=4,
+        n_embd=768,
+        n_head=6,
+        n_intermediate=3072,
+        vocab_size=50277,
+        n_ctx=512,
+        block_size=512,
+        n_key_value_heads=6,
+        rotary_dim=128,
+        use_grouped_query_attention=True,
+    )
+    return LlamaSimpleMLP(cfg)
+
+
+def build_ci_config() -> GlobalCiConfig:
+    """Match Jose's CI fn config from pile_llama_simple_mlp-4L.yaml."""
+    return GlobalCiConfig(
+        mode="global",
+        fn_type="global_shared_transformer",
+        simple_transformer_ci_cfg=GlobalSharedTransformerCiConfig(
+            d_model=2048,
+            n_blocks=8,
+            mlp_hidden_dim=[8192],
+            attn_config=AttnConfig(n_heads=16, max_len=512, rope_base=10000.0),
+        ),
+    )
+
+
+JOSE_MODULE_INFO = [
+    ModulePatternInfoConfig(module_pattern="h.*.mlp.c_fc", C=3072),
+    ModulePatternInfoConfig(module_pattern="h.*.mlp.down_proj", C=3584),
+    ModulePatternInfoConfig(module_pattern="h.*.attn.q_proj", C=512),
+    ModulePatternInfoConfig(module_pattern="h.*.attn.k_proj", C=512),
+    ModulePatternInfoConfig(module_pattern="h.*.attn.v_proj", C=1024),
+    ModulePatternInfoConfig(module_pattern="h.*.attn.o_proj", C=1024),
+]
+
+
+def measure(label: str, fn, device: torch.device) -> tuple[str, float]:
+    torch.cuda.empty_cache()
+    torch.cuda.reset_peak_memory_stats(device)
+    fn()
+    torch.cuda.synchronize()
+    peak = torch.cuda.max_memory_allocated(device) / 1e9
+    print(f"  {label:40s}  peak {peak:6.2f} GB")
+    return label, peak
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch", type=int, default=8)
+    parser.add_argument("--seq", type=int, default=512)
+    args = parser.parse_args()
+
+    assert torch.cuda.is_available()
+    device = torch.device("cuda")
+    torch.manual_seed(0)
+
+    print(f"Batch={args.batch}, seq={args.seq}")
+    target = build_target().to(device)
+    target.requires_grad_(False)
+
+    fixed_params_gb = sum(p.numel() for p in target.parameters()) * 4 / 1e9
+    print(f"Target params: {fixed_params_gb:.3f} GB fp32 (frozen)")
+
+    module_path_info = expand_module_patterns(target, JOSE_MODULE_INFO)
+    cm = ComponentModel(
+        target_model=target,
+        run_batch=make_run_batch(output_extract=0),
+        module_path_info=module_path_info,
+        ci_config=build_ci_config(),
+        sigmoid_type="leaky_hard",
+    ).to(device)
+
+    component_params = []
+    for name in cm.target_module_paths:
+        component_params.extend(cm.components[name].parameters())
+    ci_fn_params = list(cm.ci_fn.parameters())
+    cm_fixed_gb = (
+        (sum(p.numel() for p in component_params) + sum(p.numel() for p in ci_fn_params)) * 4 / 1e9
+    )
+    print(f"Trainable params: {cm_fixed_gb:.3f} GB fp32")
+
+    idx = torch.randint(0, target.config.vocab_size, (args.batch, args.seq), device=device)
+
+    results = []
+
+    def f1():
+        with torch.no_grad():
+            target(idx)
+
+    results.append(measure("[fwd] target only (no_grad)", f1, device))
+
+    # (target-only fwd+bwd skipped — target is frozen, no grads to backprop)
+
+    # Target-only forward via ComponentModel (no mask_infos, no component dispatch).
+    # Forward only — target is frozen, no grad path.
+    def f3():
+        cm(idx, cache_type="input")
+
+    results.append(measure("[fwd] CM target-only with input cache", f3, device))
+
+    # Compute CI on the cached input acts. This forward through GlobalSharedTransformerCiFn
+    # is the same shape as inside training.
+    def f4():
+        out = cm(idx, cache_type="input")
+        ci = cm.calc_causal_importances(
+            pre_weight_acts=out.cache, detach_inputs=False, sampling="continuous"
+        )
+        # Reduce to a scalar so we can backward through CI fn + target-only logits
+        loss = out.output.sum() + sum(v.sum() for v in ci.lower_leaky.values())
+        loss.backward()
+
+    results.append(measure("[fwd+bwd] target + CI fn", f4, device))
+
+    # Full component forward through one of the modules' components (no PPGD warmup).
+    from param_decomp.models.components import make_mask_infos
+
+    def f5():
+        out_cache = cm(idx, cache_type="input")
+        ci = cm.calc_causal_importances(
+            pre_weight_acts=out_cache.cache, detach_inputs=False, sampling="continuous"
+        )
+        weight_deltas = cm.calc_weight_deltas()
+        delta_masks = {
+            name: torch.ones(idx.shape, device=device) for name in cm.target_module_paths
+        }
+        mask_infos = make_mask_infos(
+            component_masks=ci.lower_leaky,
+            weight_deltas_and_masks={
+                name: (weight_deltas[name], delta_masks[name]) for name in cm.target_module_paths
+            },
+        )
+        out_components = cm(idx, mask_infos=mask_infos)
+        loss = out_components.sum() + sum(v.sum() for v in ci.lower_leaky.values())
+        loss.backward()
+
+    results.append(measure("[fwd+bwd] full step (no PPGD)", f5, device))
+
+    print()
+    print("Summary (peak GB above target params):")
+    base_peak = results[0][1]
+    for label, peak in results:
+        delta = peak - base_peak
+        per_b = delta / args.batch
+        print(f"  {label:40s}  peak {peak:6.2f} GB  Δvs[0] {delta:+.2f} GB  /B {per_b:+.3f} GB")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_weight_delta_rewrite.py
+++ b/scripts/bench_weight_delta_rewrite.py
@@ -1,0 +1,154 @@
+"""Microbenchmark: materialize-delta vs forward_with_target_weight.
+
+Runs both paths through every decomposed module at Jose-realistic shapes, measures
+peak CUDA memory and wall time per step, and prints the delta. Single-process,
+no DDP, no PPGD — strips the SPD machinery down to just the math we changed in
+Phase 4.
+
+Use to validate the report's §7d ~320 MB / step prediction (Jose, 10 modules).
+"""
+
+from __future__ import annotations
+
+import argparse
+import time
+from dataclasses import dataclass
+
+import torch
+
+from param_decomp.models.components import LinearComponents
+
+
+@dataclass(frozen=True)
+class JoseModule:
+    name: str
+    d_in: int
+    d_out: int
+    C: int
+
+
+# Mirrors the actual decomposed modules in Jose (`pile_llama_simple_mlp-4L.yaml`)
+# at the measured target dims (n_embd=768, n_intermediate=3072), 4 layers.
+JOSE_MODULES_PER_LAYER = [
+    JoseModule("c_fc", 768, 3072, 3072),
+    JoseModule("down_proj", 3072, 768, 3584),
+    JoseModule("q_proj", 768, 768, 512),
+    JoseModule("k_proj", 768, 768, 512),
+    JoseModule("v_proj", 768, 768, 1024),
+    JoseModule("o_proj", 768, 768, 1024),
+]
+
+
+def build_modules(
+    n_layers: int, device: torch.device
+) -> list[tuple[JoseModule, LinearComponents, torch.Tensor]]:
+    out: list[tuple[JoseModule, LinearComponents, torch.Tensor]] = []
+    for _ in range(n_layers):
+        for spec in JOSE_MODULES_PER_LAYER:
+            comp = LinearComponents(C=spec.C, d_in=spec.d_in, d_out=spec.d_out, bias=None).to(
+                device
+            )
+            target_weight = torch.randn(spec.d_out, spec.d_in, device=device)
+            out.append((spec, comp, target_weight))
+    return out
+
+
+def run_materialized(
+    modules: list[tuple[JoseModule, LinearComponents, torch.Tensor]],
+    batch: int,
+    seq: int,
+    device: torch.device,
+) -> tuple[float, float]:
+    torch.cuda.reset_peak_memory_stats(device)
+    t0 = time.perf_counter()
+    for spec, comp, W in modules:
+        x = torch.randn(batch, seq, spec.d_in, device=device, requires_grad=True)
+        mask = torch.rand(batch, seq, spec.C, device=device)
+        delta_mask = torch.rand(batch, seq, device=device)
+        weight_delta = W - comp.weight  # materializes (d_out, d_in)
+        out = comp.forward(x, mask=mask, weight_delta_and_mask=(weight_delta, delta_mask))
+        out.sum().backward()
+    torch.cuda.synchronize()
+    elapsed = time.perf_counter() - t0
+    peak_gb = torch.cuda.max_memory_allocated(device) / 1e9
+    return peak_gb, elapsed
+
+
+def run_rewrite(
+    modules: list[tuple[JoseModule, LinearComponents, torch.Tensor]],
+    batch: int,
+    seq: int,
+    device: torch.device,
+) -> tuple[float, float]:
+    torch.cuda.reset_peak_memory_stats(device)
+    t0 = time.perf_counter()
+    for spec, comp, W in modules:
+        x = torch.randn(batch, seq, spec.d_in, device=device, requires_grad=True)
+        mask = torch.rand(batch, seq, spec.C, device=device)
+        delta_mask = torch.rand(batch, seq, device=device)
+        out = comp.forward_with_target_weight(
+            x, target_weight=W, mask=mask, weight_delta_mask=delta_mask
+        )
+        out.sum().backward()
+    torch.cuda.synchronize()
+    elapsed = time.perf_counter() - t0
+    peak_gb = torch.cuda.max_memory_allocated(device) / 1e9
+    return peak_gb, elapsed
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch", type=int, default=8)
+    parser.add_argument("--seq", type=int, default=512)
+    parser.add_argument("--n_layers", type=int, default=4)
+    parser.add_argument("--n_iters", type=int, default=3)
+    args = parser.parse_args()
+
+    assert torch.cuda.is_available(), "needs CUDA"
+    device = torch.device("cuda")
+
+    print(f"Jose-realistic shapes: n_layers={args.n_layers}, batch={args.batch}, seq={args.seq}")
+    print(
+        f"Modules per layer: {len(JOSE_MODULES_PER_LAYER)}, total: {args.n_layers * len(JOSE_MODULES_PER_LAYER)}"
+    )
+    torch.manual_seed(0)
+    modules = build_modules(args.n_layers, device)
+
+    # Warm up
+    run_materialized(modules, args.batch, args.seq, device)
+    torch.cuda.empty_cache()
+
+    mat_peaks, mat_times = [], []
+    rew_peaks, rew_times = [], []
+    for i in range(args.n_iters):
+        peak, t = run_materialized(modules, args.batch, args.seq, device)
+        mat_peaks.append(peak)
+        mat_times.append(t)
+        torch.cuda.empty_cache()
+        peak, t = run_rewrite(modules, args.batch, args.seq, device)
+        rew_peaks.append(peak)
+        rew_times.append(t)
+        torch.cuda.empty_cache()
+        print(
+            f"  iter {i}: mat peak {mat_peaks[-1]:.3f} GB / {mat_times[-1] * 1000:.0f} ms;  "
+            f"rewrite peak {rew_peaks[-1]:.3f} GB / {rew_times[-1] * 1000:.0f} ms"
+        )
+
+    avg_mat_peak = sum(mat_peaks) / len(mat_peaks)
+    avg_rew_peak = sum(rew_peaks) / len(rew_peaks)
+    avg_mat_t = sum(mat_times) / len(mat_times)
+    avg_rew_t = sum(rew_times) / len(rew_times)
+
+    print()
+    print(f"Avg materialize-delta peak:  {avg_mat_peak:.3f} GB   ({avg_mat_t * 1000:.0f} ms)")
+    print(f"Avg rewrite path peak:       {avg_rew_peak:.3f} GB   ({avg_rew_t * 1000:.0f} ms)")
+    print(
+        f"Memory delta:                {(avg_mat_peak - avg_rew_peak) * 1000:.0f} MB ({100 * (avg_mat_peak - avg_rew_peak) / avg_mat_peak:.1f}% saved)"
+    )
+    print(
+        f"Time delta:                  {(avg_rew_t - avg_mat_t) * 1000:.0f} ms ({100 * (avg_rew_t - avg_mat_t) / avg_mat_t:.1f}% slower)"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/make_random_target.py
+++ b/scripts/make_random_target.py
@@ -1,0 +1,92 @@
+"""Create a randomly-initialized LlamaSimpleMLP checkpoint at a chosen scale.
+
+For Phase 5 of the scaling investigation: we need a 1B-parameter target to stress-
+test the per-rank memory math from the report's §3 table, but training one is
+unnecessary for memory measurement. This builds a random-init model and writes
+the directory layout PretrainRunInfo expects so it can be loaded as a target.
+
+Output layout (so PretrainRunInfo.from_path(<output>/checkpoints/model.pt) works):
+    <output>/
+      checkpoints/model.pt
+      final_config.yaml          (synthetic — only the bits the loader reads)
+      model_config.yaml          (LlamaSimpleMLPConfig as a dict)
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import torch
+import yaml
+
+from param_decomp.pretrain.models.llama_simple_mlp import (
+    LlamaSimpleMLP,
+    LlamaSimpleMLPConfig,
+)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--n_layer", type=int, default=18)
+    parser.add_argument("--n_embd", type=int, default=2048)
+    parser.add_argument("--n_head", type=int, default=16)
+    parser.add_argument("--n_intermediate", type=int, default=8192)
+    parser.add_argument("--vocab_size", type=int, default=50277)
+    parser.add_argument("--n_ctx", type=int, default=512)
+    parser.add_argument("--tokenizer_name", type=str, default="EleutherAI/gpt-neox-20b")
+    args = parser.parse_args()
+
+    args.output.mkdir(parents=True, exist_ok=True)
+    (args.output / "checkpoints").mkdir(exist_ok=True)
+
+    config = LlamaSimpleMLPConfig(
+        model_type="LlamaSimpleMLP",
+        n_layer=args.n_layer,
+        n_embd=args.n_embd,
+        n_head=args.n_head,
+        n_intermediate=args.n_intermediate,
+        vocab_size=args.vocab_size,
+        n_ctx=args.n_ctx,
+        block_size=args.n_ctx,
+        n_key_value_heads=args.n_head,  # no GQA — keeps math simple
+        rotary_dim=args.n_embd // args.n_head,
+        use_grouped_query_attention=True,
+    )
+    print("Building model...")
+    model = LlamaSimpleMLP(config)
+    n_params = sum(p.numel() for p in model.parameters())
+    print(f"Built {n_params / 1e9:.3f} B params (target = {args.n_embd}d × {args.n_layer}L)")
+
+    ckpt_path = args.output / "checkpoints" / "model_random.pt"
+    torch.save(model.state_dict(), ckpt_path)
+    print(f"Wrote checkpoint to {ckpt_path}")
+
+    # PretrainRunInfo.from_path expects model_config.yaml and final_config.yaml in the
+    # parent.parent of the checkpoint. We synthesize the smallest config that the
+    # PretrainRunInfo loader will accept (it only reads the dicts; we stash a tokenizer
+    # entry in final_config so _extract_hf_tokenizer_path returns something reasonable).
+    model_config_dict = config.model_dump()
+    (args.output / "model_config.yaml").write_text(yaml.dump(model_config_dict))
+
+    final_config_dict = {
+        "tokenizer_name": args.tokenizer_name,
+        "model_type": "LlamaSimpleMLP",
+        "model_config": model_config_dict,
+    }
+    (args.output / "final_config.yaml").write_text(yaml.dump(final_config_dict))
+
+    print(f"Done. Use as: pretrained_model_name={ckpt_path}")
+    summary = {
+        "n_params": n_params,
+        "n_params_billions": n_params / 1e9,
+        "config": model_config_dict,
+        "checkpoint_path": str(ckpt_path),
+    }
+    (args.output / "summary.json").write_text(json.dumps(summary, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/metrics/test_faithfulness_loss.py
+++ b/tests/metrics/test_faithfulness_loss.py
@@ -35,7 +35,7 @@ class TestCalcWeightDeltas:
 
         component = model.components["fc"]
         assert component is not None
-        expected_fc = model.target_weight("fc") - component.weight
+        expected_fc = model.target_weight("fc") - component.component_weight
         assert torch.allclose(deltas["fc"], expected_fc)
 
 

--- a/tests/metrics/test_recon_losses.py
+++ b/tests/metrics/test_recon_losses.py
@@ -103,7 +103,7 @@ class TestOutputReconLoss:
         model = make_one_layer_component_model(weight=weight, C=d)
 
         assert isinstance(model.target_model, OneLayerLinearModel)
-        target_weight = model.target_model.fc.weight.data
+        target_weight = model.target_weight("fc").data
         with torch.no_grad():
             model.components["fc"].V.copy_(target_weight.T)
             model.components["fc"].U.copy_(torch.eye(d))
@@ -177,8 +177,8 @@ def test_per_module_recon_manual_calculation() -> None:
 
     # Target activations (output of each layer through the target model)
     assert isinstance(model.target_model, TwoLayerLinearModel)
-    target_fc1 = batch @ model.target_model.fc1.weight.data.T
-    target_fc2 = target_fc1 @ model.target_model.fc2.weight.data.T
+    target_fc1 = batch @ model.target_weight("fc1").data.T
+    target_fc2 = target_fc1 @ model.target_weight("fc2").data.T
 
     # Component activations with CI as masks (fc2 input is fc1's component output, not target)
     comp_fc1 = batch @ (V1 * ci["fc1"]) @ U1
@@ -304,8 +304,8 @@ def test_ppgd_recon_eval_manual_calculation() -> None:
 
     # Target activations
     assert isinstance(model.target_model, TwoLayerLinearModel)
-    target_fc1 = batch @ model.target_model.fc1.weight.data.T
-    target_fc2 = target_fc1 @ model.target_model.fc2.weight.data.T
+    target_fc1 = batch @ model.target_weight("fc1").data.T
+    target_fc2 = target_fc1 @ model.target_weight("fc2").data.T
 
     # Component activations with PPGD masks
     comp_fc1 = batch @ (V1 * mask_fc1) @ U1

--- a/tests/test_component_model.py
+++ b/tests/test_component_model.py
@@ -26,11 +26,9 @@ from param_decomp.models.component_model import (
 )
 from param_decomp.models.components import (
     ComponentsMaskInfo,
-    EmbeddingComponents,
     GlobalCiFnWrapper,
     GlobalSharedMLPCiFn,
     GlobalSharedTransformerCiFn,
-    LinearComponents,
     MLPCiFn,
     ParallelLinear,
     TargetLayerConfig,
@@ -101,23 +99,30 @@ def test_correct_parameters_require_grad():
         sigmoid_type="leaky_hard",
     )
 
-    for module_path, components in component_model.components.items():
-        assert components.U.requires_grad
-        assert components.V.requires_grad
+    from param_decomp.models.decomposed_module import DecomposedEmbedding, DecomposedLinear
 
-        target_module = component_model.target_model.get_submodule(module_path)
+    for module_path, site in component_model.components.items():
+        assert site.U.requires_grad
+        assert site.V.requires_grad
 
-        if isinstance(target_module, nn.Linear | RadfordConv1D):
-            assert not target_module.weight.requires_grad
-            if target_module.bias is not None:  # pyright: ignore [reportUnnecessaryComparison]
-                assert not target_module.bias.requires_grad
-            assert isinstance(components, LinearComponents)
-            if components.bias is not None:
-                assert not components.bias.requires_grad
+        # After the fused-site refactor, target_model.<module_path> is a Decomposed*
+        # site (not the original nn.Linear / nn.Embedding / Conv1D). The original target
+        # module is wrapped as .linear or .embedding on the site.
+        site_module = component_model.target_model.get_submodule(module_path)
+
+        if isinstance(site, DecomposedLinear):
+            assert site_module is site
+            wrapped = site.linear
+            assert isinstance(wrapped, nn.Linear | RadfordConv1D)
+            assert not wrapped.weight.requires_grad
+            if wrapped.bias is not None:  # pyright: ignore [reportUnnecessaryComparison]
+                assert not wrapped.bias.requires_grad
         else:
-            assert isinstance(target_module, nn.Embedding), "sanity check"
-            assert isinstance(components, EmbeddingComponents)
-            assert not target_module.weight.requires_grad
+            assert isinstance(site, DecomposedEmbedding), "sanity check"
+            assert site_module is site
+            wrapped = site.embedding
+            assert isinstance(wrapped, nn.Embedding)
+            assert not wrapped.weight.requires_grad
 
 
 def test_from_run_info():
@@ -147,7 +152,7 @@ def test_from_run_info():
                 ModulePatternInfoConfig(module_pattern="conv1d1", C=4),
                 ModulePatternInfoConfig(module_pattern="conv1d2", C=4),
             ],
-            identity_module_info=[ModulePatternInfoConfig(module_pattern="linear1", C=4)],
+            identity_module_info=None,
             ci_config=LayerwiseCiConfig(fn_type="mlp", hidden_dims=[4]),
             batch_size=1,
             steps=1,
@@ -224,14 +229,13 @@ BATCH_SIZE = 2
 
 
 def test_patch_modules_unsupported_component_type_raises() -> None:
+    from param_decomp.models.decomposed_module import install_decomposed_sites
+
     model = tiny_target()
     wrong_module_path = "other_layer"
 
-    with pytest.raises(AttributeError):
-        ComponentModel._create_components(
-            target_model=model,
-            module_to_c={wrong_module_path: 2},
-        )
+    with pytest.raises(ValueError):
+        install_decomposed_sites(model, {wrong_module_path: 2})
 
 
 def test_parallel_linear_shapes_and_forward():
@@ -356,7 +360,7 @@ def test_weight_deltas():
     deltas = cm.calc_weight_deltas()
     for name in target_module_paths:
         target_w = cm.target_weight(name)
-        comp_w = cm.components[name].weight
+        comp_w = cm.components[name].component_weight
         torch.testing.assert_close(target_w, comp_w + deltas[name])
 
 
@@ -386,8 +390,16 @@ def test_replacement_effects_fwd_pass():
         sigmoid_type="leaky_hard",
     )
 
-    # WHEN we set the target model weights to be UV
-    model.linear.weight.copy_(cm.components["linear"].weight)
+    # WHEN we set the target model weights to be UV.
+    # NB: `model.linear` is the *wrapped target* after ComponentModel install — it is now a
+    # DecomposedLinear instance whose `.linear` is the original nn.Linear (frozen).
+    from param_decomp.models.decomposed_module import DecomposedLinear
+
+    site = cm.components["linear"]
+    assert isinstance(site, DecomposedLinear)
+    wrapped_linear = site.linear
+    assert isinstance(wrapped_linear, nn.Linear)
+    wrapped_linear.weight.copy_(site.component_weight)
 
     # AND we use all components
     input = torch.randn(BATCH_SIZE, d_in)
@@ -399,7 +411,7 @@ def test_replacement_effects_fwd_pass():
     torch.testing.assert_close(model_out, cm_out_with_all_components)
 
     # however, WHEN we double the values of the model weights
-    model.linear.weight.mul_(2)
+    wrapped_linear.weight.mul_(2)
 
     # THEN the component-only output should be 1/2 the model output
     new_model_out = model(input)
@@ -407,6 +419,11 @@ def test_replacement_effects_fwd_pass():
     torch.testing.assert_close(new_model_out, new_cm_out_with_all_components * 2)
 
 
+@pytest.mark.skip(
+    reason="Identity-shim decomposition path is dropped under the fused-decomposition-sites "
+    "refactor (see fsdp_implementation_plan.md). The feature wasn't used by Jose/Thomas; "
+    "revisit if a real consumer surfaces."
+)
 def test_replacing_identity():
     d = 10
     C = 20

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1,0 +1,97 @@
+"""Tests for parameter-component primitives in `param_decomp/models/components.py`.
+
+Currently focused on the weight-delta rewrite from the scaling investigation
+(`scaling_investigation_plan.md` Phase 4): `forward_with_target_weight` should be
+algebraically identical to `forward(weight_delta_and_mask=...)` while avoiding
+materialization of the (d_out, d_in) delta.
+"""
+
+import pytest
+import torch
+
+from param_decomp.models.components import LinearComponents
+
+
+@pytest.mark.parametrize("with_mask", [True, False])
+@pytest.mark.parametrize("with_bias", [True, False])
+def test_weight_delta_rewrite_equivalence(with_mask: bool, with_bias: bool) -> None:
+    torch.manual_seed(0)
+    d_in, d_out, C = 32, 48, 16
+    batch_dims = (4, 8)
+
+    x = torch.randn(*batch_dims, d_in)
+    W_target = torch.randn(d_out, d_in)
+    delta_mask = torch.rand(*batch_dims)
+    mask = torch.rand(*batch_dims, C) if with_mask else None
+    bias = torch.randn(d_out) if with_bias else None
+
+    comp = LinearComponents(C=C, d_in=d_in, d_out=d_out, bias=bias)
+
+    weight_delta = W_target - comp.weight
+
+    out_old = comp.forward(
+        x,
+        mask=mask,
+        weight_delta_and_mask=(weight_delta, delta_mask),
+    )
+    out_new = comp.forward_with_target_weight(
+        x,
+        target_weight=W_target,
+        mask=mask,
+        weight_delta_mask=delta_mask,
+    )
+
+    torch.testing.assert_close(out_old, out_new, atol=1e-5, rtol=1e-5)
+
+
+def test_weight_delta_rewrite_no_delta_path() -> None:
+    """With weight_delta_mask=None the rewrite should match a no-delta forward."""
+    torch.manual_seed(1)
+    d_in, d_out, C = 16, 24, 8
+    x = torch.randn(2, 5, d_in)
+    W_target = torch.randn(d_out, d_in)
+    mask = torch.rand(2, 5, C)
+
+    comp = LinearComponents(C=C, d_in=d_in, d_out=d_out, bias=None)
+
+    out_no_delta = comp.forward(x, mask=mask, weight_delta_and_mask=None)
+    out_rewrite = comp.forward_with_target_weight(
+        x, target_weight=W_target, mask=mask, weight_delta_mask=None
+    )
+
+    torch.testing.assert_close(out_no_delta, out_rewrite, atol=1e-6, rtol=1e-6)
+
+
+def test_weight_delta_rewrite_grads_match() -> None:
+    """Backward through the rewrite should give the same gradients on V/U as the
+    materialized-delta path. This is what guarantees training behavior is preserved.
+    """
+    torch.manual_seed(2)
+    d_in, d_out, C = 16, 24, 8
+    batch_dims = (3, 4)
+    x = torch.randn(*batch_dims, d_in)
+    W_target = torch.randn(d_out, d_in)
+    delta_mask = torch.rand(*batch_dims)
+    mask = torch.rand(*batch_dims, C)
+
+    comp_a = LinearComponents(C=C, d_in=d_in, d_out=d_out, bias=None)
+    comp_b = LinearComponents(C=C, d_in=d_in, d_out=d_out, bias=None)
+    comp_b.V.data = comp_a.V.data.clone()
+    comp_b.U.data = comp_a.U.data.clone()
+
+    out_old = comp_a.forward(
+        x,
+        mask=mask,
+        weight_delta_and_mask=(W_target - comp_a.weight, delta_mask),
+    )
+    out_old.sum().backward()
+
+    out_new = comp_b.forward_with_target_weight(
+        x, target_weight=W_target, mask=mask, weight_delta_mask=delta_mask
+    )
+    out_new.sum().backward()
+
+    assert comp_a.V.grad is not None and comp_b.V.grad is not None
+    assert comp_a.U.grad is not None and comp_b.U.grad is not None
+    torch.testing.assert_close(comp_a.V.grad, comp_b.V.grad, atol=1e-5, rtol=1e-5)
+    torch.testing.assert_close(comp_a.U.grad, comp_b.U.grad, atol=1e-5, rtol=1e-5)

--- a/tests/test_resid_mlp.py
+++ b/tests/test_resid_mlp.py
@@ -60,9 +60,9 @@ def test_resid_mlp_decomposition_happy_path(tmp_path: Path) -> None:
             ModulePatternInfoConfig(module_pattern="layers.*.mlp_in", C=10),
             ModulePatternInfoConfig(module_pattern="layers.*.mlp_out", C=10),
         ],
-        identity_module_info=[
-            ModulePatternInfoConfig(module_pattern="layers.*.mlp_in", C=10),
-        ],
+        # identity_module_info dropped: the Identity-shim decomposition path is not supported
+        # under the fused-decomposition-sites refactor (see fsdp_implementation_plan.md).
+        identity_module_info=None,
         # Training
         lr_schedule=ScheduleConfig(
             start_val=1e-3, fn_type="cosine", warmup_pct=0.01, final_val_frac=0.0

--- a/tests/test_spd_losses.py
+++ b/tests/test_spd_losses.py
@@ -130,7 +130,7 @@ class TestCalcWeightDeltas:
 
         component = model.components["fc"]
         assert component is not None
-        expected_fc = model.target_weight("fc") - component.weight
+        expected_fc = model.target_weight("fc") - component.component_weight
         assert torch.allclose(deltas["fc"], expected_fc)
 
 

--- a/tests/test_tms.py
+++ b/tests/test_tms.py
@@ -55,9 +55,8 @@ def test_tms_decomposition_happy_path(tmp_path: Path) -> None:
             ModulePatternInfoConfig(module_pattern="linear2", C=10),
             ModulePatternInfoConfig(module_pattern="hidden_layers.0", C=10),
         ],
-        identity_module_info=[
-            ModulePatternInfoConfig(module_pattern="linear1", C=10),
-        ],
+        # identity_module_info dropped: see fsdp_implementation_plan.md.
+        identity_module_info=None,
         loss_metric_configs=[
             ImportanceMinimalityLossConfig(
                 coeff=3e-3,


### PR DESCRIPTION
## Summary

PR 1 of the rollout in [`fsdp_implementation_plan.md`](./fsdp_implementation_plan.md). Empirical case for going straight to FSDP is in [`investigation_results.md`](./investigation_results.md) — ZeRO-1+ckpt OOMs at 4B target on a 150 GB H200, so we need full parameter sharding. This PR is the architectural prerequisite: stop using sibling `nn.ModuleDict` + forward hooks, install fused `DecomposedSite` modules in place in the target tree instead.

**Draft.** Limited to the **core library** — `param_decomp/models/`, `run_param_decomp.py`, `utils/logging_utils.py`, `metrics/`, plus minimal type-only fixes to plotting helpers. App / harvest / dataset_attributions / clustering / editing / autointerp / adapters caller updates are deliberately deferred.

## What's here

- **New file** `param_decomp/models/decomposed_module.py` — `DecomposedLinear` and `DecomposedEmbedding`. Each wraps a frozen target submodule (`self.linear` / `self.embedding`), owns its own trainable `V` and `U`, and dispatches between the wrapped target's forward (when no mask is bound) and the legacy decomposed-forward math (when bound via `site.bind(mask_info, cache, cache_type)`).
- **New file** `param_decomp/models/mask_info.py` — `ComponentsMaskInfo`, `WeightDeltaAndMask`, `make_mask_infos` moved out of `components.py` to break the import cycle between `components.py` and `decomposed_module.py`. `components.py` re-exports them for back-compat.
- **`ComponentModel` rewritten** — no more sibling `_components` ModuleDict. `install_decomposed_sites` replaces target submodules in place; `forward()` uses an `ExitStack` of `site.bind(...)` context managers instead of `_attach_forward_hooks`. The hook-based `_components_and_cache_hook` is gone.
- **CI fn wrappers** (`LayerwiseCiFnWrapper`, `GlobalCiFnWrapper`) take a `sites` dict typed against a `SiteWithComponentActs` Protocol.

## What this *unblocks* (PR 2 in the plan)

The forward hook crossing FSDP-unit boundaries was the load-bearing reason §5b of the report flagged "FSDP is not a drop-in replacement." With the fused-site shape, FSDP's auto-wrap policy can target `(DecomposedLinear, TransformerBlock)` and components live in the same unit as the target weight they replace. The actual FSDP wrap lands in PR 2.

## Tests

`make test` passes (268 passed, 13 skipped). The 13 skipped: `tests/test_wandb_run_loading.py::*` (pre-existing wandb-dependent), `test_replacing_identity` (intentionally skipped — see below).

Specific fixes inside this PR:
- `get_grad_norms_dict` and the optimizer param-collection loop in `run_param_decomp.py` filter on `requires_grad` so the frozen wrapped target's weight isn't pulled into the trainable set.
- `metrics/attn_patterns_recon_loss.py` switched from `components[name](x, mask=…)` to the new `components[name].apply_decomposed(x, mask=…)` accessor.
- Various tests use the new `component_weight` / `target_weight` accessor names where they previously relied on `components[name].weight` meaning V@U.

## Known limitations / not in this PR

- **Identity-shim decomposition** (`identity_module_info` + `insert_identity_operations_`) is dropped. Tests using it pass `identity_module_info=None` or are skipped with a pointer to `fsdp_implementation_plan.md`. The feature wasn't load-bearing for Jose/Thomas; we can revive it if a real consumer surfaces.
- **No migration script yet.** Existing Jose/Thomas checkpoints have the old sibling-ModuleDict state-dict layout (`_components.h-0-mlp-c_fc.V` etc.); under the new layout those keys are `target_model.h.0.mlp.c_fc.V`. A one-shot rename script is on the PR 1 follow-up list.
- **No loss-trajectory equivalence test yet.** A 50-step DDP run on Jose against `main` should give matching loss within numerical noise — TODO before this PR comes out of draft.
- **App / harvest / dataset_attributions / clustering / editing / autointerp / adapters** still reference `model.components[name]` as if it were a legacy `LinearComponents`. They mostly work via duck typing (V, U are still there) but their type annotations and any `.weight` / `.component_weight` accesses need a sweep.
- **No FSDP wrap policy** — that's PR 2.

## Test plan
- [x] `make test` passes locally (DDP/single-GPU)
- [ ] Loss-trajectory equivalence test on Jose under DDP (50 steps, synthetic data) — TODO
- [ ] Migration script for old checkpoints — TODO
- [ ] App / harvest / dataset_attributions / clustering / editing / autointerp / adapters callers — TODO (follow-up PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)