### PR TITLE
Split LoggingConfig out of PDConfig

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,11 +89,18 @@ README's "Custom experiments" section walks through both routes side-by-side.
 
 ### Per-experiment Configs
 
-Built-in YAML configs are pure experiment configs nested under `pd:`, `target:`, and `data:`:
+Built-in YAML configs are pure experiment configs nested under `pd:`, `logging:`, `target:`,
+and `data:`:
 
-- `LMExperimentConfig(pd, target: LMTargetConfig, data: LMDataConfig)`
-- `TMSExperimentConfig(pd, target, data)`
-- `ResidMLPExperimentConfig(pd, target, data)`
+- `LMExperimentConfig(pd, logging, target: LMTargetConfig, data: LMDataConfig)`
+- `TMSExperimentConfig(pd, logging, target, data)`
+- `ResidMLPExperimentConfig(pd, logging, target, data)`
+
+`PDConfig` carries algorithm hyperparameters (seed, ci_config, losses, optimizers, …) — the
+things that change what the trained model is. `LoggingConfig` carries observation-only
+settings (log/eval/save cadence, eval-only metrics, eval_batch_size) — fields that *don't*
+affect the trained model. Two runs with identical `PDConfig` and different `LoggingConfig`
+produce bit-identical weights.
 
 Experiment configs should not perform I/O. Put target loading and dataloader construction in
 the driver.

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -565,6 +565,63 @@ class EvalMetricsConfig(_LossCapableMetricsConfig):
 SamplingType = Literal["continuous", "binomial"]
 
 
+class LoggingConfig(BaseConfig):
+    """Observation-only settings: cadence of logging/eval/checkpointing + eval-only metrics.
+
+    Separated from `PDConfig` because none of these fields affect the trained model — two
+    runs with identical `PDConfig` and different `LoggingConfig` produce bit-identical
+    weights. Keeping them out of `PDConfig` keeps the algorithm config narrow and makes
+    "what was the experiment" cleanly separable from "how often did I peek at it".
+    """
+
+    train_log_freq: PositiveInt = Field(
+        ...,
+        description="Interval (in steps) at which to log training metrics",
+    )
+    eval_freq: PositiveInt = Field(
+        ...,
+        description="Interval (in steps) at which to log evaluation metrics",
+    )
+    eval_batch_size: PositiveInt = Field(
+        ...,
+        description="Batch size used for evaluation.",
+    )
+    slow_eval_freq: PositiveInt = Field(
+        ...,
+        description="Interval (in steps) at which to run slow evaluation metrics. Must be a multiple of `eval_freq`.",
+    )
+    n_eval_steps: PositiveInt = Field(
+        ...,
+        description="Number of steps to run evaluation for",
+    )
+    slow_eval_on_first_step: bool = Field(
+        default=True,
+        description="Whether to run slow evaluation on the first step",
+    )
+    save_freq: PositiveInt | None = Field(
+        default=None,
+        description="Interval (in steps) at which to save model checkpoints (None disables saving "
+        "until the end of training).",
+    )
+    eval_metrics: EvalMetricsConfig = Field(
+        default_factory=EvalMetricsConfig,
+        description=(
+            "Additional eval-only metrics. Metrics already set in `loss_metrics` are evaluated "
+            "automatically and should not be repeated here."
+        ),
+    )
+
+    @model_validator(mode="after")
+    def validate_model(self) -> Self:
+        assert self.slow_eval_freq % self.eval_freq == 0, (
+            "slow_eval_freq must be a multiple of eval_freq"
+        )
+        assert self.slow_eval_freq // self.eval_freq >= 1, (
+            "slow_eval_freq must be at least eval_freq"
+        )
+        return self
+
+
 class PDConfig(BaseConfig):
     # --- General ---
     seed: int = Field(
@@ -662,44 +719,6 @@ class PDConfig(BaseConfig):
         description="Weight decay for warmup phase optimizer",
     )
 
-    # --- Logging & Saving ---
-    train_log_freq: PositiveInt = Field(
-        ...,
-        description="Interval (in steps) at which to log training metrics",
-    )
-    eval_freq: PositiveInt = Field(
-        ...,
-        description="Interval (in steps) at which to log evaluation metrics",
-    )
-    eval_batch_size: PositiveInt = Field(
-        ...,
-        description="Batch size used for evaluation. If None, uses the same as `batch_size`.",
-    )
-    slow_eval_freq: PositiveInt = Field(
-        ...,
-        description="Interval (in steps) at which to run slow evaluation metrics. Must be a multiple of `eval_freq`.",
-    )
-    n_eval_steps: PositiveInt = Field(
-        ...,
-        description="Number of steps to run evaluation for",
-    )
-    slow_eval_on_first_step: bool = Field(
-        default=True,
-        description="Whether to run slow evaluation on the first step",
-    )
-    save_freq: PositiveInt | None = Field(
-        default=None,
-        description="Interval (in steps) at which to save model checkpoints (None disables saving "
-        "until the end of training).",
-    )
-    eval_metrics: EvalMetricsConfig = Field(
-        default_factory=EvalMetricsConfig,
-        description=(
-            "Additional eval-only metrics. Metrics already set in `loss_metrics` are evaluated "
-            "automatically and should not be repeated here."
-        ),
-    )
-
     # --- Component Tracking ---
     ci_alive_threshold: Probability = Field(
         default=0.0,
@@ -708,23 +727,6 @@ class PDConfig(BaseConfig):
 
     @model_validator(mode="after")
     def validate_model(self) -> Self:
-        assert self.slow_eval_freq % self.eval_freq == 0, (
-            "slow_eval_freq must be a multiple of eval_freq"
-        )
-        assert self.slow_eval_freq // self.eval_freq >= 1, (
-            "slow_eval_freq must be at least eval_freq"
-        )
-
         for cfg in self.loss_metrics.active():
             assert cfg.coeff is not None, f"loss_metrics.{type(cfg).__name__} must have a coeff"
-
-        loss_names = {name for name, val in self.loss_metrics if val is not None}
-        eval_names = {name for name, val in self.eval_metrics if val is not None}
-        overlap = loss_names & eval_names
-        assert not overlap, (
-            f"The same metric was set under both loss_metrics and eval_metrics: {sorted(overlap)}. "
-            "Loss metrics are automatically evaluated; remove the eval_metrics entry, or move it "
-            "out of loss_metrics if you want eval-only."
-        )
-
         return self

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -603,6 +603,11 @@ class LoggingConfig(BaseConfig):
         description="Interval (in steps) at which to save model checkpoints (None disables saving "
         "until the end of training).",
     )
+    ci_alive_threshold: Probability = Field(
+        default=0.0,
+        description="Causal importance threshold above which a component is considered 'firing'. "
+        "Used by L0 and component-activation-density metrics; doesn't affect training.",
+    )
 
     @model_validator(mode="after")
     def validate_model(self) -> Self:
@@ -718,12 +723,6 @@ class PDConfig(BaseConfig):
             "Additional eval-only metrics. Metrics already set in `loss_metrics` are evaluated "
             "automatically and should not be repeated here."
         ),
-    )
-
-    # --- Component Tracking ---
-    ci_alive_threshold: Probability = Field(
-        default=0.0,
-        description="Causal importance threshold above which a component is considered 'firing'",
     )
 
     @model_validator(mode="after")

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -603,13 +603,6 @@ class LoggingConfig(BaseConfig):
         description="Interval (in steps) at which to save model checkpoints (None disables saving "
         "until the end of training).",
     )
-    eval_metrics: EvalMetricsConfig = Field(
-        default_factory=EvalMetricsConfig,
-        description=(
-            "Additional eval-only metrics. Metrics already set in `loss_metrics` are evaluated "
-            "automatically and should not be repeated here."
-        ),
-    )
 
     @model_validator(mode="after")
     def validate_model(self) -> Self:
@@ -719,6 +712,14 @@ class PDConfig(BaseConfig):
         description="Weight decay for warmup phase optimizer",
     )
 
