### PR TITLE
refactor: Move RunSink.for_run out of the class; clarify the notebook factories

### DIFF
--- a/param_decomp/run_pd.py
+++ b/param_decomp/run_pd.py
@@ -20,6 +20,7 @@ indirection.
 """
 
 import gc
+import os
 from collections import defaultdict
 from functools import partial
 from pathlib import Path
@@ -28,6 +29,7 @@ from typing import Any, cast
 import torch
 import torch.nn as nn
 import torch.nn.parallel
+import wandb
 from jaxtyping import Float
 from torch import Tensor, optim
 from torch.nn.utils import clip_grad_norm_
@@ -50,8 +52,9 @@ from param_decomp.models.batch_and_loss_fns import (
     move_batch_to_device,
 )
 from param_decomp.models.component_model import ComponentModel, OutputWithCache
-from param_decomp.run import RunConfig
+from param_decomp.run import RUN_CONFIG_FILENAME, RunConfig
 from param_decomp.run_sink import RunSink
+from param_decomp.settings import PARAM_DECOMP_OUT_DIR
 from param_decomp.utils.data_utils import loop_dataloader
 from param_decomp.utils.distributed_utils import (
     DistributedState,
@@ -68,6 +71,7 @@ from param_decomp.utils.general_utils import (
 )
 from param_decomp.utils.logging_utils import get_grad_norms_dict
 from param_decomp.utils.module_utils import expand_module_patterns
+from param_decomp.utils.wandb_utils import init_wandb
 
 
 def materialize_run(
@@ -433,6 +437,63 @@ def optimize(
         logger.info("Finished training loop.")
 
 
+def _run_sink_for_run_config(
+    run_cfg: RunConfig,
+    *,
+    driver: ExperimentDriver[Any],
+    wandb_project: str | None,
+    launch_id: str | None,
+) -> RunSink:
+    """Build a ``RunSink`` tied to a ``RunConfig`` — the framework's
+    driver-mediated equivalent of ``RunSink.local`` / ``RunSink.with_wandb``.
+
+    Called only by ``run_pd``. Not part of ``RunSink``'s public surface because
+    it's stuffed full of framework-specific concerns (run_id-derived out_dir,
+    writes ``run_config.yaml``, wandb tags from driver name + ``launch_id`` +
+    ``$SLURM_ARRAY_JOB_ID``).
+
+    On non-main ranks: skips all I/O and returns a no-op sink.
+    """
+    if not is_main_process():
+        return RunSink.silent()
+
+    out_dir = PARAM_DECOMP_OUT_DIR / "decompositions" / run_cfg.run_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+    run_cfg.write(out_dir / RUN_CONFIG_FILENAME)
+    logger.info(f"Run ID: {run_cfg.run_id}")
+    logger.info(f"Output directory: {out_dir}")
+    logger.info(run_cfg.pd)
+
+    if wandb_project is None:
+        return RunSink(out_dir=out_dir, _wandb_active=False)
+
+    init_wandb(
+        wandb_project,
+        run_cfg.run_id,
+        configs={
+            "pd": run_cfg.pd,
+            "logging": run_cfg.logging,
+            "runtime": run_cfg.runtime,
+        },
+        name=run_cfg.name,
+        tags=_wandb_tags(driver_name=driver.name, launch_id=launch_id),
+        view_meta=run_cfg.view_meta,
+    )
+    wandb.save(str(out_dir / RUN_CONFIG_FILENAME), base_path=out_dir, policy="now")
+    return RunSink(out_dir=out_dir, _wandb_active=True)
+
+
+def _wandb_tags(*, driver_name: str, launch_id: str | None) -> list[str]:
+    """Tags attached to every wandb run from ``_run_sink_for_run_config``."""
+    tags = [driver_name]
+    if launch_id is not None:
+        tags.append(launch_id)
+    slurm_array_job_id = os.getenv("SLURM_ARRAY_JOB_ID")
+    if slurm_array_job_id is not None:
+        tags.append(f"slurm-array-job-id_{slurm_array_job_id}")
+    return tags
+
+
 def run_pd(
     run_cfg: RunConfig,
     *,
@@ -444,18 +505,18 @@ def run_pd(
     """Driver-mediated PD run. Composition root for ``pd-run`` / ``_worker.py``.
 
     Steps:
