### PR TITLE
Cluster visualization: force graph, dendrograms, correlation matrices

### DIFF
--- a/param_decomp/app/AGENTS.md
+++ b/param_decomp/app/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/param_decomp/app/backend/routers/clusters.py
+++ b/param_decomp/app/backend/routers/clusters.py
@@ -1,28 +1,110 @@
 """Cluster mapping endpoints."""
 
+import base64
 import json
+import math
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
+import numpy as np
+import torch
 from fastapi import APIRouter, HTTPException
-from pydantic import ValidationError, model_validator
+from pydantic import BaseModel, ValidationError, model_validator
 
+from param_decomp.app.backend.dependencies import DepLoadedRun
 from param_decomp.app.backend.state import StateManager
 from param_decomp.app.backend.utils import log_errors
 from param_decomp.base_config import BaseConfig
+from param_decomp.clustering.membership_snapshot import MembershipSnapshot, load_membership_snapshot
+from param_decomp.clustering.merge_history import MergeHistory
+from param_decomp.harvest.storage import CorrelationStorage
+from param_decomp.log import logger
 from param_decomp.settings import PARAM_DECOMP_OUT_DIR
 from param_decomp.topology import TransformerTopology
 
 router = APIRouter(prefix="/api/clusters", tags=["clusters"])
 
 
-class ClusterMapping(BaseConfig):
-    """Cluster mapping from component keys (layer:component_idx) to cluster IDs.
+# =============================================================================
+# Clustering run data cache
+# =============================================================================
 
-    Singleton clusters (components not grouped with others) have null values.
-    """
+
+@dataclass
+class ClusteringRunData:
+    """Cached data from a clustering run directory."""
+
+    run_id: str
+    run_dir: Path
+    history: MergeHistory
+    snapshot_path: Path | None
+    _membership_snapshot: MembershipSnapshot | None = None
+
+    @property
+    def membership_snapshot(self) -> MembershipSnapshot:
+        if self._membership_snapshot is None:
+            assert self.snapshot_path is not None, (
+                f"No snapshot_path for clustering run {self.run_id}"
+            )
+            logger.info(f"Loading membership snapshot from {self.snapshot_path}")
+            self._membership_snapshot = load_membership_snapshot(self.snapshot_path)
+            logger.info(
+                f"Loaded: {self._membership_snapshot.n_components} components, "
+                f"{self._membership_snapshot.n_samples} samples"
+            )
+        return self._membership_snapshot
+
+
+_clustering_cache: dict[str, ClusteringRunData] = {}
+
+
+def _load_clustering_run(clustering_run_id: str) -> ClusteringRunData:
+    if clustering_run_id in _clustering_cache:
+        return _clustering_cache[clustering_run_id]
+
+    run_dir = PARAM_DECOMP_OUT_DIR / "clustering" / "runs" / clustering_run_id
+    assert run_dir.exists(), f"Clustering run dir not found: {run_dir}"
+
+    history_path = run_dir / "history.zip"
+    assert history_path.exists(), f"history.zip not found: {history_path}"
+    logger.info(f"Loading merge history from {history_path}")
+    history = MergeHistory.read(history_path)
+
+    snapshot_path = _resolve_snapshot_path(run_dir)
+
+    data = ClusteringRunData(
+        run_id=clustering_run_id,
+        run_dir=run_dir,
+        history=history,
+        snapshot_path=snapshot_path,
+    )
+    _clustering_cache[clustering_run_id] = data
+    return data
+
+
+def _resolve_snapshot_path(run_dir: Path) -> Path | None:
+    """Resolve the membership snapshot path from a clustering run's config."""
+    merge_config_path = run_dir / "merge_config.json"
+    if merge_config_path.exists():
+        with open(merge_config_path) as f:
+            config = json.load(f)
+        if "snapshot_path" in config:
+            return Path(config["snapshot_path"])
+    return None
+
+
+# =============================================================================
+# Load cluster mapping
+# =============================================================================
+
+
+class ClusterMapping(BaseConfig):
+    """Cluster mapping response with clustering run metadata."""
 
     mapping: dict[str, int | None]
+    clustering_run_id: str
+    iteration: int
 
 
 class ClusterMappingFile(BaseConfig):
@@ -95,8 +177,27 @@ def load_cluster_mapping(file_path: str) -> ClusterMapping:
             f"but loaded run is '{run_state.run.wandb_path}'",
         )
 
+    # Pre-load clustering run data (history.zip) so subsequent requests are fast
+    _load_clustering_run(parsed.clustering_run_id)
+
+    # Persist the path so it survives page reloads via /api/status
+    state.state.cluster_mapping_path = str(path)
+
     canonical_clusters = _to_canonical_keys(parsed.clusters, run_state.topology)
