### PR TITLE
Post-review cleanup: unify driver-path loader, tighten Run dispatch, doc sweep

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,29 +105,21 @@ Built-in YAML configs are pure `Run` configs nested under `driver_path:`, `pd:`,
 - `TMSRun(driver_path, pd, logging, runtime, target, data)`
 - `ResidMLPRun(driver_path, pd, logging, runtime, target, data)`
 
-The three configs form a **determinism ladder**:
+The three configs split by **what they affect**:
 
-1. Same `PDConfig` + same `RuntimeConfig` → bit-identical trained weights.
-2. Same `PDConfig`, different `RuntimeConfig` → same algorithm, weights differ only via
-   numerical effects (precision, device).
-3. Same `PDConfig` + same `RuntimeConfig`, different `LoggingConfig` → bit-identical
-   weights; only what was observed differs.
-
-Mapping to fields:
-
-- **`PDConfig` (class 1)** — algorithm specification: seed, ci_config, losses,
-  optimizers, module_info. Flipping any field here changes what algorithm runs.
-- **`RuntimeConfig` (class 2)** — compute substrate: autocast_bf16, device, dp; future
-  NCCL flags, gradient accumulation, fp8 variants. Perturbs numerics, doesn't change
+- **`PDConfig`** — algorithm specification: seed, ci_config, losses, optimizers,
+  module_info. Flipping any field here changes what algorithm runs.
+- **`RuntimeConfig`** — compute substrate: autocast_bf16, device, dp; future home for
+  NCCL flags, gradient accumulation, fp8 variants. Perturbs numerics without changing
   the algorithm. **Config-only — no CLI overrides.** Edit the YAML (or copy it) to
   change substrate; you can't silently run "the same experiment" on different hardware.
   Cluster topology (GPUs per node) is `settings.GPUS_PER_NODE`, overridable via
   `PARAM_DECOMP_GPUS_PER_NODE` env var.