-    1. Resolve the driver once. Threaded to both ``materialize_run`` and
-       ``RunSink.for_run`` so we don't ``load_driver(...)`` twice.
+    1. Resolve the driver once, thread to both ``materialize_run`` and
+       ``_run_sink_for_run_config`` (so no double ``load_driver``).
     2. Materialize ``(target, train_loader, eval_loader)`` via the driver.
-    3. Build a ``RunSink.for_run`` — creates ``PARAM_DECOMP_OUT_DIR/
-       decompositions/<run_id>/``, writes ``run_config.yaml``, inits wandb if
-       ``wandb_project`` is set.
+    3. Build a ``RunSink`` tied to the ``RunConfig`` (creates
+       ``PARAM_DECOMP_OUT_DIR/decompositions/<run_id>/``, writes
+       ``run_config.yaml``, inits wandb if ``wandb_project`` is set).
     4. Hand off to ``optimize`` with the sink.
     5. ``sink.finish()`` for wandb cleanup.
 
     For notebook / script use, call ``optimize(...)`` directly with a
-    ``RunSink`` of your choosing (``RunSink.local`` / ``RunSink.with_wandb`` /
-    ``RunSink.silent``).
+    ``RunSink`` of your choosing (``RunSink.silent`` / ``RunSink.local`` /
+    ``RunSink.with_wandb``).
 
     ``wandb_project`` is a deploy-time parameter (which W&B account/project to
     log to), not part of the reproducible ``RunConfig``. ``None`` disables W&B.
@@ -471,7 +532,9 @@ def run_pd(
     )
     # target.model lands on `device` via ComponentModel.to(device) inside optimize().
 
-    sink = RunSink.for_run(run_cfg, wandb_project=wandb_project, launch_id=launch_id, driver=driver)
+    sink = _run_sink_for_run_config(
+        run_cfg, driver=driver, wandb_project=wandb_project, launch_id=launch_id
+    )
     try:
         optimize(
             target=target,

--- a/param_decomp/run_sink.py
+++ b/param_decomp/run_sink.py
@@ -5,26 +5,11 @@ training) → `SavedRun` (reader after). A `RunSink` lives inside the training
 process for its duration and dies with it; it owns the active `wandb.run`
 session and the on-disk output directory for the run.
 
