### PR TITLE
refactor: flatten RunConfig — drop per-driver subclasses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,25 +68,44 @@ from param_decomp import (
 
 ### Experiment Drivers
 
-Experiments are open-world drivers, not a closed discriminated union in core code. A driver owns a
-pure Pydantic `RunConfig` subclass and converts it to runtime objects:
+Experiments are open-world drivers, not a closed discriminated union in core code. There is a
+single `RunConfig` class — `target` and `data` are stored as raw `dict[str, Any]` payloads owned
+by the driver. The driver provides its own pydantic models for those payloads and validates them
+inside `validate_config` (called pre-flight by `pd-run` and the sweep launcher) and at the top of
+each `build_*` method:
 
 ```python
-class MyRunConfig(RunConfig):
-    target: MyTargetConfig
-    data: MyDataConfig
+class MyTargetConfig(BaseConfig):
+    model_path: str
+    # ... whatever the driver needs
+
+class MyDataConfig(BaseConfig):
+    dataset_name: str
+    # ...
 
 class MyDriver:
     name = "my_exp"                  # ClassVar[str] — wandb tag
-    config_type = MyRunConfig        # ClassVar[type[RunConfig]]
 
-    def build_target(self, run_cfg: MyRunConfig) -> PDTarget: ...
-    def build_dataloaders(self, run_cfg: MyRunConfig, *, train_batch_size, eval_batch_size, ...): ...
+    def validate_config(self, run_cfg: RunConfig) -> None:
+        MyTargetConfig.model_validate(run_cfg.target)
+        MyDataConfig.model_validate(run_cfg.data)
+
+    def build_target(self, run_cfg: RunConfig) -> PDTarget:
+        target = MyTargetConfig.model_validate(run_cfg.target)
+        ...
+
+    def build_train_loader(self, run_cfg: RunConfig, *, device, batch_size_override=None, dist_state=None): ...
+    def build_eval_loader(self, run_cfg: RunConfig, *, device, batch_size_override=None, dist_state=None): ...
 ```
 
-`build_target` and `build_dataloaders` always fetch from upstream (wandb pretrain run, HF, …);
-reload calls them exactly like a fresh run. Saved PD runs therefore depend on their upstream
-continuing to exist — the wandb run path / HF model name in the config is the pin.
+Driver-specific callers that need typed access from outside the driver can expose small accessor
+helpers in the driver module — see `is_lm_run` / `lm_target` / `lm_data` in
+`param_decomp/experiments/lm/experiment.py` for the pattern.
+
+`build_target`, `build_train_loader`, and `build_eval_loader` always fetch from upstream
+(wandb pretrain run, HF, …); reload calls them exactly like a fresh run. Saved PD runs therefore
+depend on their upstream continuing to exist — the wandb run path / HF model name in the config
+is the pin.
 
 Built-in runtime definitions live in `param_decomp/experiments/{lm,tms,resid_mlp}/experiment.py`.
 Custom users can run without editing core code by declaring the driver at the top of their YAML:
@@ -135,16 +154,15 @@ The user's module imports `register_metric` and `LossMetricConfig` / `MetricConf
 installed in (or otherwise importable from) the Python environment used to run / reload the
 experiment — including SLURM workers.
 
-### Per-experiment `RunConfig` subclasses
+### `RunConfig` shape
 
 Built-in YAML configs are pure `RunConfig` configs nested under `driver_path:`, `pd:`,
-`logging:`, `runtime:`, `target:`, and `data:`:
+`logging:`, `runtime:`, `target:`, and `data:`. There is one `RunConfig` class; `target` and
+`data` are raw `dict[str, Any]` payloads validated by the driver named in `driver_path`. The
+driver provides its own pydantic models (e.g. `LMTargetConfig`, `LMDataConfig`,
+`TMSTargetConfig`, …) and calls `model_validate` inside `validate_config` and each `build_*`.
 
-- `LMRunConfig(driver_path, pd, logging, runtime, target: LMTargetConfig, data: LMDataConfig)`
-- `TMSRunConfig(driver_path, pd, logging, runtime, target, data)`
-- `ResidMLPRunConfig(driver_path, pd, logging, runtime, target, data)`
-
-The three configs split by **what they affect**:
+The three core configs split by **what they affect**:
 
 - **`PDConfig`** — algorithm specification: seed, ci_config, losses, optimizers,
   module_info. Flipping any field here changes what algorithm runs.
@@ -280,7 +298,7 @@ Each experiment (`param_decomp/experiments/{tms,resid_mlp,lm}/`) contains:
 **Key Data Flow:**
 
 1. `pd-run` (`experiments/runner.py`) resolves the input source — either a built-in experiment name, `--config_path`, `--rerun`, or `--sweep_generator_path` — into a `RunConfig` (single launch) or a `SweepSpec` (many `RunConfig`s sharing one driver and substrate). Every YAML/saved `RunConfig` declares its driver via a top-level `driver_path:` field. With `--local` it dispatches in-process; otherwise `scripts/run_slurm.py:launch_run_slurm` submits a plain SLURM job (single `RunConfig`) and `launch_sweep_slurm` submits an array — one task per run — (`SweepSpec`).
-2. Each worker invocation (`experiments/_worker.py`, called as `python -m param_decomp.experiments._worker` from SLURM tasks, or directly from runner.py in --local mode) loads the driver, checks that the parsed `RunConfig` matches the driver's `config_type`, and calls the driver to build `PDTarget` plus train/eval loaders.
+2. Each worker invocation (`experiments/_worker.py`, called as `python -m param_decomp.experiments._worker` from SLURM tasks, or directly from runner.py in --local mode) loads the driver and calls it to build `PDTarget` plus train/eval loaders. Each `build_*` method validates its slice of `run_cfg.target` / `run_cfg.data` via the driver's own pydantic models; the launcher additionally calls `driver.validate_config(run_cfg)` pre-flight so bad configs fail before SLURM submit.
 3. The worker passes the typed `RunConfig` through to `run_pd`.
 4. `run_pd` saves the `RunConfig` / artifacts and trains a `ComponentModel` via `optimize()` with config-driven losses.
 5. Post-processing reloads runs through `SavedRun.load_target()` / `SavedRun.build_train_loader(...)` / `SavedRun.build_eval_loader(...)` (or just `SavedRun.load_model()` / `load_component_model(path)`).

--- a/param_decomp/__init__.py
+++ b/param_decomp/__init__.py
@@ -26,9 +26,12 @@ Reload:
 Core types:
     - `PDConfig`: training/algorithm config.
     - `PDTarget`: target model + run_batch + reconstruction_loss.
-    - `RunConfig`: serializable spec for a driver-mediated run.
-      Driver-specific subclasses (LMRunConfig, TMSRunConfig, ResidMLPRunConfig) add target/data.
-    - `ExperimentDriver`: Protocol for the open-world experiment extension point.
+    - `RunConfig`: serializable spec for a driver-mediated run. Single class —
+      `target` and `data` are stored as raw `dict[str, Any]` payloads and
+      interpreted by the driver (no per-driver subclass).
+    - `ExperimentDriver`: Protocol for the open-world experiment extension
+      point. Drivers validate their typed `target` / `data` via
+      `validate_config` and re-parse inside each `build_*` method.
     - `RunSink`: output channels (local files + opportunistic wandb +
       checkpoints) for a training run. Constructors:
       `RunSink.for_run(run_cfg, ...)` (driver-mediated),

--- a/param_decomp/adapters/param_decomp.py
+++ b/param_decomp/adapters/param_decomp.py
@@ -6,7 +6,7 @@ from torch.utils.data import DataLoader
 
 from param_decomp.adapters.base import DecompositionAdapter
 from param_decomp.autointerp.schemas import ModelMetadata
-from param_decomp.experiments.lm.experiment import LMRunConfig
+from param_decomp.experiments.lm.experiment import lm_data, lm_target
 from param_decomp.models.component_model import ComponentModel
 from param_decomp.run import RunConfig
 from param_decomp.saved_run import SavedRun
@@ -27,14 +27,6 @@ class PDAdapter(DecompositionAdapter):
     def run(self) -> RunConfig:
         assert self.pd_run.run_cfg is not None  # always set on from_path handles
         return self.pd_run.run_cfg
-
-    @cached_property
-    def lm_run(self) -> LMRunConfig:
-        run = self.run
-        assert isinstance(run, LMRunConfig), (
-            f"This method requires an LM run, got {type(run).__name__}"
-        )
-        return run
 
     @cached_property
     def component_model(self) -> ComponentModel:
@@ -62,27 +54,28 @@ class PDAdapter(DecompositionAdapter):
 
     @override
     def dataloader(self, batch_size: int) -> DataLoader[Tensor]:
-        # PDAdapter is LM-only (via `self.lm_run`); the LM driver ignores `device`
-        # because batches are moved per-step.
+        # PDAdapter is LM-only; the LM driver ignores `device` because batches
+        # are moved per-step.
         return self.pd_run.build_train_loader(device="cpu", batch_size_override=batch_size)
 
     @property
     @override
     def tokenizer_name(self) -> str:
-        return self.lm_run.data.tokenizer_name
+        return lm_data(self.run).tokenizer_name
 
     @property
     @override
     def model_metadata(self) -> ModelMetadata:
-        run = self.lm_run
+        target = lm_target(self.run)
+        data = lm_data(self.run)
         return ModelMetadata(
             n_blocks=self._topology.n_blocks,
-            model_class=run.target.model_class,
-            dataset_name=run.data.dataset_name,
+            model_class=target.model_class,
+            dataset_name=data.dataset_name,
             layer_descriptions={
                 path: self._topology.target_to_canon(path)
                 for path in self.component_model.target_module_paths
             },
-            seq_len=run.data.max_seq_len,
+            seq_len=data.max_seq_len,
             decomposition_method="pd",
         )

--- a/param_decomp/app/backend/routers/correlations.py
+++ b/param_decomp/app/backend/routers/correlations.py
@@ -12,6 +12,7 @@ from pydantic import BaseModel
 from param_decomp.app.backend.dependencies import DepLoadedRun
 from param_decomp.app.backend.utils import log_errors
 from param_decomp.autointerp.schemas import ModelMetadata
+from param_decomp.experiments.lm.experiment import lm_data
 from param_decomp.harvest import analysis
 from param_decomp.log import logger
 from param_decomp.topology import TransformerTopology
@@ -200,14 +201,15 @@ async def request_component_interpretation(
             detail=f"Token stats not available for component {component_key}",
         )
 
+    data = lm_data(loaded.experiment_config)
     model_metadata = ModelMetadata(
         n_blocks=loaded.topology.n_blocks,
         model_class=loaded.model.__class__.__name__,
-        dataset_name=loaded.experiment_config.data.dataset_name,
+        dataset_name=data.dataset_name,
         layer_descriptions={
             path: loaded.topology.target_to_canon(path) for path in loaded.model.target_module_paths
         },
-        seq_len=loaded.experiment_config.data.max_seq_len,
+        seq_len=data.max_seq_len,
         decomposition_method="pd",
     )
 

--- a/param_decomp/app/backend/routers/dataset_search.py
+++ b/param_decomp/app/backend/routers/dataset_search.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 from param_decomp.app.backend.dependencies import DepLoadedRun, DepStateManager
 from param_decomp.app.backend.state import DatasetSearchState
 from param_decomp.app.backend.utils import log_errors
+from param_decomp.experiments.lm.experiment import lm_data
 from param_decomp.log import logger
 from param_decomp.utils.distributed_utils import get_device
 
@@ -112,8 +113,9 @@ def search_dataset(
     Returns:
         Search metadata (query, split, dataset_name, total results, search time)
     """
-    dataset_name = loaded.experiment_config.data.dataset_name
-    text_column = loaded.experiment_config.data.column_name
+    data = lm_data(loaded.experiment_config)
+    dataset_name = data.dataset_name
+    text_column = data.column_name
     _assert_simplestories(dataset_name)
 
     start_time = time.time()
@@ -336,8 +338,9 @@ def get_random_samples(
     Returns:
         Random samples with metadata
     """
-    dataset_name = loaded.experiment_config.data.dataset_name
-    text_column = loaded.experiment_config.data.column_name
+    data = lm_data(loaded.experiment_config)
+    dataset_name = data.dataset_name
+    text_column = data.column_name
     _assert_simplestories(dataset_name)
 
     logger.info(f"Loading dataset {dataset_name} (split={split}) for random sampling...")
@@ -417,8 +420,9 @@ def get_random_samples_with_loss(
     Returns:
         Tokenized samples with next-token probability per token
     """
-    dataset_name = loaded.experiment_config.data.dataset_name
-    text_column = loaded.experiment_config.data.column_name
+    data = lm_data(loaded.experiment_config)
+    dataset_name = data.dataset_name
+    text_column = data.column_name
     _assert_simplestories(dataset_name)
 
     device = get_device()

--- a/param_decomp/app/backend/routers/mcp.py
+++ b/param_decomp/app/backend/routers/mcp.py
@@ -893,10 +893,12 @@ def _tool_search_dataset(params: dict[str, Any]) -> dict[str, Any]:
     from datasets import Dataset, load_dataset
 
     from param_decomp.app.backend.routers.dataset_search import _assert_simplestories
+    from param_decomp.experiments.lm.experiment import lm_data
 
     _, loaded = _get_state()
-    dataset_name = loaded.experiment_config.data.dataset_name
-    text_column = loaded.experiment_config.data.column_name
+    data = lm_data(loaded.experiment_config)
+    dataset_name = data.dataset_name
+    text_column = data.column_name
     _assert_simplestories(dataset_name)
 
     query = params["query"]

--- a/param_decomp/app/backend/routers/pretrain_info.py
+++ b/param_decomp/app/backend/routers/pretrain_info.py
@@ -13,8 +13,9 @@ from pydantic import BaseModel
 
 from param_decomp.app.backend.dependencies import DepLoadedRun
 from param_decomp.app.backend.utils import log_errors
-from param_decomp.experiments.lm.experiment import LMRunConfig
+from param_decomp.experiments.lm.experiment import is_lm_run, lm_target
 from param_decomp.log import logger
+from param_decomp.run import RunConfig
 from param_decomp.settings import PARAM_DECOMP_OUT_DIR
 from param_decomp.utils.wandb_utils import parse_wandb_run_path
 
@@ -44,12 +45,12 @@ class PretrainInfoResponse(BaseModel):
     topology: TopologyInfo | None
 
 
-def _load_lm_run_lightweight(wandb_path: str) -> LMRunConfig | None:
+def _load_lm_run_lightweight(wandb_path: str) -> RunConfig | None:
     """Load just the `RunConfig` for an LM run, without downloading checkpoints."""
     from param_decomp.saved_run import SavedRun
 
     run = SavedRun.run_cfg_from_path(wandb_path)
-    if not isinstance(run, LMRunConfig):
+    if not is_lm_run(run):
         return None
     return run
 
@@ -176,7 +177,7 @@ def _get_dataset_short(pretrain_config: dict[str, Any] | None) -> str | None:
     return None
 
 
-def _get_pretrain_info(lm_exp: LMRunConfig | None) -> PretrainInfoResponse:
+def _get_pretrain_info(lm_exp: RunConfig | None) -> PretrainInfoResponse:
     """Extract pretrain info from an LM experiment config."""
     if lm_exp is None:
         return PretrainInfoResponse(
@@ -189,11 +190,12 @@ def _get_pretrain_info(lm_exp: LMRunConfig | None) -> PretrainInfoResponse:
             topology=None,
         )
 
-    model_class_name = lm_exp.target.model_class
+    target = lm_target(lm_exp)
+    model_class_name = target.model_class
     model_type = model_class_name.rsplit(".", 1)[-1]
 
-    pretrain_path = lm_exp.target.model_name or (
-        str(lm_exp.target.model_path) if lm_exp.target.model_path is not None else None
+    pretrain_path = target.model_name or (
+        str(target.model_path) if target.model_path is not None else None
     )
 
     target_model_config: dict[str, Any] | None = None

--- a/param_decomp/app/backend/routers/runs.py
+++ b/param_decomp/app/backend/routers/runs.py
@@ -14,7 +14,7 @@ from param_decomp.app.backend.state import RunState
 from param_decomp.app.backend.utils import log_errors
 from param_decomp.autointerp.repo import InterpRepo
 from param_decomp.dataset_attributions.repo import AttributionRepo
-from param_decomp.experiments.lm.experiment import LMRunConfig
+from param_decomp.experiments.lm.experiment import is_lm_run, lm_data
 from param_decomp.graph_interp.repo import GraphInterpRepo
 from param_decomp.harvest.repo import HarvestRepo
 from param_decomp.log import logger
@@ -74,7 +74,7 @@ def load_run(wandb_path: str, context_length: int, manager: DepStateManager):
     logger.info(f"[API] Loading {clean_wandb_path}")
     pd_run = SavedRun.from_path(clean_wandb_path)
     exp = pd_run.run_cfg
-    if not isinstance(exp, LMRunConfig):
+    if not is_lm_run(exp):
         raise HTTPException(
             status_code=400,
             detail=(
@@ -82,6 +82,7 @@ def load_run(wandb_path: str, context_length: int, manager: DepStateManager):
                 "the token-based app. Use an LM run."
             ),
         )
+    exp_data = lm_data(exp)
 
     run = db.get_run_by_wandb_path(clean_wandb_path)
     if run is None:
@@ -116,8 +117,8 @@ def load_run(wandb_path: str, context_length: int, manager: DepStateManager):
     model.eval()
 
     pd_config = pd_run.pd_config
-    logger.info(f"[API] Loading tokenizer for run {run.id}: {exp.data.tokenizer_name}")
-    app_tokenizer = AppTokenizer.from_pretrained(exp.data.tokenizer_name)
+    logger.info(f"[API] Loading tokenizer for run {run.id}: {exp_data.tokenizer_name}")
+    app_tokenizer = AppTokenizer.from_pretrained(exp_data.tokenizer_name)
 
     # Build topology and sources_by_target mapping
     logger.info(f"[API] Building topology for run {run.id}")
@@ -162,7 +163,7 @@ def get_status(manager: DepStateManager) -> LoadedRun | None:
     prompt_count = manager.db.get_prompt_count(run.id, context_length)
 
     dataset_search_enabled = (
-        manager.run_state.experiment_config.data.dataset_name in _SEARCHABLE_DATASETS
+        lm_data(manager.run_state.experiment_config).dataset_name in _SEARCHABLE_DATASETS
     )
 
     return LoadedRun(

--- a/param_decomp/app/backend/state.py
+++ b/param_decomp/app/backend/state.py
@@ -18,10 +18,10 @@ from param_decomp.app.backend.database import PromptAttrDB, Run
 from param_decomp.autointerp.repo import InterpRepo
 from param_decomp.configs import PDConfig
 from param_decomp.dataset_attributions.repo import AttributionRepo
-from param_decomp.experiments.lm.experiment import LMRunConfig
 from param_decomp.graph_interp.repo import GraphInterpRepo
 from param_decomp.harvest.repo import HarvestRepo
 from param_decomp.models.component_model import ComponentModel
+from param_decomp.run import RunConfig
 from param_decomp.topology import TransformerTopology
 
 
@@ -35,7 +35,7 @@ class RunState:
     tokenizer: AppTokenizer
     sources_by_target: dict[str, list[str]]
     config: PDConfig
-    experiment_config: LMRunConfig  # The token-based app only loads LM runs.
+    experiment_config: RunConfig  # The token-based app only loads LM runs; gated upstream.
     context_length: int
     harvest: HarvestRepo | None
     interp: InterpRepo | None

--- a/param_decomp/clustering/scripts/run_harvest.py
+++ b/param_decomp/clustering/scripts/run_harvest.py
@@ -19,7 +19,7 @@ from param_decomp.clustering.harvest_config import HarvestConfig
 from param_decomp.clustering.memberships import collect_memberships
 from param_decomp.clustering.paths import clustering_harvest_dir, new_harvest_id
 from param_decomp.experiments.lm.data import build_lm_train_loader
-from param_decomp.experiments.lm.experiment import LMRunConfig
+from param_decomp.experiments.lm.experiment import is_lm_run, lm_data
 from param_decomp.log import logger
 from param_decomp.saved_run import SavedRun
 from param_decomp.utils.distributed_utils import get_device
@@ -40,9 +40,9 @@ def harvest(config: HarvestConfig) -> Path:
     pd_run = SavedRun.from_path(config.model_path)
     # LM goes direct to the helper so we can override the dataset seed
     # (config.dataset_seed) — the driver only takes a batch-size override.
-    if isinstance(pd_run.run_cfg, LMRunConfig):
+    if is_lm_run(pd_run.run_cfg):
         dataloader = build_lm_train_loader(
-            pd_run.run_cfg.data,
+            lm_data(pd_run.run_cfg),
             batch_size=config.batch_size,
             dist_state=None,
             seed=config.dataset_seed,

--- a/param_decomp/dataset_attributions/harvest.py
+++ b/param_decomp/dataset_attributions/harvest.py
@@ -24,7 +24,7 @@ from param_decomp.dataset_attributions.config import DatasetAttributionConfig
 from param_decomp.dataset_attributions.harvester import AttributionHarvester
 from param_decomp.dataset_attributions.storage import DatasetAttributionStorage
 from param_decomp.experiments.lm.data import build_lm_train_loader
-from param_decomp.experiments.lm.experiment import LMRunConfig
+from param_decomp.experiments.lm.experiment import is_lm_run, lm_data
 from param_decomp.harvest.repo import HarvestRepo
 from param_decomp.log import logger
 from param_decomp.models.component_model import ComponentModel
@@ -78,15 +78,15 @@ def harvest_attributions(
 
     pd_run = SavedRun.from_path(config.wandb_path)
     exp = pd_run.run_cfg
-    assert isinstance(exp, LMRunConfig), (
-        f"Dataset attributions currently only support LM runs, got {type(exp).__name__}"
+    assert is_lm_run(exp), (
+        f"Dataset attributions currently only support LM runs, got driver {exp.driver_path!r}"
     )
     model = pd_run.load_model().to(device)
     model.eval()
 
     pd_config = pd_run.pd_config
     train_loader = build_lm_train_loader(
-        exp.data,
+        lm_data(exp),
         batch_size=config.batch_size,
         dist_state=None,
         seed=pd_config.seed,

--- a/param_decomp/editing/_editing.py
+++ b/param_decomp/editing/_editing.py
@@ -274,13 +274,13 @@ class EditableModel:
         cls, wandb_path: str, device: str = "cuda"
     ) -> tuple["EditableModel", AppTokenizer]:
         """Load from wandb path. Returns (editable_model, tokenizer)."""
-        from param_decomp.experiments.lm.experiment import LMRunConfig
+        from param_decomp.experiments.lm.experiment import is_lm_run, lm_data
 
         pd_run = SavedRun.from_path(wandb_path)
         exp = pd_run.run_cfg
-        assert isinstance(exp, LMRunConfig)
+        assert is_lm_run(exp), f"EditableModel requires an LM run, got {exp.driver_path!r}"
         model = pd_run.load_model().to(device).eval()
-        tokenizer = AppTokenizer.from_pretrained(exp.data.tokenizer_name)
+        tokenizer = AppTokenizer.from_pretrained(lm_data(exp).tokenizer_name)
         return cls(model), tokenizer
 
     def __call__(self, tokens: Int[Tensor, " seq"]) -> Float[Tensor, "seq vocab"]:

--- a/param_decomp/experiments/_worker.py
+++ b/param_decomp/experiments/_worker.py
@@ -57,7 +57,7 @@ def main(
     wandb_project: str | None = None,
 ) -> None:
     """SLURM task entrypoint."""
-    run = RunConfig.from_dict(json.loads(run_json))
+    run = RunConfig.model_validate(json.loads(run_json))
     run_experiment(run, launch_id=launch_id, wandb_project=wandb_project)
 
 

--- a/param_decomp/experiments/driver.py
+++ b/param_decomp/experiments/driver.py
@@ -5,6 +5,10 @@ An experiment driver is the boundary layer that turns a serializable `RunConfig`
 into those runtime objects. The set of drivers is open-world: custom users can register
 their own driver class without editing core code.
 
+Drivers own the typing of `run_cfg.target` and `run_cfg.data` — core stores both as
+raw dicts. Each driver validates them via its own pydantic models in `validate_config`
+and re-parses at the top of each `build_*` method.
+
 Drivers don't own reload-time state: reload calls `build_target`,
 `build_train_loader`, and `build_eval_loader` exactly like a fresh run,
 re-fetching whatever upstream the config points at (wandb pretrain run, HF model,
@@ -21,23 +25,29 @@ from param_decomp.run import RunConfig
 from param_decomp.utils.distributed_utils import DistributedState
 
 
-class ExperimentDriver[RunConfigT: RunConfig](Protocol):
+class ExperimentDriver(Protocol):
     """Converts a serializable `RunConfig` into runtime PD objects."""
 
     name: ClassVar[str]
 
-    @property
-    def config_type(self) -> type[RunConfigT]:
-        """Pydantic model type used to validate serialized `RunConfig` data."""
+    def validate_config(self, run_cfg: RunConfig) -> None:
+        """Parse driver-private fields (`target`, `data`) and raise on bad shape.
+
+        Implementations call e.g. ``MyTargetConfig.model_validate(run_cfg.target)``
+        and ``MyDataConfig.model_validate(run_cfg.data)``, letting pydantic raise
+        on bad shape. Called pre-flight by ``pd-run`` (single run) and the sweep
+        launcher (so a 200-config sweep dies before SLURM submit, not in task 17).
+        Idempotent and cheap (no I/O).
+        """
         ...
 
-    def build_target(self, run_cfg: RunConfigT) -> PDTarget:
+    def build_target(self, run_cfg: RunConfig) -> PDTarget:
         """Build the target model bundle from upstream."""
         ...
 
     def build_train_loader(
         self,
-        run_cfg: RunConfigT,
+        run_cfg: RunConfig,
         *,
         device: str,
         batch_size_override: int | None = None,
@@ -59,7 +69,7 @@ class ExperimentDriver[RunConfigT: RunConfig](Protocol):
 
     def build_eval_loader(
         self,
-        run_cfg: RunConfigT,
+        run_cfg: RunConfig,
         *,
         device: str,
         batch_size_override: int | None = None,

--- a/param_decomp/experiments/lm/experiment.py
+++ b/param_decomp/experiments/lm/experiment.py
@@ -17,6 +17,8 @@ from param_decomp.types import ModelPath
 from param_decomp.utils.distributed_utils import DistributedState, ensure_cached_and_call
 from param_decomp.utils.general_utils import resolve_class
 
+LM_DRIVER_PATH = "param_decomp.experiments.lm.experiment:Driver"
+
 
 class LMTargetConfig(BaseConfig):
     """How to load the target language model."""
@@ -60,11 +62,6 @@ class LMTargetConfig(BaseConfig):
         return self
 
 
-class LMRunConfig(RunConfig):
-    target: LMTargetConfig
-    data: LMDataConfig
-
-
 def _load_target_model(target_cfg: LMTargetConfig) -> Any:
     model_class = resolve_class(target_cfg.model_class)
     assert hasattr(model_class, "from_pretrained"), (
@@ -91,36 +88,38 @@ def _load_target_model(target_cfg: LMTargetConfig) -> Any:
     return model_class.from_pretrained(target_cfg.model_path)  # pyright: ignore[reportAttributeAccessIssue]
 
 
-class Driver(ExperimentDriver[LMRunConfig]):
+class Driver(ExperimentDriver):
     name: ClassVar[str] = "lm"
 
-    @property
     @override
-    def config_type(self) -> type[LMRunConfig]:
-        return LMRunConfig
+    def validate_config(self, run_cfg: RunConfig) -> None:
+        LMTargetConfig.model_validate(run_cfg.target)
+        LMDataConfig.model_validate(run_cfg.data)
 
     @override
-    def build_target(self, run_cfg: LMRunConfig) -> PDTarget:
-        target_model = _load_target_model(run_cfg.target)
+    def build_target(self, run_cfg: RunConfig) -> PDTarget:
+        target = LMTargetConfig.model_validate(run_cfg.target)
+        target_model = _load_target_model(target)
         target_model.eval()
         return PDTarget(
             model=target_model,
-            run_batch=make_run_batch(run_cfg.target.output_extract),
+            run_batch=make_run_batch(target.output_extract),
             reconstruction_loss=recon_loss_kl,
         )
 
     @override
     def build_train_loader(
         self,
-        run_cfg: LMRunConfig,
+        run_cfg: RunConfig,
         *,
         device: str,
         batch_size_override: int | None = None,
         dist_state: DistributedState | None = None,
     ) -> Any:
         del device  # LM loaders hand off raw tensors; per-batch device move happens later.
+        data = LMDataConfig.model_validate(run_cfg.data)
         return build_lm_train_loader(
-            data_cfg=run_cfg.data,
+            data_cfg=data,
             batch_size=batch_size_override or run_cfg.pd.batch_size,
             seed=run_cfg.pd.seed,
             dist_state=dist_state,
@@ -129,16 +128,35 @@ class Driver(ExperimentDriver[LMRunConfig]):
     @override
     def build_eval_loader(
         self,
-        run_cfg: LMRunConfig,
+        run_cfg: RunConfig,
         *,
         device: str,
         batch_size_override: int | None = None,
         dist_state: DistributedState | None = None,
     ) -> Any:
         del device
+        data = LMDataConfig.model_validate(run_cfg.data)
         return build_lm_eval_loader(
-            data_cfg=run_cfg.data,
+            data_cfg=data,
             batch_size=batch_size_override or run_cfg.logging.eval_batch_size,
             seed=run_cfg.pd.seed,
             dist_state=dist_state,
         )
+
+
+def is_lm_run(run_cfg: RunConfig) -> bool:
+    return run_cfg.driver_path == LM_DRIVER_PATH
+
+
+def lm_target(run_cfg: RunConfig) -> LMTargetConfig:
+    assert is_lm_run(run_cfg), (
+        f"expected LM run (driver_path={LM_DRIVER_PATH!r}), got {run_cfg.driver_path!r}"
+    )
+    return LMTargetConfig.model_validate(run_cfg.target)
+
+
+def lm_data(run_cfg: RunConfig) -> LMDataConfig:
+    assert is_lm_run(run_cfg), (
+        f"expected LM run (driver_path={LM_DRIVER_PATH!r}), got {run_cfg.driver_path!r}"
+    )
+    return LMDataConfig.model_validate(run_cfg.data)

--- a/param_decomp/experiments/resid_mlp/experiment.py
+++ b/param_decomp/experiments/resid_mlp/experiment.py
@@ -31,22 +31,36 @@ class ResidMLPDataConfig(BaseConfig):
     ] = "at_least_zero_active"
 
 
-class ResidMLPRunConfig(RunConfig):
-    target: ResidMLPTargetConfig
-    data: ResidMLPDataConfig
+def _build_dataset(
+    target: ResidMLPTargetConfig, data: ResidMLPDataConfig, device: str
+) -> ResidMLPDataset:
+    train_config = ResidMLPTargetRunInfo.from_path(target.run_path).config
+    return ResidMLPDataset(
+        n_features=train_config.resid_mlp_model_config.n_features,
+        feature_probability=data.feature_probability,
+        device=device,
+        calc_labels=False,
+        label_type=None,
+        act_fn_name=None,
+        label_fn_seed=None,
+        label_coeffs=None,
+        data_generation_type=data.data_generation_type,
+        synced_inputs=train_config.synced_inputs,
+    )
 
 
-class Driver(ExperimentDriver[ResidMLPRunConfig]):
+class Driver(ExperimentDriver):
     name: ClassVar[str] = "resid_mlp"
 
-    @property
     @override
-    def config_type(self) -> type[ResidMLPRunConfig]:
-        return ResidMLPRunConfig
+    def validate_config(self, run_cfg: RunConfig) -> None:
+        ResidMLPTargetConfig.model_validate(run_cfg.target)
+        ResidMLPDataConfig.model_validate(run_cfg.data)
 
     @override
-    def build_target(self, run_cfg: ResidMLPRunConfig) -> PDTarget:
-        run_info = ResidMLPTargetRunInfo.from_path(run_cfg.target.run_path)
+    def build_target(self, run_cfg: RunConfig) -> PDTarget:
+        target = ResidMLPTargetConfig.model_validate(run_cfg.target)
+        run_info = ResidMLPTargetRunInfo.from_path(target.run_path)
         target_model = ResidMLP.from_run_info(run_info)
         target_model.eval()
         return PDTarget(
@@ -55,33 +69,20 @@ class Driver(ExperimentDriver[ResidMLPRunConfig]):
             reconstruction_loss=recon_loss_mse,
         )
 
-    def _build_dataset(self, run_cfg: ResidMLPRunConfig, device: str) -> ResidMLPDataset:
-        train_config = ResidMLPTargetRunInfo.from_path(run_cfg.target.run_path).config
-        return ResidMLPDataset(
-            n_features=train_config.resid_mlp_model_config.n_features,
-            feature_probability=run_cfg.data.feature_probability,
-            device=device,
-            calc_labels=False,
-            label_type=None,
-            act_fn_name=None,
-            label_fn_seed=None,
-            label_coeffs=None,
-            data_generation_type=run_cfg.data.data_generation_type,
-            synced_inputs=train_config.synced_inputs,
-        )
-
     @override
     def build_train_loader(
         self,
-        run_cfg: ResidMLPRunConfig,
+        run_cfg: RunConfig,
         *,
         device: str,
         batch_size_override: int | None = None,
         dist_state: DistributedState | None = None,
     ) -> DatasetGeneratedDataLoader[tuple[Tensor, Tensor]]:
         del dist_state
+        target = ResidMLPTargetConfig.model_validate(run_cfg.target)
+        data = ResidMLPDataConfig.model_validate(run_cfg.data)
         return DatasetGeneratedDataLoader(
-            self._build_dataset(run_cfg, device),
+            _build_dataset(target, data, device),
             batch_size=batch_size_override or run_cfg.pd.batch_size,
             shuffle=False,
         )
@@ -89,15 +90,17 @@ class Driver(ExperimentDriver[ResidMLPRunConfig]):
     @override
     def build_eval_loader(
         self,
-        run_cfg: ResidMLPRunConfig,
+        run_cfg: RunConfig,
         *,
         device: str,
         batch_size_override: int | None = None,
         dist_state: DistributedState | None = None,
     ) -> DatasetGeneratedDataLoader[tuple[Tensor, Tensor]]:
         del dist_state
+        target = ResidMLPTargetConfig.model_validate(run_cfg.target)
+        data = ResidMLPDataConfig.model_validate(run_cfg.data)
         return DatasetGeneratedDataLoader(
-            self._build_dataset(run_cfg, device),
+            _build_dataset(target, data, device),
             batch_size=batch_size_override or run_cfg.logging.eval_batch_size,
             shuffle=False,
         )

--- a/param_decomp/experiments/runner.py
+++ b/param_decomp/experiments/runner.py
@@ -13,6 +13,7 @@ from typing import Any
 import fire
 import yaml
 
+from param_decomp.driver_path import load_driver
 from param_decomp.experiments._worker import run_experiment
 from param_decomp.experiments.discovery import discover_experiments
 from param_decomp.run import RUN_CONFIG_FILENAME, RunConfig
@@ -170,7 +171,8 @@ def main(
         )
         return
 
-    run = RunConfig.from_dict(_resolve_source(experiment, config_path, rerun))
+    run = RunConfig.model_validate(_resolve_source(experiment, config_path, rerun))
+    load_driver(run.driver_path).validate_config(run)
 
     if local:
         assert run.runtime.dp is None, "runtime.dp is not supported with --local"

--- a/param_decomp/experiments/tms/experiment.py
+++ b/param_decomp/experiments/tms/experiment.py
@@ -34,22 +34,32 @@ class TMSDataConfig(BaseConfig):
     )
 
 
-class TMSRunConfig(RunConfig):
-    target: TMSTargetConfig
-    data: TMSDataConfig
+def _build_dataset(
+    target: TMSTargetConfig, data: TMSDataConfig, device: str
+) -> SparseFeatureDataset:
+    train_config = TMSTargetRunInfo.from_path(target.run_path).config
+    return SparseFeatureDataset(
+        n_features=train_config.tms_model_config.n_features,
+        feature_probability=data.feature_probability,
+        device=device,
+        data_generation_type=data.data_generation_type,
+        value_range=(0.0, 1.0),
+        synced_inputs=train_config.synced_inputs,
+    )
 
 
-class Driver(ExperimentDriver[TMSRunConfig]):
+class Driver(ExperimentDriver):
     name: ClassVar[str] = "tms"
 
-    @property
     @override
-    def config_type(self) -> type[TMSRunConfig]:
-        return TMSRunConfig
+    def validate_config(self, run_cfg: RunConfig) -> None:
+        TMSTargetConfig.model_validate(run_cfg.target)
+        TMSDataConfig.model_validate(run_cfg.data)
 
     @override
-    def build_target(self, run_cfg: TMSRunConfig) -> PDTarget:
-        run_info = TMSTargetRunInfo.from_path(run_cfg.target.run_path)
+    def build_target(self, run_cfg: RunConfig) -> PDTarget:
+        target = TMSTargetConfig.model_validate(run_cfg.target)
+        run_info = TMSTargetRunInfo.from_path(target.run_path)
         target_model = TMSModel.from_run_info(run_info)
         target_model.eval()
         tied_weights = [("linear1", "linear2")] if target_model.config.tied_weights else None
@@ -60,29 +70,20 @@ class Driver(ExperimentDriver[TMSRunConfig]):
             tied_weights=tied_weights,
         )
 
-    def _build_dataset(self, run_cfg: TMSRunConfig, device: str) -> SparseFeatureDataset:
-        train_config = TMSTargetRunInfo.from_path(run_cfg.target.run_path).config
-        return SparseFeatureDataset(
-            n_features=train_config.tms_model_config.n_features,
-            feature_probability=run_cfg.data.feature_probability,
-            device=device,
-            data_generation_type=run_cfg.data.data_generation_type,
-            value_range=(0.0, 1.0),
-            synced_inputs=train_config.synced_inputs,
-        )
-
     @override
     def build_train_loader(
         self,
-        run_cfg: TMSRunConfig,
+        run_cfg: RunConfig,
         *,
         device: str,
         batch_size_override: int | None = None,
         dist_state: DistributedState | None = None,
     ) -> DatasetGeneratedDataLoader[tuple[Tensor, Tensor]]:
         del dist_state
+        target = TMSTargetConfig.model_validate(run_cfg.target)
+        data = TMSDataConfig.model_validate(run_cfg.data)
         return DatasetGeneratedDataLoader(
-            self._build_dataset(run_cfg, device),
+            _build_dataset(target, data, device),
             batch_size=batch_size_override or run_cfg.pd.batch_size,
             shuffle=False,
         )
@@ -90,15 +91,17 @@ class Driver(ExperimentDriver[TMSRunConfig]):
     @override
     def build_eval_loader(
         self,
-        run_cfg: TMSRunConfig,
+        run_cfg: RunConfig,
         *,
         device: str,
         batch_size_override: int | None = None,
         dist_state: DistributedState | None = None,
     ) -> DatasetGeneratedDataLoader[tuple[Tensor, Tensor]]:
         del dist_state
+        target = TMSTargetConfig.model_validate(run_cfg.target)
+        data = TMSDataConfig.model_validate(run_cfg.data)
         return DatasetGeneratedDataLoader(
-            self._build_dataset(run_cfg, device),
+            _build_dataset(target, data, device),
             batch_size=batch_size_override or run_cfg.logging.eval_batch_size,
             shuffle=False,
         )

--- a/param_decomp/run.py
+++ b/param_decomp/run.py
@@ -1,16 +1,12 @@
 """The `RunConfig` object: serializable spec for a driver-mediated PD run.
 
-Pure data. Holds the driver import path plus the three determinism-tier configs
-(``pd``, ``logging``, ``runtime``). Driver-specific subclasses
-(``LMRunConfig``, ``TMSRunConfig``, ``ResidMLPRunConfig``) add ``target`` /
-``data`` and are pointed at by each driver's ``config_type``.
+Pure data. Holds the driver import path, the three determinism-tier configs
+(``pd``, ``logging``, ``runtime``), and two driver-private payloads
+(``target``, ``data``) as raw dicts. Core never inspects ``target`` / ``data`` —
+the driver named by ``driver_path`` validates them via its own pydantic models.
 
 Written to ``run_config.yaml`` beside the checkpoint, passed to the worker,
 and re-read on reload. One type, one shape, everywhere.
-
-``RunConfig.from_dict(...)`` dispatches to the right subclass by reading
-``driver_path``, loading the driver, and routing ``model_validate`` to
-``driver.config_type``.
 
 **Scope**: ``RunConfig`` only exists for driver-mediated runs. Notebook /
 script callers do **not** construct a ``RunConfig`` — they call ``optimize``
@@ -26,7 +22,6 @@ from pydantic import Field, model_validator
 
 from param_decomp.base_config import BaseConfig
 from param_decomp.configs import LoggingConfig, PDConfig, RuntimeConfig
-from param_decomp.driver_path import load_driver
 from param_decomp.utils.run_utils import generate_run_id
 
 RUN_CONFIG_FILENAME = "run_config.yaml"
@@ -43,6 +38,10 @@ class RunConfig(BaseConfig):
     used to build the target model and dataloaders. **Required** — there is no
     "notebook" flavour of ``RunConfig``; notebook callers skip this class
     entirely and call ``optimize`` directly.
+
+    ``target`` and ``data`` are driver-private payloads. Core stores them as
+    raw dicts; the driver named by ``driver_path`` validates them with its own
+    pydantic models (e.g. ``LMTargetConfig.model_validate(run_cfg.target)``).
     """
 
     name: str | None = None
@@ -51,6 +50,8 @@ class RunConfig(BaseConfig):
     pd: PDConfig
     logging: LoggingConfig
     runtime: RuntimeConfig
+    target: dict[str, Any]
+    data: dict[str, Any]
     view_meta: dict[str, Any] = Field(
         default_factory=dict,
         description="Free-form labels for downstream grouping/coloring/reports (e.g. "
@@ -69,28 +70,12 @@ class RunConfig(BaseConfig):
         return self
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "RunConfig":
-        """Parse a dict (e.g. from YAML) into the right `RunConfig` subclass.
-
-        Reads ``data["driver_path"]``, loads the driver, and validates against
-        ``driver.config_type``. Single unambiguous dispatch — ``driver_path`` is
-        required so there is no "fall through to bare RunConfig" branch.
-        Callers that need the concrete subtype narrow with
-        ``isinstance(run_cfg, driver.config_type)``.
-        """
-        assert "driver_path" in data and data["driver_path"], (
-            "RunConfig requires a non-empty `driver_path`. "
-            "Notebook callers should use `optimize(...)` directly instead of building a RunConfig."
-        )
-        return load_driver(data["driver_path"]).config_type.model_validate(data)
-
-    @classmethod
     @override
     def from_file(cls, path: Path | str) -> "RunConfig":
         path = Path(path)
         assert path.exists(), f"{RUN_CONFIG_FILENAME} not found at {path}"
         with open(path) as f:
-            return cls.from_dict(yaml.safe_load(f))
+            return cls.model_validate(yaml.safe_load(f))
 
     def write(self, path: Path) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)

--- a/param_decomp/run_pd.py
+++ b/param_decomp/run_pd.py
@@ -75,12 +75,11 @@ def materialize_run(
     *,
     device: str,
     dist_state: DistributedState | None = None,
-    driver: ExperimentDriver[Any] | None = None,
+    driver: ExperimentDriver | None = None,
 ) -> tuple[PDTarget, DataLoader[Any], DataLoader[Any]]:
     """Compose the ``(target, train_loader, eval_loader)`` tuple ``optimize`` needs.
 
-    Resolves the driver from ``run_cfg.driver_path``, validates that ``run_cfg``
-    is the driver's expected subtype, then calls ``build_target`` /
+    Resolves the driver from ``run_cfg.driver_path``, then calls ``build_target`` /
     ``build_train_loader`` / ``build_eval_loader``. Driver-mediated callers use
     this; notebook callers construct those three objects themselves and skip
     the indirection.
@@ -88,14 +87,13 @@ def materialize_run(
     Pass ``driver=...`` if you've already resolved it (e.g. ``run_pd`` does
     this once and threads it to both ``materialize_run`` and
     ``RunSink.for_run``). Otherwise resolved internally.
+
+    Each ``build_*`` method re-parses ``run_cfg.target`` / ``run_cfg.data`` into
+    the driver's typed configs, so a bad-shape config raises here. For
+    fail-fast before SLURM submit, callers invoke ``driver.validate_config``
+    pre-flight in the launcher.
     """
-    resolved: ExperimentDriver[Any] = (
-        driver if driver is not None else load_driver(run_cfg.driver_path)
-    )
-    assert isinstance(run_cfg, resolved.config_type), (
-        f"RunConfig has type {type(run_cfg).__name__}, "
-        f"expected {resolved.config_type.__name__} from driver {run_cfg.driver_path}"
-    )
+    resolved: ExperimentDriver = driver if driver is not None else load_driver(run_cfg.driver_path)
     return (
         resolved.build_target(run_cfg),
         resolved.build_train_loader(run_cfg, device=device, dist_state=dist_state),

--- a/param_decomp/run_sink.py
+++ b/param_decomp/run_sink.py
@@ -64,7 +64,7 @@ class RunSink:
         *,
         wandb_project: str | None = None,
         launch_id: str | None = None,
-        driver: ExperimentDriver[Any] | None = None,
+        driver: ExperimentDriver | None = None,
     ) -> "RunSink":
         """Driver-mediated setup. Used by ``run_pd``.
 

--- a/param_decomp/saved_run.py
+++ b/param_decomp/saved_run.py
@@ -32,17 +32,15 @@ from param_decomp.utils.run_files import resolve_config_path, resolve_run_files
 class SavedRun:
     """A completed PD run, resolved to local paths and parsed `RunConfig`.
 
-    `driver` is resolved from `run_cfg.driver_path` at construction time and
-    paired with `run_cfg` (whose concrete subtype is checked against
-    `driver.config_type`). Both fields are required — there is no
-    notebook-only `SavedRun`; notebook callers reload checkpoints via
-    `ComponentModel.from_checkpoint(...)` directly.
+    `driver` is resolved from `run_cfg.driver_path` at construction time.
+    Both fields are required — there is no notebook-only `SavedRun`; notebook
+    callers reload checkpoints via `ComponentModel.from_checkpoint(...)` directly.
     """
 
     path: Path
     run_cfg: RunConfig
     checkpoint_path: Path
-    driver: ExperimentDriver[Any]
+    driver: ExperimentDriver
 
     @classmethod
     def from_path(cls, path: ModelPath) -> "SavedRun":
@@ -52,9 +50,6 @@ class SavedRun:
         )
         run_cfg = RunConfig.from_file(files.config_path)
         driver = load_driver(run_cfg.driver_path)
-        assert isinstance(run_cfg, driver.config_type), (
-            f"RunConfig has type {type(run_cfg).__name__}, expected {driver.config_type.__name__}"
-        )
         return cls(
             path=files.config_path.parent,
             run_cfg=run_cfg,

--- a/param_decomp/scripts/alpha_sweep/alpha_sweep.py
+++ b/param_decomp/scripts/alpha_sweep/alpha_sweep.py
@@ -26,7 +26,7 @@ from torch import Tensor
 
 from param_decomp.configs import SamplingType
 from param_decomp.experiments.lm.data import create_lm_data_loader
-from param_decomp.experiments.lm.experiment import LMRunConfig
+from param_decomp.experiments.lm.experiment import lm_data
 from param_decomp.log import logger
 from param_decomp.models.component_model import ComponentModel
 from param_decomp.models.components import make_mask_infos
@@ -79,9 +79,7 @@ def run_r_sweep(
     """Run r sweep for a single model. Returns (run_id, ce_losses)."""
     pd_run = SavedRun.from_path(wandb_path)
     config = pd_run.pd_config
-    exp = pd_run.run_cfg
-    assert isinstance(exp, LMRunConfig)
-    data = exp.data
+    data = lm_data(pd_run.run_cfg)
     run_id = str(wandb_path).split("/")[-1]
 
     logger.info(f"Loading model {run_id}...")
@@ -92,7 +90,7 @@ def run_r_sweep(
     eval_loader, _tokenizer = create_lm_data_loader(
         data,
         split=data.eval_split,
-        batch_size=exp.logging.eval_batch_size,
+        batch_size=pd_run.run_cfg.logging.eval_batch_size,
         seed=config.seed + 1,
     )
 

--- a/param_decomp/scripts/prompt_utils.py
+++ b/param_decomp/scripts/prompt_utils.py
@@ -7,7 +7,7 @@ import torch
 from transformers import AutoTokenizer
 
 from param_decomp.experiments.lm.data import create_lm_data_loader
-from param_decomp.experiments.lm.experiment import LMRunConfig
+from param_decomp.experiments.lm.experiment import lm_data
 from param_decomp.saved_run import SavedRun
 
 
@@ -21,9 +21,7 @@ def load_prompts(path: Path) -> list[str]:
 
 def sample_prompts_from_dataset(pd_run: SavedRun, n_samples: int) -> list[str]:
     """Sample n_samples sequences from the dataset and decode to strings."""
-    exp = pd_run.run_cfg
-    assert isinstance(exp, LMRunConfig), "Run is not an LM experiment"
-    data = exp.data
+    data = lm_data(pd_run.run_cfg)
 
     tokenizer = AutoTokenizer.from_pretrained(data.tokenizer_name)
 

--- a/param_decomp/scripts/run_slurm.py
+++ b/param_decomp/scripts/run_slurm.py
@@ -16,6 +16,7 @@ from datetime import datetime
 from hashlib import sha256
 
 from param_decomp.configs import RuntimeConfig
+from param_decomp.driver_path import load_driver
 from param_decomp.log import logger
 from param_decomp.run import RunConfig
 from param_decomp.settings import GPUS_PER_NODE, PARAM_DECOMP_OUT_DIR
@@ -47,6 +48,8 @@ def launch_run_slurm(
 ) -> None:
     launch_id = _generate_launch_id()
     logger.info(f"Launch ID: {launch_id}")
+
+    load_driver(run_cfg.driver_path).validate_config(run_cfg)
 
     snapshot_ref, commit_hash = create_git_snapshot(snapshot_id=launch_id)
     logger.info(f"Created git snapshot ref: {snapshot_ref} ({commit_hash[:8]})")
@@ -92,6 +95,11 @@ def launch_sweep_slurm(
 
     run_cfgs = sweep.run_cfgs()
     logger.info(f"Sweep '{sweep.description}': {len(run_cfgs)} run(s)")
+
+    driver = load_driver(sweep.driver_path)
+    for run_cfg in run_cfgs:
+        driver.validate_config(run_cfg)
+
     sweep_dir = PARAM_DECOMP_OUT_DIR / "sweeps" / launch_id
 
     sweep.write(sweep_dir / "spec.yaml")

--- a/param_decomp/sweeps/cartesian.py
+++ b/param_decomp/sweeps/cartesian.py
@@ -72,6 +72,8 @@ def cartesian_product(
         driver_path=driver_path,
         logging=base_config.logging,
         runtime=base_config.runtime,
+        target=base_config.target,
+        data=base_config.data,
         n_agents=n_agents,
         swept_datas=swept_datas,
     )
@@ -86,7 +88,7 @@ def example_cartesian_sweep() -> SweepSpec:
     """
     base_config_path = REPO_ROOT / "param_decomp" / "experiments" / "tms" / "tms_5-2_config.yaml"
     with open(base_config_path) as f:
-        base_config = RunConfig.from_dict(yaml.safe_load(f))
+        base_config = RunConfig.model_validate(yaml.safe_load(f))
     return cartesian_product(
         base_config=base_config,
         grid={"pd.seed": [0, 1, 2]},

--- a/param_decomp/sweeps/spec.py
+++ b/param_decomp/sweeps/spec.py
@@ -1,8 +1,9 @@
 """Launch data model: ``SweepSpec`` (many runs sharing a driver and substrate).
 
 A single PD launch is just a ``RunConfig`` — the same type the worker writes
-to disk. A sweep is a ``SweepSpec`` carrying shared driver/logging/runtime
-plus a ``list[SweepData]`` of per-run varying ``pd``/``name``/``view_meta``.
+to disk. A sweep is a ``SweepSpec`` carrying shared
+driver/logging/runtime/target/data plus a ``list[SweepData]`` of per-run
+varying ``pd``/``name``/``view_meta``.
 
 A ``SweepGenerator`` is any zero-arg callable returning a ``SweepSpec``. The
 sweep is fully self-contained — it loads whatever base config it wants and
@@ -31,10 +32,12 @@ class SweepData:
 class SweepSpec:
     """A complete sweep: description and the list of runs to launch.
 
-    All runs in a sweep must share one driver and one ``runtime:`` block
-    (single SLURM array allocation, one substrate). Both invariants are
-    asserted at construction. The W&B project is supplied to the launcher
-    separately (``--project``) and is not part of the spec.
+    All runs in a sweep share one driver, one ``runtime:`` block (one SLURM
+    array allocation, one substrate), one ``logging:`` block, and one
+    driver-private ``target`` / ``data`` payload. Per-run variation lives in
+    ``swept_datas`` (``pd``, ``name``, ``view_meta``). The W&B project is
+    supplied to the launcher separately (``--project``) and is not part of
+    the spec.
 
     Serialized to ``PARAM_DECOMP_OUT_DIR/sweeps/<launch_id>/spec.yaml`` on
     submit so reproducing the sweep doesn't require re-running the generator.
@@ -44,6 +47,8 @@ class SweepSpec:
     driver_path: str
     logging: LoggingConfig
     runtime: RuntimeConfig
+    target: dict[str, Any]
+    data: dict[str, Any]
     n_agents: int
 
     swept_datas: list[SweepData]
@@ -56,6 +61,8 @@ class SweepSpec:
                 pd=sweep_data.pd_config,
                 logging=self.logging,
                 runtime=self.runtime,
+                target=self.target,
+                data=self.data,
                 view_meta=sweep_data.view_meta,
             )
             for sweep_data in self.swept_datas
@@ -67,6 +74,8 @@ class SweepSpec:
             "driver_path": self.driver_path,
             "logging": self.logging.model_dump(mode="json"),
             "runtime": self.runtime.model_dump(mode="json"),
+            "target": self.target,
+            "data": self.data,
             "n_agents": self.n_agents,
             "swept_datas": [
                 {

--- a/scripts/blog/export_components.py
+++ b/scripts/blog/export_components.py
@@ -22,7 +22,7 @@ import numpy as np
 
 from param_decomp.app.backend.app_tokenizer import AppTokenizer
 from param_decomp.autointerp.repo import InterpRepo
-from param_decomp.experiments.lm.experiment import LMRunConfig
+from param_decomp.experiments.lm.experiment import is_lm_run, lm_data
 from param_decomp.harvest.schemas import get_harvest_dir
 from param_decomp.saved_run import SavedRun
 from param_decomp.topology import TransformerTopology
@@ -115,8 +115,8 @@ def main() -> None:
     print("Loading run info...")
     pd_run = SavedRun.from_path(f"goodfire/spd/runs/{RUN_ID}")
     exp = pd_run.run_cfg
-    assert isinstance(exp, LMRunConfig), "component export only supports LM runs"
-    tokenizer = AppTokenizer.from_pretrained(exp.data.tokenizer_name)
+    assert is_lm_run(exp), "component export only supports LM runs"
+    tokenizer = AppTokenizer.from_pretrained(lm_data(exp).tokenizer_name)
 
     print("Loading model...")
     model = pd_run.load_model()

--- a/scripts/blog/export_graphs.py
+++ b/scripts/blog/export_graphs.py
@@ -18,7 +18,7 @@ from typing import Any
 from param_decomp.app.backend.app_tokenizer import AppTokenizer
 from param_decomp.autointerp.repo import InterpRepo
 from param_decomp.dataset_attributions import AttributionRepo
-from param_decomp.experiments.lm.experiment import LMRunConfig
+from param_decomp.experiments.lm.experiment import is_lm_run, lm_data
 from param_decomp.harvest.schemas import get_harvest_dir
 from param_decomp.saved_run import SavedRun
 from param_decomp.settings import PARAM_DECOMP_OUT_DIR
@@ -390,8 +390,8 @@ def main() -> None:
     print("Loading run info...")
     pd_run = SavedRun.from_path(f"goodfire/spd/runs/{RUN_ID}")
     exp = pd_run.run_cfg
-    assert isinstance(exp, LMRunConfig), "graph export only supports LM runs"
-    tokenizer = AppTokenizer.from_pretrained(exp.data.tokenizer_name)
+    assert is_lm_run(exp), "graph export only supports LM runs"
+    tokenizer = AppTokenizer.from_pretrained(lm_data(exp).tokenizer_name)
 
     print("Loading model for topology...")
     model = pd_run.load_model()

--- a/scripts/blog/export_manual_prompts.py
+++ b/scripts/blog/export_manual_prompts.py
@@ -39,7 +39,7 @@ import torch
 from param_decomp.app.backend.app_tokenizer import AppTokenizer
 from param_decomp.app.backend.compute import compute_ci_only
 from param_decomp.autointerp.repo import InterpRepo
-from param_decomp.experiments.lm.experiment import LMRunConfig
+from param_decomp.experiments.lm.experiment import is_lm_run, lm_data
 from param_decomp.saved_run import SavedRun
 from param_decomp.scripts.prompt_utils import load_prompts
 from param_decomp.topology import TransformerTopology
@@ -149,16 +149,17 @@ def export_manual_prompts(
     """Compute CI/activation values for one component across manual prompts."""
     pd_run = SavedRun.from_path(run_path)
     exp = pd_run.run_cfg
-    assert isinstance(exp, LMRunConfig), "manual prompt export only supports LM runs"
+    assert is_lm_run(exp), "manual prompt export only supports LM runs"
     model = pd_run.load_model().to(get_device())
     model.eval()
 
-    tokenizer_name = exp.data.tokenizer_name
+    data = lm_data(exp)
+    tokenizer_name = data.tokenizer_name
     assert tokenizer_name is not None, "run config missing tokenizer_name"
     tokenizer = AppTokenizer.from_pretrained(tokenizer_name)
     topology = TransformerTopology(model.target_model)
 
-    context_length = exp.data.max_seq_len
+    context_length = data.max_seq_len
 
     canonical_layer, component_idx_str = component_key.rsplit(":", 1)
     component_idx = int(component_idx_str)

--- a/tests/app/test_server_api.py
+++ b/tests/app/test_server_api.py
@@ -126,9 +126,10 @@ def app_with_state():
 
         from param_decomp.configs import RuntimeConfig
         from param_decomp.experiments.lm.data import LMDataConfig
-        from param_decomp.experiments.lm.experiment import LMRunConfig, LMTargetConfig
+        from param_decomp.experiments.lm.experiment import LMTargetConfig
+        from param_decomp.run import RunConfig
 
-        lm_exp = LMRunConfig(
+        lm_exp = RunConfig(
             driver_path="param_decomp.experiments.lm.experiment:Driver",
             pd=config,
             logging=LoggingConfig(
@@ -143,7 +144,7 @@ def app_with_state():
                 model_class="param_decomp.pretrain.models.gpt2_simple.GPT2Simple",
                 model_name="test-target",
                 model_path=None,
-            ),
+            ).model_dump(mode="json"),
             data=LMDataConfig(
                 tokenizer_name="SimpleStories/test-SimpleStories-gpt2-1.25M",
                 dataset_name="SimpleStories/SimpleStories",
@@ -155,7 +156,7 @@ def app_with_state():
                 streaming=False,
                 buffer_size=1000,
                 shuffle_each_epoch=True,
-            ),
+            ).model_dump(mode="json"),
         )
         run_state = RunState(
             run=run,

--- a/tests/scripts_run/test_main.py
+++ b/tests/scripts_run/test_main.py
@@ -55,7 +55,7 @@ class TestLaunchSlurm:
         )
         mock_get_wandb_run_url.return_value = "https://wandb.ai/test/test/runs/test"
 
-        base_config = RunConfig.from_dict(_builtin("tms_5-2"))
+        base_config = RunConfig.model_validate(_builtin("tms_5-2"))
         sweep_spec = cartesian_product(
             base_config=base_config,
             grid={"pd.seed": [0, 1, 2], "pd.steps": [10, 20]},
@@ -103,7 +103,7 @@ class TestLaunchSlurm:
         )
         mock_get_wandb_run_url.return_value = "https://wandb.ai/test/test/runs/test"
 
-        run = RunConfig.from_dict(_builtin("tms_5-2"))
+        run = RunConfig.model_validate(_builtin("tms_5-2"))
         launch_run_slurm(
             run_cfg=run,
             job_suffix=None,
@@ -121,7 +121,7 @@ class TestLaunchSlurm:
     def test_worker_args_use_run_embedded_run_id(self):
         from param_decomp.scripts.run_slurm import _build_worker_args
 
-        run = RunConfig.from_dict(_builtin("tms_5-2"))
+        run = RunConfig.model_validate(_builtin("tms_5-2"))
 
         args = _build_worker_args("launch-test", run, "test")
 

--- a/tests/sweeps/test_cartesian.py
+++ b/tests/sweeps/test_cartesian.py
@@ -14,7 +14,7 @@ TMS_DRIVER_PATH = "param_decomp.experiments.tms.experiment:Driver"
 
 def _base_config() -> RunConfig:
     with open(REPO_ROOT / "param_decomp" / "experiments" / "tms" / "tms_5-2_config.yaml") as f:
-        return RunConfig.from_dict(yaml.safe_load(f))
+        return RunConfig.model_validate(yaml.safe_load(f))
 
 
 def test_cartesian_product_basic() -> None:

--- a/tests/sweeps/test_load.py
+++ b/tests/sweeps/test_load.py
@@ -25,7 +25,7 @@ def test_load_and_call(tmp_path: Path) -> None:
         "def my_sweep():\n"
         '    with open(REPO_ROOT / "param_decomp" / "experiments" / "tms" / "tms_5-2_config.yaml") as f:\n'
         "        config = yaml.safe_load(f)\n"
-        "    base_run = RunConfig.from_dict(config)\n"
+        "    base_run = RunConfig.model_validate(config)\n"
         "    return cartesian_product(\n"
         "        base_config=base_run,\n"
         '        grid={"pd.seed": [0]},\n'

--- a/tests/test_experiment_runner_inputs.py
+++ b/tests/test_experiment_runner_inputs.py
@@ -54,7 +54,7 @@ def test_rerun_loads_driver_from_run(tmp_path: Path) -> None:
     run_path = tmp_path / RUN_CONFIG_FILENAME
     driver_path = config_data["driver_path"]
 
-    run = RunConfig.from_dict(config_data)
+    run = RunConfig.model_validate(config_data)
     run.write(run_path)
 
     raw = _resolve_source(experiment=None, config_path=None, rerun=str(run_path.parent))
@@ -67,13 +67,13 @@ def test_rerun_loads_driver_from_run(tmp_path: Path) -> None:
 def test_rerun_drops_saved_run_id(tmp_path: Path) -> None:
     config_data = _builtin("tms_5-2")
 
-    run = RunConfig.from_dict(config_data)
+    run = RunConfig.model_validate(config_data)
     run.write(tmp_path / RUN_CONFIG_FILENAME)
     original_run_id = run.run_id
 
     raw = _resolve_source(experiment=None, config_path=None, rerun=str(tmp_path))
 
-    new_run = RunConfig.from_dict(raw)
+    new_run = RunConfig.model_validate(raw)
 
     assert "run_id" not in raw
     assert new_run.run_id != original_run_id

--- a/tests/test_run_round_trip.py
+++ b/tests/test_run_round_trip.py
@@ -23,7 +23,6 @@ from param_decomp.experiments.lm.experiment import (
     Driver as LMDriver,
 )
 from param_decomp.experiments.lm.experiment import (
-    LMRunConfig,
     LMTargetConfig,
 )
 from param_decomp.experiments.resid_mlp.experiment import (
@@ -31,7 +30,6 @@ from param_decomp.experiments.resid_mlp.experiment import (
 )
 from param_decomp.experiments.resid_mlp.experiment import (
     ResidMLPDataConfig,
-    ResidMLPRunConfig,
     ResidMLPTargetConfig,
 )
 from param_decomp.experiments.tms.experiment import (
@@ -39,7 +37,6 @@ from param_decomp.experiments.tms.experiment import (
 )
 from param_decomp.experiments.tms.experiment import (
     TMSDataConfig,
-    TMSRunConfig,
     TMSTargetConfig,
 )
 from param_decomp.run import RUN_CONFIG_FILENAME, RunConfig
@@ -79,8 +76,8 @@ def _runtime_config() -> RuntimeConfig:
 
 
 def _round_trip(run: RunConfig) -> RunConfig:
-    """Round-trip ``run`` through ``model_dump`` → ``RunConfig.from_dict``."""
-    return RunConfig.from_dict(run.model_dump(mode="json"))
+    """Round-trip ``run`` through ``model_dump`` → ``RunConfig.model_validate``."""
+    return RunConfig.model_validate(run.model_dump(mode="json"))
 
 
 def test_run_generates_run_id_on_instantiation():
@@ -89,13 +86,15 @@ def test_run_generates_run_id_on_instantiation():
         pd=_pd_config(),
         logging=_logging_config(),
         runtime=_runtime_config(),
+        target={},
+        data={},
     )
 
     assert run.run_id.startswith("p-")
 
 
 def test_lm_run_round_trip():
-    run = LMRunConfig(
+    run = RunConfig(
         driver_path=LM_DRIVER_PATH,
         pd=_pd_config(),
         logging=_logging_config(),
@@ -104,45 +103,45 @@ def test_lm_run_round_trip():
             model_class="transformers.GPT2LMHeadModel",
             model_name="openai-community/gpt2",
             output_extract="logits",
-        ),
+        ).model_dump(mode="json"),
         data=LMDataConfig(
             dataset_name="SimpleStories/SimpleStories",
             tokenizer_name="gpt2",
             column_name="story",
             max_seq_len=128,
-        ),
+        ).model_dump(mode="json"),
     )
     parsed = _round_trip(run)
-    assert type(parsed) is LMRunConfig
     assert parsed == run
+    LMDriver().validate_config(parsed)
 
 
 def test_tms_run_round_trip():
-    run = TMSRunConfig(
+    run = RunConfig(
         driver_path=TMS_DRIVER_PATH,
         pd=_pd_config(),
         logging=_logging_config(),
         runtime=_runtime_config(),
-        target=TMSTargetConfig(run_path="wandb:foo/bar/runs/abc"),
-        data=TMSDataConfig(feature_probability=0.05),
+        target=TMSTargetConfig(run_path="wandb:foo/bar/runs/abc").model_dump(mode="json"),
+        data=TMSDataConfig(feature_probability=0.05).model_dump(mode="json"),
     )
     parsed = _round_trip(run)
-    assert type(parsed) is TMSRunConfig
     assert parsed == run
+    TMSDriver().validate_config(parsed)
 
 
 def test_resid_mlp_run_round_trip():
-    run = ResidMLPRunConfig(
+    run = RunConfig(
         driver_path=RESID_MLP_DRIVER_PATH,
         pd=_pd_config(),
         logging=_logging_config(),
         runtime=_runtime_config(),
-        target=ResidMLPTargetConfig(run_path="wandb:foo/bar/runs/abc"),
-        data=ResidMLPDataConfig(feature_probability=0.05),
+        target=ResidMLPTargetConfig(run_path="wandb:foo/bar/runs/abc").model_dump(mode="json"),
+        data=ResidMLPDataConfig(feature_probability=0.05).model_dump(mode="json"),
     )
     parsed = _round_trip(run)
-    assert type(parsed) is ResidMLPRunConfig
     assert parsed == run
+    ResidMLPDriver().validate_config(parsed)
 
 
 def test_run_requires_runtime_config():
@@ -155,7 +154,7 @@ def test_run_requires_runtime_config():
     }
 
     with pytest.raises(ValidationError, match="runtime"):
-        RunConfig.from_dict(data)
+        RunConfig.model_validate(data)
 
 
 def test_driver_class_paths_load():
@@ -165,13 +164,13 @@ def test_driver_class_paths_load():
 
 
 def test_run_round_trip_via_file(tmp_path: Path):
-    run = TMSRunConfig(
+    run = RunConfig(
         driver_path=TMS_DRIVER_PATH,
         pd=_pd_config(),
         logging=_logging_config(),
         runtime=_runtime_config(),
-        target=TMSTargetConfig(run_path="wandb:foo/bar/runs/abc"),
-        data=TMSDataConfig(feature_probability=0.05),
+        target=TMSTargetConfig(run_path="wandb:foo/bar/runs/abc").model_dump(mode="json"),
+        data=TMSDataConfig(feature_probability=0.05).model_dump(mode="json"),
     )
     path = tmp_path / RUN_CONFIG_FILENAME
     run.write(path)
@@ -182,14 +181,14 @@ def test_run_round_trip_via_file(tmp_path: Path):
 
 
 def test_run_from_file_preserves_existing_run_id(tmp_path: Path):
-    run = TMSRunConfig(
+    run = RunConfig(
         run_id="p-existing",
         driver_path=TMS_DRIVER_PATH,
         pd=_pd_config(),
         logging=_logging_config(),
         runtime=_runtime_config(),
-        target=TMSTargetConfig(run_path="wandb:foo/bar/runs/abc"),
-        data=TMSDataConfig(feature_probability=0.05),
+        target=TMSTargetConfig(run_path="wandb:foo/bar/runs/abc").model_dump(mode="json"),
+        data=TMSDataConfig(feature_probability=0.05).model_dump(mode="json"),
     )
     path = tmp_path / RUN_CONFIG_FILENAME
     path.write_text(yaml.safe_dump(run.model_dump(mode="json")))
@@ -206,6 +205,45 @@ def test_lm_target_requires_exactly_one_location():
             model_name=None,
             model_path=None,
         )
+
+
+def test_lm_driver_validate_config_rejects_wrong_shape():
+    run = RunConfig(
+        driver_path=LM_DRIVER_PATH,
+        pd=_pd_config(),
+        logging=_logging_config(),
+        runtime=_runtime_config(),
+        target={"completely": "wrong"},
+        data={"also": "wrong"},
+    )
+    with pytest.raises(ValidationError):
+        LMDriver().validate_config(run)
+
+
+def test_tms_driver_validate_config_rejects_wrong_shape():
+    run = RunConfig(
+        driver_path=TMS_DRIVER_PATH,
+        pd=_pd_config(),
+        logging=_logging_config(),
+        runtime=_runtime_config(),
+        target={"completely": "wrong"},
+        data={},
+    )
+    with pytest.raises(ValidationError):
+        TMSDriver().validate_config(run)
+
+
+def test_resid_mlp_driver_validate_config_rejects_wrong_shape():
+    run = RunConfig(
+        driver_path=RESID_MLP_DRIVER_PATH,
+        pd=_pd_config(),
+        logging=_logging_config(),
+        runtime=_runtime_config(),
+        target={"completely": "wrong"},
+        data={},
+    )
+    with pytest.raises(ValidationError):
+        ResidMLPDriver().validate_config(run)
 
 
 def test_layerwise_mlp_ci_hidden_dims_must_be_non_empty():


### PR DESCRIPTION
## Description

Flattens `RunConfig` so there's one class, not a base + per-driver subclass per experiment. `target` and `data` become raw `dict[str, Any]` payloads owned by the driver. The driver Protocol gains `validate_config(run_cfg)` for pre-flight; the `config_type` ClassVar and the `RunConfig.from_dict` dispatch are removed. Callers use `RunConfig.model_validate(...)`.

Driver-private typed access at caller sites (the nine `isinstance(run, LMRunConfig)` gates across adapters, app routers, clustering, dataset_attributions, editing, blog export scripts) goes through small helpers exposed by each driver module — `is_lm_run`, `lm_target`, `lm_data` in `param_decomp/experiments/lm/experiment.py`.

## Motivation and Context

The framework already stored `target` / `data` as `dict[str, Any]` on `SweepSpec` (because the sweep code can't statically know which driver's typed shape to use) while keeping them strongly typed on `RunConfig` subclasses (`LMRunConfig`, `TMSRunConfig`, `ResidMLPRunConfig`). That asymmetry was the prompt for this work — and it stayed even after bug 003 hoisted `target` / `data` onto `SweepSpec`.

Open-world drivers stay justified: postprocessing pipelines (`pd-harvest`, `pd-autointerp`, `pd-attributions`, `pd-graph-interp`, the app) all reach `SavedRun.from_path` → driver → `build_target`, so dropping dynamic driver loading would gut the value proposition for users bringing their own (e.g. bio) model. But the abstraction was over-weight for that goal — a driver is now `name` + `validate_config` + three `build_*` methods, period. No `RunConfig` subclass dance, no `config_type` ClassVar.

`SweepSpec.run_cfgs()` becomes a trivial dict forward (no more driver-dispatched `model_validate`). Pre-flight `driver.validate_config(run_cfg)` in `runner.py` and both `launch_*_slurm` helpers gives the fail-fast property a 200-config sweep needs: a malformed `target` block dies before SLURM submit, not in task 17.

Design background and full landing-order plan: `/mnt/polished-lake/home/braun/.claude/plans/please-make-a-plan-structured-harbor.md`.

## How Has This Been Tested?

- `make check` — pyright + ruff clean (0 errors, 0 warnings).
- `make test` — full suite, 466 passed, 7 skipped. New tests cover the `validate_config` contract for each driver (LM, TMS, ResidMLP) — they reject `target={"completely": "wrong"}` with `ValidationError`.
- `pd-run tms_5-2 --local` and `pd-run resid_mlp1 --local` reach `build_target` successfully (i.e. `RunConfig.model_validate` ✓, `driver.validate_config` ✓, `TMSTargetConfig`/`ResidMLPTargetConfig.model_validate` ✓), then fail downstream on a **pre-existing** schema mismatch in stale cached upstream pretrain configs (`lr_schedule: 'cosine'` string vs the new `ScheduleConfig` model in `TMSTrainConfig`/`ResidMLPTrainConfig`). Unrelated to this PR. The pretrain configs need regenerating, or `TMSTrainConfig`/`ResidMLPTrainConfig` need to accept the old shape.

Not run (left to reviewer): wandb reload smoke (`load_component_model('<existing-LM-wandb-path>')`) and the deliberately-corrupt-sweep pre-flight test described in the plan.

## Does this PR introduce a breaking change?

**Source-level**, yes: `LMRunConfig` / `TMSRunConfig` / `ResidMLPRunConfig` are deleted; `RunConfig.from_dict` is deleted; the `ExperimentDriver[RunConfigT]` generic is gone; `config_type` is gone. External users who subclassed `RunConfig` or read `driver.config_type` need to migrate to the flatter shape — driver code reduces to one class with `name`, `validate_config`, and three `build_*` methods, all taking `RunConfig`.

**Data-level**, no: existing `run_config.yaml` files on disk and in W&B reload unchanged. They already serialize `target` / `data` as dicts; the new `RunConfig` accepts those dicts as-is and the driver re-parses them inside `build_*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)