-- **`LoggingConfig` (class 3)** — observation: cadence (`*_freq`), `eval_batch_size`,
-  `ci_alive_threshold`, eval-only metrics, plus `wandb_run_name` / `view_meta`.
-  Never touches the optimizer. **Note:** the W&B *project* lives outside the
-  `Run` (it's a deploy-time parameter — which account/team to log to) and is
-  passed via `--project` to `pd-run` or `wandb_project=` to `run_pd`.
+- **`LoggingConfig`** — observation: cadence (`*_freq`), `eval_batch_size`,
+  `ci_alive_threshold`, eval-only metrics, plus `wandb_run_name` / `view_meta`. Never
+  touches the optimizer. **Note:** the W&B *project* lives outside the `Run` (it's a
+  deploy-time parameter — which account/team to log to) and is passed via `--project`
+  to `pd-run` or `wandb_project=` to `run_pd`.
 
 `Run` configs should not perform I/O. Put target loading and dataloader construction in
 the driver.

--- a/param_decomp/app/backend/routers/pretrain_info.py
+++ b/param_decomp/app/backend/routers/pretrain_info.py
@@ -15,7 +15,6 @@ from param_decomp.app.backend.dependencies import DepLoadedRun
 from param_decomp.app.backend.utils import log_errors
 from param_decomp.experiments.lm.experiment import LMRun
 from param_decomp.log import logger
-from param_decomp.saved_run import PDRun
 from param_decomp.settings import PARAM_DECOMP_OUT_DIR
 from param_decomp.utils.wandb_utils import parse_wandb_run_path
 
@@ -47,7 +46,10 @@ class PretrainInfoResponse(BaseModel):
 
 def _load_lm_run_lightweight(wandb_path: str) -> LMRun | None:
     """Load just the `Run` for an LM run, without downloading checkpoints."""
-    run = PDRun.run_from_path(wandb_path)
+    from param_decomp.run import RUN_METADATA_FILENAME, Run
+    from param_decomp.utils.run_files import resolve_config_path
+
+    run = Run.from_file(resolve_config_path(wandb_path, config_filename=RUN_METADATA_FILENAME))
     if not isinstance(run, LMRun):
         return None
     return run

--- a/param_decomp/base_config.py
+++ b/param_decomp/base_config.py
@@ -1,4 +1,5 @@
 import json
+from functools import cached_property
 from pathlib import Path
 from typing import ClassVar, Self
 
@@ -10,12 +11,13 @@ class BaseConfig(BaseModel):
     """Pydantic BaseModel suited for configs.
 
     Uses the pydantic `model_config` to enforce `extra="forbid"` and `frozen=True` and add loading
-    and saving from/to YAML, JSON.
+    and saving from/to YAML, JSON. ``cached_property`` is in ``ignored_types`` so subclasses can
+    use it for derived state on frozen models.
     """
 
-    model_config: ClassVar[ConfigDict] = ConfigDict(extra="forbid", frozen=True)
-
-    # TODO: add a "config_type" field, which is set to the class name, so that when loading a config we can check whether the config type matches the expected class
+    model_config: ClassVar[ConfigDict] = ConfigDict(
+        extra="forbid", frozen=True, ignored_types=(cached_property,)
+    )
 
     @classmethod
     def from_file(cls, path: Path | str) -> Self:

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -1,5 +1,6 @@
 """Config classes of various types"""
 
+from functools import cached_property
 from typing import Annotated, Any, Literal, Self
 
 from pydantic import (
@@ -506,19 +507,28 @@ MetricConfigType = LossMetricConfigType | EvalOnlyMetricConfigType
 class _LossCapableMetricsConfig(BaseConfig):
     """Shared loss-capable metric fields used by both `LossMetricsConfig` and `EvalMetricsConfig`."""
 
+    # general
     faithfulness: FaithfulnessLossConfig | None = None
     importance_minimality: ImportanceMinimalityLossConfig | None = None
     unmasked_recon: UnmaskedReconLossConfig | None = None
+
+    # CI-masked reconstruction
     ci_masked_recon: CIMaskedReconLossConfig | None = None
     ci_masked_recon_subset: CIMaskedReconSubsetLossConfig | None = None
     ci_masked_recon_layerwise: CIMaskedReconLayerwiseLossConfig | None = None
+
+    # stochastic reconstruction
     stochastic_recon: StochasticReconLossConfig | None = None
     stochastic_recon_subset: StochasticReconSubsetLossConfig | None = None
     stochastic_recon_layerwise: StochasticReconLayerwiseLossConfig | None = None
     stochastic_hidden_acts_recon: StochasticHiddenActsReconLossConfig | None = None
+
+    # PGD reconstruction
     pgd_recon: PGDReconLossConfig | None = None
     pgd_recon_subset: PGDReconSubsetLossConfig | None = None
     pgd_recon_layerwise: PGDReconLayerwiseLossConfig | None = None
+
+    # persistent PGD reconstruction
     persistent_pgd_recon: PersistentPGDReconLossConfig | None = None
     persistent_pgd_recon_subset: PersistentPGDReconSubsetLossConfig | None = None
 
@@ -566,19 +576,11 @@ SamplingType = Literal["continuous", "binomial"]
 
 
 class RuntimeConfig(BaseConfig):
-    """Compute substrate the algorithm runs on.
+    """Compute substrate: device, precision, data-parallelism degree.
 
-    The three configs form a determinism ladder:
-
-    1. Same ``PDConfig`` + same ``RuntimeConfig`` → bit-identical trained weights.
-    2. Same ``PDConfig``, different ``RuntimeConfig`` → same algorithm, weights differ
-       only via numerical effects (precision, device).
-    3. Same ``PDConfig`` + same ``RuntimeConfig``, different ``LoggingConfig`` →
-       bit-identical weights; only what was observed differs.
-
-    ``RuntimeConfig`` is class 2: device placement, precision, parallelism degree —
-    things that perturb numerics without changing the algorithm. Future home for
-    NCCL flags, gradient accumulation steps, fp8 variants, etc.
+    Perturbs numerics but doesn't change the algorithm. Future home for NCCL flags,
+    gradient accumulation steps, fp8 variants, etc. See CLAUDE.md for how the
+    ``PDConfig`` / ``RuntimeConfig`` / ``LoggingConfig`` triple splits.
     """
 
     autocast_bf16: bool = Field(
@@ -610,12 +612,10 @@ class RuntimeConfig(BaseConfig):
 
 
 class LoggingConfig(BaseConfig):
-    """Observation-only settings: cadence + eval-only metrics + display thresholds.
+    """Observation-only settings: cadence, eval-only metrics, display thresholds.
 
-    Determinism class 3 in the PDConfig/RuntimeConfig/LoggingConfig ladder: fields
-    here never touch the optimizer. Two runs with identical ``PDConfig`` +
-    ``RuntimeConfig`` and different ``LoggingConfig`` produce bit-identical weights —
-    only what you observed about the run differs.
+    Fields here don't touch the optimizer. See CLAUDE.md for how the
+    ``PDConfig`` / ``RuntimeConfig`` / ``LoggingConfig`` triple splits.
     """
 
     train_log_freq: PositiveInt = Field(
@@ -682,12 +682,10 @@ class LoggingConfig(BaseConfig):
 
 
 class PDConfig(BaseConfig):
-    """Algorithm specification.
+    """Algorithm specification: seed, CI function, losses, optimizers, module info.
 
-    Determinism class 1 in the PDConfig/RuntimeConfig/LoggingConfig ladder: these are
-    the fields that determine the trained weights given a fixed substrate. Two runs
-    with identical ``PDConfig`` and identical ``RuntimeConfig`` produce bit-identical
-    weights; flipping any field here changes what algorithm runs.
+    Flipping any field here changes what algorithm runs. See CLAUDE.md for how the
+    ``PDConfig`` / ``RuntimeConfig`` / ``LoggingConfig`` triple splits.
     """
 
     # --- General ---
@@ -724,7 +722,7 @@ class PDConfig(BaseConfig):
         "Identity operations will be inserted at these modules.",
     )
 
-    @property
+    @cached_property
     def all_module_info(self) -> list[ModulePatternInfoConfig]:
         """Combine target and identity patterns with their C values.
 

--- a/param_decomp/driver_path.py
+++ b/param_decomp/driver_path.py
@@ -1,0 +1,20 @@
+"""Resolve ``"module:attr"`` driver paths to driver objects.
+
+Lives outside ``experiments/`` so both ``param_decomp.run`` (for ``Run`` subclass
+dispatch) and ``experiments.driver`` (for the public re-export) can import it
+without forming an import cycle through the ``ExperimentDriver`` Protocol.
+"""
+
+from importlib import import_module
+from typing import Any
+
+
+def load_driver(driver_path: str) -> Any:
+    """Load a driver object or no-arg driver class from a ``module:attr`` import path."""
+    module_path, sep, attr = driver_path.partition(":")
+    if sep == "":
+        raise ValueError(f"Driver path must be of the form 'module:attr', got {driver_path!r}")
+    driver = getattr(import_module(module_path), attr)
+    if isinstance(driver, type):
+        driver = driver()
+    return driver

--- a/param_decomp/experiments/_worker.py
+++ b/param_decomp/experiments/_worker.py
@@ -15,7 +15,7 @@ import json
 import fire
 
 from param_decomp import run_pd
-from param_decomp.experiments.driver import load_driver
+from param_decomp.driver_path import load_driver
 from param_decomp.log import logger
 from param_decomp.run import Run
 from param_decomp.utils.distributed_utils import (
@@ -39,9 +39,6 @@ def run_experiment(
     logger.info(f"Distributed state: {dist_state}")
 
     driver = load_driver(run.driver_path)
-    assert isinstance(run, driver.config_type), (
-        f"Run has type {type(run).__name__}, expected {driver.config_type.__name__}"
-    )
     set_seed(run.pd.seed)
     device = get_device()
 
@@ -81,7 +78,7 @@ def main(
     wandb_project: str | None = None,
 ) -> None:
     """SLURM task entrypoint."""
-    run = Run.from_dict(json.loads(run_json))
+    run = Run.model_validate(json.loads(run_json))
     run_experiment(run, launch_id=launch_id, wandb_project=wandb_project)
 
 

--- a/param_decomp/experiments/driver.py
+++ b/param_decomp/experiments/driver.py
@@ -10,11 +10,11 @@ exactly like a fresh run, re-fetching whatever upstream the config points at (wa
 pretrain run, HF model, etc.). Saved PD runs depend on their upstream continuing to exist.
 """
 
-from importlib import import_module
 from typing import Any, ClassVar, Protocol
 
 from torch.utils.data import DataLoader
 
+from param_decomp.driver_path import load_driver
 from param_decomp.models.batch_and_loss_fns import PDTarget
 from param_decomp.run import Run
 from param_decomp.utils.distributed_utils import DistributedState
@@ -45,18 +45,6 @@ class ExperimentDriver[RunT: Run](Protocol):
     ) -> tuple[DataLoader[Any], DataLoader[Any]]:
         """Build train/eval dataloaders."""
         ...
-
-
-def load_driver(driver_path: str) -> ExperimentDriver[Any]:
-    """Load a driver object or no-arg driver class from a `module:attr` import path."""
-    module_path, sep, attr = driver_path.partition(":")
-    if sep == "":
-        raise ValueError(f"Driver path must be of the form 'module:attr', got {driver_path!r}")
-    module = import_module(module_path)
-    driver = getattr(module, attr)
-    if isinstance(driver, type):
-        driver = driver()
-    return driver
 
 
 __all__ = [

--- a/param_decomp/experiments/runner.py
+++ b/param_decomp/experiments/runner.py
@@ -15,13 +15,14 @@ import yaml
 
 from param_decomp.experiments._worker import run_experiment
 from param_decomp.experiments.discovery import discover_experiments
-from param_decomp.run import Run
+from param_decomp.run import RUN_METADATA_FILENAME, Run
 from param_decomp.settings import (
     DEFAULT_PARTITION_NAME,
     DEFAULT_PROJECT_NAME,
     REPO_ROOT,
 )
-from param_decomp.sweeps import SweepSpec, load_sweep_generator
+from param_decomp.sweeps import load_sweep_generator
+from param_decomp.utils.run_files import resolve_config_path
 
 
 def _resolve_source(
@@ -29,14 +30,14 @@ def _resolve_source(
     config_path: str | Path | None,
     rerun: str | None,
 ) -> dict[str, Any]:
-    """Resolve the chosen input source into a dict ready for ``Run.from_dict``.
+    """Resolve the chosen input source into a dict ready for ``Run.model_validate``.
 
     Exactly one of ``experiment``, ``config_path``, or ``rerun`` must be set.
     Every source is expected to provide ``driver_path`` as a top-level field
     (built-in YAMLs, user YAMLs, and saved ``run_metadata.yaml`` all declare it).
 
     Stamps ``logging.wandb_run_name`` (the experiment slug, config filename
-    stem, or ``"rerun"``) so each YAML doesn't have to set one.
+    stem, or ``"rerun"``) only when the source YAML doesn't already specify one.
     """
     sources_set = sum(x is not None for x in (experiment, config_path, rerun))
     assert sources_set == 1, (
@@ -56,9 +57,7 @@ def _resolve_source(
         name = Path(config_path).stem
     else:
         assert rerun is not None  # by `sources_set == 1`
-        from param_decomp.saved_run import PDRun
-
-        config_data = PDRun.run_from_path(rerun).model_dump(mode="json")
+        config_data = _load_yaml(resolve_config_path(rerun, config_filename=RUN_METADATA_FILENAME))
         config_data.pop("run_id", None)
         name = "rerun"
 
@@ -67,7 +66,12 @@ def _resolve_source(
         "Every PD config must declare its driver (e.g. "
         "`driver_path: param_decomp.experiments.tms.experiment:Driver`)."
     )
-    config_data["logging"] = {**config_data.get("logging", {}), "wandb_run_name": name}
+    # User-supplied wandb_run_name in the source YAML wins; only fill in the auto-derived
+    # name when the YAML left it unset (missing or null).
+    logging_block = dict(config_data.get("logging", {}))
+    if logging_block.get("wandb_run_name") is None:
+        logging_block["wandb_run_name"] = name
+    config_data["logging"] = logging_block
     return config_data
 
 
@@ -76,20 +80,6 @@ def _load_yaml(path: Path) -> dict[str, Any]:
         data = yaml.safe_load(f)
     assert isinstance(data, dict), f"config must be a YAML mapping: {path}"
     return data
-
-
-def _resolve_sweep_spec(sweep_generator_path: str) -> SweepSpec:
-    """Load and invoke a sweep generator.
-
-    ``SweepSpec.__post_init__`` enforces shared driver + shared ``runtime:``
-    block across all runs.
-    """
-    generator = load_sweep_generator(sweep_generator_path)
-    spec = generator()
-    assert isinstance(spec, SweepSpec), (
-        f"sweep generator {generator!r} returned {type(spec).__name__}, expected SweepSpec"
-    )
-    return spec
 
 
 def main(
@@ -133,7 +123,7 @@ def main(
         pd-run tms_5-2                                                              # one SLURM job
         pd-run --sweep_generator_path /abs/path/my_sweep.py:my_sweep --n_agents 4   # sweep
         pd-run --config_path my.yaml                                                # custom config
-        pd-run --rerun s-a1b2c3d4                                                   # rerun from saved run
+        pd-run --rerun p-a1b2c3d4                                                   # rerun from saved run
         pd-run tms_5-2 --local                                                      # in-process; no SLURM
     """
     if (
@@ -160,12 +150,11 @@ def main(
         assert shutil.which("sbatch") is not None, (
             "`sbatch` not found on PATH. Off-cluster, use `pd-run ... --local` (no sweep)."
         )
-        sweep_spec = _resolve_sweep_spec(sweep_generator_path)
+        sweep_spec = load_sweep_generator(sweep_generator_path)()
         from param_decomp.scripts.run_slurm import launch_slurm
 
         launch_slurm(
             launchable=sweep_spec,
-            runtime=sweep_spec.runs[0].runtime,
             n_agents=n_agents,
             job_suffix=job_suffix,
             partition=partition,
@@ -173,7 +162,7 @@ def main(
         )
         return
 
-    run = Run.from_dict(_resolve_source(experiment, config_path, rerun))
+    run = Run.model_validate(_resolve_source(experiment, config_path, rerun))
 
     if local:
         assert run.runtime.dp is None, "runtime.dp is not supported with --local"
@@ -192,7 +181,6 @@ def main(
 
     launch_slurm(
         launchable=run,
-        runtime=run.runtime,
         n_agents=n_agents,
         job_suffix=job_suffix,
         partition=partition,

--- a/param_decomp/run.py
+++ b/param_decomp/run.py
@@ -1,26 +1,34 @@
 """The `Run` object: one type for "what a PD run is".
 
-Holds the driver import path plus the three determinism-tier configs (``pd``,
-``logging``, ``runtime``). Driver-specific subclasses (``LMRun``, ``TMSRun``,
-``ResidMLPRun``) add ``target`` / ``data`` and are pointed at by each driver's
-``config_type``.
+Holds the driver import path plus three configs (``pd``, ``logging``, ``runtime``)
+that split algorithm / substrate / observation. Driver-specific subclasses
+(``LMRun``, ``TMSRun``, ``ResidMLPRun``) add ``target`` / ``data`` and are pointed
+at by each driver's ``config_type``.
 
 Written to ``run_metadata.yaml`` beside the checkpoint, passed to the worker,
 and re-read on reload. One type, one shape, everywhere.
+
+A ``mode="wrap"`` model validator on the base ``Run`` dispatches to the right
+subclass when validating a dict: it reads ``driver_path``, loads the driver,
+and re-routes ``model_validate`` to ``driver.config_type``. Callers therefore
+use ``Run.model_validate(data)`` / ``Run.from_file(path)`` (inherited from
+``BaseConfig``) and get back the appropriate subtype.
 """
 
-import importlib
 from pathlib import Path
-from typing import Any, override
+from typing import Any
 
 import yaml
-from pydantic import Field
+from pydantic import Field, ValidatorFunctionWrapHandler, model_validator
 
 from param_decomp.base_config import BaseConfig
 from param_decomp.configs import LoggingConfig, PDConfig, RuntimeConfig
+from param_decomp.driver_path import load_driver
 from param_decomp.utils.run_utils import generate_run_id
 
 RUN_METADATA_FILENAME = "run_metadata.yaml"
+
+_BASE_RUN_FIELDS = frozenset({"run_id", "driver_path", "pd", "logging", "runtime"})
 
 
 class Run(BaseConfig):
@@ -41,44 +49,32 @@ class Run(BaseConfig):
     logging: LoggingConfig
     runtime: RuntimeConfig
 
+    @model_validator(mode="wrap")
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "Run":
-        """Parse a dict (e.g. from YAML) into the right `Run` subclass.
+    def _dispatch_to_subclass(cls, data: Any, handler: ValidatorFunctionWrapHandler) -> "Run":
+        """Route base-``Run`` validation to the driver's ``config_type`` subclass.
 
-        Looks up ``driver_path`` → driver → ``config_type`` and validates the
-        dict against that subclass. When ``driver_path`` is ``None``, validates
-        as a bare ``Run``. Callers that need the concrete subtype narrow with
-        ``isinstance(run, driver.config_type)``.
+        Only triggers when the caller asked for the base class (``cls is Run``)
+        and is passing a dict — direct ``LMRun.model_validate(...)`` calls and
+        validation of an already-constructed model fall through unchanged.
         """
-        driver_path = data.get("driver_path")
-        if driver_path is None:
-            return cls.model_validate(data)
-        return _load_config_type(driver_path).model_validate(data)
-
-    @classmethod
-    @override
-    def from_file(cls, path: Path | str) -> "Run":
-        path = Path(path)
-        assert path.exists(), f"{RUN_METADATA_FILENAME} not found at {path}"
-        with open(path) as f:
-            return cls.from_dict(yaml.safe_load(f))
+        if cls is Run and isinstance(data, dict):
+            driver_path = data.get("driver_path")
+            if driver_path is not None:
+                subclass = load_driver(driver_path).config_type
+                if subclass is not Run:
+                    return subclass.model_validate(data)
+            else:
+                extras = set(data) - _BASE_RUN_FIELDS
+                if extras:
+                    raise ValueError(
+                        f"Config has extra fields {sorted(extras)} but no driver_path. "
+                        "Set `driver_path: module:Driver` so the right Run subclass can "
+                        "be selected, or remove the extra fields for a notebook-style run."
+                    )
+        return handler(data)
 
     def write(self, path: Path) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "w") as f:
             yaml.dump(self.model_dump(mode="json"), f, default_flow_style=False, sort_keys=False)
-
-
-def _load_config_type(driver_path: str) -> type[Run]:
-    """Resolve a ``module:attr`` driver path to its ``config_type`` (a ``Run`` subclass).
-
-    Inlined here (rather than reusing ``experiments.driver.load_driver``) to avoid a
-    static import cycle between this module and ``experiments.driver``.
-    """
-    module_path, sep, attr = driver_path.partition(":")
-    if sep == "":
-        raise ValueError(f"Driver path must be of the form 'module:attr', got {driver_path!r}")
-    driver = getattr(importlib.import_module(module_path), attr)
-    if isinstance(driver, type):
-        driver = driver()
-    return driver.config_type

--- a/param_decomp/run_pd.py
+++ b/param_decomp/run_pd.py
@@ -97,9 +97,8 @@ def run_faithfulness_warmup(
                 f"Faithfulness warmup step {faithfulness_warmup_step + 1} / {config.faithfulness_warmup_steps}; Faithfulness loss: {loss.item():.9f}"
             )
     del faithfulness_warmup_optimizer
-    # TODO: we should reverse the order of these two calls
-    torch.cuda.empty_cache()
     gc.collect()
+    torch.cuda.empty_cache()
 
 
 def optimize(
@@ -408,9 +407,8 @@ def optimize(
                         try_wandb(wandb.log, wandb_logs, step=step)
 
                 del metrics
-                # TODO: we should reverse the order of these two calls
-                torch.cuda.empty_cache()
                 gc.collect()
+                torch.cuda.empty_cache()
 
         # --- Saving Checkpoint --- #
         if (

--- a/param_decomp/saved_run.py
+++ b/param_decomp/saved_run.py
@@ -8,13 +8,14 @@ from typing import Any
 from torch.utils.data import DataLoader
 
 from param_decomp.configs import PDConfig
-from param_decomp.experiments.driver import ExperimentDriver, load_driver
+from param_decomp.driver_path import load_driver
+from param_decomp.experiments.driver import ExperimentDriver
 from param_decomp.models.batch_and_loss_fns import PDTarget
 from param_decomp.models.component_model import ComponentModel
 from param_decomp.run import RUN_METADATA_FILENAME, Run
 from param_decomp.types import ModelPath
 from param_decomp.utils.distributed_utils import DistributedState
-from param_decomp.utils.run_files import resolve_config_path, resolve_run_files
+from param_decomp.utils.run_files import resolve_run_files
 
 
 @dataclass
@@ -38,11 +39,6 @@ class PDRun:
             checkpoint_path=files.checkpoint_path,
         )
 
-    @classmethod
-    def run_from_path(cls, path: ModelPath) -> Run:
-        """Load just the `Run` config, without resolving or downloading checkpoints."""
-        return Run.from_file(resolve_config_path(path, config_filename=RUN_METADATA_FILENAME))
-
     @cached_property
     def driver(self) -> ExperimentDriver[Any] | None:
         return load_driver(self.run.driver_path) if self.run.driver_path else None
@@ -62,9 +58,6 @@ class PDRun:
             "Run has no driver. Use `load_component_model(path, target=...)` with an "
             "explicit target."
         )
-        assert isinstance(self.run, self.driver.config_type), (
-            f"Run has type {type(self.run).__name__}, expected {self.driver.config_type.__name__}"
-        )
         return self.driver.build_target(self.run)
 
     def load_dataloaders(
@@ -77,9 +70,6 @@ class PDRun:
     ) -> tuple[DataLoader[Any], DataLoader[Any]]:
         assert self.driver is not None, (
             "Run has no driver. Build dataloaders explicitly for custom runs."
-        )
-        assert isinstance(self.run, self.driver.config_type), (
-            f"Run has type {type(self.run).__name__}, expected {self.driver.config_type.__name__}"
         )
         return self.driver.build_dataloaders(
             self.run,

--- a/param_decomp/scripts/run_slurm.py
+++ b/param_decomp/scripts/run_slurm.py
@@ -39,7 +39,6 @@ _CUDA_FLAGS = {
 
 def launch_slurm(
     launchable: Run | SweepSpec,
-    runtime: RuntimeConfig,
     n_agents: int | None,
     job_suffix: str | None,
     partition: str,
@@ -64,7 +63,8 @@ def launch_slurm(
 
     logger.info(f"Launch ID: {launch_id}")
 
-    n_gpus = _n_gpus_for(runtime)
+    # All runs in a sweep share a runtime (asserted by SweepSpec.__post_init__).
+    n_gpus = _n_gpus_for(runs[0].runtime)
     logger.info(f"Running on {_format_compute_info(n_gpus)}")
 
     if is_sweep:

--- a/param_decomp/sweeps/cartesian.py
+++ b/param_decomp/sweeps/cartesian.py
@@ -8,20 +8,19 @@ zero-arg function returning a ``SweepSpec`` works. This module ships
 pattern without writing the product loop themselves.
 """
 
+import copy
 import itertools
 from typing import Any
 
 import yaml
 
-from param_decomp.experiments.driver import load_driver
 from param_decomp.run import Run
 from param_decomp.settings import REPO_ROOT
 from param_decomp.sweeps.spec import SweepSpec
-from param_decomp.utils.run_utils import apply_nested_updates
 
 
 def cartesian_product(
-    base_config: Run | dict[str, Any],
+    base_config: dict[str, Any],
     grid: dict[str, list[Any]],
     *,
     description: str,
@@ -39,21 +38,22 @@ def cartesian_product(
             f"grid['{axis}'] must be a non-empty list, got {values!r}"
         )
 
+    base_config_data = dict(base_config)
+    base_config_data.pop("run_id", None)
+
     axes = list(grid.keys())
     value_lists = [grid[a] for a in axes]
-    base_config_data = _config_data(base_config)
-    config_type = load_driver(driver_path).config_type
     runs: list[Run] = []
     for combo in itertools.product(*value_lists):
         updates = dict(zip(axes, combo, strict=True))
-        config_data = apply_nested_updates(base_config_data, updates)
+        config_data = _apply_nested_updates(base_config_data, updates)
         name = "_".join(f"{_short_axis(a)}={_short_value(v)}" for a, v in updates.items())
         logging_data = {
             **config_data.get("logging", {}),
             "wandb_run_name": name,
             "view_meta": dict(updates),
         }
-        run = config_type.model_validate(
+        run = Run.model_validate(
             {**config_data, "driver_path": driver_path, "logging": logging_data}
         )
         runs.append(run)
@@ -92,7 +92,23 @@ def _short_value(v: Any) -> str:
     return str(v).replace("/", "_")
 
 
-def _config_data(config: Run | dict[str, Any]) -> dict[str, Any]:
-    data = config.model_dump(mode="json") if isinstance(config, Run) else dict(config)
-    data.pop("run_id", None)
-    return data
+def _apply_nested_updates(base_dict: dict[str, Any], updates: dict[str, Any]) -> dict[str, Any]:
+    """Deep-merge dot-pathed ``updates`` into a copy of ``base_dict``.
+
+    Example: ``{"pd.loss_metrics.importance_minimality.coeff": 0.1}`` sets
+    ``result["pd"]["loss_metrics"]["importance_minimality"]["coeff"] = 0.1``.
+    """
+    result = copy.deepcopy(base_dict)
+    for key, value in updates.items():
+        if "." in key:
+            keys = key.split(".")
+            current: dict[str, Any] = result
+            for k in keys[:-1]:
+                if k not in current:
+                    current[k] = {}
+                assert isinstance(current[k], dict)
+                current = current[k]
+            current[keys[-1]] = value
+        else:
+            result[key] = value
+    return result

--- a/param_decomp/utils/run_files.py
+++ b/param_decomp/utils/run_files.py
@@ -3,7 +3,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import wandb
-from wandb.apis.public import Run
+from wandb.apis.public import Run as WandbRun
 
 from param_decomp.log import logger
 from param_decomp.settings import PARAM_DECOMP_OUT_DIR
@@ -102,7 +102,7 @@ def resolve_config_path(path: ModelPath, *, config_filename: str) -> Path:
 
     logger.info(f"Downloading config from wandb: {entity}/{project}/{run_id}")
     api = wandb.Api()
-    run: Run = api.run(f"{entity}/{project}/{run_id}")
+    run: WandbRun = api.run(f"{entity}/{project}/{run_id}")
     run_dir = fetch_wandb_run_dir(run.id)
     return download_wandb_file(run, run_dir, config_filename)
 
@@ -139,7 +139,7 @@ def _download_run_files_from_wandb(
     extras_from_config_path: Callable[[Path], list[str]],
 ) -> RunFiles:
     api = wandb.Api()
-    run: Run = api.run(wandb_path)
+    run: WandbRun = api.run(wandb_path)
     run_dir = fetch_wandb_run_dir(run.id)
 
     config_path = download_wandb_file(run, run_dir, config_filename)

--- a/param_decomp/utils/run_utils.py
+++ b/param_decomp/utils/run_utils.py
@@ -1,6 +1,5 @@
 """Utilities for managing experiment run directories and IDs."""
 
-import copy
 import json
 import os
 import secrets
@@ -42,22 +41,14 @@ def _save_text(data: str, path: Path | str, encoding: str = "utf-8") -> None:
 
 
 def save_file(data: dict[str, Any] | Any, path: Path | str, **kwargs: Any) -> None:
-    """Save a file.
+    """Write ``data`` to ``path``, dispatching on the file extension.
 
-    NOTE: This function was originally designed to save files with specific permissions,
-    bypassing the system's umask. This is not needed anymore, but we're keeping this
-    abstraction for convenience and brevity.
+    Ensures the parent directory exists. Format:
 
-    File type is determined by extension:
-    - .json: Save as JSON
-    - .yaml/.yml: Save as YAML
-    - .pth/.pt: Save as PyTorch model
-    - .txt or other: Save as plain text (data must be string)
-
-    Args:
-        data: Data to save (format depends on file type)
-        path: File path to save to
-        **kwargs: Additional arguments passed to the specific save function
+    - ``.json`` → JSON via ``json.dump``
+    - ``.yaml`` / ``.yml`` → YAML via ``yaml.dump`` (sort_keys=False)
+    - ``.pth`` / ``.pt`` → ``torch.save``
+    - anything else → plain text (``data`` must be a string)
     """
     path = Path(path)
     suffix = path.suffix.lower()
@@ -74,37 +65,6 @@ def save_file(data: dict[str, Any] | Any, path: Path | str, **kwargs: Any) -> No
         # Default to text file
         assert isinstance(data, str), f"For {suffix} files, data must be a string, got {type(data)}"
         _save_text(data, path, encoding=kwargs.get("encoding", "utf-8"))
-
-
-def apply_nested_updates(base_dict: dict[str, Any], updates: dict[str, Any]) -> dict[str, Any]:
-    """Apply nested updates to a dictionary with dot-flattened keys.
-
-    Example: `{"pd.loss_metrics.importance_minimality.coeff": 0.1}` deep-merges into
-    `base_dict["pd"]["loss_metrics"]["importance_minimality"]["coeff"] = 0.1`.
-
-    Args:
-        base_dict: The base configuration dictionary
-        updates: Dictionary of flattened key-value pairs
-
-    Returns:
-        Updated dictionary (deep copy, original unchanged)
-    """
-    result = copy.deepcopy(base_dict)
-
-    for key, value in updates.items():
-        if "." in key:
-            keys = key.split(".")
-            current: dict[str, Any] = result
-            for k in keys[:-1]:
-                if k not in current:
-                    current[k] = {}
-                assert isinstance(current[k], dict)
-                current = current[k]
-            current[keys[-1]] = value
-        else:
-            result[key] = value
-
-    return result
 
 
 RunType = Literal[

--- a/param_decomp/utils/wandb_utils.py
+++ b/param_decomp/utils/wandb_utils.py
@@ -14,13 +14,14 @@ from param_decomp.log import logger
 from param_decomp.settings import DEFAULT_PROJECT_NAME, REPO_ROOT
 from param_decomp.utils.general_utils import fetch_latest_checkpoint_name
 
-# Regex patterns for parsing W&B run references
-# Run IDs can be 8 chars (e.g., "d2ec3bfe") or prefixed with char-dash (e.g., "s-d2ec3bfe")
+# Regex patterns for parsing W&B run references. PD run IDs are formatted as
+# `p-<8 hex chars>` (see `RUN_TYPE_ABBREVIATIONS`). Legacy `s-…` IDs predate the
+# Run refactor; they still resolve when given as a full `entity/project/runs/id` path.
 DEFAULT_WANDB_ENTITY = "goodfire"
 DEFAULT_WANDB_PROJECT = DEFAULT_PROJECT_NAME
 
 _RUN_ID_PATTERN = r"(?:[a-z0-9]-)?[a-z0-9]{8}"
-_BARE_RUN_ID_RE = re.compile(r"^([sp]-[a-z0-9]{8})$")
+_BARE_RUN_ID_RE = re.compile(r"^(p-[a-z0-9]{8})$")
 _WANDB_PATH_RE = re.compile(rf"^([^/\s]+)/([^/\s]+)/({_RUN_ID_PATTERN})$")
 _WANDB_PATH_WITH_RUNS_RE = re.compile(rf"^([^/\s]+)/([^/\s]+)/runs/({_RUN_ID_PATTERN})$")
 _WANDB_URL_RE = re.compile(
@@ -91,12 +92,15 @@ def parse_wandb_run_path(input_path: str) -> tuple[str, str, str]:
     """Parse various W&B run reference formats into (entity, project, run_id).
 
     Accepts:
-    - "s-xxxxxxxx" (bare PD run ID, defaults to goodfire/param-decomp)
+    - "p-xxxxxxxx" (bare PD run ID, defaults to goodfire/param-decomp)
     - "entity/project/runId" (compact form)
     - "entity/project/runs/runId" (with /runs/)
     - "wandb:entity/project/runId" (with wandb: prefix)
     - "wandb:entity/project/runs/runId" (full wandb: form)
     - "https://wandb.ai/entity/project/runs/runId..." (URL)
+
+    The bare-ID shortcut only accepts the current `p-…` prefix; legacy `s-…` IDs
+    (pre-refactor) still resolve via the full `entity/project/runs/id` form.
 
     Returns:
         Tuple of (entity, project, run_id)
@@ -110,7 +114,7 @@ def parse_wandb_run_path(input_path: str) -> tuple[str, str, str]:
     if s.startswith("wandb:"):
         s = s[6:]
 
-    # Bare run ID (e.g. "s-17805b61") → default entity/project
+    # Bare run ID (e.g. "p-17805b61") → default entity/project
     if m := _BARE_RUN_ID_RE.match(s):
         return DEFAULT_WANDB_ENTITY, DEFAULT_WANDB_PROJECT, m.group(1)
 
@@ -128,7 +132,7 @@ def parse_wandb_run_path(input_path: str) -> tuple[str, str, str]:
 
     raise ValueError(
         f"Invalid W&B run reference. Expected one of:\n"
-        f' - "s-xxxxxxxx" (bare run ID)\n'
+        f' - "p-xxxxxxxx" (bare PD run ID)\n'
         f' - "entity/project/xxxxxxxx"\n'
         f' - "entity/project/runs/xxxxxxxx"\n'
         f' - "wandb:entity/project/runs/xxxxxxxx"\n'

--- a/tests/scripts_run/test_main.py
+++ b/tests/scripts_run/test_main.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 import pytest
 import yaml
 
-from param_decomp.configs import RuntimeConfig
 from param_decomp.experiments.discovery import discover_experiments
 from param_decomp.run import Run
 from param_decomp.settings import REPO_ROOT
@@ -67,7 +66,6 @@ class TestLaunchSlurm:
             launchable=sweep_spec,
             n_agents=2,
             job_suffix=None,
-            runtime=RuntimeConfig(),
             partition="cpu",
             project="test",
         )
@@ -104,12 +102,11 @@ class TestLaunchSlurm:
 
         base_config = _builtin("tms_5-2")
         logging_data = {**base_config.get("logging", {}), "wandb_run_name": "tms_5-2"}
-        run = Run.from_dict({**base_config, "logging": logging_data})
+        run = Run.model_validate({**base_config, "logging": logging_data})
         launch_slurm(
             launchable=run,
             n_agents=None,
             job_suffix=None,
-            runtime=RuntimeConfig(),
             partition="cpu",
             project="test",
         )
@@ -125,7 +122,7 @@ class TestLaunchSlurm:
         from param_decomp.scripts.run_slurm import _build_worker_args
 
         base_config = _builtin("tms_5-2")
-        run = Run.from_dict(base_config)
+        run = Run.model_validate(base_config)
 
         args = _build_worker_args("launch-test", run, "test")
 

--- a/tests/sweeps/test_cartesian.py
+++ b/tests/sweeps/test_cartesian.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import yaml
 
-from param_decomp.run import Run
 from param_decomp.settings import REPO_ROOT
 from param_decomp.sweeps import SweepSpec
 from param_decomp.sweeps.cartesian import cartesian_product, example_cartesian_sweep
@@ -61,19 +60,18 @@ def test_cartesian_run_names_encode_axis_values() -> None:
     }
 
 
-def test_cartesian_product_generates_new_run_ids_from_run_template() -> None:
-    base_config = _base_config()
-    base_run = Run.from_dict(base_config)
+def test_cartesian_product_strips_run_id_from_base_config() -> None:
+    base_config = {**_base_config(), "run_id": "p-deadbeef"}
     spec = cartesian_product(
-        base_config=base_run,
+        base_config=base_config,
         grid={"pd.seed": [0, 1]},
-        description="from run",
+        description="strips run_id",
         driver_path=TMS_DRIVER_PATH,
     )
 
     run_ids = {r.run_id for r in spec.runs}
     assert len(run_ids) == 2
-    assert base_run.run_id not in run_ids
+    assert "p-deadbeef" not in run_ids
 
 
 def test_example_cartesian_sweep_smoke() -> None:

--- a/tests/sweeps/test_load.py
+++ b/tests/sweeps/test_load.py
@@ -28,7 +28,7 @@ def test_load_and_call(tmp_path: Path) -> None:
         "    return SweepSpec(\n"
         '        description="tiny",\n'
         "        runs=[\n"
-        "            Run.from_dict({**config, 'driver_path': DRIVER}),\n"
+        "            Run.model_validate({**config, 'driver_path': DRIVER}),\n"
         "        ],\n"
         "    )\n",
     )

--- a/tests/test_experiment_runner_inputs.py
+++ b/tests/test_experiment_runner_inputs.py
@@ -53,7 +53,7 @@ def test_rerun_loads_driver_from_run(tmp_path: Path) -> None:
     config_data["pd"]["seed"] = 123
     run_path = tmp_path / RUN_METADATA_FILENAME
     driver_path = config_data["driver_path"]
-    run = Run.from_dict(config_data)
+    run = Run.model_validate(config_data)
     run.write(run_path)
 
     raw = _resolve_source(experiment=None, config_path=None, rerun=str(run_path.parent))
@@ -65,12 +65,12 @@ def test_rerun_loads_driver_from_run(tmp_path: Path) -> None:
 
 def test_rerun_drops_saved_run_id(tmp_path: Path) -> None:
     config_data = _builtin("tms_5-2")
-    run = Run.from_dict(config_data)
+    run = Run.model_validate(config_data)
     run.write(tmp_path / RUN_METADATA_FILENAME)
     original_run_id = run.run_id
 
     raw = _resolve_source(experiment=None, config_path=None, rerun=str(tmp_path))
-    new_run = Run.from_dict(raw)
+    new_run = Run.model_validate(raw)
 
     assert "run_id" not in raw
     assert new_run.run_id != original_run_id

--- a/tests/test_run_round_trip.py
+++ b/tests/test_run_round_trip.py
@@ -80,8 +80,8 @@ def _runtime_config() -> RuntimeConfig:
 
 
 def _round_trip(run: Run) -> Run:
-    """Round-trip ``run`` through ``model_dump`` → ``Run.from_dict``."""
-    return Run.from_dict(run.model_dump(mode="json"))
+    """Round-trip ``run`` through ``model_dump`` → ``Run.model_validate``."""
+    return Run.model_validate(run.model_dump(mode="json"))
 
 
 def test_run_generates_run_id_on_instantiation():
@@ -154,7 +154,7 @@ def test_run_requires_runtime_config():
     }
 
     with pytest.raises(ValidationError, match="runtime"):
-        Run.from_dict(data)
+        Run.model_validate(data)
 
 
 def test_driver_class_paths_load():


### PR DESCRIPTION
## Summary

Behavior-preserving cleanups from the review of `refactor/runtime-config`. No algorithmic effect on training.

### Driver-path + Run dispatch
- New `param_decomp/driver_path.py` holds the single `module:attr` resolver. `run.py` and `experiments/driver.py` both consume it; the manually duplicated `_load_config_type` in `run.py` is gone.
- `Run` dispatches to the right subclass via a `mode=\"wrap\"` model validator on `model_validate`. Dedicated `from_dict` / `from_file` overrides are gone — callers use `Run.model_validate(...)` / `Run.from_file(...)` (inherited from `BaseConfig`) and get back the right subtype.
- Friendlier error when a config has extra fields but no `driver_path`.
- Drops now-redundant `isinstance(run, driver.config_type)` asserts from `saved_run.py` and `_worker.py`.

### Runner & launcher
- `--rerun` no longer parses pydantic twice. Drops the now-unused `PDRun.run_from_path` classmethod; `pretrain_info.py`'s one caller switches to `resolve_config_path` + `Run.from_file`.
- `launch_slurm` no longer takes a redundant `runtime` arg — derives it from the `Run`/`SweepSpec`.
- `_resolve_sweep_spec` inlined.
- User-supplied `wandb_run_name` in the YAML now wins over the auto-derived name (was silently overwritten).

### Docs / strings
- Drop the legacy `s-` prefix from `_BARE_RUN_ID_RE` and the misleading 8-char-no-prefix comment. PD now mints `p-…` IDs; legacy `s-…` still resolves via the full `entity/project/runs/id` form.
- Drop the stale `BaseConfig` config_type TODO.
- Drop the apologetic note from `save_file`; tighten the docstring.
- Drop two \"reverse the order of these two calls\" TODOs around `torch.cuda.empty_cache()` / `gc.collect()`. Reversed.
- Replace the determinism-ladder copy-paste in `RuntimeConfig` / `LoggingConfig` / `PDConfig` docstrings (and CLAUDE.md) with a short \"what each config controls\" description. Drops bit-identical-weights claims.

### Other
- `apply_nested_updates` moved next to its only caller (`sweeps/cartesian.py`) and made module-private.
- `cartesian_product` no longer accepts a `Run` input (dict only); uses `Run.model_validate` directly.
- `wandb.apis.public.Run` aliased to `WandbRun` in `run_files.py` to stop shadowing the param-decomp `Run`.
- `_LossCapableMetricsConfig` fields grouped by family with section comments.
- `PDConfig.all_module_info` becomes `@cached_property`; `BaseConfig` adds `cached_property` to `ignored_types` so frozen models support it.

## Test plan

- [x] \`make check\` (basedpyright + ruff)
- [x] \`make test\` (461 passed)
- [ ] Smoke-launch a TMS run end-to-end on cluster if you want extra confidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)