-Three usage modes:
-
-    # Driver-mediated (run_pd does this for you):
-    sink = RunSink.for_run(run_cfg, *, wandb_project=..., launch_id=...)
-
-    # Notebook with local persistence:
-    sink = RunSink.local(Path("/tmp/my_run"))
-
-    # Notebook with local + wandb:
-    sink = RunSink.with_wandb(Path("/tmp/my_run"), project="my-proj")
-
-    # No persistence (tests, quick checks):
-    sink = RunSink.silent()
-
-All ranks construct a sink; non-main ranks transparently get a no-op sink
-(`out_dir` is `None`, wandb is treated as inactive). The trainer never has
-to check rank for logging.
+For driver-mediated runs, ``run_pd`` constructs a sink for you via its own
+internal helper — you don't touch ``RunSink`` directly. The three public
+constructors below are the notebook / script entry points.
 """
 
-import os
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -33,23 +18,36 @@ import wandb
 from PIL import Image
 from tqdm import tqdm
 
-from param_decomp.driver_path import load_driver
-from param_decomp.experiments.driver import ExperimentDriver
 from param_decomp.log import logger
-from param_decomp.run import RUN_CONFIG_FILENAME, RunConfig
-from param_decomp.settings import PARAM_DECOMP_OUT_DIR
 from param_decomp.utils.distributed_utils import is_main_process
 from param_decomp.utils.logging_utils import local_log
 from param_decomp.utils.run_utils import save_file
-from param_decomp.utils.wandb_utils import init_wandb, try_wandb
+from param_decomp.utils.wandb_utils import try_wandb
 
 
 @dataclass(frozen=True)
 class RunSink:
-    """Side-effect sink for a training run: structured metrics + checkpoints + console.
+    """Side-effect sink for a training run: metrics + checkpoints + console output.
 
-    Construct via one of the classmethods, not ``__init__`` directly. Non-main
-    ranks always get a no-op sink (``out_dir=None``, ``_wandb_active=False``).
+    Construct via one of the classmethods, not ``__init__`` directly. The
+    three notebook constructors map to the three useful combinations of
+    ``(out_dir, wandb)``:
+
+        |              | no out_dir   | with out_dir                       |
+        |--------------|--------------|------------------------------------|
+        | no wandb     | ``silent()`` | ``local(out_dir)``                 |
+        | with wandb   |  (n/a)       | ``with_wandb(out_dir, project=…)`` |
+
+    The (no out_dir, with wandb) combination is omitted because a wandb-only
+    run can't be reloaded later — if you want wandb you almost always want a
+    local copy of the checkpoint too.
+
+    Driver-mediated runs (``pd-run`` / ``_worker.py``) don't use these
+    classmethods — they go through ``run_pd``, which constructs a sink via
+    an internal helper that knows about ``RunConfig`` fields.
+
+    Non-main DDP ranks transparently get a no-op sink (``out_dir=None``,
+    ``_wandb_active=False``). The trainer never has to check rank for logging.
     """
 
     out_dir: Path | None
@@ -58,58 +56,13 @@ class RunSink:
     # =========================== Constructors ===========================
 
     @classmethod
-    def for_run(
-        cls,
-        run_cfg: RunConfig,
-        *,
-        wandb_project: str | None = None,
-        launch_id: str | None = None,
-        driver: ExperimentDriver[Any] | None = None,
-    ) -> "RunSink":
-        """Driver-mediated setup. Used by ``run_pd``.
-
-        On the main rank: creates ``PARAM_DECOMP_OUT_DIR/decompositions/<run_id>/``,
-        writes ``run_config.yaml`` next to (eventual) checkpoints, and (if
-        ``wandb_project`` is set) inits wandb with tags derived from the driver
-        name + ``launch_id`` + ``$SLURM_ARRAY_JOB_ID``.
-
-        Pass ``driver=...`` if you've already resolved it (avoids a second
-        ``load_driver`` call). Otherwise resolved internally.
-
-        On non-main ranks: skips all the I/O and returns a no-op handle.
-        """
-        if not is_main_process():
-            return cls(out_dir=None, _wandb_active=False)
-
-        out_dir = PARAM_DECOMP_OUT_DIR / "decompositions" / run_cfg.run_id
-        out_dir.mkdir(parents=True, exist_ok=True)
-        run_cfg.write(out_dir / RUN_CONFIG_FILENAME)
-        logger.info(f"Run ID: {run_cfg.run_id}")
-        logger.info(f"Output directory: {out_dir}")
-
-        wandb_active = False
-        if wandb_project:
-            resolved_driver = driver if driver is not None else load_driver(run_cfg.driver_path)
-            init_wandb(
-                wandb_project,
-                run_cfg.run_id,
-                configs={
-                    "pd": run_cfg.pd,
-                    "logging": run_cfg.logging,
-                    "runtime": run_cfg.runtime,
-                },
-                name=run_cfg.name,
-                tags=_wandb_tags(driver_name=resolved_driver.name, launch_id=launch_id),
-                view_meta=run_cfg.view_meta,
-            )
-            wandb.save(str(out_dir / RUN_CONFIG_FILENAME), base_path=out_dir, policy="now")
-            wandb_active = True
-        logger.info(run_cfg.pd)
-        return cls(out_dir=out_dir, _wandb_active=wandb_active)
+    def silent(cls) -> "RunSink":
+        """No persistence, no wandb. Useful for tests / quick interactive runs."""
+        return cls(out_dir=None, _wandb_active=False)
 
     @classmethod
     def local(cls, out_dir: Path) -> "RunSink":