-    return ClusterMapping(mapping=canonical_clusters)
+    return ClusterMapping(
+        mapping=canonical_clusters,
+        clustering_run_id=parsed.clustering_run_id,
+        iteration=parsed.iteration,
+    )
+
+
+@router.post("/clear")
+@log_errors
+def clear_cluster_mapping() -> dict[str, str]:
+    """Clear the persisted cluster mapping path."""
+    state = StateManager.get()
+    state.state.cluster_mapping_path = None
+    return {"status": "cleared"}
 
 
 def _to_canonical_keys(
@@ -109,3 +210,543 @@ def _to_canonical_keys(
         canonical_layer = topology.target_to_canon(layer)
         result[f"{canonical_layer}:{idx}"] = cluster_id
     return result
+
+
+def _canonical_to_concrete(canonical_key: str, topology: TransformerTopology) -> str:
+    layer, idx = canonical_key.rsplit(":", 1)
+    concrete = topology.canon_to_target(layer)
+    return f"{concrete}:{idx}"
+
+
+# =============================================================================
+# Pairwise correlation metrics (from harvest data)
+# =============================================================================
+
+
+class PairCorrelation(BaseModel):
+    """Pairwise correlation between two components."""
+
+    key_a: str
+    key_b: str
+    jaccard: float
+    precision_ab: float
+    precision_ba: float
+    pmi: float | None
+    count_a: int
+    count_b: int
+    count_ab: int
+
+
+class ClusterPairwiseResponse(BaseModel):
+    pairs: list[PairCorrelation]
+    n_tokens: int
+
+
+class PairwiseRequest(BaseModel):
+    component_keys: list[str]
+
+
+@router.post("/pairwise_correlations")
+@log_errors
+def get_pairwise_correlations(
+    body: PairwiseRequest,
+    loaded: DepLoadedRun,
+) -> ClusterPairwiseResponse:
+    """Compute pairwise correlation metrics for a set of components (from harvest data)."""
+    assert loaded.harvest is not None, "No harvest data available"
+    correlations = loaded.harvest.get_correlations()
+    assert correlations is not None, "No correlations data available"
+
+    concrete_keys = [_canonical_to_concrete(k, loaded.topology) for k in body.component_keys]
+
+    pairs = _compute_pairwise_from_counts(correlations, body.component_keys, concrete_keys)
+    return ClusterPairwiseResponse(pairs=pairs, n_tokens=correlations.count_total)
+
+
+def _compute_pairwise_from_counts(
+    storage: CorrelationStorage,
+    canonical_keys: list[str],
+    concrete_keys: list[str],
+) -> list[PairCorrelation]:
+    pairs: list[PairCorrelation] = []
+    n = len(concrete_keys)
+    key_to_idx = storage.key_to_idx
+
+    for a in range(n):
+        ck_a = concrete_keys[a]
+        if ck_a not in key_to_idx:
+            continue
+        i = key_to_idx[ck_a]
+        count_a = int(storage.count_i[i].item())
+        if count_a == 0:
+            continue
+
+        for b in range(a + 1, n):
+            ck_b = concrete_keys[b]
+            if ck_b not in key_to_idx:
+                continue
+            j = key_to_idx[ck_b]
+            count_b = int(storage.count_i[j].item())
+            if count_b == 0:
+                continue
+
+            count_ab = int(storage.count_ij[i][j].item())
+            pairs.append(
+                _make_pair_correlation(
+                    canonical_keys[a],
+                    canonical_keys[b],
+                    count_a,
+                    count_b,
+                    count_ab,
+                    storage.count_total,
+                )
+            )
+
+    return pairs
+
+
+def _make_pair_correlation(
+    key_a: str, key_b: str, count_a: int, count_b: int, count_ab: int, n_tokens: int
+) -> PairCorrelation:
+    union = count_a + count_b - count_ab
+    jaccard = count_ab / union if union > 0 else 0.0
+    prec_ab = count_ab / count_a if count_a > 0 else 0.0
+    prec_ba = count_ab / count_b if count_b > 0 else 0.0
+
+    if count_ab > 0:
+        p_ab = count_ab / n_tokens
+        p_a = count_a / n_tokens
+        p_b = count_b / n_tokens
+        pmi: float | None = math.log(p_ab / (p_a * p_b))
+    else:
+        pmi = None
+
+    return PairCorrelation(
+        key_a=key_a,
+        key_b=key_b,
+        jaccard=jaccard,
+        precision_ab=prec_ab,
+        precision_ba=prec_ba,
+        pmi=pmi,
+        count_a=count_a,
+        count_b=count_b,
+        count_ab=count_ab,
+    )
+
+
+# =============================================================================
+# Pairwise coactivation from clustering memberships.npz
+# =============================================================================
+
+
+class CoactivationRequest(BaseModel):
+    component_keys: list[str]
+    clustering_run_id: str
+
+
+@router.post("/clustering_coactivation")
+@log_errors
+def get_clustering_coactivation(
+    body: CoactivationRequest,
+    loaded: DepLoadedRun,
+) -> ClusterPairwiseResponse:
+    """Compute pairwise co-firing from the clustering's own membership snapshot."""
+    run_data = _load_clustering_run(body.clustering_run_id)
+    snapshot = run_data.membership_snapshot
+
+    label_to_idx = {label: i for i, label in enumerate(snapshot.labels)}
+
+    concrete_keys = [_canonical_to_concrete(k, loaded.topology) for k in body.component_keys]
+
+    # Find valid indices into the membership matrix
+    valid: list[tuple[int, int, str]] = []  # (position_in_request, col_in_matrix, canonical_key)
+    for pos, (ck, canonical) in enumerate(zip(concrete_keys, body.component_keys, strict=True)):
+        if ck in label_to_idx:
+            valid.append((pos, label_to_idx[ck], canonical))
+
+    if len(valid) < 2:
+        return ClusterPairwiseResponse(pairs=[], n_tokens=snapshot.n_samples)
+
+    col_indices = [v[1] for v in valid]
+    sub_matrix = snapshot.matrix_csc[:, col_indices]
+
+    # Cast from uint8 to int32 to avoid overflow in dot product
+    sub_matrix = sub_matrix.astype(np.int32)
+    coact = (sub_matrix.T @ sub_matrix).toarray()
+    assert isinstance(coact, np.ndarray)
+
+    pairs: list[PairCorrelation] = []
+    m = len(valid)
+    for a in range(m):
+        count_a = int(coact[a, a])
+        if count_a == 0:
+            continue
+        for b in range(a + 1, m):
+            count_b = int(coact[b, b])
+            if count_b == 0:
+                continue
+            count_ab = int(coact[a, b])
+            pairs.append(
+                _make_pair_correlation(
+                    valid[a][2], valid[b][2], count_a, count_b, count_ab, snapshot.n_samples
+                )
+            )
+
+    return ClusterPairwiseResponse(pairs=pairs, n_tokens=snapshot.n_samples)
+
+
+# =============================================================================
+# Merge iterations (when did each pair first share a group?)
+# =============================================================================
+
+
+class MergeIterationsRequest(BaseModel):
+    component_keys: list[str]
+    clustering_run_id: str
+    iteration: int
+
+
+class MergePairIteration(BaseModel):
+    key_a: str
+    key_b: str
+    merge_iteration: int
+
+
+class MergeIterationsResponse(BaseModel):
+    pairs: list[MergePairIteration]
+    total_iterations: int
+
+
+@router.post("/merge_iterations")
+@log_errors
+def get_merge_iterations(
+    body: MergeIterationsRequest,
+    loaded: DepLoadedRun,
+) -> MergeIterationsResponse:
+    """For each pair of components, find the first iteration where they share a group.
+
+    Lower iteration = merged earlier = stronger natural pairing.
+    """
+    run_data = _load_clustering_run(body.clustering_run_id)
+    history = run_data.history
+
+    assert 0 <= body.iteration < history.n_iters_current
+
+    concrete_keys = [_canonical_to_concrete(k, loaded.topology) for k in body.component_keys]
+
+    label_to_idx = {label: i for i, label in enumerate(history.labels)}
+
+    # Find valid component indices in the history
+    valid: list[tuple[int, str]] = []  # (component_idx_in_history, canonical_key)
+    for ck, canonical in zip(concrete_keys, body.component_keys, strict=True):
+        if ck in label_to_idx:
+            valid.append((label_to_idx[ck], canonical))
+
+    if len(valid) < 2:
+        return MergeIterationsResponse(pairs=[], total_iterations=history.n_iters_current)
+
+    # group_idxs shape: (n_iters, n_components)
+    group_idxs = history.merges.group_idxs[: body.iteration + 1].numpy()
+    comp_indices = [v[0] for v in valid]
+
+    # For each pair, find earliest iteration where they share a group
+    # Extract columns for our components: shape (n_iters, n_valid)
+    sub_groups = group_idxs[:, comp_indices]
+
+    pairs: list[MergePairIteration] = []
+    m = len(valid)
+    for a in range(m):
+        for b in range(a + 1, m):
+            same_group = sub_groups[:, a] == sub_groups[:, b]
+            matching_iters = np.where(same_group)[0]
+            merge_iter = int(matching_iters[0]) if len(matching_iters) > 0 else -1
+            pairs.append(
+                MergePairIteration(
+                    key_a=valid[a][1],
+                    key_b=valid[b][1],
+                    merge_iteration=merge_iter,
+                )
+            )
+
+    return MergeIterationsResponse(
+        pairs=pairs,
+        total_iterations=history.n_iters_current,
+    )
+
+
+# =============================================================================
+# Full matrix heatmap
+# =============================================================================
+
+FullMatrixMetric = Literal["jaccard", "precision", "pmi"]
+
+
+class ClusterBoundary(BaseModel):
+    cluster_id: int
+    start: int
+    end: int
+
+
+class MatrixRegion(BaseModel):
+    row: int
+    col: int
+    size: int
+
+
+class FullMatrixResponse(BaseModel):
+    matrix_b64: str
+    width: int
+    height: int
+    full_size: int
+    component_keys: list[str]
+    row_boundaries: list[ClusterBoundary]
+    col_boundaries: list[ClusterBoundary]
+    metric: str
+    n_tokens: int
+
+
+class FullMatrixRequest(BaseModel):
+    metric: FullMatrixMetric
+    cluster_mapping: dict[str, int | None]
+    max_size: int = 2000
+    region: MatrixRegion | None = None
+
+
+# Cache the sorted keys + computed metric matrix so the detail endpoint doesn't recompute
+_matrix_cache: dict[str, tuple[np.ndarray, list[str], list[ClusterBoundary], int]] = {}
+
+
+@router.post("/full_matrix")
+@log_errors
+def get_full_matrix(
+    body: FullMatrixRequest,
+    loaded: DepLoadedRun,
+) -> FullMatrixResponse:
+    """Compute the full pairwise metric matrix, sorted by cluster assignment.
+
+    If region is set, returns that sub-region at full resolution (no binning).
+    Otherwise returns the full matrix binned to max_size.
+    """
+    assert loaded.harvest is not None, "No harvest data available"
+    correlations = loaded.harvest.get_correlations()
+    assert correlations is not None, "No correlations data available"
+
+    cache_key = f"{loaded.harvest.subrun_id}:{body.metric}"
+
+    if cache_key in _matrix_cache:
+        full_matrix, sorted_keys, boundaries, n_tokens = _matrix_cache[cache_key]
+    else:
+        all_keys = list(body.cluster_mapping.keys())
+        raw_matrix = _compute_full_metric_matrix(
+            correlations, all_keys, body.metric, loaded.topology
+        )
+        sorted_keys, boundaries, full_matrix = _sort_by_cluster(
+            body.cluster_mapping, raw_matrix, all_keys
+        )
+        n_tokens = correlations.count_total
+        _matrix_cache[cache_key] = (full_matrix, sorted_keys, boundaries, n_tokens)
+
+    full_n = full_matrix.shape[0]
+
+    if body.region is not None:
+        r = body.region
+        row_end = min(r.row + r.size, full_n)
+        col_end = min(r.col + r.size, full_n)
+        matrix = full_matrix[r.row : row_end, r.col : col_end]
+        region_keys = sorted_keys[r.row : row_end]
+        row_boundaries = [
+            ClusterBoundary(
+                cluster_id=b.cluster_id,
+                start=max(0, b.start - r.row),
+                end=min(row_end - r.row, b.end - r.row),
+            )
+            for b in boundaries
+            if b.end > r.row and b.start < row_end
+        ]
+        col_boundaries = [
+            ClusterBoundary(
+                cluster_id=b.cluster_id,
+                start=max(0, b.start - r.col),
+                end=min(col_end - r.col, b.end - r.col),
+            )
+            for b in boundaries
+            if b.end > r.col and b.start < col_end
+        ]
+    else:
+        region_keys = sorted_keys
+        row_boundaries = boundaries
+        col_boundaries = boundaries
+        matrix = full_matrix
+        if matrix.shape[0] > body.max_size:
+            matrix, row_boundaries = _bin_matrix(matrix, row_boundaries, body.max_size)
+            col_boundaries = row_boundaries
+
+    matrix_bytes = matrix.astype(np.float32).tobytes()
+    matrix_b64 = base64.b64encode(matrix_bytes).decode("ascii")
+
+    return FullMatrixResponse(
+        matrix_b64=matrix_b64,
+        width=matrix.shape[1],
+        height=matrix.shape[0],
+        full_size=full_n,
+        component_keys=region_keys,
+        row_boundaries=row_boundaries,
+        col_boundaries=col_boundaries,
+        metric=body.metric,
+        n_tokens=n_tokens,
+    )
+
+
+def _sort_by_cluster(
+    cluster_mapping: dict[str, int | None],
+    metric_matrix: np.ndarray,
+    all_keys: list[str],
+) -> tuple[list[str], list[ClusterBoundary], np.ndarray]:
+    """Sort components by cluster, with clusters ordered by hierarchical similarity.
+
+    Returns (sorted_keys, boundaries, permuted_matrix).
+    """
+    from scipy.cluster.hierarchy import leaves_list, linkage
+    from scipy.spatial.distance import squareform
+
+    clustered: dict[int, list[int]] = {}
+    singleton_indices: list[int] = []
+    key_to_idx = {k: i for i, k in enumerate(all_keys)}
+
+    for key, cid in cluster_mapping.items():
+        if key not in key_to_idx:
+            continue
+        idx = key_to_idx[key]
+        if cid is None:
+            singleton_indices.append(idx)
+        else:
+            clustered.setdefault(cid, []).append(idx)
+
+    cluster_ids = sorted(clustered.keys())
+
+    # Order clusters by hierarchical clustering on inter-cluster mean similarity
+    if len(cluster_ids) > 2:
+        n_clusters = len(cluster_ids)
+        cluster_sim = np.zeros((n_clusters, n_clusters), dtype=np.float32)
+        for i, cid_a in enumerate(cluster_ids):
+            for j, cid_b in enumerate(cluster_ids):
+                if i == j:
+                    continue
+                block = metric_matrix[np.ix_(clustered[cid_a], clustered[cid_b])]
+                valid = block[~np.isnan(block)]
+                cluster_sim[i, j] = float(valid.mean()) if len(valid) > 0 else 0.0
+
+        # Convert similarity to distance (higher sim = lower distance)
+        max_sim = np.nanmax(cluster_sim)
+        dist_matrix = max_sim - cluster_sim
+        np.fill_diagonal(dist_matrix, 0)
+        condensed = squareform(dist_matrix, checks=False)
+        Z = linkage(condensed, method="average")
+        leaf_order = leaves_list(Z).tolist()
+        cluster_ids = [cluster_ids[i] for i in leaf_order]
+
+    # Build permutation: clusters in leaf order, singletons last
+    perm: list[int] = []
+    boundaries: list[ClusterBoundary] = []
+    for cid in cluster_ids:
+        members = sorted(clustered[cid])
+        start = len(perm)
+        perm.extend(members)
+        boundaries.append(ClusterBoundary(cluster_id=cid, start=start, end=len(perm)))
+    perm.extend(sorted(singleton_indices))
+
+    sorted_keys = [all_keys[i] for i in perm]
+    permuted = metric_matrix[np.ix_(perm, perm)]
+
+    return sorted_keys, boundaries, permuted
+
+
+def _compute_full_metric_matrix(
+    storage: CorrelationStorage,
+    sorted_canonical_keys: list[str],
+    metric: FullMatrixMetric,
+    topology: TransformerTopology,
+) -> np.ndarray:
+    """Compute the full NxN metric matrix for the given sorted keys."""
+    n = len(sorted_canonical_keys)
+    concrete_keys = [_canonical_to_concrete(k, topology) for k in sorted_canonical_keys]
+
+    indices = []
+    for ck in concrete_keys:
+        if ck in storage.key_to_idx:
+            indices.append(storage.key_to_idx[ck])
+        else:
+            indices.append(-1)
+
+    idx_tensor = torch.tensor(indices, dtype=torch.long)
+    valid_mask = idx_tensor >= 0
+
+    count_i = storage.count_i.float()
+    count_ij = storage.count_ij.float()
+
+    # Extract sub-matrix for our components
+    valid_indices = idx_tensor[valid_mask]
+    sub_count_i = count_i[valid_indices]
+    sub_count_ij = count_ij[valid_indices][:, valid_indices]
+    match metric:
+        case "jaccard":
+            union = sub_count_i[:, None] + sub_count_i[None, :] - sub_count_ij
+            sub_matrix = torch.where(
+                union > 0, sub_count_ij / union, torch.zeros_like(sub_count_ij)
+            )
+        case "precision":
+            sub_matrix = torch.where(
+                sub_count_i[:, None] > 0,
+                sub_count_ij / sub_count_i[:, None],
+                torch.zeros_like(sub_count_ij),
+            )
+        case "pmi":
+            p_ij = sub_count_ij / storage.count_total
+            p_i = sub_count_i / storage.count_total
+            lift = p_ij / (p_i[:, None] * p_i[None, :])
+            sub_matrix = torch.log(lift)
+            sub_matrix = sub_matrix.nan_to_num(float("nan"))
+            sub_matrix[sub_count_ij == 0] = float("nan")
+
+    # Place into full NxN matrix (with NaN for missing components)
+    result = np.full((n, n), float("nan"), dtype=np.float32)
+    valid_idx_np = np.where(valid_mask.numpy())[0]
+    result[np.ix_(valid_idx_np, valid_idx_np)] = sub_matrix.numpy()
+
+    return result
+
+
+def _bin_matrix(
+    matrix: np.ndarray,
+    boundaries: list[ClusterBoundary],
+    max_size: int,
+) -> tuple[np.ndarray, list[ClusterBoundary]]:
+    """Bin-average a matrix down to max_size × max_size."""
+    n = matrix.shape[0]
+    bin_size = math.ceil(n / max_size)
+    new_n = math.ceil(n / bin_size)
+
+    # Pad to exact multiple of bin_size
+    padded_n = new_n * bin_size
+    if padded_n != n:
+        padded = np.full((padded_n, padded_n), float("nan"), dtype=np.float32)
+        padded[:n, :n] = matrix
+    else:
+        padded = matrix
+
+    # Reshape into blocks and nanmean
+    reshaped = padded.reshape(new_n, bin_size, new_n, bin_size)
+    with np.errstate(all="ignore"):
+        binned = np.nanmean(reshaped, axis=(1, 3)).astype(np.float32)
+
+    scale = new_n / n
+    new_boundaries = [
+        ClusterBoundary(
+            cluster_id=b.cluster_id,
+            start=int(b.start * scale),
+            end=int(b.end * scale),
+        )
+        for b in boundaries
+    ]
+
+    return binned, new_boundaries

--- a/param_decomp/app/backend/routers/runs.py
+++ b/param_decomp/app/backend/routers/runs.py
@@ -45,6 +45,7 @@ class LoadedRun(BaseModel):
     dataset_search_enabled: bool
     graph_interp_available: bool
     autointerp_available: bool
+    cluster_mapping_path: str | None
 
 
 router = APIRouter(prefix="/api", tags=["runs"])
@@ -171,6 +172,7 @@ def get_status(manager: DepStateManager) -> LoadedRun | None:
         dataset_search_enabled=dataset_search_enabled,
         graph_interp_available=manager.run_state.graph_interp is not None,
         autointerp_available=manager.run_state.interp is not None,
+        cluster_mapping_path=manager.state.cluster_mapping_path,
     )
 
 

--- a/param_decomp/app/backend/state.py
+++ b/param_decomp/app/backend/state.py
@@ -56,6 +56,7 @@ class AppState:
     db: PromptAttrDB
     run_state: RunState | None = field(default=None)
     dataset_search_state: DatasetSearchState | None = field(default=None)
+    cluster_mapping_path: str | None = field(default=None)
 
 
 class StateManager:

--- a/param_decomp/app/frontend/src/components/ClusterCorrelationMatrix.svelte
+++ b/param_decomp/app/frontend/src/components/ClusterCorrelationMatrix.svelte
@@ -1,0 +1,428 @@
+<script lang="ts">
+    import { getContext } from "svelte";
+    import { SvelteMap } from "svelte/reactivity";
+    import { RUN_KEY, type RunContext } from "../lib/useRun.svelte";
+    import type { PairCorrelation, ClusterPairwiseResponse } from "../lib/api/clusters";
+    import { fetchClusterPairwiseCorrelations, fetchClusteringCoactivation } from "../lib/api/clusters";
+
+    type ComponentMember = { layer: string; cIdx: number };
+
+    type Props = {
+        members: ComponentMember[];
+        clusteringRunId: string;
+    };
+
+    let { members, clusteringRunId }: Props = $props();
+
+    const runState = getContext<RunContext>(RUN_KEY);
+
+    type DataSource = "harvest" | "clustering";
+    type Metric = "jaccard" | "precision_ab" | "pmi";
+
+    let selectedSource = $state<DataSource>("harvest");
+    let selectedMetric = $state<Metric>("jaccard");
+
+    type PairwiseData =
+        | { status: "loading" }
+        | { status: "loaded"; response: ClusterPairwiseResponse }
+        | { status: "error"; error: string };
+
+    let harvestData = $state<PairwiseData>({ status: "loading" });
+    let clusteringData = $state<PairwiseData>({ status: "loading" });
+
+    const keys = $derived(members.map((m) => `${m.layer}:${m.cIdx}`));
+
+    function getLabel(key: string): string {
+        const loadable = runState.getInterpretation(key);
+        if (loadable.status === "loaded" && loadable.data.status === "generated") {
+            return loadable.data.data.label;
+        }
+        return key;
+    }
+
+    $effect(() => {
+        const currentKeys = keys;
+        if (currentKeys.length < 2) {
+            harvestData = { status: "loaded", response: { pairs: [], n_tokens: 0 } };
+            clusteringData = { status: "loaded", response: { pairs: [], n_tokens: 0 } };
+            return;
+        }
+
+        harvestData = { status: "loading" };
+        fetchClusterPairwiseCorrelations(currentKeys)
+            .then((response) => (harvestData = { status: "loaded", response }))
+            .catch((e) => (harvestData = { status: "error", error: String(e) }));
+
+        clusteringData = { status: "loading" };
+        fetchClusteringCoactivation(currentKeys, clusteringRunId)
+            .then((response) => (clusteringData = { status: "loaded", response }))
+            .catch((e) => (clusteringData = { status: "error", error: String(e) }));
+    });
+
+    // Build lookups from pair data
+    function buildPairLookup(pairs: PairCorrelation[]): SvelteMap<string, PairCorrelation> {
+        const map = new SvelteMap<string, PairCorrelation>();
+        for (const pair of pairs) {
+            map.set(`${pair.key_a}|${pair.key_b}`, pair);
+            map.set(`${pair.key_b}|${pair.key_a}`, pair);
+        }
+        return map;
+    }
+
+    const activePairData = $derived.by((): PairwiseData => {
+        switch (selectedSource) {
+            case "harvest":
+                return harvestData;
+            case "clustering":
+                return clusteringData;
+        }
+    });
+
+    const pairLookup = $derived.by(() => {
+        const data = activePairData;
+        if (data.status !== "loaded") return new SvelteMap<string, PairCorrelation>();
+        return buildPairLookup(data.response.pairs);
+    });
+
+    function getCellValue(rowKey: string, colKey: string): number | null {
+        if (rowKey === colKey) return null;
+        const pair = pairLookup.get(`${rowKey}|${colKey}`);
+        if (!pair) return null;
+        switch (selectedMetric) {
+            case "jaccard":
+                return pair.jaccard;
+            case "pmi":
+                return pair.pmi;
+            case "precision_ab":
+                if (pair.key_a === rowKey) return pair.precision_ab;
+                return pair.precision_ba;
+        }
+    }
+
+    function cellColor(val: number | null): string {
+        if (val === null) return "transparent";
+
+        if (selectedMetric === "pmi") {
+            if (val > 0) {
+                const norm = Math.min(val / 6, 1);
+                return `rgba(59, 130, 246, ${norm * 0.7})`;
+            } else {
+                const norm = Math.min(Math.abs(val) / 6, 1);
+                return `rgba(239, 68, 68, ${norm * 0.7})`;
+            }
+        }
+
+        const norm = Math.min(Math.max(val, 0), 1);
+        return `rgba(59, 130, 246, ${norm * 0.7})`;
+    }
+
+    function cellTitle(rowKey: string, colKey: string): string {
+        const pair = pairLookup.get(`${rowKey}|${colKey}`);
+        if (!pair) return "";
+        const precAB = pair.key_a === rowKey ? pair.precision_ab : pair.precision_ba;
+        const precBA = pair.key_a === rowKey ? pair.precision_ba : pair.precision_ab;
+        return `${rowKey} × ${colKey}\nco-fire: ${pair.count_ab} / A: ${pair.count_a} / B: ${pair.count_b}\nJaccard: ${pair.jaccard.toFixed(4)}\nP(row|col): ${precAB.toFixed(4)}\nP(col|row): ${precBA.toFixed(4)}\nPMI: ${pair.pmi !== null ? pair.pmi.toFixed(4) : "−∞"}`;
+    }
+
+    const currentStatus = $derived(activePairData.status);
+
+    const currentError = $derived.by((): string => {
+        const data = activePairData;
+        if (data.status === "error") return data.error;
+        return "";
+    });
+
+    const sourceDescription = $derived.by((): string => {
+        const metricExplanation =
+            selectedMetric === "jaccard"
+                ? "Each cell shows the Jaccard index: the proportion of tokens where at least one of the pair fires that both fire."
+                : selectedMetric === "precision_ab"
+                  ? "Each cell (row, col) shows the proportion of row's activations where col is also active."
+                  : "Each cell shows the pointwise mutual information: log-ratio of observed co-firing vs expected under independence. Blue = positive, red = negative.";
+
+        switch (selectedSource) {
+            case "harvest":
+                return `Co-firing statistics from the harvest pipeline (ci_threshold from harvest config). ${metricExplanation}`;
+            case "clustering":
+                return `Co-firing statistics from the clustering's own membership snapshot (activation_threshold from merge config) — the exact data the algorithm used to decide merges. ${metricExplanation}`;
+        }
+    });
+
+    const footerText = $derived.by((): string => {
+        const data = activePairData;
+        if (data.status === "loaded") {
+            return `${data.response.n_tokens.toLocaleString()} tokens · ${data.response.pairs.length} pairs`;
+        }
+        return "";
+    });
+</script>
+
+<div class="correlation-matrix">
+    <div class="matrix-controls">
+        <div class="source-toggle">
+            <span class="control-label">Source:</span>
+            <button
+                class="source-btn"
+                class:active={selectedSource === "harvest"}
+                onclick={() => (selectedSource = "harvest")}>Harvest</button
+            >
+            <button
+                class="source-btn"
+                class:active={selectedSource === "clustering"}
+                onclick={() => (selectedSource = "clustering")}>Clustering</button
+            >
+        </div>
+        <div class="metric-toggle">
+            <span class="control-label">Metric:</span>
+            <button
+                class="metric-btn"
+                class:active={selectedMetric === "jaccard"}
+                onclick={() => (selectedMetric = "jaccard")}>Jaccard</button
+            >
+            <button
+                class="metric-btn"
+                class:active={selectedMetric === "precision_ab"}
+                onclick={() => (selectedMetric = "precision_ab")}>Precision</button
+            >
+            <button class="metric-btn" class:active={selectedMetric === "pmi"} onclick={() => (selectedMetric = "pmi")}
+                >PMI</button
+            >
+        </div>
+    </div>
+    <div class="source-description">{sourceDescription}</div>
+
+    <div class="color-legend">
+        {#if selectedMetric === "pmi"}
+            <span class="legend-label">-6</span>
+            <div class="legend-bar legend-bar-diverging"></div>
+            <span class="legend-label">0</span>
+            <div class="legend-bar legend-bar-diverging-pos"></div>
+            <span class="legend-label">+6</span>
+        {:else}
+            <span class="legend-label">0</span>
+            <div class="legend-bar legend-bar-sequential"></div>
+            <span class="legend-label">1</span>
+        {/if}
+    </div>
+
+    {#if currentStatus === "loading"}
+        <div class="loading">Loading...</div>
+    {:else if currentStatus === "error"}
+        <div class="error">{currentError}</div>
+    {:else if keys.length < 2}
+        <div class="empty">Need at least 2 components for pairwise correlations.</div>
+    {:else}
+        <div class="matrix-scroll">
+            <table class="matrix-table">
+                <thead>
+                    <tr>
+                        <th class="corner"></th>
+                        {#each keys as colKey (colKey)}
+                            <th class="col-header" title={colKey}>
+                                <div class="header-text">{getLabel(colKey)}</div>
+                            </th>
+                        {/each}
+                    </tr>
+                </thead>
+                <tbody>
+                    {#each keys as rowKey (rowKey)}
+                        <tr>
+                            <th class="row-header" title={rowKey}>{getLabel(rowKey)}</th>
+                            {#each keys as colKey (colKey)}
+                                {@const val = getCellValue(rowKey, colKey)}
+                                <td
+                                    class="cell"
+                                    class:diagonal={rowKey === colKey}
+                                    style="background: {cellColor(val)}"
+                                    title={rowKey === colKey ? rowKey : cellTitle(rowKey, colKey)}
+                                ></td>
+                            {/each}
+                        </tr>
+                    {/each}
+                </tbody>
+            </table>
+        </div>
+        <div class="matrix-footer">{footerText}</div>
+    {/if}
+</div>
+
+<style>
+    .correlation-matrix {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+    }
+
+    .matrix-controls {
+        display: flex;
+        align-items: center;
+        gap: var(--space-4);
+        flex-wrap: wrap;
+    }
+
+    .source-toggle,
+    .metric-toggle {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+    }
+
+    .source-description {
+        font-size: var(--text-xs);
+        color: var(--text-muted);
+        line-height: 1.4;
+        max-width: 600px;
+    }
+
+    .control-label {
+        font-size: var(--text-sm);
+        color: var(--text-muted);
+    }
+
+    .source-btn,
+    .metric-btn {
+        padding: var(--space-1) var(--space-3);
+        font: inherit;
+        font-size: var(--text-sm);
+        background: var(--bg-surface);
+        border: 1px solid var(--border-default);
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        color: var(--text-secondary);
+        transition:
+            background var(--transition-normal),
+            border-color var(--transition-normal);
+    }
+
+    .source-btn:hover,
+    .metric-btn:hover {
+        background: var(--bg-elevated);
+        border-color: var(--border-strong);
+    }
+
+    .source-btn.active {
+        background: var(--bg-elevated);
+        border-color: var(--accent-positive);
+        color: var(--text-primary);
+    }
+
+    .metric-btn.active {
+        background: var(--bg-elevated);
+        border-color: var(--accent-primary);
+        color: var(--text-primary);
+    }
+
+    .loading,
+    .error,
+    .empty {
+        font-size: var(--text-sm);
+        color: var(--text-muted);
+        padding: var(--space-4);
+    }
+
+    .error {
+        color: var(--status-error);
+    }
+
+    .matrix-scroll {
+        overflow: auto;
+    }
+
+    .matrix-table {
+        border-collapse: collapse;
+        font-size: var(--text-xs);
+        font-family: var(--font-mono);
+    }
+
+    .corner {
+        position: sticky;
+        top: 0;
+        left: 0;
+        z-index: 2;
+        background: var(--bg-base);
+    }
+
+    .col-header {
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        background: var(--bg-base);
+        padding: var(--space-1);
+        max-width: 100px;
+        vertical-align: bottom;
+    }
+
+    .header-text {
+        writing-mode: vertical-rl;
+        transform: rotate(180deg);
+        max-height: 120px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-weight: 500;
+        color: var(--text-secondary);
+    }
+
+    .row-header {
+        position: sticky;
+        left: 0;
+        z-index: 1;
+        background: var(--bg-base);
+        text-align: right;
+        padding: var(--space-1) var(--space-2);
+        max-width: 160px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+        font-weight: 500;
+        color: var(--text-secondary);
+    }
+
+    .cell {
+        padding: 0;
+        min-width: 20px;
+        height: 20px;
+        border: 1px solid var(--border-subtle);
+        cursor: default;
+    }
+
+    .cell.diagonal {
+        background: var(--bg-inset) !important;
+    }
+
+    .color-legend {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+    }
+
+    .legend-label {
+        font-size: var(--text-xs);
+        color: var(--text-muted);
+        font-family: var(--font-mono);
+    }
+
+    .legend-bar {
+        width: 100px;
+        height: 12px;
+        border-radius: 2px;
+        border: 1px solid var(--border-subtle);
+    }
+
+    .legend-bar-sequential {
+        background: linear-gradient(to right, transparent, rgba(59, 130, 246, 0.7));
+    }
+
+    .legend-bar-diverging {
+        background: linear-gradient(to right, rgba(239, 68, 68, 0.7), transparent);
+    }
+
+    .legend-bar-diverging-pos {
+        background: linear-gradient(to right, transparent, rgba(59, 130, 246, 0.7));
+    }
+
+    .matrix-footer {
+        font-size: var(--text-xs);
+        color: var(--text-muted);
+    }
+</style>

--- a/param_decomp/app/frontend/src/components/ClusterDendrogram.svelte
+++ b/param_decomp/app/frontend/src/components/ClusterDendrogram.svelte
@@ -1,0 +1,262 @@
+<script lang="ts">
+    import { getContext } from "svelte";
+    import { SvelteMap } from "svelte/reactivity";
+    import { RUN_KEY, type RunContext } from "../lib/useRun.svelte";
+    import type { MergeIterationsResponse } from "../lib/api/clusters";
+    import { fetchMergeIterations, fetchClusterPairwiseCorrelations } from "../lib/api/clusters";
+    import {
+        buildDendrogram,
+        assignLeafPositions,
+        collectLeaves,
+        collectInternalNodes,
+        maxIter,
+        generateLines,
+        type TreeNode,
+    } from "../lib/dendrogram";
+
+    type ComponentMember = { layer: string; cIdx: number };
+
+    type Props = {
+        members: ComponentMember[];
+        clusteringRunId: string;
+        iteration: number;
+        onLeafOrder?: (orderedMembers: ComponentMember[]) => void;
+    };
+
+    let { members, clusteringRunId, iteration, onLeafOrder }: Props = $props();
+
+    const runState = getContext<RunContext>(RUN_KEY);
+
+    type DataState =
+        | { status: "loading" }
+        | { status: "loaded"; response: MergeIterationsResponse }
+        | { status: "error"; error: string };
+
+    let data = $state<DataState>({ status: "loading" });
+
+    const keys = $derived(members.map((m) => `${m.layer}:${m.cIdx}`));
+
+    function getLabel(key: string): string {
+        const loadable = runState.getInterpretation(key);
+        if (loadable.status === "loaded" && loadable.data.status === "generated") {
+            return loadable.data.data.label;
+        }
+        return key;
+    }
+
+    let firingCounts = new SvelteMap<string, number>();
+
+    $effect(() => {
+        const currentKeys = keys;
+        if (currentKeys.length < 2) {
+            data = { status: "loaded", response: { pairs: [], total_iterations: 0 } };
+            return;
+        }
+        data = { status: "loading" };
+        fetchMergeIterations(currentKeys, clusteringRunId, iteration)
+            .then((response) => (data = { status: "loaded", response }))
+            .catch((e) => (data = { status: "error", error: String(e) }));
+
+        fetchClusterPairwiseCorrelations(currentKeys)
+            .then((response) => {
+                firingCounts.clear();
+                for (const p of response.pairs) {
+                    firingCounts.set(p.key_a, p.count_a);
+                    firingCounts.set(p.key_b, p.count_b);
+                }
+            })
+            .catch(() => {});
+    });
+
+    function countLeaves(node: TreeNode): number {
+        if (node.type === "leaf") return 1;
+        return countLeaves(node.left) + countLeaves(node.right);
+    }
+
+    // Computed dendrogram
+    const tree = $derived.by(() => {
+        if (data.status !== "loaded" || keys.length < 2) return null;
+        const root = buildDendrogram(keys, data.response.pairs);
+        if (!root) return null;
+        assignLeafPositions(root, 0);
+        return root;
+    });
+
+    const leaves = $derived(tree ? collectLeaves(tree) : []);
+    const internalNodes = $derived(tree ? collectInternalNodes(tree) : []);
+    const maxFiringCount = $derived(Math.max(1, ...leaves.map((l) => firingCounts.get(l.key) ?? 0)));
+
+    // Emit leaf order to parent
+    $effect(() => {
+        if (!onLeafOrder || leaves.length === 0) return;
+        const keyToMember = new SvelteMap<string, ComponentMember>();
+        for (const m of members) keyToMember.set(`${m.layer}:${m.cIdx}`, m);
+        const ordered = leaves.map((l) => keyToMember.get(l.key)!).filter(Boolean);
+        onLeafOrder(ordered);
+    });
+
+    // SVG dimensions
+    const LABEL_WIDTH = 250;
+    const TREE_WIDTH = 300;
+    const ROW_HEIGHT = 24;
+    const PADDING = 16;
+
+    const svgWidth = $derived(LABEL_WIDTH + TREE_WIDTH + PADDING * 2);
+    const svgHeight = $derived(leaves.length * ROW_HEIGHT + PADDING * 2);
+
+    const maxMergeIter = $derived(tree ? maxIter(tree) : 1);
+
+    // X scale: merge iteration -> x position (early merges on the right, late on the left)
+    // This makes the tree grow from right (leaves) to left (root)
+    const xScale = $derived((iter: number) => {
+        const treeRight = PADDING + TREE_WIDTH;
+        const treeLeft = PADDING;
+        if (maxMergeIter === 0) return treeLeft;
+        return treeRight - (iter / maxMergeIter) * (treeRight - treeLeft);
+    });
+
+    const yScale = $derived((pos: number) => PADDING + pos * ROW_HEIGHT + ROW_HEIGHT / 2);
+
+    const lines = $derived.by(() => {
+        if (!tree || tree.type === "leaf") return [];
+        const rightX = PADDING + TREE_WIDTH;
+        return generateLines(tree, xScale, yScale, rightX);
+    });
+</script>
+
+<div class="dendrogram-section">
+    <h3 class="section-title">Merge Tree</h3>
+    <div class="section-description">
+        How components were grouped by the clustering algorithm. Branches that join on the right were merged early
+        (strong co-activation); branches that join on the left were merged late (weaker signal).
+    </div>
+
+    {#if data.status === "loading"}
+        <div class="status">Loading...</div>
+    {:else if data.status === "error"}
+        <div class="status error">{data.error}</div>
+    {:else if keys.length < 2}
+        <div class="status">Need at least 2 components.</div>
+    {:else if tree}
+        <div class="dendrogram-scroll">
+            <svg width={svgWidth} height={svgHeight} class="dendrogram-svg">
+                <!-- Tree lines -->
+                {#each lines as line, i (i)}
+                    <line x1={line.x1} y1={line.y1} x2={line.x2} y2={line.y2} class="tree-line" />
+                {/each}
+
+                <!-- Merge node circles -->
+                {#each internalNodes as node, i (i)}
+                    {@const cx = node.mergeIter >= 0 ? xScale(node.mergeIter) : PADDING}
+                    {@const cy = yScale(node.y)}
+                    {@const leftCount = countLeaves(node.left)}
+                    {@const rightCount = countLeaves(node.right)}
+                    <circle {cx} {cy} r="4" class="merge-node">
+                        <title>Iteration {node.mergeIter}: merge {leftCount} + {rightCount} components</title>
+                    </circle>
+                {/each}
+
+                <!-- Leaf labels + firing density -->
+                {#each leaves as leaf (leaf.key)}
+                    {@const firing = firingCounts.get(leaf.key) ?? 0}
+                    {@const barWidth = (firing / maxFiringCount) * 40}
+                    <rect
+                        x={PADDING + TREE_WIDTH + 4}
+                        y={yScale(leaf.y) - 4}
+                        width={barWidth}
+                        height={8}
+                        class="firing-bar"
+                    >
+                        <title>{leaf.key}: {firing} activations</title>
+                    </rect>
+                    <text
+                        x={PADDING + TREE_WIDTH + 48}
+                        y={yScale(leaf.y)}
+                        class="leaf-label"
+                        dominant-baseline="central"
+                    >
+                        <title>{leaf.key}: {firing} activations</title>
+                        {getLabel(leaf.key)}
+                    </text>
+                {/each}
+
+                <!-- Iteration axis labels -->
+                <text x={PADDING + TREE_WIDTH} y={svgHeight - 2} class="axis-label" text-anchor="end">0 (early)</text>
+                <text x={PADDING} y={svgHeight - 2} class="axis-label" text-anchor="start">{maxMergeIter} (late)</text>
+            </svg>
+        </div>
+    {/if}
+</div>
+
+<style>
+    .dendrogram-section {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+    }
+
+    .section-title {
+        font-size: var(--text-base);
+        font-weight: 600;
+        margin: 0;
+    }
+
+    .section-description {
+        font-size: var(--text-xs);
+        color: var(--text-muted);
+        line-height: 1.4;
+        max-width: 600px;
+    }
+
+    .status {
+        font-size: var(--text-sm);
+        color: var(--text-muted);
+        padding: var(--space-2);
+    }
+
+    .status.error {
+        color: var(--status-error);
+    }
+
+    .dendrogram-scroll {
+        overflow: auto;
+    }
+
+    .dendrogram-svg {
+        display: block;
+    }
+
+    .tree-line {
+        stroke: var(--accent-primary);
+        stroke-width: 1.5;
+        fill: none;
+    }
+
+    .leaf-label {
+        font-size: 11px;
+        font-family: var(--font-sans);
+        fill: var(--text-secondary);
+    }
+
+    .axis-label {
+        font-size: 10px;
+        font-family: var(--font-mono);
+        fill: var(--text-muted);
+    }
+
+    .merge-node {
+        fill: var(--accent-primary);
+        opacity: 0.6;
+        cursor: default;
+    }
+
+    .merge-node:hover {
+        opacity: 1;
+        r: 6;
+    }
+
+    .firing-bar {
+        fill: var(--accent-primary);
+        opacity: 0.4;
+    }
+</style>

--- a/param_decomp/app/frontend/src/components/ClusterForceGraph.svelte
+++ b/param_decomp/app/frontend/src/components/ClusterForceGraph.svelte
@@ -1,0 +1,601 @@
+<script lang="ts">
+    import { getContext } from "svelte";
+    import { fetchClusteringCoactivation, type ClusterPairwiseResponse } from "../lib/api/clusters";
+    import ZoomControls from "../lib/ZoomControls.svelte";
+    import { useZoomPan } from "../lib/useZoomPan.svelte";
+    import { RUN_KEY, type RunContext } from "../lib/useRun.svelte";
+
+    type ComponentMember = { layer: string; cIdx: number };
+
+    type Props = {
+        members: ComponentMember[];
+        clusteringRunId: string;
+    };
+
+    type DataState =
+        | { status: "loading" }
+        | { status: "loaded"; response: ClusterPairwiseResponse }
+        | { status: "error"; error: string };
+
+    type GraphNode = {
+        key: string;
+        member: ComponentMember;
+        count: number;
+        radius: number;
+        x: number;
+        y: number;
+        vx: number;
+        vy: number;
+    };
+
+    type GraphEdge = {
+        source: string;
+        target: string;
+        weight: number;
+        countAB: number;
+    };
+
+    let { members, clusteringRunId }: Props = $props();
+
+    const runState = getContext<RunContext>(RUN_KEY);
+
+    let dataState: DataState = $state({ status: "loading" });
+    let minJaccard = $state(0.08);
+    let showIsolated = $state(true);
+    let selectedNodeKey: string | null = $state(null);
+    let hoveredNodeKey: string | null = $state(null);
+
+    let graphContainer: HTMLDivElement | null = $state(null);
+    const zoom = useZoomPan(() => graphContainer);
+
+    const keys = $derived(members.map((member) => `${member.layer}:${member.cIdx}`));
+
+    function getLabel(key: string): string {
+        const loadable = runState.getInterpretation(key);
+        if (loadable.status === "loaded" && loadable.data.status === "generated") {
+            return loadable.data.data.label;
+        }
+        return key;
+    }
+
+    $effect(() => {
+        const currentKeys = keys;
+        const runId = clusteringRunId;
+        if (currentKeys.length < 2) {
+            dataState = { status: "loaded", response: { pairs: [], n_tokens: 0 } };
+            return;
+        }
+
+        dataState = { status: "loading" };
+        fetchClusteringCoactivation(currentKeys, runId)
+            .then((response) => {
+                dataState = { status: "loaded", response };
+            })
+            .catch((error) => {
+                dataState = { status: "error", error: String(error) };
+            });
+    });
+
+    const baseGraph = $derived.by(() => {
+        const memberByKey = new Map<string, ComponentMember>();
+        for (const member of members) {
+            memberByKey.set(`${member.layer}:${member.cIdx}`, member);
+        }
+
+        const counts = new Map<string, number>();
+        const allEdges: GraphEdge[] = [];
+        let maxCount = 1;
+
+        if (dataState.status === "loaded") {
+            for (const pair of dataState.response.pairs) {
+                counts.set(pair.key_a, pair.count_a);
+                counts.set(pair.key_b, pair.count_b);
+                maxCount = Math.max(maxCount, pair.count_a, pair.count_b);
+                allEdges.push({
+                    source: pair.key_a,
+                    target: pair.key_b,
+                    weight: pair.jaccard,
+                    countAB: pair.count_ab,
+                });
+            }
+        }
+
+        const nodes = keys
+            .map((key) => ({
+                key,
+                member: memberByKey.get(key)!,
+                count: counts.get(key) ?? 0,
+            }))
+            .filter((node) => node.member !== undefined)
+            .map((node) => ({
+                ...node,
+                radius: 6 + (Math.sqrt(node.count) / Math.sqrt(maxCount || 1)) * 10,
+            }));
+
+        return { nodes, allEdges };
+    });
+
+    const visibleGraph = $derived.by(() => {
+        const edges = baseGraph.allEdges.filter((edge) => edge.weight >= minJaccard);
+        const connected = new Set<string>();
+        for (const edge of edges) {
+            connected.add(edge.source);
+            connected.add(edge.target);
+        }
+
+        const nodes = showIsolated ? baseGraph.nodes : baseGraph.nodes.filter((node) => connected.has(node.key));
+
+        const visibleNodeKeys = new Set(nodes.map((node) => node.key));
+        return {
+            nodes,
+            edges: edges.filter((edge) => visibleNodeKeys.has(edge.source) && visibleNodeKeys.has(edge.target)),
+        };
+    });
+
+    const nodeLabels = $derived(new Map(keys.map((key) => [key, getLabel(key)])));
+
+    let renderedNodes: GraphNode[] = $state([]);
+    let simNodes: GraphNode[] = [];
+    let lastPositions = new Map<string, { x: number; y: number }>();
+
+    const WIDTH = 920;
+    const HEIGHT = 580;
+
+    function pushRenderedNodes() {
+        renderedNodes = simNodes.map((node: GraphNode) => ({ ...node }));
+        lastPositions = new Map(simNodes.map((node: GraphNode) => [node.key, { x: node.x, y: node.y }]));
+    }
+
+    $effect(() => {
+        const graph = visibleGraph;
+        const edgeCount = graph.edges.length;
+        const nodeCount = graph.nodes.length;
+        if (nodeCount === 0) {
+            renderedNodes = [];
+            return;
+        }
+
+        simNodes = graph.nodes.map((node, index) => {
+            const saved = lastPositions.get(node.key);
+            const angle = (index / Math.max(nodeCount, 1)) * Math.PI * 2;
+            return {
+                ...node,
+                x: saved?.x ?? WIDTH / 2 + Math.cos(angle) * Math.min(220, 60 + nodeCount * 8),
+                y: saved?.y ?? HEIGHT / 2 + Math.sin(angle) * Math.min(180, 50 + nodeCount * 6),
+                vx: 0,
+                vy: 0,
+            };
+        });
+
+        let frame = 0;
+        let raf = 0;
+
+        const step = () => {
+            const nodeByKey = new Map(simNodes.map((node) => [node.key, node]));
+
+            for (let i = 0; i < simNodes.length; i++) {
+                const a = simNodes[i];
+                for (let j = i + 1; j < simNodes.length; j++) {
+                    const b = simNodes[j];
+                    const dx = a.x - b.x;
+                    const dy = a.y - b.y;
+                    const distSq = Math.max(dx * dx + dy * dy, 1);
+                    const force = 2400 / distSq;
+                    const fx = (dx / Math.sqrt(distSq)) * force;
+                    const fy = (dy / Math.sqrt(distSq)) * force;
+                    a.vx += fx;
+                    a.vy += fy;
+                    b.vx -= fx;
+                    b.vy -= fy;
+                }
+            }
+
+            for (const edge of graph.edges) {
+                const source = nodeByKey.get(edge.source);
+                const target = nodeByKey.get(edge.target);
+                if (!source || !target) continue;
+                const dx = target.x - source.x;
+                const dy = target.y - source.y;
+                const dist = Math.max(Math.sqrt(dx * dx + dy * dy), 1);
+                const desired = 150 - edge.weight * 90;
+                const spring = 0.003 + edge.weight * 0.03;
+                const force = (dist - desired) * spring;
+                const fx = (dx / dist) * force;
+                const fy = (dy / dist) * force;
+                source.vx += fx;
+                source.vy += fy;
+                target.vx -= fx;
+                target.vy -= fy;
+            }
+
+            let totalSpeed = 0;
+            for (const node of simNodes) {
+                const cx = WIDTH / 2 - node.x;
+                const cy = HEIGHT / 2 - node.y;
+                node.vx += cx * 0.0008;
+                node.vy += cy * 0.0008;
+                node.vx *= 0.86;
+                node.vy *= 0.86;
+                node.x = Math.max(24, Math.min(WIDTH - 24, node.x + node.vx));
+                node.y = Math.max(24, Math.min(HEIGHT - 24, node.y + node.vy));
+                totalSpeed += Math.abs(node.vx) + Math.abs(node.vy);
+            }
+
+            pushRenderedNodes();
+            frame += 1;
+            if (frame < Math.max(180, edgeCount * 8) || totalSpeed > 0.4) {
+                raf = requestAnimationFrame(step);
+            }
+        };
+
+        raf = requestAnimationFrame(step);
+        return () => cancelAnimationFrame(raf);
+    });
+
+    const nodeLookup = $derived(new Map<string, GraphNode>(renderedNodes.map((node: GraphNode) => [node.key, node])));
+    const rankedCounts = $derived([...renderedNodes].map((node: GraphNode) => node.count).sort((a, b) => b - a));
+    const labelThreshold = $derived(rankedCounts[Math.min(5, Math.max(rankedCounts.length - 1, 0))] ?? 0);
+
+    function edgePath(edge: GraphEdge): string {
+        const source = nodeLookup.get(edge.source);
+        const target = nodeLookup.get(edge.target);
+        if (!source || !target) return "";
+        return `M ${source.x} ${source.y} L ${target.x} ${target.y}`;
+    }
+
+    function edgeOpacity(weight: number): number {
+        return 0.12 + Math.min(weight / 0.3, 1) * 0.68;
+    }
+
+    function edgeWidth(weight: number): number {
+        return 1 + Math.min(weight / 0.3, 1) * 4;
+    }
+
+    function shouldShowLabel(node: GraphNode): boolean {
+        return (
+            renderedNodes.length <= 12 ||
+            node.key === selectedNodeKey ||
+            node.key === hoveredNodeKey ||
+            node.count >= labelThreshold
+        );
+    }
+
+    function nodeFill(node: GraphNode): string {
+        if (node.key === selectedNodeKey) return "var(--accent-positive)";
+        if (node.key === hoveredNodeKey) return "var(--accent-primary)";
+        return "rgba(59, 130, 246, 0.85)";
+    }
+
+    function nodeStroke(node: GraphNode): string {
+        if (node.key === selectedNodeKey || node.key === hoveredNodeKey) return "rgba(255, 255, 255, 0.95)";
+        return "rgba(15, 23, 42, 0.2)";
+    }
+
+    function graphPointFromEvent(event: MouseEvent): { x: number; y: number } | null {
+        if (!graphContainer) return null;
+        const rect = graphContainer.getBoundingClientRect();
+        return {
+            x: (event.clientX - rect.left + graphContainer.scrollLeft - zoom.translateX) / zoom.scale,
+            y: (event.clientY - rect.top + graphContainer.scrollTop - zoom.translateY) / zoom.scale,
+        };
+    }
+
+    let draggedNodeKey: string | null = $state(null);
+
+    function handleGraphMouseDown(event: MouseEvent) {
+        if (event.button === 1 || (event.button === 0 && event.shiftKey)) {
+            zoom.startPan(event);
+        }
+    }
+
+    function handleNodeMouseDown(event: MouseEvent, key: string) {
+        if (event.button !== 0 || event.shiftKey) return;
+        event.preventDefault();
+        event.stopPropagation();
+        draggedNodeKey = key;
+        selectedNodeKey = key;
+    }
+
+    function handleGraphMouseMove(event: MouseEvent) {
+        if (draggedNodeKey) {
+            const point = graphPointFromEvent(event);
+            if (!point) return;
+            const node = simNodes.find((candidate: GraphNode) => candidate.key === draggedNodeKey);
+            if (!node) return;
+            node.x = Math.max(24, Math.min(WIDTH - 24, point.x));
+            node.y = Math.max(24, Math.min(HEIGHT - 24, point.y));
+            node.vx = 0;
+            node.vy = 0;
+            pushRenderedNodes();
+            return;
+        }
+        zoom.updatePan(event);
+    }
+
+    function handleGraphMouseUp() {
+        draggedNodeKey = null;
+        zoom.endPan();
+    }
+
+    const highlightedEdges = $derived.by(() => {
+        const focus = selectedNodeKey ?? hoveredNodeKey;
+        if (!focus) return new Set<string>();
+        return new Set(
+            visibleGraph.edges
+                .filter((edge) => edge.source === focus || edge.target === focus)
+                .map((edge) => `${edge.source}|${edge.target}`),
+        );
+    });
+
+    const selectedSummary = $derived.by(() => {
+        const focus = selectedNodeKey ?? hoveredNodeKey;
+        if (!focus) return null;
+        const node = renderedNodes.find((candidate: GraphNode) => candidate.key === focus);
+        if (!node) return null;
+        const neighbors = visibleGraph.edges
+            .filter((edge) => edge.source === focus || edge.target === focus)
+            .map((edge) => ({
+                key: edge.source === focus ? edge.target : edge.source,
+                weight: edge.weight,
+                countAB: edge.countAB,
+            }))
+            .sort((a, b) => b.weight - a.weight)
+            .slice(0, 5);
+        return { node, neighbors };
+    });
+</script>
+
+<div class="force-graph-section">
+    <div class="section-header">
+        <div>
+            <h3 class="section-title">Force-Directed Co-Firing Graph</h3>
+            <div class="section-description">
+                Obsidian-style network view of cluster members. Edge strength is clustering-snapshot Jaccard; raise the
+                threshold to surface the core scaffold.
+            </div>
+        </div>
+        <div class="graph-controls">
+            <label class="slider-control">
+                <span>Min Jaccard</span>
+                <input type="range" min="0" max="0.5" step="0.01" bind:value={minJaccard} />
+                <span class="mono">{minJaccard.toFixed(2)}</span>
+            </label>
+            <label class="checkbox-control">
+                <input type="checkbox" bind:checked={showIsolated} />
+                <span>Show isolated</span>
+            </label>
+            <div class="graph-stats mono">{visibleGraph.nodes.length} nodes · {visibleGraph.edges.length} edges</div>
+        </div>
+    </div>
+
+    {#if dataState.status === "loading"}
+        <div class="status">Loading co-firing graph...</div>
+    {:else if dataState.status === "error"}
+        <div class="status error">{dataState.error}</div>
+    {:else if keys.length < 2}
+        <div class="status">Need at least 2 components.</div>
+    {:else if visibleGraph.nodes.length === 0}
+        <div class="status">No nodes remain at this threshold.</div>
+    {:else}
+        <!-- svelte-ignore a11y_no_static_element_interactions -->
+        <div
+            class="graph-shell"
+            bind:this={graphContainer}
+            class:panning={zoom.isPanning}
+            onmousedown={handleGraphMouseDown}
+            onmousemove={handleGraphMouseMove}
+            onmouseup={handleGraphMouseUp}
+            onmouseleave={handleGraphMouseUp}
+        >
+            <ZoomControls
+                scale={zoom.scale}
+                onZoomIn={zoom.zoomIn}
+                onZoomOut={zoom.zoomOut}
+                onReset={zoom.reset}
+                hint="Shift+scroll zoom"
+            />
+
+            <svg
+                class="graph-canvas"
+                width={WIDTH}
+                height={HEIGHT}
+                style="transform: translate({zoom.translateX}px, {zoom.translateY}px) scale({zoom.scale})"
+            >
+                {#each visibleGraph.edges as edge (`${edge.source}|${edge.target}`)}
+                    {@const highlighted = highlightedEdges.has(`${edge.source}|${edge.target}`)}
+                    <path
+                        d={edgePath(edge)}
+                        fill="none"
+                        stroke="rgba(59, 130, 246, 0.9)"
+                        stroke-width={edgeWidth(edge.weight)}
+                        opacity={highlighted ? Math.min(1, edgeOpacity(edge.weight) + 0.2) : edgeOpacity(edge.weight)}
+                    >
+                        <title
+                            >{edge.source} ↔ {edge.target} · Jaccard {edge.weight.toFixed(3)} · co-fire {edge.countAB}</title
+                        >
+                    </path>
+                {/each}
+
+                {#each renderedNodes as node (node.key)}
+                    <g transform={`translate(${node.x}, ${node.y})`}>
+                        <circle
+                            r={node.radius}
+                            fill={nodeFill(node)}
+                            stroke={nodeStroke(node)}
+                            stroke-width={node.key === selectedNodeKey ? 2.5 : 1.5}
+                            class="graph-node"
+                            onmouseenter={() => (hoveredNodeKey = node.key)}
+                            onmouseleave={() => (hoveredNodeKey = null)}
+                            onmousedown={(event: MouseEvent) => handleNodeMouseDown(event, node.key)}
+                            onclick={() => (selectedNodeKey = selectedNodeKey === node.key ? null : node.key)}
+                        >
+                            <title>{node.key} · {node.count.toLocaleString()} activations</title>
+                        </circle>
+                        {#if shouldShowLabel(node)}
+                            <text x={node.radius + 6} y="4" class="node-label">{nodeLabels.get(node.key) ?? node.key}</text>
+                        {/if}
+                    </g>
+                {/each}
+            </svg>
+        </div>
+
+        {#if selectedSummary}
+            <div class="selection-panel">
+                <div class="selection-title">{nodeLabels.get(selectedSummary.node.key) ?? selectedSummary.node.key}</div>
+                <div class="selection-meta mono">
+                    {selectedSummary.node.key} · {selectedSummary.node.count.toLocaleString()} activations
+                </div>
+                <div class="neighbor-list">
+                    {#if selectedSummary.neighbors.length === 0}
+                        <span class="neighbor-empty">No visible neighbors at this threshold.</span>
+                    {:else}
+                        {#each selectedSummary.neighbors as neighbor (neighbor.key)}
+                            <span class="neighbor-pill">
+                                {nodeLabels.get(neighbor.key) ?? neighbor.key} · J {neighbor.weight.toFixed(2)} · {neighbor.countAB}
+                            </span>
+                        {/each}
+                    {/if}
+                </div>
+            </div>
+        {/if}
+    {/if}
+</div>
+
+<style>
+    .force-graph-section {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+    }
+
+    .section-header {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: var(--space-4);
+        flex-wrap: wrap;
+    }
+
+    .section-title {
+        margin: 0;
+        font-size: var(--text-base);
+        font-weight: 600;
+    }
+
+    .section-description {
+        margin-top: var(--space-1);
+        max-width: 720px;
+        color: var(--text-muted);
+        font-size: var(--text-xs);
+        line-height: 1.4;
+    }
+
+    .graph-controls {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+        flex-wrap: wrap;
+    }
+
+    .slider-control,
+    .checkbox-control {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+        font-size: var(--text-sm);
+        color: var(--text-secondary);
+    }
+
+    .mono,
+    .graph-stats {
+        font-family: var(--font-mono);
+        font-size: var(--text-xs);
+        color: var(--text-muted);
+    }
+
+    .graph-shell {
+        position: relative;
+        overflow: auto;
+        border: 1px solid var(--border-default);
+        border-radius: var(--radius-md);
+        background:
+            radial-gradient(circle at top, rgba(59, 130, 246, 0.08), transparent 35%),
+            linear-gradient(180deg, rgba(15, 23, 42, 0.04), transparent 20%), var(--bg-base);
+        cursor: default;
+    }
+
+    .graph-shell.panning {
+        cursor: grabbing;
+    }
+
+    .graph-canvas {
+        display: block;
+        transform-origin: 0 0;
+    }
+
+    .graph-node {
+        cursor: grab;
+        transition:
+            fill var(--transition-fast),
+            stroke var(--transition-fast);
+    }
+
+    .graph-node:active {
+        cursor: grabbing;
+    }
+
+    .node-label {
+        font-size: 11px;
+        fill: var(--text-secondary);
+        pointer-events: none;
+    }
+
+    .selection-panel {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+        padding: var(--space-3);
+        border: 1px solid var(--border-default);
+        border-radius: var(--radius-md);
+        background: var(--bg-elevated);
+    }
+
+    .selection-title {
+        font-size: var(--text-sm);
+        font-weight: 600;
+        color: var(--text-primary);
+    }
+
+    .selection-meta {
+        color: var(--text-muted);
+    }
+
+    .neighbor-list {
+        display: flex;
+        flex-wrap: wrap;
+        gap: var(--space-2);
+    }
+
+    .neighbor-pill {
+        padding: var(--space-1) var(--space-2);
+        border-radius: var(--radius-sm);
+        background: var(--bg-inset);
+        color: var(--text-secondary);
+        font-size: var(--text-xs);
+        white-space: nowrap;
+    }
+
+    .neighbor-empty,
+    .status {
+        font-size: var(--text-sm);
+        color: var(--text-muted);
+    }
+
+    .status {
+        padding: var(--space-4);
+    }
+
+    .status.error {
+        color: var(--status-error);
+    }
+</style>

--- a/param_decomp/app/frontend/src/components/ClusterFullMatrix.svelte
+++ b/param_decomp/app/frontend/src/components/ClusterFullMatrix.svelte
@@ -1,0 +1,558 @@
+<script lang="ts">
+    import type { FullMatrixResponse, FullMatrixMetric, ClusterBoundary } from "../lib/api/clusters";
+    import { fetchFullMatrix } from "../lib/api/clusters";
+    import type { ClusterMappingData } from "../lib/useRun.svelte";
+
+    type Props = {
+        clusterMappingData: ClusterMappingData;
+        onSelectCluster: (clusterId: number) => void;
+    };
+
+    let { clusterMappingData, onSelectCluster }: Props = $props();
+
+    let selectedMetric = $state<FullMatrixMetric>("jaccard");
+
+    type LoadedData = { response: FullMatrixResponse; floats: Float32Array };
+    type DataState =
+        | { status: "idle" }
+        | { status: "loading" }
+        | { status: "loaded"; data: LoadedData }
+        | { status: "error"; error: string };
+
+    let overviewState = $state<DataState>({ status: "idle" });
+    let detailState = $state<DataState>({ status: "idle" });
+
+    let overviewCanvas = $state<HTMLCanvasElement | null>(null);
+    let detailCanvas = $state<HTMLCanvasElement | null>(null);
+
+    // Selection rectangle on overview (in overview pixel coords)
+    let selRow = $state(0);
+    let selCol = $state(0);
+    let isDragging = $state(false);
+
+    const OVERVIEW_SIZE = 700;
+    const DETAIL_SIZE = 500;
+    const DETAIL_REGION = 200;
+
+    let hoverInfo = $state<{
+        x: number;
+        y: number;
+        rowKey: string;
+        colKey: string;
+        value: number | null;
+        cluster: ClusterBoundary | null;
+    } | null>(null);
+
+    function decodeMatrix(response: FullMatrixResponse): Float32Array {
+        const binaryStr = atob(response.matrix_b64);
+        const bytes = new Uint8Array(binaryStr.length);
+        for (let i = 0; i < binaryStr.length; i++) {
+            bytes[i] = binaryStr.charCodeAt(i);
+        }
+        return new Float32Array(bytes.buffer);
+    }
+
+    // Fetch overview (small, binned)
+    $effect(() => {
+        const metric = selectedMetric;
+        const mapping = clusterMappingData;
+        overviewState = { status: "loading" };
+        detailState = { status: "idle" };
+        selRow = 0;
+        selCol = 0;
+        fetchFullMatrix(metric, mapping, 500)
+            .then((response) => {
+                overviewState = { status: "loaded", data: { response, floats: decodeMatrix(response) } };
+            })
+            .catch((e) => (overviewState = { status: "error", error: String(e) }));
+    });
+
+    // Debounced detail fetch
+    let detailTimer: ReturnType<typeof setTimeout> | null = null;
+
+    $effect(() => {
+        if (overviewState.status !== "loaded") return;
+        // Read reactive deps
+        const fullSize = overviewState.data.response.full_size;
+        const row = Math.round((selRow * fullSize) / overviewState.data.response.height);
+        const col = Math.round((selCol * fullSize) / overviewState.data.response.width);
+        const metric = selectedMetric;
+        const mapping = clusterMappingData;
+
+        if (detailTimer !== null) clearTimeout(detailTimer);
+        detailTimer = setTimeout(() => {
+            detailState = { status: "loading" };
+            fetchFullMatrix(metric, mapping, DETAIL_REGION, { row, col, size: DETAIL_REGION })
+                .then((response) => {
+                    detailState = { status: "loaded", data: { response, floats: decodeMatrix(response) } };
+                })
+                .catch((e) => (detailState = { status: "error", error: String(e) }));
+        }, 150);
+    });
+
+    // Render overview image once when data loads
+    let overviewImageData = $state<ImageData | null>(null);
+
+    $effect(() => {
+        if (overviewState.status !== "loaded") return;
+        const { response, floats } = overviewState.data;
+        const imgData = new ImageData(response.width, response.height);
+        const pixels = imgData.data;
+        for (let i = 0; i < floats.length; i++) {
+            const [r, g, b] = metricToColor(floats[i], selectedMetric);
+            const off = i * 4;
+            pixels[off] = r;
+            pixels[off + 1] = g;
+            pixels[off + 2] = b;
+            pixels[off + 3] = 255;
+        }
+        overviewImageData = imgData;
+    });
+
+    // Redraw overview canvas (image + boundaries + selection rect) when selection moves
+    $effect(() => {
+        if (!overviewCanvas || !overviewImageData || overviewState.status !== "loaded") return;
+        const ov = overviewState.data.response;
+        overviewCanvas.width = ov.width;
+        overviewCanvas.height = ov.height;
+        const ctx = overviewCanvas.getContext("2d")!;
+        ctx.putImageData(overviewImageData, 0, 0);
+
+        // Cluster boundaries (overview is always the full symmetric matrix, so row=col)
+        ctx.strokeStyle = "rgba(0, 0, 0, 0.3)";
+        ctx.lineWidth = 1;
+        for (const b of ov.row_boundaries) {
+            ctx.strokeRect(b.start, b.start, b.end - b.start, b.end - b.start);
+        }
+
+        // Selection rectangle
+        const _row = selRow;
+        const _col = selCol;
+        const selW = Math.round((DETAIL_REGION * ov.width) / ov.full_size);
+        const selH = Math.round((DETAIL_REGION * ov.height) / ov.full_size);
+        ctx.strokeStyle = "rgba(255, 200, 0, 0.9)";
+        ctx.lineWidth = 2;
+        ctx.strokeRect(_col, _row, selW, selH);
+    });
+
+    // Render detail
+    $effect(() => {
+        if (detailState.status !== "loaded" || !detailCanvas) return;
+        const { response, floats } = detailState.data;
+        detailCanvas.width = response.width;
+        detailCanvas.height = response.height;
+        renderCanvas(
+            detailCanvas,
+            floats,
+            response.width,
+            response.height,
+            response.row_boundaries,
+            response.col_boundaries,
+            selectedMetric,
+        );
+    });
+
+    function metricToColor(val: number, metric: FullMatrixMetric): [number, number, number] {
+        if (isNaN(val)) return [240, 240, 240];
+        if (metric === "pmi") {
+            if (val > 0) {
+                const n = Math.min(val / 6, 1);
+                return [
+                    Math.round(59 * n + 255 * (1 - n)),
+                    Math.round(130 * n + 255 * (1 - n)),
+                    Math.round(246 * n + 255 * (1 - n)),
+                ];
+            } else {
+                const n = Math.min(Math.abs(val) / 6, 1);
+                return [
+                    Math.round(239 * n + 255 * (1 - n)),
+                    Math.round(68 * n + 255 * (1 - n)),
+                    Math.round(68 * n + 255 * (1 - n)),
+                ];
+            }
+        }
+        const n = Math.min(Math.max(val, 0), 1);
+        return [
+            Math.round(59 * n + 255 * (1 - n)),
+            Math.round(130 * n + 255 * (1 - n)),
+            Math.round(246 * n + 255 * (1 - n)),
+        ];
+    }
+
+    function renderCanvas(
+        cvs: HTMLCanvasElement,
+        floats: Float32Array,
+        width: number,
+        height: number,
+        rowBoundaries: ClusterBoundary[],
+        colBoundaries: ClusterBoundary[],
+        metric: FullMatrixMetric,
+    ) {
+        cvs.width = width;
+        cvs.height = height;
+        const ctx = cvs.getContext("2d")!;
+        const imageData = ctx.createImageData(width, height);
+        const pixels = imageData.data;
+        for (let i = 0; i < floats.length; i++) {
+            const [r, g, b] = metricToColor(floats[i], metric);
+            const off = i * 4;
+            pixels[off] = r;
+            pixels[off + 1] = g;
+            pixels[off + 2] = b;
+            pixels[off + 3] = 255;
+        }
+        ctx.putImageData(imageData, 0, 0);
+
+        ctx.strokeStyle = "rgba(0, 0, 0, 0.3)";
+        ctx.lineWidth = 1;
+        // Horizontal lines at row boundaries
+        for (const b of rowBoundaries) {
+            ctx.beginPath();
+            ctx.moveTo(0, b.start);
+            ctx.lineTo(width, b.start);
+            ctx.stroke();
+            ctx.beginPath();
+            ctx.moveTo(0, b.end);
+            ctx.lineTo(width, b.end);
+            ctx.stroke();
+        }
+        // Vertical lines at col boundaries
+        for (const b of colBoundaries) {
+            ctx.beginPath();
+            ctx.moveTo(b.start, 0);
+            ctx.lineTo(b.start, height);
+            ctx.stroke();
+            ctx.beginPath();
+            ctx.moveTo(b.end, 0);
+            ctx.lineTo(b.end, height);
+            ctx.stroke();
+        }
+    }
+
+    function overviewToSel(e: MouseEvent) {
+        if (!overviewCanvas || overviewState.status !== "loaded") return;
+        const rect = overviewCanvas.getBoundingClientRect();
+        const ov = overviewState.data.response;
+        const scaleX = ov.width / rect.width;
+        const scaleY = ov.height / rect.height;
+        const mx = (e.clientX - rect.left) * scaleX;
+        const my = (e.clientY - rect.top) * scaleY;
+        const selW = Math.round((DETAIL_REGION * ov.width) / ov.full_size);
+        const selH = Math.round((DETAIL_REGION * ov.height) / ov.full_size);
+        selCol = Math.max(0, Math.min(Math.round(mx - selW / 2), ov.width - selW));
+        selRow = Math.max(0, Math.min(Math.round(my - selH / 2), ov.height - selH));
+    }
+
+    function handleOverviewMouseDown(e: MouseEvent) {
+        if (e.button !== 0) return;
+        isDragging = true;
+        overviewToSel(e);
+    }
+
+    function handleOverviewMouseMove(e: MouseEvent) {
+        if (isDragging) overviewToSel(e);
+    }
+
+    function handleOverviewMouseUp() {
+        isDragging = false;
+    }
+
+    function handleDetailMouseMove(e: MouseEvent) {
+        if (detailState.status !== "loaded" || !detailCanvas) {
+            hoverInfo = null;
+            return;
+        }
+        const rect = detailCanvas.getBoundingClientRect();
+        const d = detailState.data.response;
+        const scaleX = d.width / rect.width;
+        const scaleY = d.height / rect.height;
+        const matX = Math.floor((e.clientX - rect.left) * scaleX);
+        const matY = Math.floor((e.clientY - rect.top) * scaleY);
+        if (matX < 0 || matX >= d.width || matY < 0 || matY >= d.height) {
+            hoverInfo = null;
+            return;
+        }
+        const idx = matY * d.width + matX;
+        const val = detailState.data.floats[idx];
+        const colKey = matX < d.component_keys.length ? d.component_keys[matX] : "";
+        const rowKey = matY < d.component_keys.length ? d.component_keys[matY] : "";
+        const rowCluster = d.row_boundaries.find((b) => matY >= b.start && matY < b.end) ?? null;
+        const colCluster = d.col_boundaries.find((b) => matX >= b.start && matX < b.end) ?? null;
+        const cluster = rowCluster && colCluster && rowCluster.cluster_id === colCluster.cluster_id ? rowCluster : null;
+        hoverInfo = { x: e.clientX, y: e.clientY, rowKey, colKey, value: isNaN(val) ? null : val, cluster };
+    }
+
+    function handleDetailClick(e: MouseEvent) {
+        if (detailState.status !== "loaded" || !detailCanvas) return;
+        const rect = detailCanvas.getBoundingClientRect();
+        const d = detailState.data.response;
+        const scaleX = d.width / rect.width;
+        const scaleY = d.height / rect.height;
+        const matX = Math.floor((e.clientX - rect.left) * scaleX);
+        const matY = Math.floor((e.clientY - rect.top) * scaleY);
+        const rowCluster = d.row_boundaries.find((b) => matY >= b.start && matY < b.end);
+        const colCluster = d.col_boundaries.find((b) => matX >= b.start && matX < b.end);
+        const cluster = rowCluster && colCluster && rowCluster.cluster_id === colCluster.cluster_id ? rowCluster : null;
+        if (cluster) onSelectCluster(cluster.cluster_id);
+    }
+</script>
+
+<svelte:window onmouseup={handleOverviewMouseUp} />
+
+<div class="full-matrix">
+    <div class="matrix-header">
+        <div class="matrix-controls">
+            <span class="control-label">Metric:</span>
+            <button
+                class="metric-btn"
+                class:active={selectedMetric === "jaccard"}
+                onclick={() => (selectedMetric = "jaccard")}>Jaccard</button
+            >
+            <button
+                class="metric-btn"
+                class:active={selectedMetric === "precision"}
+                onclick={() => (selectedMetric = "precision")}>Precision</button
+            >
+            <button class="metric-btn" class:active={selectedMetric === "pmi"} onclick={() => (selectedMetric = "pmi")}
+                >PMI</button
+            >
+        </div>
+        {#if overviewState.status === "loaded"}
+            <span class="info-text">
+                {overviewState.data.response.full_size}×{overviewState.data.response.full_size} components · {overviewState.data.response.n_tokens.toLocaleString()}
+                tokens · {overviewState.data.response.row_boundaries.length} clusters
+            </span>
+        {/if}
+    </div>
+
+    {#if overviewState.status === "loading"}
+        <div class="status">Loading overview...</div>
+    {:else if overviewState.status === "error"}
+        <div class="status error">{overviewState.error}</div>
+    {:else if overviewState.status === "loaded"}
+        <div class="matrix-panels">
+            <div class="panel overview-panel">
+                <div class="panel-label">Overview (click to select region)</div>
+                <canvas
+                    bind:this={overviewCanvas}
+                    style="width: {OVERVIEW_SIZE}px; height: {OVERVIEW_SIZE}px;"
+                    class="matrix-canvas overview"
+                    class:dragging={isDragging}
+                    onmousedown={handleOverviewMouseDown}
+                    onmousemove={handleOverviewMouseMove}
+                ></canvas>
+            </div>
+            <div class="panel detail-panel">
+                <div class="panel-label">
+                    Detail ({DETAIL_REGION}×{DETAIL_REGION})
+                    {#if detailState.status === "loading"}
+                        <span class="loading-dot">loading...</span>
+                    {/if}
+                </div>
+                {#if detailState.status === "loaded"}
+                    <div class="detail-canvas-wrapper">
+                        <canvas
+                            bind:this={detailCanvas}
+                            style="width: {DETAIL_SIZE}px; height: {DETAIL_SIZE}px;"
+                            class="matrix-canvas detail"
+                            onmousemove={handleDetailMouseMove}
+                            onmouseleave={() => (hoverInfo = null)}
+                            onclick={handleDetailClick}
+                        ></canvas>
+                        {#if hoverInfo}
+                            <div class="tooltip" style="left: {hoverInfo.x + 12}px; top: {hoverInfo.y - 40}px;">
+                                <div class="tooltip-row">
+                                    <span class="tooltip-label">row</span><span class="tooltip-key"
+                                        >{hoverInfo.rowKey}</span
+                                    >
+                                </div>
+                                <div class="tooltip-row">
+                                    <span class="tooltip-label">col</span><span class="tooltip-key"
+                                        >{hoverInfo.colKey}</span
+                                    >
+                                </div>
+                                <div class="tooltip-row">
+                                    <span class="tooltip-label">{selectedMetric}</span>
+                                    <span class="tooltip-val"
+                                        >{hoverInfo.value !== null ? hoverInfo.value.toFixed(4) : "—"}</span
+                                    >
+                                    {#if hoverInfo.cluster}<span class="tooltip-cluster"
+                                            >Cluster {hoverInfo.cluster.cluster_id}</span
+                                        >{/if}
+                                </div>
+                            </div>
+                        {/if}
+                    </div>
+                {:else if detailState.status === "error"}
+                    <div class="status error">{detailState.error}</div>
+                {/if}
+            </div>
+        </div>
+        <div class="matrix-footer">Click a cluster block in the detail view to inspect</div>
+    {/if}
+</div>
+
+<style>
+    .full-matrix {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-3);
+        height: 100%;
+        min-height: 0;
+    }
+
+    .matrix-header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        flex-shrink: 0;
+    }
+
+    .matrix-controls {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+    }
+
+    .info-text {
+        font-size: var(--text-xs);
+        color: var(--text-muted);
+        font-family: var(--font-mono);
+    }
+
+    .control-label {
+        font-size: var(--text-sm);
+        color: var(--text-muted);
+    }
+
+    .metric-btn {
+        padding: var(--space-1) var(--space-3);
+        font: inherit;
+        font-size: var(--text-sm);
+        background: var(--bg-surface);
+        border: 1px solid var(--border-default);
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        color: var(--text-secondary);
+        transition:
+            background var(--transition-normal),
+            border-color var(--transition-normal);
+    }
+
+    .metric-btn:hover {
+        background: var(--bg-elevated);
+        border-color: var(--border-strong);
+    }
+
+    .metric-btn.active {
+        background: var(--bg-elevated);
+        border-color: var(--accent-primary);
+        color: var(--text-primary);
+    }
+
+    .status {
+        font-size: var(--text-sm);
+        color: var(--text-muted);
+        padding: var(--space-4);
+    }
+
+    .status.error {
+        color: var(--status-error);
+    }
+
+    .matrix-panels {
+        display: flex;
+        gap: var(--space-4);
+        flex: 1;
+        min-height: 0;
+        align-items: flex-start;
+    }
+
+    .panel {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-2);
+    }
+
+    .panel-label {
+        font-size: var(--text-xs);
+        color: var(--text-muted);
+        font-weight: 500;
+    }
+
+    .loading-dot {
+        color: var(--text-muted);
+        font-style: italic;
+    }
+
+    .matrix-canvas {
+        border: 1px solid var(--border-default);
+        image-rendering: pixelated;
+    }
+
+    .matrix-canvas.overview {
+        cursor: crosshair;
+    }
+
+    .matrix-canvas.overview.dragging {
+        cursor: grabbing;
+    }
+
+    .matrix-canvas.detail {
+        cursor: crosshair;
+    }
+
+    .detail-canvas-wrapper {
+        position: relative;
+    }
+
+    .tooltip {
+        position: fixed;
+        z-index: 1000;
+        padding: var(--space-2);
+        background: var(--bg-elevated);
+        border: 1px solid var(--border-strong);
+        border-radius: var(--radius-sm);
+        font-size: var(--text-xs);
+        font-family: var(--font-mono);
+        pointer-events: none;
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        box-shadow: var(--shadow-md);
+        white-space: nowrap;
+    }
+
+    .tooltip-row {
+        display: flex;
+        gap: var(--space-2);
+        align-items: center;
+    }
+
+    .tooltip-label {
+        color: var(--text-muted);
+        min-width: 2em;
+    }
+
+    .tooltip-key {
+        color: var(--text-secondary);
+        max-width: 250px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+
+    .tooltip-val {
+        color: var(--text-primary);
+        font-weight: 600;
+    }
+
+    .tooltip-cluster {
+        color: var(--accent-primary);
+    }
+
+    .matrix-footer {
+        font-size: var(--text-xs);
+        color: var(--text-muted);
+        flex-shrink: 0;
+    }
+</style>

--- a/param_decomp/app/frontend/src/components/ClusterMiniMatrix.svelte
+++ b/param_decomp/app/frontend/src/components/ClusterMiniMatrix.svelte
@@ -1,0 +1,299 @@
+<script lang="ts">
+    import { onMount } from "svelte";
+    import {
+        fetchClusteringCoactivation,
+        fetchMergeIterations,
+        type ClusterPairwiseResponse,
+        type MergeIterationsResponse,
+    } from "../lib/api/clusters";
+    import {
+        buildDendrogram,
+        assignLeafPositions,
+        collectLeaves,
+        generateLines,
+        dendrogramLeafOrder,
+    } from "../lib/dendrogram";
+
+    type ComponentMember = { layer: string; cIdx: number };
+
+    type Props = {
+        members: ComponentMember[];
+        clusteringRunId: string;
+        iteration: number;
+    };
+
+    let { members, clusteringRunId, iteration }: Props = $props();
+
+    const MAX_PREVIEW_MEMBERS = 24;
+    const CANVAS_SIZE = 336;
+
+    type DataState =
+        | { status: "idle" }
+        | { status: "loading" }
+        | { status: "loaded"; response: ClusterPairwiseResponse }
+        | { status: "error"; error: string };
+
+    let dataState: DataState = $state({ status: "idle" });
+    let canvasEl: HTMLCanvasElement | null = $state(null);
+    let rootEl: HTMLDivElement | null = $state(null);
+    let isVisible = $state(false);
+
+    const previewMembers = $derived.by(() =>
+        [...members]
+            .sort((a, b) => {
+                if (a.layer !== b.layer) return a.layer < b.layer ? -1 : 1;
+                return a.cIdx - b.cIdx;
+            })
+            .slice(0, MAX_PREVIEW_MEMBERS),
+    );
+    const previewKeys = $derived(previewMembers.map((member) => `${member.layer}:${member.cIdx}`));
+
+    function pairKey(a: string, b: string): string {
+        return a < b ? `${a}|${b}` : `${b}|${a}`;
+    }
+
+    let leafOrder = $state<string[] | null>(null);
+    let mergeData = $state<MergeIterationsResponse | null>(null);
+
+    $effect(() => {
+        const keys = previewKeys;
+        const runId = clusteringRunId;
+        const iter = iteration;
+        if (!isVisible || keys.length < 2 || dataState.status !== "idle") return;
+
+        dataState = { status: "loading" };
+        Promise.all([
+            fetchClusteringCoactivation(keys, runId),
+            fetchMergeIterations(keys, runId, iter),
+        ])
+            .then(([coactResponse, mergeResponse]) => {
+                mergeData = mergeResponse;
+                leafOrder = dendrogramLeafOrder(keys, mergeResponse.pairs);
+                dataState = { status: "loaded", response: coactResponse };
+            })
+            .catch((error) => {
+                dataState = { status: "error", error: String(error) };
+            });
+    });
+
+    const orderedKeys = $derived(leafOrder ?? previewKeys);
+
+    const DENDRO_WIDTH = 576;
+    const DENDRO_PADDING = 12;
+
+    const miniDendro = $derived.by(() => {
+        if (!mergeData || orderedKeys.length < 2) return null;
+        const root = buildDendrogram(orderedKeys, mergeData.pairs);
+        if (!root) return null;
+        assignLeafPositions(root, 0);
+        const leaves = collectLeaves(root);
+        const nLeaves = leaves.length;
+        const totalIters = mergeData.total_iterations;
+        const height = CANVAS_SIZE;
+        const treeRight = DENDRO_WIDTH - DENDRO_PADDING;
+        const treeLeft = DENDRO_PADDING;
+        const xScale = (iter: number) => {
+            if (totalIters === 0) return treeLeft;
+            return treeRight - (iter / totalIters) * (treeRight - treeLeft);
+        };
+        const yScale = (pos: number) => DENDRO_PADDING + (pos / Math.max(nLeaves - 1, 1)) * (height - DENDRO_PADDING * 2);
+        const lines = generateLines(root, xScale, yScale, treeRight);
+        const totalLabel = totalIters >= 1000 ? `${(totalIters / 1000).toFixed(totalIters % 1000 === 0 ? 0 : 1)}k` : String(totalIters);
+        return { lines, height, totalLabel };
+    });
+
+    $effect(() => {
+        if (!canvasEl || dataState.status !== "loaded") return;
+
+        const keys = orderedKeys;
+        const size = keys.length;
+        const ctx = canvasEl.getContext("2d");
+        if (!ctx) return;
+
+        canvasEl.width = size;
+        canvasEl.height = size;
+
+        const lookup = new Map<string, number>();
+        for (const pair of dataState.response.pairs) {
+            lookup.set(pairKey(pair.key_a, pair.key_b), pair.jaccard);
+        }
+
+        const image = ctx.createImageData(size, size);
+        for (let row = 0; row < size; row++) {
+            for (let col = 0; col < size; col++) {
+                const offset = (row * size + col) * 4;
+                let r = 242;
+                let g = 244;
+                let b = 247;
+                const value = row === col ? 1 : (lookup.get(pairKey(keys[row], keys[col])) ?? 0);
+                const alpha = Math.max(0, Math.min(value, 1));
+                r = Math.round(242 - alpha * 183);
+                g = Math.round(244 - alpha * 114);
+                b = Math.round(247 - alpha * 1);
+                image.data[offset] = r;
+                image.data[offset + 1] = g;
+                image.data[offset + 2] = b;
+                image.data[offset + 3] = 255;
+            }
+        }
+
+        ctx.putImageData(image, 0, 0);
+    });
+
+    const stats = $derived.by(() => {
+        if (dataState.status !== "loaded" || dataState.response.pairs.length === 0) {
+            return { mean: 0, max: 0 };
+        }
+        let sum = 0;
+        let max = 0;
+        for (const pair of dataState.response.pairs) {
+            sum += pair.jaccard;
+            max = Math.max(max, pair.jaccard);
+        }
+        return { mean: sum / dataState.response.pairs.length, max };
+    });
+
+    const titleText = $derived.by(() => {
+        const shown = previewKeys.length;
+        const suffix = shown < members.length ? ` first ${shown}/${members.length} members` : ` ${shown} members`;
+        if (dataState.status === "loaded") {
+            return `Clustering Jaccard mini-matrix for${suffix}. Mean ${stats.mean.toFixed(3)}, max ${stats.max.toFixed(3)}.`;
+        }
+        if (dataState.status === "error") {
+            return `Failed to load mini-matrix for${suffix}.`;
+        }
+        return `Clustering Jaccard mini-matrix for${suffix}.`;
+    });
+
+    onMount(() => {
+        if (!rootEl) return;
+        const observer = new IntersectionObserver(
+            (entries) => {
+                if (entries.some((entry) => entry.isIntersecting)) {
+                    isVisible = true;
+                    observer.disconnect();
+                }
+            },
+            { rootMargin: "120px" },
+        );
+        observer.observe(rootEl);
+        return () => observer.disconnect();
+    });
+</script>
+
+<div class="mini-cluster-preview" bind:this={rootEl} title={titleText}>
+    <div class="mini-visuals">
+        {#if previewKeys.length < 2}
+            <div class="mini-empty">1x</div>
+        {:else if dataState.status === "error"}
+            <div class="mini-empty">!</div>
+        {:else if dataState.status !== "loaded"}
+            <div class="mini-loading"></div>
+        {:else}
+            {#if miniDendro}
+                <div class="dendro-col">
+                    <svg class="mini-dendro" width={DENDRO_WIDTH} height={miniDendro.height}>
+                        {#each miniDendro.lines as line, i (i)}
+                            <line x1={line.x1} y1={line.y1} x2={line.x2} y2={line.y2} class="dendro-line" />
+                        {/each}
+                    </svg>
+                    <div class="dendro-axis" style={`width: ${DENDRO_WIDTH}px; padding: 0 ${DENDRO_PADDING}px;`}>
+                        <span>{miniDendro.totalLabel}</span>
+                        <span>0</span>
+                    </div>
+                </div>
+            {/if}
+            <canvas
+                bind:this={canvasEl}
+                class="mini-canvas"
+                width={CANVAS_SIZE}
+                height={CANVAS_SIZE}
+                style={`width: ${CANVAS_SIZE}px; height: ${CANVAS_SIZE}px;`}
+            ></canvas>
+        {/if}
+    </div>
+    <div class="mini-meta">
+        <span>J</span>
+        <span>{dataState.status === "loaded" ? stats.mean.toFixed(2) : "..."}</span>
+    </div>
+</div>
+
+<style>
+    .mini-cluster-preview {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 4px;
+        flex-shrink: 0;
+    }
+
+    .mini-visuals {
+        display: flex;
+        align-items: stretch;
+        gap: 1px;
+    }
+
+    .mini-canvas,
+    .mini-loading,
+    .mini-empty {
+        width: 336px;
+        height: 336px;
+        border: 1px solid var(--border-default);
+        border-radius: var(--radius-sm);
+        background: var(--bg-base);
+        image-rendering: pixelated;
+    }
+
+    .dendro-col {
+        display: flex;
+        flex-direction: column;
+        flex-shrink: 0;
+    }
+
+    .mini-dendro {
+        flex-shrink: 0;
+    }
+
+    .dendro-axis {
+        display: flex;
+        justify-content: space-between;
+        font-size: 9px;
+        font-family: var(--font-mono);
+        color: var(--text-muted);
+        border-top: 1px solid var(--border-default);
+        padding-top: 2px;
+        box-sizing: border-box;
+    }
+
+    .dendro-line {
+        stroke: var(--accent-primary);
+        stroke-width: 1.5;
+        fill: none;
+        opacity: 0.6;
+    }
+
+    .mini-loading {
+        background:
+            linear-gradient(135deg, var(--bg-inset) 25%, transparent 25%) -8px 0/16px 16px,
+            linear-gradient(225deg, var(--bg-inset) 25%, transparent 25%) -8px 0/16px 16px,
+            linear-gradient(315deg, var(--bg-inset) 25%, transparent 25%) 0 0/16px 16px,
+            linear-gradient(45deg, var(--bg-inset) 25%, var(--bg-base) 25%) 0 0/16px 16px;
+    }
+
+    .mini-empty {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: var(--text-muted);
+        font-size: var(--text-xs);
+        font-family: var(--font-mono);
+    }
+
+    .mini-meta {
+        display: flex;
+        gap: 4px;
+        color: var(--text-muted);
+        font-size: 10px;
+        font-family: var(--font-mono);
+    }
+</style>

--- a/param_decomp/app/frontend/src/components/ClusterPathInput.svelte
+++ b/param_decomp/app/frontend/src/components/ClusterPathInput.svelte
@@ -36,7 +36,13 @@
         error = null;
         try {
             const result = await loadClusterMapping(path);
-            runState.setClusterMapping(result.mapping, path, loadedRun.wandb_path);
+            runState.setClusterMapping(
+                result.mapping,
+                path,
+                loadedRun.wandb_path,
+                result.clustering_run_id,
+                result.iteration,
+            );
             inputPath = "";
         } catch (e) {
             error = e instanceof Error ? e.message : "Failed to load";

--- a/param_decomp/app/frontend/src/components/ClustersTab.svelte
+++ b/param_decomp/app/frontend/src/components/ClustersTab.svelte
@@ -11,7 +11,11 @@
 
 <div class="tab-wrapper">
     {#if clusterMapping}
-        <ClustersViewer clusterMappingData={clusterMapping.data} />
+        <ClustersViewer
+            clusterMappingData={clusterMapping.data}
+            clusteringRunId={clusterMapping.clusteringRunId}
+            iteration={clusterMapping.iteration}
+        />
     {:else}
         <StatusText
             >No clusters loaded. Use the cluster path input in the header bar to load a cluster mapping.</StatusText

--- a/param_decomp/app/frontend/src/components/ClustersViewer.svelte
+++ b/param_decomp/app/frontend/src/components/ClustersViewer.svelte
@@ -2,19 +2,32 @@
     import { getContext } from "svelte";
     import { RUN_KEY, type RunContext, type ClusterMappingData } from "../lib/useRun.svelte";
     import ClusterComponentCard from "./ClusterComponentCard.svelte";
+    import ClusterCorrelationMatrix from "./ClusterCorrelationMatrix.svelte";
+    import ClusterDendrogram from "./ClusterDendrogram.svelte";
+    import ClusterForceGraph from "./ClusterForceGraph.svelte";
+    import ClusterFullMatrix from "./ClusterFullMatrix.svelte";
+    import ClusterMiniMatrix from "./ClusterMiniMatrix.svelte";
 
     const runState = getContext<RunContext>(RUN_KEY);
 
     type Props = {
         clusterMappingData: ClusterMappingData;
+        clusteringRunId: string;
+        iteration: number;
     };
 
-    let { clusterMappingData }: Props = $props();
+    let { clusterMappingData, clusteringRunId, iteration }: Props = $props();
 
     type ComponentMember = { layer: string; cIdx: number };
 
+    type SubTab = "matrix" | "list";
+    let activeSubTab = $state<SubTab>("matrix");
+    type DetailViz = "graph" | "matrix";
+    let activeDetailViz = $state<DetailViz>("graph");
+
     /** "unclustered" is a sentinel for the singletons group */
     let selectedClusterId = $state<number | "unclustered" | null>(null);
+    let orderedMembers = $state<ComponentMember[]>([]);
 
     /** Invert the mapping: cluster ID -> list of component members */
     const clusterGroups = $derived.by(() => {
@@ -47,6 +60,24 @@
         return group ? group[1] : [];
     });
 
+    const PAGE_SIZE = 12;
+    let cardPage = $state(0);
+    const cardPageCount = $derived(Math.max(1, Math.ceil(selectedMembers.length / PAGE_SIZE)));
+    const pagedMembers = $derived(selectedMembers.slice(cardPage * PAGE_SIZE, (cardPage + 1) * PAGE_SIZE));
+
+    const layerGroups = $derived.by((): { layer: string; members: ComponentMember[] }[] => {
+        const groups: Record<string, ComponentMember[]> = {};
+        for (const m of selectedMembers) {
+            (groups[m.layer] ??= []).push(m);
+        }
+        return Object.entries(groups)
+            .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+            .map(([layer, members]) => ({
+                layer,
+                members: members.sort((a, b) => a.cIdx - b.cIdx),
+            }));
+    });
+
     function getPreviewLabels(members: ComponentMember[]): string[] {
         const labels: string[] = [];
         for (const member of members) {
@@ -59,48 +90,163 @@
         }
         return labels;
     }
+
+    function resetDetailState() {
+        orderedMembers = [];
+        activeDetailViz = "graph";
+        cardPage = 0;
+    }
+
+    function selectCluster(clusterId: number | "unclustered") {
+        selectedClusterId = clusterId;
+        resetDetailState();
+    }
+
+    function clearSelection() {
+        selectedClusterId = null;
+        resetDetailState();
+    }
+
+    function handleLeafOrder(order: ComponentMember[]) {
+        if (
+            orderedMembers.length === order.length &&
+            orderedMembers.every(
+                (member, idx) => member.layer === order[idx]?.layer && member.cIdx === order[idx]?.cIdx,
+            )
+        ) {
+            return;
+        }
+        orderedMembers = order;
+    }
 </script>
 
 <div class="clusters-viewer">
     {#if selectedClusterId === null}
-        <div class="cluster-list">
-            <h2 class="list-header">Clusters ({clusterGroups.sorted.length})</h2>
-            {#each clusterGroups.sorted as [clusterId, members] (clusterId)}
-                {@const previewLabels = getPreviewLabels(members)}
-                <button class="cluster-row" onclick={() => (selectedClusterId = clusterId)}>
-                    <div class="cluster-row-main">
-                        <span class="cluster-id">Cluster {clusterId}</span>
-                        <span class="cluster-count">{members.length} components</span>
-                    </div>
-                    {#if previewLabels.length > 0}
-                        <div class="preview-labels">
-                            {#each previewLabels as label, i (i)}
-                                <span class="preview-pill">{label}</span>
-                            {/each}
-                        </div>
-                    {/if}
-                </button>
-            {/each}
-            {#if clusterGroups.singletons.length > 0}
-                <button class="cluster-row singletons-row" onclick={() => (selectedClusterId = "unclustered")}>
-                    <div class="cluster-row-main">
-                        <span class="cluster-id">Unclustered</span>
-                        <span class="cluster-count">{clusterGroups.singletons.length} components</span>
-                    </div>
-                </button>
-            {/if}
+        <div class="subtab-bar">
+            <button
+                class="subtab-btn"
+                class:active={activeSubTab === "matrix"}
+                onclick={() => (activeSubTab = "matrix")}>Matrix</button
+            >
+            <button class="subtab-btn" class:active={activeSubTab === "list"} onclick={() => (activeSubTab = "list")}
+                >List ({clusterGroups.sorted.length})</button
+            >
         </div>
+        {#if activeSubTab === "matrix"}
+            <div class="matrix-pane">
+                <ClusterFullMatrix
+                    {clusterMappingData}
+                    onSelectCluster={(id) => {
+                        selectCluster(id);
+                    }}
+                />
+            </div>
+        {:else}
+            <div class="cluster-list">
+                {#each clusterGroups.sorted as [clusterId, members] (clusterId)}
+                    {@const previewLabels = getPreviewLabels(members)}
+                    <button class="cluster-row" onclick={() => selectCluster(clusterId)}>
+                        <div class="cluster-row-top">
+                            <div class="cluster-row-main">
+                                <span class="cluster-id">Cluster {clusterId}</span>
+                                <span class="cluster-count">{members.length} components</span>
+                            </div>
+                            <ClusterMiniMatrix {members} {clusteringRunId} {iteration} />
+                        </div>
+                        {#if previewLabels.length > 0}
+                            <div class="preview-labels">
+                                {#each previewLabels as label, i (i)}
+                                    <span class="preview-pill">{label}</span>
+                                {/each}
+                            </div>
+                        {/if}
+                    </button>
+                {/each}
+                {#if clusterGroups.singletons.length > 0}
+                    <button class="cluster-row singletons-row" onclick={() => selectCluster("unclustered")}>
+                        <div class="cluster-row-main">
+                            <span class="cluster-id">Unclustered</span>
+                            <span class="cluster-count">{clusterGroups.singletons.length} components</span>
+                        </div>
+                    </button>
+                {/if}
+            </div>
+        {/if}
     {:else}
         <div class="cluster-detail">
             <div class="detail-header">
-                <button class="back-button" onclick={() => (selectedClusterId = null)}>&lt; Back</button>
-                <h2 class="detail-title">
-                    {selectedClusterId === "unclustered" ? "Unclustered" : `Cluster ${selectedClusterId}`}
-                </h2>
-                <span class="detail-count">{selectedMembers.length} components</span>
+                <div class="detail-header-left">
+                    <button class="back-button" onclick={clearSelection}>&lt; Back</button>
+                    <h2 class="detail-title">
+                        {selectedClusterId === "unclustered" ? "Unclustered" : `Cluster ${selectedClusterId}`}
+                    </h2>
+                    <span class="detail-count">{selectedMembers.length} components</span>
+                </div>
+                {#if layerGroups.length > 0}
+                    <div class="layer-breakdown">
+                        {#each layerGroups as group (group.layer)}
+                            <div class="layer-group">
+                                <span class="layer-group-label">{group.layer}</span>
+                                <div class="layer-group-pills">
+                                    {#each group.members as member (`${group.layer}:${member.cIdx}`)}
+                                        {@const key = `${member.layer}:${member.cIdx}`}
+                                        {@const interp = runState.getInterpretation(key)}
+                                        <span
+                                            class="component-idx-pill"
+                                            title={interp.status === "loaded" && interp.data.status === "generated"
+                                                ? `${key}: ${interp.data.data.label}`
+                                                : key}
+                                        >
+                                            {member.cIdx}
+                                        </span>
+                                    {/each}
+                                </div>
+                            </div>
+                        {/each}
+                    </div>
+                {/if}
             </div>
+            {#if selectedMembers.length >= 2}
+                <div class="detail-viz-tabs">
+                    <button
+                        class="subtab-btn"
+                        class:active={activeDetailViz === "graph"}
+                        onclick={() => (activeDetailViz = "graph")}>Graph</button
+                    >
+                    <button
+                        class="subtab-btn"
+                        class:active={activeDetailViz === "matrix"}
+                        onclick={() => (activeDetailViz = "matrix")}>Matrix + Merge Tree</button
+                    >
+                </div>
+                {#if activeDetailViz === "graph"}
+                    <ClusterForceGraph members={selectedMembers} {clusteringRunId} />
+                {:else}
+                    <div class="grid-and-dendrogram">
+                        <ClusterCorrelationMatrix
+                            members={orderedMembers.length > 0 ? orderedMembers : selectedMembers}
+                            {clusteringRunId}
+                        />
+                        <ClusterDendrogram
+                            members={selectedMembers}
+                            {clusteringRunId}
+                            {iteration}
+                            onLeafOrder={handleLeafOrder}
+                        />
+                    </div>
+                {/if}
+            {/if}
+            {#if cardPageCount > 1}
+                <div class="card-pagination">
+                    <button class="page-btn" disabled={cardPage === 0} onclick={() => cardPage--}>&lsaquo; Prev</button>
+                    <span class="page-indicator">Page {cardPage + 1} of {cardPageCount}</span>
+                    <button class="page-btn" disabled={cardPage >= cardPageCount - 1} onclick={() => cardPage++}
+                        >Next &rsaquo;</button
+                    >
+                </div>
+            {/if}
             <div class="cluster-cards">
-                {#each selectedMembers as member (`${member.layer}:${member.cIdx}`)}
+                {#each pagedMembers as member (`${member.layer}:${member.cIdx}`)}
                     <div class="cluster-card-item">
                         <ClusterComponentCard layer={member.layer} cIdx={member.cIdx} />
                     </div>
@@ -114,15 +260,62 @@
     .clusters-viewer {
         font-family: var(--font-sans);
         color: var(--text-primary);
+        height: 100%;
+        display: flex;
+        flex-direction: column;
+        min-height: 0;
+    }
+
+    .subtab-bar {
+        display: flex;
+        gap: var(--space-1);
+        flex-shrink: 0;
+        margin-bottom: var(--space-3);
+    }
+
+    .subtab-btn {
+        padding: var(--space-2) var(--space-4);
+        font: inherit;
+        font-size: var(--text-sm);
+        font-weight: 500;
+        background: transparent;
+        border: none;
+        border-bottom: 2px solid transparent;
+        cursor: pointer;
+        color: var(--text-muted);
+        transition:
+            color var(--transition-normal),
+            border-color var(--transition-normal);
+    }
+
+    .subtab-btn:hover {
+        color: var(--text-secondary);
+    }
+
+    .subtab-btn.active {
+        color: var(--text-primary);
+        border-bottom-color: var(--accent-primary);
+    }
+
+    .matrix-pane {
+        flex: 1;
+        min-height: 0;
+        display: flex;
+        flex-direction: column;
+    }
+
+    .grid-and-dendrogram {
+        display: flex;
+        gap: var(--space-4);
+        align-items: flex-start;
+    }
+
+    .detail-viz-tabs {
+        display: flex;
+        gap: var(--space-1);
     }
 
     /* Cluster list */
-    .list-header {
-        font-size: var(--text-lg);
-        font-weight: 600;
-        margin: 0 0 var(--space-4) 0;
-    }
-
     .cluster-list {
         display: flex;
         flex-direction: column;
@@ -146,6 +339,13 @@
             border-color var(--transition-normal);
     }
 
+    .cluster-row-top {
+        display: flex;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: var(--space-3);
+    }
+
     .cluster-row:hover {
         background: var(--bg-elevated);
         border-color: var(--border-strong);
@@ -154,7 +354,9 @@
     .cluster-row-main {
         display: flex;
         align-items: center;
+        flex-wrap: wrap;
         gap: var(--space-3);
+        min-width: 0;
     }
 
     .cluster-id {
@@ -200,7 +402,50 @@
     .detail-header {
         display: flex;
         align-items: center;
+        justify-content: space-between;
         gap: var(--space-3);
+    }
+
+    .detail-header-left {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+    }
+
+    .layer-breakdown {
+        display: flex;
+        flex-direction: column;
+        gap: var(--space-1);
+    }
+
+    .layer-group {
+        display: flex;
+        align-items: center;
+        gap: var(--space-2);
+    }
+
+    .layer-group-label {
+        font-size: var(--text-xs);
+        font-family: var(--font-mono);
+        color: var(--text-secondary);
+        white-space: nowrap;
+    }
+
+    .layer-group-pills {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 2px;
+    }
+
+    .component-idx-pill {
+        font-size: var(--text-xs);
+        font-family: var(--font-mono);
+        padding: 1px var(--space-1);
+        background: var(--bg-inset);
+        border-radius: var(--radius-sm);
+        color: var(--accent-primary);
+        font-weight: 600;
+        cursor: default;
     }
 
     .back-button {
@@ -227,6 +472,39 @@
     }
 
     .detail-count {
+        font-size: var(--text-sm);
+        color: var(--text-muted);
+    }
+
+    .card-pagination {
+        display: flex;
+        align-items: center;
+        gap: var(--space-3);
+    }
+
+    .page-btn {
+        padding: var(--space-1) var(--space-3);
+        background: var(--bg-elevated);
+        border: 1px solid var(--border-default);
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        font: inherit;
+        font-size: var(--text-sm);
+        color: var(--text-secondary);
+    }
+
+    .page-btn:hover:not(:disabled) {
+        background: var(--bg-inset);
+        border-color: var(--border-strong);
+        color: var(--text-primary);
+    }
+
+    .page-btn:disabled {
+        opacity: 0.4;
+        cursor: default;
+    }
+
+    .page-indicator {
         font-size: var(--text-sm);
         color: var(--text-muted);
     }

--- a/param_decomp/app/frontend/src/components/SubrunSelector.svelte
+++ b/param_decomp/app/frontend/src/components/SubrunSelector.svelte
@@ -58,13 +58,9 @@
             </thead>
             <tbody>
                 {#each subruns as subrun (subrun.subrun_id)}
-                    <tr
-                        class:selected={selectedIds.has(subrun.subrun_id)}
-                        onclick={() => toggle(subrun.subrun_id)}
-                    >
+                    <tr class:selected={selectedIds.has(subrun.subrun_id)} onclick={() => toggle(subrun.subrun_id)}>
                         <td class="col-select">
-                            <span class="checkbox" class:checked={selectedIds.has(subrun.subrun_id)}
-                            ></span>
+                            <span class="checkbox" class:checked={selectedIds.has(subrun.subrun_id)}></span>
                         </td>
                         <td class="col-note">
                             {#if subrun.note}

--- a/param_decomp/app/frontend/src/lib/api/clusters.ts
+++ b/param_decomp/app/frontend/src/lib/api/clusters.ts
@@ -5,7 +5,37 @@
 import { apiUrl } from "./index";
 
 export type ClusterMapping = {
-    mapping: Record<string, number>;
+    mapping: Record<string, number | null>;
+    clustering_run_id: string;
+    iteration: number;
+};
+
+export type PairCorrelation = {
+    key_a: string;
+    key_b: string;
+    jaccard: number;
+    precision_ab: number;
+    precision_ba: number;
+    pmi: number | null;
+    count_a: number;
+    count_b: number;
+    count_ab: number;
+};
+
+export type ClusterPairwiseResponse = {
+    pairs: PairCorrelation[];
+    n_tokens: number;
+};
+
+export type MergePairIteration = {
+    key_a: string;
+    key_b: string;
+    merge_iteration: number;
+};
+
+export type MergeIterationsResponse = {
+    pairs: MergePairIteration[];
+    total_iterations: number;
 };
 
 export async function loadClusterMapping(filePath: string): Promise<ClusterMapping> {
@@ -19,4 +49,122 @@ export async function loadClusterMapping(filePath: string): Promise<ClusterMappi
     }
 
     return (await response.json()) as ClusterMapping;
+}
+
+export async function clearClusterMappingBackend(): Promise<void> {
+    const url = apiUrl("/api/clusters/clear");
+    const response = await fetch(url.toString(), { method: "POST" });
+    if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.detail || "Failed to clear cluster mapping");
+    }
+}
+
+export async function fetchClusterPairwiseCorrelations(componentKeys: string[]): Promise<ClusterPairwiseResponse> {
+    const url = apiUrl("/api/clusters/pairwise_correlations");
+
+    const response = await fetch(url.toString(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ component_keys: componentKeys }),
+    });
+    if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.detail || "Failed to fetch pairwise correlations");
+    }
+
+    return (await response.json()) as ClusterPairwiseResponse;
+}
+
+export async function fetchClusteringCoactivation(
+    componentKeys: string[],
+    clusteringRunId: string,
+): Promise<ClusterPairwiseResponse> {
+    const url = apiUrl("/api/clusters/clustering_coactivation");
+
+    const response = await fetch(url.toString(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ component_keys: componentKeys, clustering_run_id: clusteringRunId }),
+    });
+    if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.detail || "Failed to fetch clustering coactivation");
+    }
+
+    return (await response.json()) as ClusterPairwiseResponse;
+}
+
+export async function fetchMergeIterations(
+    componentKeys: string[],
+    clusteringRunId: string,
+    iteration: number,
+): Promise<MergeIterationsResponse> {
+    const url = apiUrl("/api/clusters/merge_iterations");
+
+    const response = await fetch(url.toString(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+            component_keys: componentKeys,
+            clustering_run_id: clusteringRunId,
+            iteration,
+        }),
+    });
+    if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.detail || "Failed to fetch merge iterations");
+    }
+
+    return (await response.json()) as MergeIterationsResponse;
+}
+
+export type ClusterBoundary = {
+    cluster_id: number;
+    start: number;
+    end: number;
+};
+
+export type FullMatrixResponse = {
+    matrix_b64: string;
+    width: number;
+    height: number;
+    full_size: number;
+    component_keys: string[];
+    row_boundaries: ClusterBoundary[];
+    col_boundaries: ClusterBoundary[];
+    metric: string;
+    n_tokens: number;
+};
+
+export type FullMatrixMetric = "jaccard" | "precision" | "pmi";
+
+export type MatrixRegion = {
+    row: number;
+    col: number;
+    size: number;
+};
+
+export async function fetchFullMatrix(
+    metric: FullMatrixMetric,
+    clusterMapping: Record<string, number | null>,
+    maxSize: number = 2000,
+    region?: MatrixRegion,
+): Promise<FullMatrixResponse> {
+    const url = apiUrl("/api/clusters/full_matrix");
+
+    const body: Record<string, unknown> = { metric, cluster_mapping: clusterMapping, max_size: maxSize };
+    if (region) body.region = region;
+
+    const response = await fetch(url.toString(), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+    });
+    if (!response.ok) {
+        const error = await response.json();
+        throw new Error(error.detail || "Failed to fetch full matrix");
+    }
+
+    return (await response.json()) as FullMatrixResponse;
 }

--- a/param_decomp/app/frontend/src/lib/api/runs.ts
+++ b/param_decomp/app/frontend/src/lib/api/runs.ts
@@ -16,6 +16,7 @@ export type LoadedRun = {
     dataset_search_enabled: boolean;
     graph_interp_available: boolean;
     autointerp_available: boolean;
+    cluster_mapping_path: string | null;
 };
 
 export async function getStatus(): Promise<LoadedRun | null> {

--- a/param_decomp/app/frontend/src/lib/dendrogram.ts
+++ b/param_decomp/app/frontend/src/lib/dendrogram.ts
@@ -1,0 +1,157 @@
+/**
+ * Dendrogram tree construction from merge iteration data.
+ * Used by ClusterDendrogram (full visualization) and ClusterMiniMatrix (leaf ordering).
+ */
+
+import type { MergePairIteration } from "./api/clusters";
+
+export type LeafNode = { type: "leaf"; key: string; y: number };
+export type InternalNode = {
+    type: "internal";
+    left: TreeNode;
+    right: TreeNode;
+    mergeIter: number;
+    y: number;
+};
+export type TreeNode = LeafNode | InternalNode;
+
+/** Build dendrogram from pairwise merge iterations via single-linkage. */
+export function buildDendrogram(componentKeys: string[], pairs: MergePairIteration[]): TreeNode | null {
+    if (componentKeys.length === 0) return null;
+    if (componentKeys.length === 1) return { type: "leaf", key: componentKeys[0], y: 0 };
+
+    const sorted = pairs
+        .filter((p) => p.merge_iteration >= 0)
+        .sort((a, b) => a.merge_iteration - b.merge_iteration);
+
+    const parent = new Map<string, string>();
+    const nodes = new Map<string, TreeNode>();
+    let leafY = 0;
+
+    for (const key of componentKeys) {
+        parent.set(key, key);
+        nodes.set(key, { type: "leaf", key, y: leafY });
+        leafY++;
+    }
+
+    function find(x: string): string {
+        let root = x;
+        while (parent.get(root) !== root) root = parent.get(root)!;
+        let curr = x;
+        while (curr !== root) {
+            const next = parent.get(curr)!;
+            parent.set(curr, root);
+            curr = next;
+        }
+        return root;
+    }
+
+    for (const pair of sorted) {
+        const rootA = find(pair.key_a);
+        const rootB = find(pair.key_b);
+        if (rootA === rootB) continue;
+
+        const nodeA = nodes.get(rootA)!;
+        const nodeB = nodes.get(rootB)!;
+        const merged: InternalNode = {
+            type: "internal",
+            left: nodeA,
+            right: nodeB,
+            mergeIter: pair.merge_iteration,
+            y: (nodeA.y + nodeB.y) / 2,
+        };
+
+        const mergedKey = `${rootA}|${rootB}`;
+        parent.set(rootA, mergedKey);
+        parent.set(rootB, mergedKey);
+        parent.set(mergedKey, mergedKey);
+        nodes.set(mergedKey, merged);
+    }
+
+    const roots = new Set<string>();
+    for (const key of componentKeys) {
+        roots.add(find(key));
+    }
+    const rootNodes = [...roots].map((r) => nodes.get(r)!);
+    if (rootNodes.length === 1) return rootNodes[0];
+
+    let result = rootNodes[0];
+    for (let i = 1; i < rootNodes.length; i++) {
+        result = {
+            type: "internal",
+            left: result,
+            right: rootNodes[i],
+            mergeIter: -1,
+            y: (result.y + rootNodes[i].y) / 2,
+        };
+    }
+    return result;
+}
+
+/** Assign leaf y-positions by in-order traversal (so tree doesn't cross). */
+export function assignLeafPositions(node: TreeNode, startY: number): number {
+    if (node.type === "leaf") {
+        node.y = startY;
+        return startY + 1;
+    }
+    const nextY = assignLeafPositions(node.left, startY);
+    const finalY = assignLeafPositions(node.right, nextY);
+    node.y = (node.left.y + node.right.y) / 2;
+    return finalY;
+}
+
+/** Collect all leaves in in-order traversal order. */
+export function collectLeaves(node: TreeNode): LeafNode[] {
+    if (node.type === "leaf") return [node];
+    return [...collectLeaves(node.left), ...collectLeaves(node.right)];
+}
+
+/** Get the dendrogram leaf order as keys. Returns input unchanged if tree can't be built. */
+export function dendrogramLeafOrder(componentKeys: string[], pairs: MergePairIteration[]): string[] {
+    const root = buildDendrogram(componentKeys, pairs);
+    if (!root) return componentKeys;
+    assignLeafPositions(root, 0);
+    return collectLeaves(root).map((l) => l.key);
+}
+
+export function collectInternalNodes(node: TreeNode): InternalNode[] {
+    if (node.type === "leaf") return [];
+    return [node, ...collectInternalNodes(node.left), ...collectInternalNodes(node.right)];
+}
+
+export function maxIter(node: TreeNode): number {
+    if (node.type === "leaf") return 0;
+    return Math.max(node.mergeIter, maxIter(node.left), maxIter(node.right));
+}
+
+export type SvgLine = { x1: number; y1: number; x2: number; y2: number; mergeIter: number };
+
+export function generateLines(
+    node: TreeNode,
+    xScale: (iter: number) => number,
+    yScale: (pos: number) => number,
+    rightX: number,
+): SvgLine[] {
+    if (node.type === "leaf") return [];
+
+    const nodeX = node.mergeIter >= 0 ? xScale(node.mergeIter) : 0;
+    const leftChild = node.left;
+    const rightChild = node.right;
+
+    const leftX = leftChild.type === "leaf" ? rightX : xScale(leftChild.mergeIter);
+    const rightChildX = rightChild.type === "leaf" ? rightX : xScale(rightChild.mergeIter);
+
+    const lines: SvgLine[] = [
+        { x1: nodeX, y1: yScale(leftChild.y), x2: nodeX, y2: yScale(rightChild.y), mergeIter: node.mergeIter },
+        { x1: nodeX, y1: yScale(leftChild.y), x2: leftX, y2: yScale(leftChild.y), mergeIter: node.mergeIter },
+        {
+            x1: nodeX,
+            y1: yScale(rightChild.y),
+            x2: rightChildX,
+            y2: yScale(rightChild.y),
+            mergeIter: node.mergeIter,
+        },
+    ];
+
+    return [...lines, ...generateLines(leftChild, xScale, yScale, rightX), ...generateLines(rightChild, xScale, yScale, rightX)];
+}

--- a/param_decomp/app/frontend/src/lib/registry.ts
+++ b/param_decomp/app/frontend/src/lib/registry.ts
@@ -23,16 +23,24 @@ export const CANONICAL_RUNS: RegistryEntry[] = [
         notes: "VPD paper run: pile_llama_simple_mlp-4L",
         clusterMappings: [
             {
-                path: "/mnt/polished-lake/artifacts/mechanisms/param-decomp/clustering/runs/c-70b28465/cluster_mapping.json",
-                notes: "All layers, iteration 9100",
+                path: "/mnt/polished-lake/artifacts/mechanisms/param-decomp/clustering/runs/c-bd99c7aa/cluster_mapping.json",
+                notes: "exp_rank α=5 decay=0.8, iter 6351, 10M toks (MDL-optimal, best quality)",
             },
             {
-                path: "/mnt/polished-lake/artifacts/mechanisms/param-decomp/clustering/runs/c-7e8b960e/cluster_mapping_alpha10_i3000.json",
-                notes: "All layers, iteration 3000, α 10"
+                path: "/mnt/polished-lake/artifacts/mechanisms/param-decomp/clustering/runs/c-651d85c4/cluster_mapping.json",
+                notes: "exp_rank α=10 decay=0.8, iter 4423, 10M toks (MDL-optimal, tightest clusters)",
+            },
+            {
+                path: "/mnt/polished-lake/artifacts/mechanisms/param-decomp/clustering/runs/c-e8fb48bb/cluster_mapping.json",
+                notes: "exp_rank α=2 decay=0.8, iter 7038, 10M toks (last good merge iteration)",
             },
             {
                 path: "/mnt/polished-lake/artifacts/mechanisms/param-decomp/clustering/runs/c-eae05b96/cluster_mapping_alpha2_i8000.json",
-                notes: "All layers, iteration 8000, α 2"
+                notes: "range α=2, iter 8000, 10M toks (old, lower quality)",
+            },
+            {
+                path: "/mnt/polished-lake/artifacts/mechanisms/param-decomp/clustering/runs/c-70b28465/cluster_mapping.json",
+                notes: "range α=1, iter 9100, 500K toks (old, lower quality)",
             },
         ],
     },
@@ -43,7 +51,7 @@ export const CANONICAL_RUNS: RegistryEntry[] = [
         clusterMappings: [
             {
                 path: "/mnt/polished-lake/artifacts/mechanisms/param-decomp/clustering/runs/c-f9cc81c8/cluster_mapping.json",
-                notes: "All layers, 9100 iterations",
+                notes: "All layers, iteration 9100",
             },
         ],
     },

--- a/param_decomp/app/frontend/src/lib/useRun.svelte.ts
+++ b/param_decomp/app/frontend/src/lib/useRun.svelte.ts
@@ -17,6 +17,8 @@ type ClusterMapping = {
     data: ClusterMappingData;
     filePath: string;
     runWandbPath: string;
+    clusteringRunId: string;
+    iteration: number;
 };
 
 /**
@@ -133,6 +135,10 @@ export function useRun() {
                 if (interpretations.status === "uninitialized") {
                     fetchRunScopedData();
                 }
+                // Restore cluster mapping from backend if we don't have it locally
+                if (clusterMapping === null && status.cluster_mapping_path) {
+                    restoreClusterMapping(status.cluster_mapping_path);
+                }
             } else if (run.status === "loaded") {
                 run = { status: "error", error: "Backend state lost" };
             } else {
@@ -143,6 +149,23 @@ export function useRun() {
                 run = { status: "error", error: "Backend unreachable" };
             }
         }
+    }
+
+    /** Restore cluster mapping from a backend-persisted path (re-loads from file) */
+    function restoreClusterMapping(filePath: string) {
+        api.loadClusterMapping(filePath)
+            .then((result) => {
+                clusterMapping = {
+                    data: result.mapping,
+                    filePath,
+                    runWandbPath: run.status === "loaded" ? run.data.wandb_path : "",
+                    clusteringRunId: result.clustering_run_id,
+                    iteration: result.iteration,
+                };
+            })
+            .catch((err) => {
+                console.error("Failed to restore cluster mapping:", err);
+            });
     }
 
     /** Refresh prompts list (e.g., after generating new prompts) */
@@ -198,13 +221,22 @@ export function useRun() {
     }
 
     /** Set cluster mapping for the current run */
-    function setClusterMapping(data: ClusterMappingData, filePath: string, runWandbPath: string) {
-        clusterMapping = { data, filePath, runWandbPath };
+    function setClusterMapping(
+        data: ClusterMappingData,
+        filePath: string,
+        runWandbPath: string,
+        clusteringRunId: string,
+        iteration: number,
+    ) {
+        clusterMapping = { data, filePath, runWandbPath, clusteringRunId, iteration };
     }
 
-    /** Clear cluster mapping */
+    /** Clear cluster mapping (local state + backend) */
     function clearClusterMapping() {
         clusterMapping = null;
+        api.clearClusterMappingBackend().catch((err) => {
+            console.error("Failed to clear cluster mapping on backend:", err);
+        });
     }
 
     function getClusterId(layer: string, cIdx: number): number | null {

--- a/param_decomp/app/frontend/vite.config.ts
+++ b/param_decomp/app/frontend/vite.config.ts
@@ -9,7 +9,7 @@ const backendUrl = process.env.BACKEND_URL || "http://localhost:8000";
 export default defineConfig({
     plugins: [svelte()],
     server: {
-        hmr: false,
+        hmr: true,
         proxy: {
             "/api": {
                 target: backendUrl,

--- a/param_decomp/clustering/membership_snapshot.py
+++ b/param_decomp/clustering/membership_snapshot.py
@@ -1,0 +1,98 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+from scipy import sparse
+
+from param_decomp.clustering.consts import ComponentLabels
+from param_decomp.clustering.sample_membership import (
+    CompressedMembership,
+    memberships_to_sample_component_matrix,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class MembershipSnapshot:
+    """Disk-friendly sparse membership snapshot for repeatable merge benchmarks."""
+
+    matrix_csc: sparse.csc_matrix
+    labels: ComponentLabels
+
+    @property
+    def n_samples(self) -> int:
+        shape = self.matrix_csc.shape
+        assert shape is not None
+        return int(shape[0])
+
+    @property
+    def n_components(self) -> int:
+        shape = self.matrix_csc.shape
+        assert shape is not None
+        return int(shape[1])
+
+    def to_memberships(self) -> list[CompressedMembership]:
+        memberships: list[CompressedMembership] = []
+        for col_idx in range(self.n_components):
+            sample_indices = self.matrix_csc.indices[
+                self.matrix_csc.indptr[col_idx] : self.matrix_csc.indptr[col_idx + 1]
+            ].astype(np.int64, copy=False)
+            memberships.append(
+                CompressedMembership.from_sample_indices(
+                    sample_indices=sample_indices,
+                    n_samples=self.n_samples,
+                )
+            )
+        return memberships
+
+    def to_csr(self) -> sparse.sparray | sparse.spmatrix:
+        return self.matrix_csc.tocsr()
+
+
+def memberships_to_csc(
+    memberships: list[CompressedMembership],
+    n_samples: int,
+) -> sparse.csc_matrix:
+    matrix = memberships_to_sample_component_matrix(memberships, fmt="csc")
+    assert isinstance(matrix, sparse.csc_matrix)
+    shape = matrix.shape
+    assert shape is not None
+    assert shape[0] == n_samples
+    return matrix
+
+
+def save_membership_snapshot(
+    output_dir: Path,
+    *,
+    memberships: list[CompressedMembership],
+    labels: ComponentLabels,
+    n_samples: int,
+) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    matrix_path = output_dir / "memberships.npz"
+    metadata_path = output_dir / "metadata.json"
+
+    matrix_csc = memberships_to_csc(memberships, n_samples=n_samples)
+    sparse.save_npz(matrix_path, matrix_csc)
+    metadata_path.write_text(
+        json.dumps(
+            {
+                "n_samples": n_samples,
+                "n_components": len(labels),
+                "labels": list(labels),
+            },
+            indent=2,
+        )
+    )
+    return output_dir
+
+
+def load_membership_snapshot(path: Path) -> MembershipSnapshot:
+    matrix_path = path / "memberships.npz"
+    metadata_path = path / "metadata.json"
+    matrix_csc = sparse.load_npz(matrix_path).tocsc()
+    metadata = json.loads(metadata_path.read_text())
+    labels = ComponentLabels(metadata["labels"])
+    assert matrix_csc.shape[0] == metadata["n_samples"]
+    assert matrix_csc.shape[1] == metadata["n_components"]
+    return MembershipSnapshot(matrix_csc=matrix_csc, labels=labels)


### PR DESCRIPTION
## Description

Adds the cluster visualization UI from the stale `clustering-app` branch onto current main. Includes a new force-graph view, dendrograms, full/mini correlation matrices, and the backend endpoints to feed them (pairwise correlations, coactivation, merge iterations, full metric matrix).

Cherry-picked from `clustering-app@2a73ff529` (\"Cluster visualization\"), with paths remapped `spd/` → `param_decomp/`. The companion commit on `clustering-app` (\"Clustering core: compressed memberships, harvest-merge split\") was **skipped** — main already has its own clustering refactor from `clustering-core` and bringing both in produced unresolvable conflicts.

## Motivation and Context

`clustering-app` had been sitting stale; this lands the viz work on top of the post-rename main.

## How Has This Been Tested?

- [ ] `make check` passes (basedpyright + ruff lint + ruff format) ✅
- [ ] Manual: load a cluster mapping and verify force graph / dendrogram / matrix tabs render

## Notes for reviewer

- `param_decomp/clustering/membership_snapshot.py` and `param_decomp/clustering/sample_membership.py` were pulled in from the skipped \"Clustering core\" commit — the viz backend endpoints depend on `MembershipSnapshot` / `load_membership_snapshot`. They're self-contained and pass type-check, but they were authored against the old clustering layout, so worth an eyeball to confirm they play nicely with main's `memberships.py`.
- `param_decomp/app/backend/routers/clusters.py` hunks 1 & 2 of the patch had to be hand-merged on top of main's evolved version (imports, the `ClusteringRunData` cache, `_load_clustering_run`, `clustering_run_id`/`iteration` fields on `ClusterMapping`).
- `registry.ts` updated: Jose now has 5 MDL-annotated cluster mappings (replacing 3), Thomas's note updated to \"All layers, iteration 9100\".

## Does this PR introduce a breaking change?

No — purely additive to the app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)