+    eval_metrics: EvalMetricsConfig = Field(
+        default_factory=EvalMetricsConfig,
+        description=(
+            "Additional eval-only metrics. Metrics already set in `loss_metrics` are evaluated "
+            "automatically and should not be repeated here."
+        ),
+    )
+
     # --- Component Tracking ---
     ci_alive_threshold: Probability = Field(
         default=0.0,
@@ -729,4 +730,14 @@ class PDConfig(BaseConfig):
     def validate_model(self) -> Self:
         for cfg in self.loss_metrics.active():
             assert cfg.coeff is not None, f"loss_metrics.{type(cfg).__name__} must have a coeff"
+
+        loss_names = {name for name, val in self.loss_metrics if val is not None}
+        eval_names = {name for name, val in self.eval_metrics if val is not None}
+        overlap = loss_names & eval_names
+        assert not overlap, (
+            f"The same metric was set under both loss_metrics and eval_metrics: {sorted(overlap)}. "
+            "Loss metrics are automatically evaluated; remove the eval_metrics entry, or move it "
+            "out of loss_metrics if you want eval-only."
+        )
+
         return self

--- a/param_decomp/eval.py
+++ b/param_decomp/eval.py
@@ -118,6 +118,7 @@ def init_metric(
     cfg: MetricConfigType,
     model: ComponentModel,
     run_config: PDConfig,
+    ci_alive_threshold: float,
     device: str,
     reconstruction_loss: ReconstructionLoss,
     ppgd_states: dict[
@@ -153,7 +154,7 @@ def init_metric(
             metric = CI_L0(
                 model=model,
                 device=device,
-                ci_alive_threshold=run_config.ci_alive_threshold,
+                ci_alive_threshold=ci_alive_threshold,
                 groups=cfg.groups,
             )
         case CIMaskedReconSubsetLossConfig():
@@ -179,7 +180,7 @@ def init_metric(
             metric = CIMeanPerComponent(model=model, device=device)
         case ComponentActivationDensityConfig():
             metric = ComponentActivationDensity(
-                model=model, device=device, ci_alive_threshold=run_config.ci_alive_threshold
+                model=model, device=device, ci_alive_threshold=ci_alive_threshold
             )
         case IdentityCIErrorConfig():
             metric = IdentityCIError(
@@ -346,6 +347,7 @@ def evaluate(
     eval_iterator: Iterator[Any],
     device: str,
     run_config: PDConfig,
+    ci_alive_threshold: float,
     slow_step: bool,
     n_eval_steps: int,
     current_frac_of_training: float,
@@ -369,6 +371,7 @@ def evaluate(
             cfg=cfg,
             model=model,
             run_config=run_config,
+            ci_alive_threshold=ci_alive_threshold,
             device=device,
             reconstruction_loss=reconstruction_loss,
             ppgd_states=ppgd_states,

--- a/param_decomp/experiments/_worker.py
+++ b/param_decomp/experiments/_worker.py
@@ -61,7 +61,7 @@ def run_experiment(
     train_loader, eval_loader = driver.build_dataloaders(
         experiment_config,
         train_batch_size=experiment_config.pd.batch_size,
-        eval_batch_size=experiment_config.pd.eval_batch_size,
+        eval_batch_size=experiment_config.logging.eval_batch_size,
         dist_state=dist_state,
         device=device,
     )
@@ -76,6 +76,7 @@ def run_experiment(
     )
     run_pd(
         config=experiment_config.pd,
+        logging_config=experiment_config.logging,
         target=target,
         train_loader=train_loader,
         eval_loader=eval_loader,

--- a/param_decomp/experiments/driver.py
+++ b/param_decomp/experiments/driver.py
@@ -11,9 +11,8 @@ pretrain run, HF model, etc.). Saved PD runs depend on their upstream continuing
 """
 
 from importlib import import_module
-from typing import Any, ClassVar, Protocol, Self
+from typing import Any, ClassVar, Protocol
 
-from pydantic import model_validator
 from torch.utils.data import DataLoader
 
 from param_decomp.base_config import BaseConfig
@@ -27,18 +26,6 @@ class ExperimentConfig(BaseConfig):
 
     pd: PDConfig
     logging: LoggingConfig
-
-    @model_validator(mode="after")
-    def validate_metric_overlap(self) -> Self:
-        loss_names = {name for name, val in self.pd.loss_metrics if val is not None}
-        eval_names = {name for name, val in self.logging.eval_metrics if val is not None}
-        overlap = loss_names & eval_names
-        assert not overlap, (
-            f"The same metric was set under both pd.loss_metrics and logging.eval_metrics: "
-            f"{sorted(overlap)}. Loss metrics are automatically evaluated; remove the "
-            "logging.eval_metrics entry, or move it out of pd.loss_metrics if you want eval-only."
-        )
-        return self
 
 
 class ExperimentDriver[ConfigT: ExperimentConfig](Protocol):

--- a/param_decomp/experiments/driver.py
+++ b/param_decomp/experiments/driver.py
@@ -11,12 +11,13 @@ pretrain run, HF model, etc.). Saved PD runs depend on their upstream continuing
 """
 
 from importlib import import_module
-from typing import Any, ClassVar, Protocol
+from typing import Any, ClassVar, Protocol, Self
 
+from pydantic import model_validator
 from torch.utils.data import DataLoader
 
 from param_decomp.base_config import BaseConfig
-from param_decomp.configs import PDConfig
+from param_decomp.configs import LoggingConfig, PDConfig
 from param_decomp.models.batch_and_loss_fns import PDTarget
 from param_decomp.utils.distributed_utils import DistributedState
 
@@ -25,6 +26,19 @@ class ExperimentConfig(BaseConfig):
     """Pure-data config shared by all experiment configs. Drivers subclass this."""
 
     pd: PDConfig
+    logging: LoggingConfig
+
+    @model_validator(mode="after")
+    def validate_metric_overlap(self) -> Self:
+        loss_names = {name for name, val in self.pd.loss_metrics if val is not None}
+        eval_names = {name for name, val in self.logging.eval_metrics if val is not None}
+        overlap = loss_names & eval_names
+        assert not overlap, (
+            f"The same metric was set under both pd.loss_metrics and logging.eval_metrics: "
+            f"{sorted(overlap)}. Loss metrics are automatically evaluated; remove the "
+            "logging.eval_metrics entry, or move it out of pd.loss_metrics if you want eval-only."
+        )
+        return self
 
 
 class ExperimentDriver[ConfigT: ExperimentConfig](Protocol):

--- a/param_decomp/experiments/lm/gpt2_config.yaml
+++ b/param_decomp/experiments/lm/gpt2_config.yaml
@@ -41,14 +41,6 @@ pd:
       p_anneal_end_frac: 1.0
     stochastic_recon_layerwise:
       coeff: 2.0
-logging:
-  train_log_freq: 100
-  eval_freq: 1000
-  slow_eval_freq: 5000
-  slow_eval_on_first_step: true
-  n_eval_steps: 5
-  eval_batch_size: 2
-  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 5
@@ -59,6 +51,14 @@ logging:
       rounding_threshold: 0.0
     ci_mean_per_component: {}
     stochastic_hidden_acts_recon: {}
+logging:
+  train_log_freq: 100
+  eval_freq: 1000
+  slow_eval_freq: 5000
+  slow_eval_on_first_step: true
+  n_eval_steps: 5
+  eval_batch_size: 2
+  save_freq: null
 target:
   model_class: transformers.GPT2LMHeadModel
   model_name: openai-community/gpt2

--- a/param_decomp/experiments/lm/gpt2_config.yaml
+++ b/param_decomp/experiments/lm/gpt2_config.yaml
@@ -14,7 +14,6 @@ pd:
   sampling: continuous
   use_delta_component: true
   batch_size: 2
-  eval_batch_size: 2
   steps: 50000
   components_optimizer:
     lr_schedule:
@@ -31,12 +30,6 @@ pd:
   faithfulness_warmup_steps: 200
   faithfulness_warmup_lr: 0.01
   faithfulness_warmup_weight_decay: 0.1
-  train_log_freq: 100
-  eval_freq: 1000
-  slow_eval_freq: 5000
-  slow_eval_on_first_step: true
-  n_eval_steps: 5
-  save_freq: null
   ci_alive_threshold: 0.0
   loss_metrics:
     importance_minimality:
@@ -48,6 +41,14 @@ pd:
       p_anneal_end_frac: 1.0
     stochastic_recon_layerwise:
       coeff: 2.0
+logging:
+  train_log_freq: 100
+  eval_freq: 1000
+  slow_eval_freq: 5000
+  slow_eval_on_first_step: true
+  n_eval_steps: 5
+  eval_batch_size: 2
+  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 5

--- a/param_decomp/experiments/lm/gpt2_config.yaml
+++ b/param_decomp/experiments/lm/gpt2_config.yaml
@@ -30,7 +30,6 @@ pd:
   faithfulness_warmup_steps: 200
   faithfulness_warmup_lr: 0.01
   faithfulness_warmup_weight_decay: 0.1
-  ci_alive_threshold: 0.0
   loss_metrics:
     importance_minimality:
       coeff: 0.0003
@@ -59,6 +58,7 @@ logging:
   n_eval_steps: 5
   eval_batch_size: 2
   save_freq: null
+  ci_alive_threshold: 0.0
 target:
   model_class: transformers.GPT2LMHeadModel
   model_name: openai-community/gpt2

--- a/param_decomp/experiments/lm/pile_llama_simple_mlp-12L.yaml
+++ b/param_decomp/experiments/lm/pile_llama_simple_mlp-12L.yaml
@@ -82,14 +82,6 @@ pd:
       n_warmup_steps: 2
     faithfulness:
       coeff: 10000000.0
-logging:
-  train_log_freq: 200
-  eval_freq: 1000
-  slow_eval_freq: 10000
-  slow_eval_on_first_step: true
-  n_eval_steps: 1
-  eval_batch_size: 64
-  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 1
@@ -132,6 +124,14 @@ logging:
       step_size: 0.1
       n_steps: 20
       mask_scope: shared_across_batch
+logging:
+  train_log_freq: 200
+  eval_freq: 1000
+  slow_eval_freq: 10000
+  slow_eval_on_first_step: true
+  n_eval_steps: 1
+  eval_batch_size: 64
+  save_freq: null
 target:
   model_class: param_decomp.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
   model_name: goodfire/spd/runs/t-f99617bb

--- a/param_decomp/experiments/lm/pile_llama_simple_mlp-12L.yaml
+++ b/param_decomp/experiments/lm/pile_llama_simple_mlp-12L.yaml
@@ -50,7 +50,6 @@ pd:
   faithfulness_warmup_steps: 400
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_weight_decay: 0.0
-  ci_alive_threshold: 0.0
   loss_metrics:
     importance_minimality:
       coeff: 0.0001
@@ -132,6 +131,7 @@ logging:
   n_eval_steps: 1
   eval_batch_size: 64
   save_freq: null
+  ci_alive_threshold: 0.0
 target:
   model_class: param_decomp.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
   model_name: goodfire/spd/runs/t-f99617bb

--- a/param_decomp/experiments/lm/pile_llama_simple_mlp-12L.yaml
+++ b/param_decomp/experiments/lm/pile_llama_simple_mlp-12L.yaml
@@ -50,13 +50,6 @@ pd:
   faithfulness_warmup_steps: 400
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_weight_decay: 0.0
-  train_log_freq: 200
-  eval_freq: 1000
-  eval_batch_size: 64
-  slow_eval_freq: 10000
-  n_eval_steps: 1
-  slow_eval_on_first_step: true
-  save_freq: null
   ci_alive_threshold: 0.0
   loss_metrics:
     importance_minimality:
@@ -89,6 +82,14 @@ pd:
       n_warmup_steps: 2
     faithfulness:
       coeff: 10000000.0
+logging:
+  train_log_freq: 200
+  eval_freq: 1000
+  slow_eval_freq: 10000
+  slow_eval_on_first_step: true
+  n_eval_steps: 1
+  eval_batch_size: 64
+  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 1

--- a/param_decomp/experiments/lm/pile_llama_simple_mlp-4L.yaml
+++ b/param_decomp/experiments/lm/pile_llama_simple_mlp-4L.yaml
@@ -82,14 +82,6 @@ pd:
       n_warmup_steps: 2
     faithfulness:
       coeff: 10000000.0
-logging:
-  train_log_freq: 200
-  eval_freq: 1000
-  slow_eval_freq: 10000
-  slow_eval_on_first_step: true
-  n_eval_steps: 1
-  eval_batch_size: 128
-  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 1
@@ -116,6 +108,14 @@ logging:
       step_size: 0.1
       n_steps: 20
       mask_scope: shared_across_batch
+logging:
+  train_log_freq: 200
+  eval_freq: 1000
+  slow_eval_freq: 10000
+  slow_eval_on_first_step: true
+  n_eval_steps: 1
+  eval_batch_size: 128
+  save_freq: null
 target:
   model_class: param_decomp.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
   model_name: goodfire/spd/runs/t-9d2b8f02

--- a/param_decomp/experiments/lm/pile_llama_simple_mlp-4L.yaml
+++ b/param_decomp/experiments/lm/pile_llama_simple_mlp-4L.yaml
@@ -50,13 +50,6 @@ pd:
   faithfulness_warmup_steps: 400
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_weight_decay: 0.0
-  train_log_freq: 200
-  eval_freq: 1000
-  eval_batch_size: 128
-  slow_eval_freq: 10000
-  n_eval_steps: 1
-  slow_eval_on_first_step: true
-  save_freq: null
   ci_alive_threshold: 0.0
   loss_metrics:
     importance_minimality:
@@ -89,6 +82,14 @@ pd:
       n_warmup_steps: 2
     faithfulness:
       coeff: 10000000.0
+logging:
+  train_log_freq: 200
+  eval_freq: 1000
+  slow_eval_freq: 10000
+  slow_eval_on_first_step: true
+  n_eval_steps: 1
+  eval_batch_size: 128
+  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 1

--- a/param_decomp/experiments/lm/pile_llama_simple_mlp-4L.yaml
+++ b/param_decomp/experiments/lm/pile_llama_simple_mlp-4L.yaml
@@ -50,7 +50,6 @@ pd:
   faithfulness_warmup_steps: 400
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_weight_decay: 0.0
-  ci_alive_threshold: 0.0
   loss_metrics:
     importance_minimality:
       coeff: 0.0002
@@ -116,6 +115,7 @@ logging:
   n_eval_steps: 1
   eval_batch_size: 128
   save_freq: null
+  ci_alive_threshold: 0.0
 target:
   model_class: param_decomp.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
   model_name: goodfire/spd/runs/t-9d2b8f02

--- a/param_decomp/experiments/lm/ss_llama_simple_mlp-2L.yaml
+++ b/param_decomp/experiments/lm/ss_llama_simple_mlp-2L.yaml
@@ -50,7 +50,6 @@ pd:
   faithfulness_warmup_steps: 400
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_weight_decay: 0.0
-  ci_alive_threshold: 0.0
   loss_metrics:
     importance_minimality:
       coeff: 0.001
@@ -112,6 +111,7 @@ logging:
   n_eval_steps: 1
   eval_batch_size: 128
   save_freq: null
+  ci_alive_threshold: 0.0
 target:
   model_class: param_decomp.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
   model_name: goodfire/spd/runs/gf6rbga0

--- a/param_decomp/experiments/lm/ss_llama_simple_mlp-2L.yaml
+++ b/param_decomp/experiments/lm/ss_llama_simple_mlp-2L.yaml
@@ -50,13 +50,6 @@ pd:
   faithfulness_warmup_steps: 400
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_weight_decay: 0.0
-  train_log_freq: 200
-  eval_freq: 1000
-  eval_batch_size: 128
-  slow_eval_freq: 10000
-  n_eval_steps: 1
-  slow_eval_on_first_step: true
-  save_freq: null
   ci_alive_threshold: 0.0
   loss_metrics:
     importance_minimality:
@@ -89,6 +82,14 @@ pd:
       n_warmup_steps: 2
     faithfulness:
       coeff: 10000000.0
+logging:
+  train_log_freq: 200
+  eval_freq: 1000
+  slow_eval_freq: 10000
+  slow_eval_on_first_step: true
+  n_eval_steps: 1
+  eval_batch_size: 128
+  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 1

--- a/param_decomp/experiments/lm/ss_llama_simple_mlp-2L.yaml
+++ b/param_decomp/experiments/lm/ss_llama_simple_mlp-2L.yaml
@@ -82,14 +82,6 @@ pd:
       n_warmup_steps: 2
     faithfulness:
       coeff: 10000000.0
-logging:
-  train_log_freq: 200
-  eval_freq: 1000
-  slow_eval_freq: 10000
-  slow_eval_on_first_step: true
-  n_eval_steps: 1
-  eval_batch_size: 128
-  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 1
@@ -112,6 +104,14 @@ logging:
       step_size: 0.1
       n_steps: 20
       mask_scope: shared_across_batch
+logging:
+  train_log_freq: 200
+  eval_freq: 1000
+  slow_eval_freq: 10000
+  slow_eval_on_first_step: true
+  n_eval_steps: 1
+  eval_batch_size: 128
+  save_freq: null
 target:
   model_class: param_decomp.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
   model_name: goodfire/spd/runs/gf6rbga0

--- a/param_decomp/experiments/resid_mlp/resid_mlp1_config.yaml
+++ b/param_decomp/experiments/resid_mlp/resid_mlp1_config.yaml
@@ -29,7 +29,6 @@ pd:
   faithfulness_warmup_steps: 200
   faithfulness_warmup_lr: 0.01
   faithfulness_warmup_weight_decay: 0.1
-  ci_alive_threshold: 0.1
   loss_metrics:
     importance_minimality:
       coeff: 1e-5
@@ -67,6 +66,7 @@ logging:
   n_eval_steps: 100
   eval_batch_size: 2048
   save_freq: null
+  ci_alive_threshold: 0.1
 target:
   run_path: wandb:goodfire/spd-pre-Sep-2025/runs/pziyck78
 data:

--- a/param_decomp/experiments/resid_mlp/resid_mlp1_config.yaml
+++ b/param_decomp/experiments/resid_mlp/resid_mlp1_config.yaml
@@ -39,14 +39,6 @@ pd:
       coeff: 1.0
     stochastic_recon:
       coeff: 1.0
-logging:
-  train_log_freq: 100
-  eval_freq: 500
-  slow_eval_freq: 5000
-  slow_eval_on_first_step: true
-  n_eval_steps: 100
-  eval_batch_size: 2048
-  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 5
@@ -67,6 +59,14 @@ logging:
       groups: null
     ci_mean_per_component: {}
     stochastic_hidden_acts_recon: {}
+logging:
+  train_log_freq: 100
+  eval_freq: 500
+  slow_eval_freq: 5000
+  slow_eval_on_first_step: true
+  n_eval_steps: 100
+  eval_batch_size: 2048
+  save_freq: null
 target:
   run_path: wandb:goodfire/spd-pre-Sep-2025/runs/pziyck78
 data:

--- a/param_decomp/experiments/resid_mlp/resid_mlp1_config.yaml
+++ b/param_decomp/experiments/resid_mlp/resid_mlp1_config.yaml
@@ -15,7 +15,6 @@ pd:
   identity_module_info: null
   use_delta_component: true
   batch_size: 2048
-  eval_batch_size: 2048
   steps: 20000
   components_optimizer:
     lr_schedule:
@@ -30,12 +29,6 @@ pd:
   faithfulness_warmup_steps: 200
   faithfulness_warmup_lr: 0.01
   faithfulness_warmup_weight_decay: 0.1
-  train_log_freq: 100
-  eval_freq: 500
-  n_eval_steps: 100
-  slow_eval_freq: 5000
-  slow_eval_on_first_step: true
-  save_freq: null
   ci_alive_threshold: 0.1
   loss_metrics:
     importance_minimality:
@@ -46,6 +39,14 @@ pd:
       coeff: 1.0
     stochastic_recon:
       coeff: 1.0
+logging:
+  train_log_freq: 100
+  eval_freq: 500
+  slow_eval_freq: 5000
+  slow_eval_on_first_step: true
+  n_eval_steps: 100
+  eval_batch_size: 2048
+  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 5

--- a/param_decomp/experiments/resid_mlp/resid_mlp1_global_config.yaml
+++ b/param_decomp/experiments/resid_mlp/resid_mlp1_global_config.yaml
@@ -16,7 +16,6 @@ pd:
   identity_module_info: null
   use_delta_component: true
   batch_size: 2048
-  eval_batch_size: 2048
   steps: 20000
   components_optimizer:
     lr_schedule:
@@ -31,12 +30,6 @@ pd:
   faithfulness_warmup_steps: 200
   faithfulness_warmup_lr: 0.01
   faithfulness_warmup_weight_decay: 0.1
-  train_log_freq: 100
-  eval_freq: 500
-  n_eval_steps: 100
-  slow_eval_freq: 5000
-  slow_eval_on_first_step: true
-  save_freq: null
   ci_alive_threshold: 0.1
   loss_metrics:
     importance_minimality:
@@ -47,6 +40,14 @@ pd:
       coeff: 1.0
     stochastic_recon:
       coeff: 1.0
+logging:
+  train_log_freq: 100
+  eval_freq: 500
+  slow_eval_freq: 5000
+  slow_eval_on_first_step: true
+  n_eval_steps: 100
+  eval_batch_size: 2048
+  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 5

--- a/param_decomp/experiments/resid_mlp/resid_mlp1_global_config.yaml
+++ b/param_decomp/experiments/resid_mlp/resid_mlp1_global_config.yaml
@@ -40,14 +40,6 @@ pd:
       coeff: 1.0
     stochastic_recon:
       coeff: 1.0
-logging:
-  train_log_freq: 100
-  eval_freq: 500
-  slow_eval_freq: 5000
-  slow_eval_on_first_step: true
-  n_eval_steps: 100
-  eval_batch_size: 2048
-  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 5
@@ -68,6 +60,14 @@ logging:
       groups: null
     ci_mean_per_component: {}
     stochastic_hidden_acts_recon: {}
+logging:
+  train_log_freq: 100
+  eval_freq: 500
+  slow_eval_freq: 5000
+  slow_eval_on_first_step: true
+  n_eval_steps: 100
+  eval_batch_size: 2048
+  save_freq: null
 target:
   run_path: wandb:goodfire/spd-pre-Sep-2025/runs/pziyck78
 data:

--- a/param_decomp/experiments/resid_mlp/resid_mlp1_global_config.yaml
+++ b/param_decomp/experiments/resid_mlp/resid_mlp1_global_config.yaml
@@ -30,7 +30,6 @@ pd:
   faithfulness_warmup_steps: 200
   faithfulness_warmup_lr: 0.01
   faithfulness_warmup_weight_decay: 0.1
-  ci_alive_threshold: 0.1
   loss_metrics:
     importance_minimality:
       coeff: 1e-5
@@ -68,6 +67,7 @@ logging:
   n_eval_steps: 100
   eval_batch_size: 2048
   save_freq: null
+  ci_alive_threshold: 0.1
 target:
   run_path: wandb:goodfire/spd-pre-Sep-2025/runs/pziyck78
 data:

--- a/param_decomp/experiments/resid_mlp/resid_mlp2_config.yaml
+++ b/param_decomp/experiments/resid_mlp/resid_mlp2_config.yaml
@@ -28,7 +28,6 @@ pd:
   faithfulness_warmup_steps: 200
   faithfulness_warmup_lr: 0.01
   faithfulness_warmup_weight_decay: 0.0
-  ci_alive_threshold: 0.1
   loss_metrics:
     importance_minimality:
       coeff: 0.0001
@@ -77,6 +76,7 @@ logging:
   n_eval_steps: 100
   eval_batch_size: 2048
   save_freq: null
+  ci_alive_threshold: 0.1
 target:
   run_path: wandb:goodfire/spd-pre-Sep-2025/runs/any9ekl9
 data:

--- a/param_decomp/experiments/resid_mlp/resid_mlp2_config.yaml
+++ b/param_decomp/experiments/resid_mlp/resid_mlp2_config.yaml
@@ -44,14 +44,6 @@ pd:
       mask_scope: shared_across_batch
     faithfulness:
       coeff: 0.0
-logging:
-  train_log_freq: 50
-  eval_freq: 500
-  slow_eval_freq: 5000
-  slow_eval_on_first_step: true
-  n_eval_steps: 100
-  eval_batch_size: 2048
-  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 5
@@ -77,6 +69,14 @@ logging:
       step_size: 0.1
       n_steps: 20
       mask_scope: shared_across_batch
+logging:
+  train_log_freq: 50
+  eval_freq: 500
+  slow_eval_freq: 5000
+  slow_eval_on_first_step: true
+  n_eval_steps: 100
+  eval_batch_size: 2048
+  save_freq: null
 target:
   run_path: wandb:goodfire/spd-pre-Sep-2025/runs/any9ekl9
 data:

--- a/param_decomp/experiments/resid_mlp/resid_mlp2_config.yaml
+++ b/param_decomp/experiments/resid_mlp/resid_mlp2_config.yaml
@@ -14,7 +14,6 @@ pd:
     C: 400
   use_delta_component: true
   batch_size: 2048
-  eval_batch_size: 2048
   steps: 25000
   components_optimizer:
     lr_schedule:
@@ -29,12 +28,6 @@ pd:
   faithfulness_warmup_steps: 200
   faithfulness_warmup_lr: 0.01
   faithfulness_warmup_weight_decay: 0.0
-  train_log_freq: 50
-  eval_freq: 500
-  slow_eval_freq: 5000
-  n_eval_steps: 100
-  slow_eval_on_first_step: true
-  save_freq: null
   ci_alive_threshold: 0.1
   loss_metrics:
     importance_minimality:
@@ -51,6 +44,14 @@ pd:
       mask_scope: shared_across_batch
     faithfulness:
       coeff: 0.0
+logging:
+  train_log_freq: 50
+  eval_freq: 500
+  slow_eval_freq: 5000
+  slow_eval_on_first_step: true
+  n_eval_steps: 100
+  eval_batch_size: 2048
+  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 5

--- a/param_decomp/experiments/resid_mlp/resid_mlp3_config.yaml
+++ b/param_decomp/experiments/resid_mlp/resid_mlp3_config.yaml
@@ -14,7 +14,6 @@ pd:
     C: 500
   use_delta_component: true
   batch_size: 2048
-  eval_batch_size: 2048
   steps: 50000
   components_optimizer:
     lr_schedule:
@@ -29,12 +28,6 @@ pd:
   faithfulness_warmup_steps: 200
   faithfulness_warmup_lr: 0.01
   faithfulness_warmup_weight_decay: 0.1
-  train_log_freq: 50
-  eval_freq: 500
-  n_eval_steps: 100
-  slow_eval_freq: 5000
-  slow_eval_on_first_step: true
-  save_freq: null
   ci_alive_threshold: 0.1
   loss_metrics:
     importance_minimality:
@@ -45,6 +38,14 @@ pd:
       coeff: 1.0
     stochastic_recon:
       coeff: 1.0
+logging:
+  train_log_freq: 50
+  eval_freq: 500
+  slow_eval_freq: 5000
+  slow_eval_on_first_step: true
+  n_eval_steps: 100
+  eval_batch_size: 2048
+  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 5

--- a/param_decomp/experiments/resid_mlp/resid_mlp3_config.yaml
+++ b/param_decomp/experiments/resid_mlp/resid_mlp3_config.yaml
@@ -38,14 +38,6 @@ pd:
       coeff: 1.0
     stochastic_recon:
       coeff: 1.0
-logging:
-  train_log_freq: 50
-  eval_freq: 500
-  slow_eval_freq: 5000
-  slow_eval_on_first_step: true
-  n_eval_steps: 100
-  eval_batch_size: 2048
-  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 5
@@ -66,6 +58,14 @@ logging:
       groups: null
     ci_mean_per_component: {}
     stochastic_hidden_acts_recon: {}
+logging:
+  train_log_freq: 50
+  eval_freq: 500
+  slow_eval_freq: 5000
+  slow_eval_on_first_step: true
+  n_eval_steps: 100
+  eval_batch_size: 2048
+  save_freq: null
 target:
   run_path: wandb:goodfire/spd-pre-Sep-2025/runs/6hk3uciu
 data:

--- a/param_decomp/experiments/resid_mlp/resid_mlp3_config.yaml
+++ b/param_decomp/experiments/resid_mlp/resid_mlp3_config.yaml
@@ -28,7 +28,6 @@ pd:
   faithfulness_warmup_steps: 200
   faithfulness_warmup_lr: 0.01
   faithfulness_warmup_weight_decay: 0.1
-  ci_alive_threshold: 0.1
   loss_metrics:
     importance_minimality:
       coeff: 1e-5
@@ -66,6 +65,7 @@ logging:
   n_eval_steps: 100
   eval_batch_size: 2048
   save_freq: null
+  ci_alive_threshold: 0.1
 target:
   run_path: wandb:goodfire/spd-pre-Sep-2025/runs/6hk3uciu
 data:

--- a/param_decomp/experiments/tms/tms_40-10-id_config.yaml
+++ b/param_decomp/experiments/tms/tms_40-10-id_config.yaml
@@ -42,13 +42,6 @@ pd:
       coeff: 1.0
     stochastic_recon:
       coeff: 1.0
-logging:
-  train_log_freq: 100
-  eval_freq: 1000
-  slow_eval_freq: 5000
-  n_eval_steps: 100
-  eval_batch_size: 4096
-  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 5
@@ -72,6 +65,13 @@ logging:
       groups: null
     ci_mean_per_component: {}
     stochastic_hidden_acts_recon: {}
+logging:
+  train_log_freq: 100
+  eval_freq: 1000
+  slow_eval_freq: 5000
+  n_eval_steps: 100
+  eval_batch_size: 4096
+  save_freq: null
 target:
   run_path: wandb:goodfire/spd-pre-Sep-2025/runs/eggs3wp8
 data:

--- a/param_decomp/experiments/tms/tms_40-10-id_config.yaml
+++ b/param_decomp/experiments/tms/tms_40-10-id_config.yaml
@@ -16,7 +16,6 @@ pd:
     C: 200
   use_delta_component: true
   batch_size: 4096
-  eval_batch_size: 4096
   steps: 20000
   components_optimizer:
     lr_schedule:
@@ -33,11 +32,6 @@ pd:
   faithfulness_warmup_steps: 200
   faithfulness_warmup_lr: 0.01
   faithfulness_warmup_weight_decay: 0.1
-  train_log_freq: 100
-  eval_freq: 1000
-  n_eval_steps: 100
-  slow_eval_freq: 5000
-  save_freq: null
   ci_alive_threshold: 0.1
   loss_metrics:
     importance_minimality:
@@ -48,6 +42,13 @@ pd:
       coeff: 1.0
     stochastic_recon:
       coeff: 1.0
+logging:
+  train_log_freq: 100
+  eval_freq: 1000
+  slow_eval_freq: 5000
+  n_eval_steps: 100
+  eval_batch_size: 4096
+  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 5

--- a/param_decomp/experiments/tms/tms_40-10-id_config.yaml
+++ b/param_decomp/experiments/tms/tms_40-10-id_config.yaml
@@ -32,7 +32,6 @@ pd:
   faithfulness_warmup_steps: 200
   faithfulness_warmup_lr: 0.01
   faithfulness_warmup_weight_decay: 0.1
-  ci_alive_threshold: 0.1
   loss_metrics:
     importance_minimality:
       coeff: 1e-4
@@ -72,6 +71,7 @@ logging:
   n_eval_steps: 100
   eval_batch_size: 4096
   save_freq: null
+  ci_alive_threshold: 0.1
 target:
   run_path: wandb:goodfire/spd-pre-Sep-2025/runs/eggs3wp8
 data:

--- a/param_decomp/experiments/tms/tms_40-10_config.yaml
+++ b/param_decomp/experiments/tms/tms_40-10_config.yaml
@@ -41,13 +41,6 @@ pd:
       coeff: 1.0
     stochastic_recon:
       coeff: 1.0
-logging:
-  train_log_freq: 500
-  eval_freq: 1000
-  slow_eval_freq: 5000
-  n_eval_steps: 100
-  eval_batch_size: 4096
-  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 5
@@ -68,6 +61,13 @@ logging:
       groups: null
     ci_mean_per_component: {}
     stochastic_hidden_acts_recon: {}
+logging:
+  train_log_freq: 500
+  eval_freq: 1000
+  slow_eval_freq: 5000
+  n_eval_steps: 100
+  eval_batch_size: 4096
+  save_freq: null
 target:
   run_path: wandb:goodfire/spd-pre-Sep-2025/runs/urpntmfu
 data:

--- a/param_decomp/experiments/tms/tms_40-10_config.yaml
+++ b/param_decomp/experiments/tms/tms_40-10_config.yaml
@@ -15,7 +15,6 @@ pd:
   identity_module_info: null
   use_delta_component: true
   batch_size: 4096
-  eval_batch_size: 4096
   steps: 10000
   components_optimizer:
     lr_schedule:
@@ -32,11 +31,6 @@ pd:
   faithfulness_warmup_steps: 200
   faithfulness_warmup_lr: 0.01
   faithfulness_warmup_weight_decay: 0.1
-  train_log_freq: 500
-  eval_freq: 1000
-  n_eval_steps: 100
-  slow_eval_freq: 5000
-  save_freq: null
   ci_alive_threshold: 0.1
   loss_metrics:
     importance_minimality:
@@ -47,6 +41,13 @@ pd:
       coeff: 1.0
     stochastic_recon:
       coeff: 1.0
+logging:
+  train_log_freq: 500
+  eval_freq: 1000
+  slow_eval_freq: 5000
+  n_eval_steps: 100
+  eval_batch_size: 4096
+  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 5

--- a/param_decomp/experiments/tms/tms_40-10_config.yaml
+++ b/param_decomp/experiments/tms/tms_40-10_config.yaml
@@ -31,7 +31,6 @@ pd:
   faithfulness_warmup_steps: 200
   faithfulness_warmup_lr: 0.01
   faithfulness_warmup_weight_decay: 0.1
-  ci_alive_threshold: 0.1
   loss_metrics:
     importance_minimality:
       coeff: 1e-4
@@ -68,6 +67,7 @@ logging:
   n_eval_steps: 100
   eval_batch_size: 4096
   save_freq: null
+  ci_alive_threshold: 0.1
 target:
   run_path: wandb:goodfire/spd-pre-Sep-2025/runs/urpntmfu
 data:

--- a/param_decomp/experiments/tms/tms_5-2-id_config.yaml
+++ b/param_decomp/experiments/tms/tms_5-2-id_config.yaml
@@ -42,13 +42,6 @@ pd:
       coeff: 1.0
     stochastic_recon:
       coeff: 1.0
-logging:
-  train_log_freq: 100
-  eval_freq: 1000
-  slow_eval_freq: 5000
-  n_eval_steps: 100
-  eval_batch_size: 4096
-  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 5
@@ -72,6 +65,13 @@ logging:
       groups: null
     ci_mean_per_component: {}
     stochastic_hidden_acts_recon: {}
+logging:
+  train_log_freq: 100
+  eval_freq: 1000
+  slow_eval_freq: 5000
+  n_eval_steps: 100
+  eval_batch_size: 4096
+  save_freq: null
 target:
   run_path: wandb:goodfire/spd-pre-Sep-2025/runs/gfgchmxj
 data:

--- a/param_decomp/experiments/tms/tms_5-2-id_config.yaml
+++ b/param_decomp/experiments/tms/tms_5-2-id_config.yaml
@@ -16,7 +16,6 @@ pd:
     C: 20
   use_delta_component: true
   batch_size: 4096
-  eval_batch_size: 4096
   steps: 10000
   components_optimizer:
     lr_schedule:
@@ -33,11 +32,6 @@ pd:
   faithfulness_warmup_steps: 200
   faithfulness_warmup_lr: 0.01
   faithfulness_warmup_weight_decay: 0.1
-  train_log_freq: 100
-  eval_freq: 1000
-  n_eval_steps: 100
-  slow_eval_freq: 5000
-  save_freq: null
   ci_alive_threshold: 0.1
   loss_metrics:
     importance_minimality:
@@ -48,6 +42,13 @@ pd:
       coeff: 1.0
     stochastic_recon:
       coeff: 1.0
+logging:
+  train_log_freq: 100
+  eval_freq: 1000
+  slow_eval_freq: 5000
+  n_eval_steps: 100
+  eval_batch_size: 4096
+  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 5

--- a/param_decomp/experiments/tms/tms_5-2-id_config.yaml
+++ b/param_decomp/experiments/tms/tms_5-2-id_config.yaml
@@ -32,7 +32,6 @@ pd:
   faithfulness_warmup_steps: 200
   faithfulness_warmup_lr: 0.01
   faithfulness_warmup_weight_decay: 0.1
-  ci_alive_threshold: 0.1
   loss_metrics:
     importance_minimality:
       coeff: 3e-3
@@ -72,6 +71,7 @@ logging:
   n_eval_steps: 100
   eval_batch_size: 4096
   save_freq: null
+  ci_alive_threshold: 0.1
 target:
   run_path: wandb:goodfire/spd-pre-Sep-2025/runs/gfgchmxj
 data:

--- a/param_decomp/experiments/tms/tms_5-2_config.yaml
+++ b/param_decomp/experiments/tms/tms_5-2_config.yaml
@@ -39,7 +39,6 @@ pd:
   faithfulness_warmup_steps: 200
   faithfulness_warmup_lr: 0.01
   faithfulness_warmup_weight_decay: 0.1
-  ci_alive_threshold: 0.1
   eval_metrics:
     ci_histograms:
       n_batches_accum: 5
@@ -67,6 +66,7 @@ logging:
   n_eval_steps: 100
   eval_batch_size: 4096
   save_freq: null
+  ci_alive_threshold: 0.1
 target:
   run_path: wandb:goodfire/spd-pre-Sep-2025/runs/0hsp07o4
 data:

--- a/param_decomp/experiments/tms/tms_5-2_config.yaml
+++ b/param_decomp/experiments/tms/tms_5-2_config.yaml
@@ -23,7 +23,6 @@ pd:
     stochastic_recon_layerwise:
       coeff: 1.0
   batch_size: 4096
-  eval_batch_size: 4096
   steps: 10000
   components_optimizer:
     lr_schedule:
@@ -40,12 +39,14 @@ pd:
   faithfulness_warmup_steps: 200
   faithfulness_warmup_lr: 0.01
   faithfulness_warmup_weight_decay: 0.1
+  ci_alive_threshold: 0.1
+logging:
   train_log_freq: 100
   eval_freq: 1000
-  n_eval_steps: 100
   slow_eval_freq: 5000
+  n_eval_steps: 100
+  eval_batch_size: 4096
   save_freq: null
-  ci_alive_threshold: 0.1
   eval_metrics:
     ci_histograms:
       n_batches_accum: 5

--- a/param_decomp/experiments/tms/tms_5-2_config.yaml
+++ b/param_decomp/experiments/tms/tms_5-2_config.yaml
@@ -40,13 +40,6 @@ pd:
   faithfulness_warmup_lr: 0.01
   faithfulness_warmup_weight_decay: 0.1
   ci_alive_threshold: 0.1
-logging:
-  train_log_freq: 100
-  eval_freq: 1000
-  slow_eval_freq: 5000
-  n_eval_steps: 100
-  eval_batch_size: 4096
-  save_freq: null
   eval_metrics:
     ci_histograms:
       n_batches_accum: 5
@@ -67,6 +60,13 @@ logging:
       groups: null
     ci_mean_per_component: {}
     stochastic_hidden_acts_recon: {}
+logging:
+  train_log_freq: 100
+  eval_freq: 1000
+  slow_eval_freq: 5000
+  n_eval_steps: 100
+  eval_batch_size: 4096
+  save_freq: null
 target:
   run_path: wandb:goodfire/spd-pre-Sep-2025/runs/0hsp07o4
 data:

--- a/param_decomp/run_pd.py
+++ b/param_decomp/run_pd.py
@@ -18,6 +18,7 @@ from torch.utils.data import DataLoader
 from tqdm import tqdm
 
 from param_decomp.configs import (
+    LoggingConfig,
     MetricConfigType,
     PDConfig,
     PersistentPGDReconLossConfig,
@@ -103,6 +104,7 @@ def run_faithfulness_warmup(
 def optimize(
     target_model: nn.Module,
     config: PDConfig,
+    logging_config: LoggingConfig,
     device: str,
     train_loader: DataLoader[Any],
     eval_loader: DataLoader[Any],
@@ -221,15 +223,15 @@ def optimize(
     ] = [
         cfg
         for cfg in (
-            config.eval_metrics.pgd_multibatch_recon,
-            config.eval_metrics.pgd_multibatch_recon_subset,
+            logging_config.eval_metrics.pgd_multibatch_recon,
+            logging_config.eval_metrics.pgd_multibatch_recon_subset,
         )
         if cfg is not None
     ]
 
     eval_metric_configs: list[MetricConfigType] = [
         cfg
-        for cfg in config.loss_metrics.active() + config.eval_metrics.active()
+        for cfg in config.loss_metrics.active() + logging_config.eval_metrics.active()
         if not isinstance(cfg, PGDMultiBatchConfig)
     ]
 
@@ -334,7 +336,7 @@ def optimize(
             batch_log_data[f"train/l0/{layer_name}"] = l0_val
 
         # --- Train Logging --- #
-        if step % config.train_log_freq == 0:
+        if step % logging_config.train_log_freq == 0:
             avg_metrics = avg_metrics_across_ranks(batch_log_data, device=device)
             batch_log_data = cast(defaultdict[str, float], avg_metrics)
 
@@ -358,12 +360,12 @@ def optimize(
                     try_wandb(wandb.log, batch_log_data, step=step)
 
         # --- Evaluation --- #
-        if step % config.eval_freq == 0:
+        if step % logging_config.eval_freq == 0:
             with torch.no_grad(), bf16_autocast(enabled=config.autocast_bf16):
                 slow_step: bool = (
-                    config.slow_eval_on_first_step
+                    logging_config.slow_eval_on_first_step
                     if step == 0
-                    else step % config.slow_eval_freq == 0
+                    else step % logging_config.slow_eval_freq == 0
                 )
 
                 multibatch_pgd_metrics = evaluate_multibatch_pgd(
@@ -382,7 +384,7 @@ def optimize(
                     device=device,
                     run_config=config,
                     slow_step=slow_step,
-                    n_eval_steps=config.n_eval_steps,
+                    n_eval_steps=logging_config.n_eval_steps,
                     current_frac_of_training=step / config.steps,
                     reconstruction_loss=reconstruction_loss,
                     ppgd_states=ppgd_states,
@@ -409,7 +411,11 @@ def optimize(
 
         # --- Saving Checkpoint --- #
         if (
-            (config.save_freq is not None and step % config.save_freq == 0 and step > 0)
+            (
+                logging_config.save_freq is not None
+                and step % logging_config.save_freq == 0
+                and step > 0
+            )
             or step == config.steps
         ) and is_main_process():
             assert out_dir is not None
@@ -458,6 +464,7 @@ def _validate_pgd_scope(config: PDConfig, dist_state: DistributedState | None) -
 
 def run_pd(
     config: PDConfig,
+    logging_config: LoggingConfig,
     target: PDTarget,
     train_loader: DataLoader[Any],
     eval_loader: DataLoader[Any],
@@ -492,7 +499,10 @@ def run_pd(
         if metadata is None:
             metadata = RunMetadata(
                 driver=None,
-                config={"pd": config.model_dump(mode="json")},
+                config={
+                    "pd": config.model_dump(mode="json"),
+                    "logging": logging_config.model_dump(mode="json"),
+                },
             )
 
         tags = list(wandb_tags or [])
@@ -507,6 +517,7 @@ def run_pd(
                 run_id,
                 name=metadata.wandb_run_name,
                 tags=tags,
+                extra_configs={"logging": logging_config},
                 view_meta=metadata.view_meta,
             )
 
@@ -524,6 +535,7 @@ def run_pd(
     optimize(
         target_model=target.model,
         config=config,
+        logging_config=logging_config,
         device=device,
         train_loader=train_loader,
         eval_loader=eval_loader,

--- a/param_decomp/run_pd.py
+++ b/param_decomp/run_pd.py
@@ -332,7 +332,7 @@ def optimize(
             ppgd_states[ppgd_cfg].step(ppgd_grads[ppgd_cfg])
 
         for layer_name, layer_ci in ci.lower_leaky.items():
-            l0_val = calc_ci_l_zero(layer_ci, config.ci_alive_threshold)
+            l0_val = calc_ci_l_zero(layer_ci, logging_config.ci_alive_threshold)
             batch_log_data[f"train/l0/{layer_name}"] = l0_val
 
         # --- Train Logging --- #
@@ -383,6 +383,7 @@ def optimize(
                     eval_iterator=eval_iterator,
                     device=device,
                     run_config=config,
+                    ci_alive_threshold=logging_config.ci_alive_threshold,
                     slow_step=slow_step,
                     n_eval_steps=logging_config.n_eval_steps,
                     current_frac_of_training=step / config.steps,

--- a/param_decomp/run_pd.py
+++ b/param_decomp/run_pd.py
@@ -223,15 +223,15 @@ def optimize(
     ] = [
         cfg
         for cfg in (
-            logging_config.eval_metrics.pgd_multibatch_recon,
-            logging_config.eval_metrics.pgd_multibatch_recon_subset,
+            config.eval_metrics.pgd_multibatch_recon,
+            config.eval_metrics.pgd_multibatch_recon_subset,
         )
         if cfg is not None
     ]
 
     eval_metric_configs: list[MetricConfigType] = [
         cfg
-        for cfg in config.loss_metrics.active() + logging_config.eval_metrics.active()
+        for cfg in config.loss_metrics.active() + config.eval_metrics.active()
         if not isinstance(cfg, PGDMultiBatchConfig)
     ]
 

--- a/param_decomp/scripts/alpha_sweep/alpha_sweep.py
+++ b/param_decomp/scripts/alpha_sweep/alpha_sweep.py
@@ -92,7 +92,7 @@ def run_r_sweep(
     eval_loader, _tokenizer = create_lm_data_loader(
         data,
         split=data.eval_split,
-        batch_size=config.eval_batch_size,
+        batch_size=exp.logging.eval_batch_size,
         seed=config.seed + 1,
     )
 

--- a/param_decomp/utils/wandb_utils.py
+++ b/param_decomp/utils/wandb_utils.py
@@ -261,15 +261,13 @@ def init_wandb(
     config_dict = config.model_dump(mode="json")
     flattened = flatten_metric_configs(config_dict)
     config_dict.pop("loss_metrics", None)
+    config_dict.pop("eval_metrics", None)
     wandb.config.update({**config_dict, **flattened})
 
     if extra_configs:
         for prefix, extra in extra_configs.items():
             extra_dict = extra.model_dump(mode="json")
-            flattened_extra = flatten_metric_configs(extra_dict)
-            extra_dict.pop("eval_metrics", None)
             wandb.config.update({f"{prefix}/{k}": v for k, v in extra_dict.items()})
-            wandb.config.update({f"{prefix}/{k}": v for k, v in flattened_extra.items()})
 
     if view_meta:
         wandb.config.update({f"view_meta/{k}": v for k, v in view_meta.items()})

--- a/param_decomp/utils/wandb_utils.py
+++ b/param_decomp/utils/wandb_utils.py
@@ -228,16 +228,20 @@ def init_wandb(
     *,
     name: str | None = None,
     tags: list[str] | None = None,
+    extra_configs: dict[str, BaseConfig] | None = None,
     view_meta: dict[str, Any] | None = None,
 ) -> None:
     """Initialize Weights & Biases and log the config.
 
     Args:
-        config: The config to log.
+        config: The primary config to log (flattened into ``wandb.config``).
         project: The name of the wandb project.
         run_id: The unique run ID (from ExecutionStamp).
         name: The name of the wandb run.
         tags: Optional list of tags to add to the run.
+        extra_configs: Sibling configs to also log, keyed by prefix
+            (e.g. ``{"logging": LoggingConfig(...)}``). Each is dumped under its
+            key in ``wandb.config`` so fields don't collide with the primary config.
         view_meta: Free-form labels (typically populated by a sweep generator)
             merged into ``wandb.config`` under a ``view_meta/`` prefix so the W&B
             UI can group/color runs by researcher-facing axes.
@@ -255,12 +259,18 @@ def init_wandb(
     )
 
     config_dict = config.model_dump(mode="json")
-    # We also want flattened names for easier wandb searchability
-    flattened_config_dict = flatten_metric_configs(config_dict)
-    # Remove the nested metric configs to avoid duplication (if they exist)
+    flattened = flatten_metric_configs(config_dict)
     config_dict.pop("loss_metrics", None)
-    config_dict.pop("eval_metrics", None)
-    wandb.config.update({**config_dict, **flattened_config_dict})
+    wandb.config.update({**config_dict, **flattened})
+
+    if extra_configs:
+        for prefix, extra in extra_configs.items():
+            extra_dict = extra.model_dump(mode="json")
+            flattened_extra = flatten_metric_configs(extra_dict)
+            extra_dict.pop("eval_metrics", None)
+            wandb.config.update({f"{prefix}/{k}": v for k, v in extra_dict.items()})
+            wandb.config.update({f"{prefix}/{k}": v for k, v in flattened_extra.items()})
+
     if view_meta:
         wandb.config.update({f"view_meta/{k}": v for k, v in view_meta.items()})
 

--- a/tests/app/test_server_api.py
+++ b/tests/app/test_server_api.py
@@ -22,6 +22,7 @@ from param_decomp.app.backend.server import app
 from param_decomp.app.backend.state import RunState, StateManager
 from param_decomp.configs import (
     LayerwiseCiConfig,
+    LoggingConfig,
     ModulePatternInfoConfig,
     OptimizerConfig,
     PDConfig,
@@ -101,11 +102,6 @@ def app_with_state():
             ci_fn_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
             steps=1,
             batch_size=1,
-            eval_batch_size=1,
-            n_eval_steps=1,
-            eval_freq=1,
-            slow_eval_freq=1,
-            train_log_freq=1,
         )
         module_path_info = expand_module_patterns(target_model, config.module_info)
         model = ComponentModel(
@@ -133,6 +129,13 @@ def app_with_state():
 
         lm_exp = LMExperimentConfig(
             pd=config,
+            logging=LoggingConfig(
+                eval_batch_size=1,
+                n_eval_steps=1,
+                eval_freq=1,
+                slow_eval_freq=1,
+                train_log_freq=1,
+            ),
             target=LMTargetConfig(
                 model_class="param_decomp.pretrain.models.gpt2_simple.GPT2Simple",
                 model_name="test-target",

--- a/tests/test_component_model.py
+++ b/tests/test_component_model.py
@@ -129,14 +129,9 @@ def test_from_checkpoint():
             steps=1,
             components_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
             ci_fn_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
-            n_eval_steps=1,
-            eval_batch_size=1,
-            eval_freq=1,
-            slow_eval_freq=1,
             loss_metrics=LossMetricsConfig(
                 importance_minimality=ImportanceMinimalityLossConfig(coeff=1.0, pnorm=1.0, beta=0.5)
             ),
-            train_log_freq=1,
             n_mask_samples=1,
         )
 
@@ -532,14 +527,9 @@ def test_checkpoint_ci_config_mismatch_global_to_layerwise():
             steps=1,
             components_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
             ci_fn_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
-            n_eval_steps=1,
-            eval_batch_size=1,
-            eval_freq=1,
-            slow_eval_freq=1,
             loss_metrics=LossMetricsConfig(
                 importance_minimality=ImportanceMinimalityLossConfig(coeff=1.0, pnorm=1.0, beta=0.5)
             ),
-            train_log_freq=1,
             n_mask_samples=1,
         )
 
@@ -567,14 +557,9 @@ def test_checkpoint_ci_config_mismatch_global_to_layerwise():
             steps=1,
             components_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
             ci_fn_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
-            n_eval_steps=1,
-            eval_batch_size=1,
-            eval_freq=1,
-            slow_eval_freq=1,
             loss_metrics=LossMetricsConfig(
                 importance_minimality=ImportanceMinimalityLossConfig(coeff=1.0, pnorm=1.0, beta=0.5)
             ),
-            train_log_freq=1,
             n_mask_samples=1,
         )
 
@@ -619,14 +604,9 @@ def test_checkpoint_ci_config_mismatch_layerwise_to_global():
             steps=1,
             components_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
             ci_fn_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
-            n_eval_steps=1,
-            eval_batch_size=1,
-            eval_freq=1,
-            slow_eval_freq=1,
             loss_metrics=LossMetricsConfig(
                 importance_minimality=ImportanceMinimalityLossConfig(coeff=1.0, pnorm=1.0, beta=0.5)
             ),
-            train_log_freq=1,
             n_mask_samples=1,
         )
 
@@ -654,14 +634,9 @@ def test_checkpoint_ci_config_mismatch_layerwise_to_global():
             steps=1,
             components_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
             ci_fn_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
-            n_eval_steps=1,
-            eval_batch_size=1,
-            eval_freq=1,
-            slow_eval_freq=1,
             loss_metrics=LossMetricsConfig(
                 importance_minimality=ImportanceMinimalityLossConfig(coeff=1.0, pnorm=1.0, beta=0.5)
             ),
-            train_log_freq=1,
             n_mask_samples=1,
         )
 
@@ -1273,14 +1248,9 @@ def test_global_ci_save_and_load():
             steps=1,
             components_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
             ci_fn_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
-            n_eval_steps=1,
-            eval_batch_size=1,
-            eval_freq=1,
-            slow_eval_freq=1,
             loss_metrics=LossMetricsConfig(
                 importance_minimality=ImportanceMinimalityLossConfig(coeff=1.0, pnorm=1.0, beta=0.5)
             ),
-            train_log_freq=1,
             n_mask_samples=1,
         )
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -5,7 +5,6 @@ from unittest.mock import Mock
 import pytest
 import torch
 
-from param_decomp.configs import PDConfig
 from param_decomp.metrics import CIHistograms
 from param_decomp.models.component_model import CIOutputs, ComponentModel
 from param_decomp.models.sigmoids import lower_leaky_hard_sigmoid, upper_leaky_hard_sigmoid
@@ -13,14 +12,6 @@ from param_decomp.models.sigmoids import lower_leaky_hard_sigmoid, upper_leaky_h
 
 class TestCIHistograms:
     """Test suite for CIHistograms class."""
-
-    @pytest.fixture
-    def mock_config(self):
-        """Create a mock PDConfig object."""
-        config = Mock(spec=PDConfig)
-        config.ci_alive_threshold = 0.5
-        config.sigmoid_type = "straight_through"
-        return config
 
     @pytest.fixture
     def mock_model(self):

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -73,12 +73,12 @@ def test_gpt_2_decomposition_happy_path(tmp_path: Path) -> None:
         ),
         batch_size=4,
         steps=2,
-        ci_alive_threshold=0.1,
         eval_metrics=EvalMetricsConfig(
             ci_l0=CI_L0Config(groups=None),
         ),
     )
     logging_config = LoggingConfig(
+        ci_alive_threshold=0.1,
         n_eval_steps=1,
         train_log_freq=50,
         eval_freq=500,

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -74,6 +74,9 @@ def test_gpt_2_decomposition_happy_path(tmp_path: Path) -> None:
         batch_size=4,
         steps=2,
         ci_alive_threshold=0.1,
+        eval_metrics=EvalMetricsConfig(
+            ci_l0=CI_L0Config(groups=None),
+        ),
     )
     logging_config = LoggingConfig(
         n_eval_steps=1,
@@ -83,9 +86,6 @@ def test_gpt_2_decomposition_happy_path(tmp_path: Path) -> None:
         slow_eval_freq=500,
         slow_eval_on_first_step=False,
         save_freq=None,
-        eval_metrics=EvalMetricsConfig(
-            ci_l0=CI_L0Config(groups=None),
-        ),
     )
 
     model_name = "SimpleStories/test-SimpleStories-gpt2-1.25M"

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -11,6 +11,7 @@ from param_decomp.configs import (
     FaithfulnessLossConfig,
     ImportanceMinimalityLossConfig,
     LayerwiseCiConfig,
+    LoggingConfig,
     LossMetricsConfig,
     ModulePatternInfoConfig,
     OptimizerConfig,
@@ -72,6 +73,9 @@ def test_gpt_2_decomposition_happy_path(tmp_path: Path) -> None:
         ),
         batch_size=4,
         steps=2,
+        ci_alive_threshold=0.1,
+    )
+    logging_config = LoggingConfig(
         n_eval_steps=1,
         train_log_freq=50,
         eval_freq=500,
@@ -79,7 +83,6 @@ def test_gpt_2_decomposition_happy_path(tmp_path: Path) -> None:
         slow_eval_freq=500,
         slow_eval_on_first_step=False,
         save_freq=None,
-        ci_alive_threshold=0.1,
         eval_metrics=EvalMetricsConfig(
             ci_l0=CI_L0Config(groups=None),
         ),
@@ -124,6 +127,7 @@ def test_gpt_2_decomposition_happy_path(tmp_path: Path) -> None:
     optimize(
         target_model=target_model,
         config=config,
+        logging_config=logging_config,
         device=device,
         train_loader=train_loader,
         eval_loader=eval_loader,

--- a/tests/test_resid_mlp.py
+++ b/tests/test_resid_mlp.py
@@ -4,6 +4,7 @@ from param_decomp.configs import (
     FaithfulnessLossConfig,
     ImportanceMinimalityLossConfig,
     LayerwiseCiConfig,
+    LoggingConfig,
     LossMetricsConfig,
     ModulePatternInfoConfig,
     OptimizerConfig,
@@ -72,6 +73,9 @@ def test_resid_mlp_decomposition_happy_path(tmp_path: Path) -> None:
         ),
         batch_size=4,
         steps=3,
+        ci_alive_threshold=0.1,
+    )
+    logging_config = LoggingConfig(
         n_eval_steps=1,
         eval_freq=10,
         eval_batch_size=4,
@@ -79,7 +83,6 @@ def test_resid_mlp_decomposition_happy_path(tmp_path: Path) -> None:
         slow_eval_on_first_step=True,
         train_log_freq=50,
         save_freq=None,
-        ci_alive_threshold=0.1,
     )
 
     target_model = ResidMLP(config=resid_mlp_model_config).to(device)
@@ -103,13 +106,14 @@ def test_resid_mlp_decomposition_happy_path(tmp_path: Path) -> None:
 
     train_loader = DatasetGeneratedDataLoader(dataset, batch_size=config.batch_size, shuffle=False)
     eval_loader = DatasetGeneratedDataLoader(
-        dataset, batch_size=config.eval_batch_size, shuffle=False
+        dataset, batch_size=logging_config.eval_batch_size, shuffle=False
     )
 
     # Run optimize function
     optimize(
         target_model=target_model,
         config=config,
+        logging_config=logging_config,
         device=device,
         train_loader=train_loader,
         eval_loader=eval_loader,

--- a/tests/test_resid_mlp.py
+++ b/tests/test_resid_mlp.py
@@ -73,9 +73,9 @@ def test_resid_mlp_decomposition_happy_path(tmp_path: Path) -> None:
         ),
         batch_size=4,
         steps=3,
-        ci_alive_threshold=0.1,
     )
     logging_config = LoggingConfig(
+        ci_alive_threshold=0.1,
         n_eval_steps=1,
         eval_freq=10,
         eval_batch_size=4,

--- a/tests/test_run_metadata_round_trip.py
+++ b/tests/test_run_metadata_round_trip.py
@@ -61,12 +61,12 @@ def _pd_config() -> PDConfig:
         ci_fn_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
         steps=1,
         batch_size=4,
-        ci_alive_threshold=0.0,
     )
 
 
 def _logging_config() -> LoggingConfig:
     return LoggingConfig(
+        ci_alive_threshold=0.0,
         eval_batch_size=4,
         train_log_freq=1,
         eval_freq=1,

--- a/tests/test_run_metadata_round_trip.py
+++ b/tests/test_run_metadata_round_trip.py
@@ -10,6 +10,7 @@ from param_decomp.configs import (
     GlobalCiConfig,
     GlobalSharedTransformerCiConfig,
     LayerwiseCiConfig,
+    LoggingConfig,
     OptimizerConfig,
     PDConfig,
     ScheduleConfig,
@@ -60,13 +61,18 @@ def _pd_config() -> PDConfig:
         ci_fn_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
         steps=1,
         batch_size=4,
+        ci_alive_threshold=0.0,
+    )
+
+
+def _logging_config() -> LoggingConfig:
+    return LoggingConfig(
         eval_batch_size=4,
         train_log_freq=1,
         eval_freq=1,
         slow_eval_freq=1,
         n_eval_steps=1,
         slow_eval_on_first_step=False,
-        ci_alive_threshold=0.0,
     )
 
 
@@ -84,6 +90,7 @@ def _round_trip(experiment_config: ExperimentConfig, driver_path: str) -> Experi
 def test_lm_experiment_round_trip():
     exp = LMExperimentConfig(
         pd=_pd_config(),
+        logging=_logging_config(),
         target=LMTargetConfig(
             model_class="transformers.GPT2LMHeadModel",
             model_name="openai-community/gpt2",
@@ -104,6 +111,7 @@ def test_lm_experiment_round_trip():
 def test_tms_experiment_round_trip():
     exp = TMSExperimentConfig(
         pd=_pd_config(),
+        logging=_logging_config(),
         target=TMSTargetConfig(run_path="wandb:foo/bar/runs/abc"),
         data=TMSDataConfig(feature_probability=0.05),
     )
@@ -115,6 +123,7 @@ def test_tms_experiment_round_trip():
 def test_resid_mlp_experiment_round_trip():
     exp = ResidMLPExperimentConfig(
         pd=_pd_config(),
+        logging=_logging_config(),
         target=ResidMLPTargetConfig(run_path="wandb:foo/bar/runs/abc"),
         data=ResidMLPDataConfig(feature_probability=0.05),
     )
@@ -134,7 +143,10 @@ def test_save_pre_run_info_writes_run_metadata(tmp_path: Path):
 
     metadata = RunMetadata(
         driver=None,
-        config={"pd": _pd_config().model_dump(mode="json")},
+        config={
+            "pd": _pd_config().model_dump(mode="json"),
+            "logging": _logging_config().model_dump(mode="json"),
+        },
     )
     save_pre_run_info(
         save_to_wandb=False,

--- a/tests/test_tms.py
+++ b/tests/test_tms.py
@@ -8,6 +8,7 @@ from param_decomp.configs import (
     FaithfulnessLossConfig,
     ImportanceMinimalityLossConfig,
     LayerwiseCiConfig,
+    LoggingConfig,
     LossMetricsConfig,
     ModulePatternInfoConfig,
     OptimizerConfig,
@@ -79,13 +80,15 @@ def test_tms_decomposition_happy_path(tmp_path: Path) -> None:
         ),
         batch_size=4,
         steps=3,
-        n_eval_steps=1,
         faithfulness_warmup_steps=2,
         faithfulness_warmup_lr=0.001,
         faithfulness_warmup_weight_decay=0.0,
+        ci_alive_threshold=0.1,
+    )
+    logging_config = LoggingConfig(
+        n_eval_steps=1,
         train_log_freq=2,
         save_freq=None,
-        ci_alive_threshold=0.1,
         eval_batch_size=4,
         eval_freq=10,
         slow_eval_freq=10,
@@ -117,6 +120,7 @@ def test_tms_decomposition_happy_path(tmp_path: Path) -> None:
     optimize(
         target_model=target_model,
         config=config,
+        logging_config=logging_config,
         device=device,
         train_loader=train_loader,
         eval_loader=eval_loader,

--- a/tests/test_tms.py
+++ b/tests/test_tms.py
@@ -83,9 +83,9 @@ def test_tms_decomposition_happy_path(tmp_path: Path) -> None:
         faithfulness_warmup_steps=2,
         faithfulness_warmup_lr=0.001,
         faithfulness_warmup_weight_decay=0.0,
-        ci_alive_threshold=0.1,
     )
     logging_config = LoggingConfig(
+        ci_alive_threshold=0.1,
         n_eval_steps=1,
         train_log_freq=2,
         save_freq=None,


### PR DESCRIPTION
## Description

Stacks on #501. Moves 8 fields out of `PDConfig` into a new sibling `LoggingConfig`:

```
train_log_freq, eval_freq, slow_eval_freq, slow_eval_on_first_step,
n_eval_steps, eval_batch_size, save_freq, eval_metrics
```

All eight are observation knobs — they control *how often* / *with what cadence* you peek at a run, not what the run computes. Two runs with identical `PDConfig` and different `LoggingConfig` produce **bit-identical trained models**.

```python
class ExperimentConfig(BaseConfig):
    pd: PDConfig
    logging: LoggingConfig    # new
```

`optimize()` and `run_pd()` take both as separate args. The `loss_metrics` / `eval_metrics` overlap validator moves to `ExperimentConfig` (needs both sides); the `slow_eval_freq % eval_freq == 0` validator moves to `LoggingConfig`. W&B config dump nests logging-side keys under a `logging/` prefix to avoid colliding with PDConfig keys.

## Motivation and Context

Direct follow-up to PR #501. Same lens: keep `PDConfig` as the algorithm config, push everything else out. `wandb_project` / `wandb_run_name` went to `RunMetadata` last PR; the observation cadence + eval-only metrics go to `LoggingConfig` here.

Concrete wins:
- `PDConfig` shrinks from ~25 fields to ~17 algorithm-only fields
- Sweep grids stop having to reason about whether `eval_freq` is "a hyperparameter" (it isn't)
- Reload semantics get cleaner — same algorithm with different observation cadence is obviously the same experiment

## How Has This Been Tested?

- [x] `make check` clean
- [x] Full test suite: 455 passed, 7 skipped
- [x] All 12 in-tree PD experiment YAMLs migrated by script and validated by reload
- [x] Tests that construct `PDConfig` inline (test_tms, test_resid_mlp, test_gpt2, test_component_model, test_server_api, test_run_metadata_round_trip) updated to also construct `LoggingConfig` and pass it to `optimize()`

Not exercised on a real cluster — w&b prefix logging is unverified visually.

## Does this PR introduce a breaking change?

Yes.

- **8 fields removed from `PDConfig`.** Any external YAML or `PDConfig(...)` instantiation that sets `train_log_freq` / `eval_freq` / `slow_eval_freq` / `slow_eval_on_first_step` / `n_eval_steps` / `eval_batch_size` / `save_freq` / `eval_metrics` will fail pydantic validation. Move them into a `LoggingConfig` block alongside `pd:` in the experiment YAML, or pass `logging_config=...` to `run_pd` / `optimize`.
- **`run_pd` and `optimize` signatures gain a required `logging_config: LoggingConfig` parameter.** Notebook callers must construct and pass one.
- **`init_wandb` keyword arg `view_meta` and new `extra_configs` are now keyword-only.** Existing callers (run_pd, train_resid_mlp) already pass them as kwargs.