-        """Notebook: local-files-only sink. No wandb."""
+        """Local-files-only sink. No wandb."""
         if not is_main_process():
             return cls(out_dir=None, _wandb_active=False)
         out_dir.mkdir(parents=True, exist_ok=True)
@@ -125,17 +78,12 @@ class RunSink:
         tags: list[str] | None = None,
         config: dict[str, Any] | None = None,
     ) -> "RunSink":
-        """Notebook: local files + wandb. Inits wandb with the given project/name/tags."""
+        """Local files + wandb. Calls ``wandb.init(...)`` with the given project/name/tags."""
         if not is_main_process():
             return cls(out_dir=None, _wandb_active=False)
         out_dir.mkdir(parents=True, exist_ok=True)
         wandb.init(project=project, name=name, tags=tags or [], config=config or {})
         return cls(out_dir=out_dir, _wandb_active=True)
-
-    @classmethod
-    def silent(cls) -> "RunSink":
-        """No persistence, no wandb. Useful for tests / quick interactive runs."""
-        return cls(out_dir=None, _wandb_active=False)
 
     # =========================== Output API ===========================
 
@@ -191,14 +139,3 @@ def _wandb_value(v: Any) -> Any:
     if isinstance(v, Image.Image):
         return wandb.Image(v)
     return v
-
-
-def _wandb_tags(*, driver_name: str, launch_id: str | None) -> list[str]:
-    """Tags attached to every wandb run from ``RunSink.for_run``."""
-    tags = [driver_name]
-    if launch_id is not None:
-        tags.append(launch_id)
-    slurm_array_job_id = os.getenv("SLURM_ARRAY_JOB_ID")
-    if slurm_array_job_id is not None:
-        tags.append(f"slurm-array-job-id_{slurm_array_job_id}")
-    return tags


### PR DESCRIPTION
Follow-up to #508.

The `RunSink` classmethods (`for_run` / `local` / `with_wandb` / `silent`) had no obvious shared structure. They served two conceptually different purposes mashed into one namespace:

- **Three notebook constructors** (`silent` / `local` / `with_wandb`) — caller picks the presence/absence of `out_dir` + wandb.
- **One framework constructor** (`for_run`) — derives `out_dir` from `run_cfg.run_id`, writes `run_config.yaml`, tags wandb with `driver.name` + `launch_id` + `\$SLURM_ARRAY_JOB_ID`. Only ever called by `run_pd`.

## Changes

- **Move `RunSink.for_run` out of the class** into `run_pd.py` as a private `_run_sink_for_run_config(run_cfg, *, driver, wandb_project, launch_id)`. Same body, just relocated next to its only caller. `_wandb_tags` moves with it.
- **`RunSink`'s public surface is now just three notebook constructors.** Class docstring shows the matrix explicitly:

```
|              | no out_dir   | with out_dir                       |
|--------------|--------------|------------------------------------|
| no wandb     | silent()     | local(out_dir)                     |
| with wandb   |  (n/a)       | with_wandb(out_dir, project=…)     |
```

  Plus a note that driver-mediated callers don't use these — they go through `run_pd`.

- **`run_pd` updated** to call `_run_sink_for_run_config(...)` instead of `RunSink.for_run(...)`. No behavior change.

## Test plan

- [x] `make type` — 0 errors
- [x] `make test` — 463 passed, 7 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)