### PR TITLE
Add 1-pool resumption: Trainer class + canonical training-state checkpoints

### DIFF
--- a/param_decomp/metrics/base.py
+++ b/param_decomp/metrics/base.py
@@ -114,3 +114,22 @@ class Metric[TConfig: BaseConfig](ABC):
         Override when a metric needs to step internal state coupled to the outer
         backward — e.g. `PersistentPGDReconLoss` steps its adversarial sources here.
         """
+
+    def state_dict(self) -> dict[str, Any]:
+        """Return persistent metric state for round-tripping across a training restart.
+
+        Default is an empty dict: most metrics are stateless w.r.t. the optimizer
+        trajectory (their accumulators reset between eval passes). Override when a
+        metric carries trajectory-dependent state — e.g. `PersistentPGDReconLoss`
+        round-trips its adversarial sources here. Mirrors the `nn.Module` / `Optimizer`
+        convention; the parent `Trainer` composes these into its own state blob.
+        """
+        return {}
+
+    def load_state_dict(self, state: dict[str, Any]) -> None:  # noqa: B027 — intentional no-op default
+        """Load persistent state produced by a prior :meth:`state_dict` call.
+
+        Default is a no-op (matches the default empty `state_dict`). Override
+        alongside `state_dict` for any metric carrying trajectory-dependent state.
+        """
+        del state

--- a/param_decomp/metrics/persistent_pgd_recon.py
+++ b/param_decomp/metrics/persistent_pgd_recon.py
@@ -7,7 +7,7 @@ state + optimizer state machine live in `persistent_pgd_state`.
 """
 
 from collections.abc import Iterable
-from typing import Annotated, ClassVar, Literal, override
+from typing import Annotated, Any, ClassVar, Literal, override
 
 import torch
 from jaxtyping import Float
@@ -128,6 +128,9 @@ class _PersistentPGDReconBase[
         super().__init__(cfg)
         self.state: PersistentPGDState | None = None
         self._pending_source_grads: PPGDSources | None = None
+        # Stash from `load_state_dict` if called before the first `update()` —
+        # `PersistentPGDState` needs batch_dims, which we only learn from a live ctx.
+        self._pending_resume_state: dict[str, Any] | None = None
 
     def _ensure_state(self, ctx: MetricContext) -> None:
         if self.state is not None:
@@ -146,6 +149,9 @@ class _PersistentPGDReconBase[
             router=_router_for_cfg(self.cfg, self.device),
             reconstruction_loss=ctx.reconstruction_loss,
         )
+        if self._pending_resume_state is not None:
+            self.state.load_state_dict(self._pending_resume_state)
+            self._pending_resume_state = None
 
     @override
     def reset(self) -> None:
@@ -246,6 +252,24 @@ class _PersistentPGDReconBase[
         assert self.state is not None
         self.state.step(self._pending_source_grads)
         self._pending_source_grads = None
+
+    @override
+    def state_dict(self) -> dict[str, Any]:
+        if self.state is None:
+            return {}
+        return self.state.state_dict()
+
+    @override
+    def load_state_dict(self, state: dict[str, Any]) -> None:
+        if not state:
+            self._pending_resume_state = None
+            return
+        if self.state is None:
+            # `PersistentPGDState` needs batch_dims, which only arrives with the first
+            # `update()` ctx. Defer the load until `_ensure_state` constructs the state.
+            self._pending_resume_state = state
+        else:
+            self.state.load_state_dict(state)
 
 
 class PersistentPGDReconLoss(_PersistentPGDReconBase[PersistentPGDReconLossConfig]):

--- a/param_decomp/metrics/persistent_pgd_state.py
+++ b/param_decomp/metrics/persistent_pgd_state.py
@@ -6,7 +6,7 @@ these primitives.
 """
 
 from abc import ABC, abstractmethod
-from typing import Annotated, Literal, override
+from typing import Annotated, Any, Literal, override
 
 import torch
 from jaxtyping import Float, Int
@@ -105,6 +105,18 @@ class PPGDOptimizer(ABC):
     @abstractmethod
     def set_lr(self, lr: float) -> None: ...
 
+    def state_dict(self) -> dict[str, Any]:
+        """Return trajectory-dependent optimizer state.
+
+        Default empty — stateless optimizers (e.g. SignPGD) need nothing. Override
+        in optimizers that carry momentum or step counts across training steps.
+        """
+        return {}
+
+    def load_state_dict(self, state: dict[str, Any]) -> None:  # noqa: B027 — intentional no-op default
+        """Restore optimizer state produced by a prior :meth:`state_dict` call."""
+        del state
+
 
 class SignPGDOptimizer(PPGDOptimizer):
     def __init__(self, cfg: SignPGDConfig) -> None:
@@ -159,6 +171,23 @@ class AdamPGDOptimizer(PPGDOptimizer):
     @override
     def set_lr(self, lr: float) -> None:
         self._lr = lr
+
+    @override
+    def state_dict(self) -> dict[str, Any]:
+        return {
+            "step_count": self._step_count,
+            "m": dict(self._m),
+            "v": dict(self._v),
+        }
+
+    @override
+    def load_state_dict(self, state: dict[str, Any]) -> None:
+        self._step_count = state["step_count"]
+        with torch.no_grad():
+            for k, t in state["m"].items():
+                self._m[k].copy_(t.to(self._m[k].device))
+            for k, t in state["v"].items():
+                self._v[k].copy_(t.to(self._v[k].device))
 
 
 def make_ppgd_optimizer(cfg: PGDOptimizerConfig) -> PPGDOptimizer:
@@ -264,6 +293,20 @@ class PersistentPGDState:
     def update_lr(self, step: int, total_steps: int) -> None:
         lr = get_scheduled_value(step, total_steps, self._lr_schedule)
         self.optimizer.set_lr(lr)
+
+    def state_dict(self) -> dict[str, Any]:
+        """Round-trip the persistent adversary trajectory: sources + optimizer state."""
+        return {
+            "sources": {k: v.detach() for k, v in self.sources.items()},
+            "optimizer": self.optimizer.state_dict(),
+        }
+
+    def load_state_dict(self, state: dict[str, Any]) -> None:
+        """Restore sources + optimizer state in-place. Shapes must already match."""
+        with torch.no_grad():
+            for k, src in self.sources.items():
+                src.copy_(state["sources"][k].to(src.device))
+        self.optimizer.load_state_dict(state["optimizer"])
 
     def warmup(
         self,

--- a/param_decomp/optimize.py
+++ b/param_decomp/optimize.py
@@ -1,13 +1,25 @@
-"""PD optimization loop.
+"""The PD trainer.
 
-`optimize()` is the sole core entrypoint; `EvalLoop` bundles the eval runtime objects
-with their timing.
+Two entry points:
+
+- :class:`Trainer` — stateful training class. Construction sets up the
+  `ComponentModel`, the two optimizers, and the loss-metric instances from
+  ``pd_config``. :meth:`Trainer.run` advances the training loop from
+  ``self.step`` to ``pd_config.steps``. :meth:`Trainer.snapshot` and
+  :meth:`Trainer.from_snapshot` round-trip an atomic
+  :class:`~param_decomp.trainer_snapshot.TrainerSnapshot` that lets a caller
+  persist and restore the full training state (used by resumption).
+- :func:`optimize` — thin convenience wrapper that constructs a `Trainer` and
+  calls :meth:`Trainer.run`. Preserves the original function-style entry point
+  for callers that don't need resumption.
+
+Both go through the same code path.
 """
 
 import gc
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Self, cast
 
 import torch
 import torch.nn as nn
@@ -47,19 +59,28 @@ from param_decomp.metrics.persistent_pgd_recon import validate_pgd_scope
 from param_decomp.run_sink import RunSink
 from param_decomp.schedule import get_scheduled_value
 from param_decomp.torch_helpers import bf16_autocast, loop_dataloader
+from param_decomp.training_state import TrainingState
 
 
 @dataclass(frozen=True)
 class EvalLoop:
     """Eval-loop runtime objects bundled with their timing.
 
-    Pass `eval_loop=None` to `optimize` to skip eval entirely. When set, the trainer
-    evaluates every `every` steps; on steps that are also multiples of `slow_every`,
-    slow metrics fire too. `slow_every` must be a multiple of `every` — `should_run_slow_eval`
-    is only checked on steps where `should_eval` already fired.
+    Pass ``eval_loop=None`` to :meth:`Trainer.run` (or :func:`optimize`) to skip
+    eval entirely. When set, the trainer evaluates every ``every`` steps; on steps
+    that are also multiples of ``slow_every``, slow metrics fire too. ``slow_every``
+    must be a multiple of ``every`` — the trainer only checks :meth:`should_run_slow_eval`
+    on steps where :meth:`should_eval` already fired.
 
-    `optimize` calls `Metric.bind(model, device)` on every entry of `metrics` before the
-    loop starts.
+    Attributes:
+        loader: Eval data loader. Looped for the lifetime of training.
+        metrics: Caller-instantiated eval ``Metric``s. ``optimize`` calls
+            ``Metric.bind(model, device)`` on each before the loop.
+        n_steps: Number of eval batches per eval pass.
+        every: Period (in train steps) between eval passes.
+        slow_every: Period (in train steps) between *slow* eval passes. Must
+            be a multiple of ``every``.
+        slow_on_first_step: Whether slow eval fires at step 0.
     """
 
     loader: DataLoader[Any]
@@ -75,13 +96,14 @@ class EvalLoop:
         )
 
     def should_eval(self, step: int) -> bool:
+        """Whether a (regular) eval pass should fire at ``step``."""
         return step % self.every == 0
 
     def should_run_slow_eval(self, step: int) -> bool:
-        """Whether slow eval should fire at `step`.
+        """Whether slow eval metrics should fire at ``step``.
 
-        Slow eval is gated on top of `should_eval`; only call this on steps where
-        `should_eval` is already true.
+        Slow eval is gated on top of ``should_eval``; callers are expected to
+        only call this on steps where ``should_eval`` is already true.
         """
         if step == 0:
             return self.slow_on_first_step
@@ -126,6 +148,29 @@ def _build_metric_context(
     )
 
 
+def _assert_ctx_invariants(ctx: MetricContext, device: str, step: int) -> None:
+    """Fail loudly if anything is off about the metric context handed to the
+    loss metrics — wrong device, non-finite target output, empty ci dict, etc.
+    These would otherwise propagate silently through the loss + backward path.
+    """
+    assert isinstance(ctx.target_out, torch.Tensor)
+    device_prefix = str(device).split(":")[0]
+    assert str(ctx.target_out.device).startswith(device_prefix), (
+        f"ctx.target_out device mismatch at step {step}: target_out on "
+        f"{ctx.target_out.device}, trainer on {device}"
+    )
+    assert torch.isfinite(ctx.target_out).all(), f"non-finite values in target_out at step {step}"
+    assert ctx.ci.lower_leaky, f"empty ci.lower_leaky dict at step {step}"
+    assert ctx.ci.upper_leaky.keys() == ctx.ci.lower_leaky.keys(), (
+        f"ci upper/lower leaky key mismatch at step {step}"
+    )
+    for name, t in ctx.ci.lower_leaky.items():
+        assert torch.isfinite(t).all(), f"non-finite ci.lower_leaky[{name!r}] at step {step}"
+        assert str(t.device).startswith(device_prefix), (
+            f"ci.lower_leaky[{name!r}] device mismatch at step {step}: {t.device} vs {device}"
+        )
+
+
 def tie_component_weights(
     component_model: ComponentModel, tied_weights: list[tuple[str, str]]
 ) -> None:
@@ -137,6 +182,457 @@ def tie_component_weights(
         )
         tgt.U.data = src.V.data.T
         tgt.V.data = src.U.data.T
+
+
+def optimizer_state_by_name(
+    optimizer: torch.optim.Optimizer,
+    named_params: list[tuple[str, nn.Parameter]],
+) -> dict[str, dict[str, Any]]:
+    """Convert ``optimizer.state_dict()["state"]`` from integer-indexed to name-keyed.
+
+    PyTorch optimizers key their internal per-parameter state (Adam moments, step
+    counter, etc.) by the integer position of each parameter in
+    ``param_groups[*]["params"]``. That position is topology-dependent: a rank
+    holding a subset of sites indexes them 0..N for *its own* sites, in the
+    order they were added. To make optimizer state survive a topology change,
+    the caller passes the ``(name, param)`` pairs in the same order they were
+    added to the optimizer, and this returns ``{name: state_entry}``.
+
+    Names that have no optimizer state yet (e.g. fresh param, no step taken)
+    are simply omitted.
+    """
+    raw_state: dict[int, dict[str, Any]] = optimizer.state_dict()["state"]
+    by_name: dict[str, dict[str, Any]] = {}
+    for i, (name, _) in enumerate(named_params):
+        if i in raw_state:
+            by_name[name] = raw_state[i]
+    return by_name
+
+
+def load_optimizer_state_by_name(
+    optimizer: torch.optim.Optimizer,
+    named_params: list[tuple[str, nn.Parameter]],
+    by_name: dict[str, dict[str, Any]],
+) -> None:
+    """Inverse of :func:`optimizer_state_by_name`.
+
+    Each ``(name, param)`` pair in ``named_params`` matches its position in
+    the live optimizer's ``param_groups[*]["params"]``. For each name present
+    in ``by_name``, install the saved entry under the matching integer index
+    in ``optimizer.state``. Param groups (lr, betas, etc.) are taken from the
+    live optimizer — they're hyperparameters configured at construction time,
+    not state to be round-tripped.
+    """
+    current = optimizer.state_dict()
+    new_state: dict[int, dict[str, Any]] = {}
+    for i, (name, _) in enumerate(named_params):
+        if name in by_name:
+            new_state[i] = by_name[name]
+    current["state"] = new_state
+    optimizer.load_state_dict(current)
+
+
+class Trainer:
+    """Stateful PD trainer.
+
+    Construction wires up the `ComponentModel`, both AdamW optimizers, and the
+    loss-metric instances declared in ``pd_config.loss_metrics``. :meth:`run`
+    advances the training loop from ``self.step`` to ``pd_config.steps``.
+    :meth:`snapshot` and :meth:`from_snapshot` round-trip a
+    :class:`~param_decomp.trainer_snapshot.TrainerSnapshot` that a caller can
+    persist and restore.
+
+    All ranks construct a `Trainer`. Sink output and the loader-replay skip on
+    resume are governed by ``self.step`` (advanced by :meth:`run`,
+    overwritten by :meth:`_load_state`).
+    """
+
+    pd_config: PDConfig
+    runtime_config: RuntimeConfig
+    reconstruction_loss: ReconstructionLoss
+    component_model: ComponentModel
+    components_optimizer: optim.Optimizer
+    ci_fn_optimizer: optim.Optimizer
+    loss_metrics: dict[str, Metric[Any]]
+    step: int
+
+    def __init__(
+        self,
+        *,
+        target_model: nn.Module,
+        run_batch: RunBatch,
+        reconstruction_loss: ReconstructionLoss,
+        pd_config: PDConfig,
+        runtime_config: RuntimeConfig,
+    ) -> None:
+        self.pd_config = pd_config
+        self.runtime_config = runtime_config
+        self.reconstruction_loss = reconstruction_loss
+        self.step = 0
+
+        dist_state = get_distributed_state()
+        device = runtime_config.device
+        validate_pgd_scope(
+            pd_config.loss_metrics,
+            batch_size=pd_config.batch_size,
+            world_size=dist_state.world_size if dist_state is not None else 1,
+        )
+
+        if pd_config.identity_decomposition_targets is not None:
+            insert_identity_operations_(
+                target_model,
+                identity_decomposition_targets=pd_config.identity_decomposition_targets,
+            )
+
+        target_model.requires_grad_(False)
+        target_model.eval()
+        decomposition_targets = resolve_decomposition_targets(
+            target_model, pd_config.all_decomposition_target_configs
+        )
+
+        seed_all_ranks(pd_config.seed)
+        model = ComponentModel(
+            target_model=target_model,
+            run_batch=run_batch,
+            decomposition_targets=decomposition_targets,
+            ci_config=pd_config.ci_config,
+            sigmoid_type=pd_config.sigmoid_type,
+        )
+        model.to(device)
+
+        # Diverge global RNG per rank so stochastic masks/sources differ across DP workers.
+        seed_per_rank(pd_config.seed)
+
+        if dist_state is not None:
+            if dist_state.backend == "nccl":
+                device_id = dist_state.local_rank
+                self._wrapped_model: nn.Module = torch.nn.parallel.DistributedDataParallel(
+                    model, device_ids=[device_id], output_device=device_id
+                )
+            else:
+                self._wrapped_model = torch.nn.parallel.DistributedDataParallel(model)
+            component_model = cast(ComponentModel, self._wrapped_model.module)
+        else:
+            self._wrapped_model = model
+            component_model = model
+        assert isinstance(component_model, ComponentModel)
+        self.component_model = component_model
+
+        if pd_config.tied_weights is not None:
+            tie_component_weights(component_model, pd_config.tied_weights)
+
+        self._component_params: list[torch.nn.Parameter] = []
+        for name in component_model.target_module_paths:
+            self._component_params.extend(component_model.components[name].parameters())
+        assert component_model.ci_fn is not None, (
+            "single-pool Trainer assumes a ComponentModel with the CI fn intact"
+        )
+        self._ci_fn_params = list(component_model.ci_fn.parameters())
+        assert len(self._component_params) > 0, "No parameters found in components to optimize"
+
+        self.components_optimizer = optim.AdamW(
+            self._component_params,
+            lr=pd_config.components_optimizer.lr_schedule.start_val,
+            betas=pd_config.components_optimizer.betas,
+            weight_decay=pd_config.components_optimizer.weight_decay,
+        )
+        self.ci_fn_optimizer = optim.AdamW(
+            self._ci_fn_params,
+            lr=pd_config.ci_fn_optimizer.lr_schedule.start_val,
+            betas=pd_config.ci_fn_optimizer.betas,
+            weight_decay=pd_config.ci_fn_optimizer.weight_decay,
+        )
+
+        self.loss_metrics, _ = instantiate_metrics(pd_config, component_model, device)
+
+    # ============================ Named-param accessors for optimizer state ============================
+
+    def _components_optimizer_named_params(self) -> list[tuple[str, nn.Parameter]]:
+        """The ``(name, param)`` pairs in the order they were added to ``components_optimizer``.
+
+        Names follow ``components.<module_path>.<param_name_inside_component>`` so they're
+        topology-independent (a sharded trainer holding only a subset of sites produces
+        the same names for those sites as a 1-pool trainer holding all of them).
+        """
+        out: list[tuple[str, nn.Parameter]] = []
+        for module_path in self.component_model.target_module_paths:
+            for pname, p in self.component_model.components[module_path].named_parameters():
+                out.append((f"components.{module_path}.{pname}", p))
+        return out
+
+    def _ci_fn_optimizer_named_params(self) -> list[tuple[str, nn.Parameter]]:
+        """The ``(name, param)`` pairs for ``ci_fn_optimizer``."""
+        assert self.component_model.ci_fn is not None
+        return [(f"ci_fn.{n}", p) for n, p in self.component_model.ci_fn.named_parameters()]
+
+    # ============================ Atomic cfg + state ============================
+
+    def snapshot(self) -> TrainingState:
+        """Canonical point-in-time view of this trainer.
+
+        Returns a :class:`TrainingState` carrying configs (model_dump'd), model
+        state dict, both optimizer states (keyed by parameter NAME so they
+        survive topology changes), and every loss metric's ``state_dict()``.
+        For 1-pool DDP this state is identical across ranks (the model and
+        optimizers are replicated); the lab sink writes from rank 0 only.
+        """
+        return TrainingState(
+            step=self.step,
+            pd_config=self.pd_config.model_dump(),
+            runtime_config=self.runtime_config.model_dump(),
+            component_model=self.component_model.state_dict(),
+            components_optimizer=optimizer_state_by_name(
+                self.components_optimizer, self._components_optimizer_named_params()
+            ),
+            ci_fn_optimizer=optimizer_state_by_name(
+                self.ci_fn_optimizer, self._ci_fn_optimizer_named_params()
+            ),
+            loss_metrics={n: m.state_dict() for n, m in self.loss_metrics.items()},
+        )
+
+    @classmethod
+    def from_snapshot(
+        cls,
+        snapshot: TrainingState,
+        *,
+        target_model: nn.Module,
+        run_batch: RunBatch,
+        reconstruction_loss: ReconstructionLoss,
+        cfg_overrides: dict[str, Any] | None = None,
+    ) -> Self:
+        """Reconstruct a Trainer from a :class:`TrainingState`.
+
+        ``cfg_overrides`` is a flat patch applied to the saved ``pd_config``
+        dict before pydantic validation — used for narrow resume-time
+        overrides such as extending ``steps``.
+        """
+        pd_dict = snapshot.pd_config
+        if cfg_overrides is not None:
+            pd_dict = {**pd_dict, **cfg_overrides}
+        pd_config = PDConfig.model_validate(pd_dict)
+        runtime_config = RuntimeConfig.model_validate(snapshot.runtime_config)
+        trainer = cls(
+            target_model=target_model,
+            run_batch=run_batch,
+            reconstruction_loss=reconstruction_loss,
+            pd_config=pd_config,
+            runtime_config=runtime_config,
+        )
+        trainer._load_state(snapshot)
+        return trainer
+
+    def _load_state(self, state: TrainingState) -> None:
+        """In-place load of the trainer's runtime state. Caller's responsibility
+        to have constructed self with a matching cfg (use :meth:`from_snapshot`
+        to guarantee this).
+        """
+        self.step = state.step
+        self.component_model.load_state_dict(state.component_model)
+        load_optimizer_state_by_name(
+            self.components_optimizer,
+            self._components_optimizer_named_params(),
+            state.components_optimizer,
+        )
+        load_optimizer_state_by_name(
+            self.ci_fn_optimizer,
+            self._ci_fn_optimizer_named_params(),
+            state.ci_fn_optimizer,
+        )
+        for name, m in self.loss_metrics.items():
+            m.load_state_dict(state.loss_metrics[name])
+
+    # ============================ Training loop ============================
+
+    def run(
+        self,
+        train_loader: DataLoader[Any],
+        sink: RunSink,
+        cadence: Cadence,
+        eval_loop: EvalLoop | None = None,
+    ) -> None:
+        """Advance training from ``self.step`` to ``self.pd_config.steps``.
+
+        When ``self.step == 0`` and ``pd_config.faithfulness_warmup_steps > 0``,
+        faithfulness warmup runs once before the loop. When ``self.step > 0``
+        (i.e. resumed mid-trajectory), warmup is skipped and the train loader is
+        skip-advanced by ``self.step`` batches to reproduce the corresponding
+        position in the data stream.
+        """
+        pd_config = self.pd_config
+        runtime_config = self.runtime_config
+        device = runtime_config.device
+
+        train_iterator = loop_dataloader(train_loader)
+        eval_iterator = loop_dataloader(eval_loop.loader) if eval_loop is not None else None
+
+        # Loader replay: if we're starting from non-zero step, advance the iterator to
+        # the matching position. Deterministic given the loader's seed.
+        for _ in range(self.step):
+            next(train_iterator)
+
+        if self.step == 0 and pd_config.faithfulness_warmup_steps > 0:
+            run_faithfulness_warmup(self.component_model, self._component_params, pd_config)
+
+        eval_only_instances: dict[str, Metric[Any]] = {}
+        if eval_loop is not None:
+            for m in eval_loop.metrics:
+                m.bind(model=self.component_model, device=device)
+
+            # Loss metrics are auto-evaluated alongside dedicated eval metrics. We disallow
+            # duplicate registry names across the two pools because `evaluate()` keys metrics
+            # by class name.
+            for m in eval_loop.metrics:
+                metric_name = type(m).__name__
+                assert metric_name not in eval_only_instances, (
+                    f"duplicate eval metric {metric_name!r}"
+                )
+                eval_only_instances[metric_name] = m
+            overlap = sorted(set(self.loss_metrics) & set(eval_only_instances))
+            assert not overlap, (
+                f"eval_loop.metrics overlap with pd_config.loss_metrics: {overlap}. Loss "
+                "metrics are automatically evaluated; remove the duplicates from "
+                "eval_loop.metrics."
+            )
+        all_instances = {**self.loss_metrics, **eval_only_instances}
+
+        for step in tqdm(
+            range(self.step, pd_config.steps + 1), ncols=0, disable=not is_main_process()
+        ):
+            self.step = step
+            self.components_optimizer.zero_grad()
+            self.ci_fn_optimizer.zero_grad()
+
+            components_lr = get_scheduled_value(
+                step=step,
+                total_steps=pd_config.steps,
+                config=pd_config.components_optimizer.lr_schedule,
+            )
+            ci_fn_lr = get_scheduled_value(
+                step=step,
+                total_steps=pd_config.steps,
+                config=pd_config.ci_fn_optimizer.lr_schedule,
+            )
+            for group in self.components_optimizer.param_groups:
+                group["lr"] = components_lr
+            for group in self.ci_fn_optimizer.param_groups:
+                group["lr"] = ci_fn_lr
+
+            batch_log_data: defaultdict[str, float] = defaultdict(float)
+
+            with bf16_autocast(enabled=runtime_config.autocast_bf16):
+                ctx = _build_metric_context(
+                    next(train_iterator),
+                    step=step,
+                    is_eval=False,
+                    device=device,
+                    wrapped_model=self._wrapped_model,
+                    component_model=self.component_model,
+                    config=pd_config,
+                    reconstruction_loss=self.reconstruction_loss,
+                )
+                _assert_ctx_invariants(ctx, device, step)
+                losses = {name: m.update(ctx) for name, m in self.loss_metrics.items()}
+
+            total_loss = torch.zeros((), device=device)
+            active_loss_names: list[str] = []
+            for metric_name, loss_val in losses.items():
+                if loss_val is None:
+                    continue
+                active_loss_names.append(metric_name)
+                assert torch.isfinite(loss_val).all(), (
+                    f"non-finite loss from metric {metric_name!r} at step {step}: {loss_val}"
+                )
+                cfg = cast(LossMetricConfig, self.loss_metrics[metric_name].cfg)
+                assert cfg.coeff is not None
+                total_loss = total_loss + cfg.coeff * loss_val
+                batch_log_data[f"loss/{type(self.loss_metrics[metric_name]).__name__}"] = (
+                    loss_val.item()
+                )
+            assert active_loss_names, (
+                f"No active loss metrics returned a loss at step {step}. "
+                f"Configured loss metrics: {list(self.loss_metrics)}"
+            )
+            assert torch.isfinite(total_loss).all(), (
+                f"total_loss is non-finite at step {step}: {total_loss}"
+            )
+            batch_log_data["loss/total"] = total_loss.item()
+
+            for metric_name, m in self.loss_metrics.items():
+                m.before_backward(losses[metric_name])
+
+            total_loss.backward()
+
+            for m in self.loss_metrics.values():
+                m.after_backward()
+
+            # --- Train Logging --- #
+            if cadence.should_log_train(step):
+                avg_metrics = avg_metrics_across_ranks(batch_log_data, device=device)
+                batch_log_data = cast(defaultdict[str, float], avg_metrics)
+
+                grad_norms = component_grad_norms(self.component_model, device)
+                grad_norm_log_data = {f"grad_norms/{k}": v for k, v in grad_norms.items()}
+                assert not set(batch_log_data) & set(grad_norm_log_data)
+                batch_log_data.update(grad_norm_log_data)
+                batch_log_data["schedules/lr/components"] = components_lr
+                batch_log_data["schedules/lr/ci_fn"] = ci_fn_lr
+
+                sink.console(
+                    f"--- Step {step} ---",
+                    f"LR[components]: {components_lr:.6f}",
+                    f"LR[ci_fn]: {ci_fn_lr:.6f}",
+                    *(f"train/{name}: {value:.15f}" for name, value in batch_log_data.items()),
+                )
+                sink.log({f"train/{k}": v for k, v in batch_log_data.items()}, step=step)
+
+            # --- Evaluation --- #
+            if eval_loop is not None and eval_loop.should_eval(step):
+                assert eval_iterator is not None
+                with torch.no_grad(), bf16_autocast(enabled=runtime_config.autocast_bf16):
+                    slow_step = eval_loop.should_run_slow_eval(step)
+                    active = [m for m in all_instances.values() if not (m.slow and not slow_step)]
+                    for m in active:
+                        m.reset()
+                    for _ in range(eval_loop.n_steps):
+                        ctx = _build_metric_context(
+                            next(eval_iterator),
+                            step=step,
+                            is_eval=True,
+                            device=device,
+                            wrapped_model=self._wrapped_model,
+                            component_model=self.component_model,
+                            config=pd_config,
+                            reconstruction_loss=self.reconstruction_loss,
+                        )
+                        for m in active:
+                            m.update(ctx)
+                    metrics = collect_metric_outputs(active)
+
+                    sink.console(*(f"eval/{k}: {v}" for k, v in metrics.items()))
+                    sink.log({f"eval/{k}": v for k, v in metrics.items()}, step=step)
+
+                    del metrics
+                    torch.cuda.empty_cache()
+                    gc.collect()
+
+            # --- Saving Checkpoint --- #
+            if step == pd_config.steps or cadence.should_save(step):
+                sink.checkpoint(self.snapshot())
+
+            # Skip gradient step at the very last step (last step is just for plotting/logging).
+            if step != pd_config.steps:
+                sync_across_processes()
+                if pd_config.components_optimizer.grad_clip_norm is not None:
+                    clip_grad_norm_(
+                        self._component_params, pd_config.components_optimizer.grad_clip_norm
+                    )
+                if pd_config.ci_fn_optimizer.grad_clip_norm is not None:
+                    clip_grad_norm_(self._ci_fn_params, pd_config.ci_fn_optimizer.grad_clip_norm)
+                self.components_optimizer.step()
+                self.ci_fn_optimizer.step()
+
+        if is_main_process():
+            logger.info("Finished training loop.")
 
 
 def optimize(
@@ -152,237 +648,14 @@ def optimize(
 ) -> None:
     """Run the PD optimization loop.
 
-    Builds the `ComponentModel` internally, instantiates loss metrics from
-    `pd_config.loss_metrics`, optionally runs a faithfulness warmup, then loops for
-    `pd_config.steps + 1` training steps. Every step computes losses from
-    `loss_metrics`, accumulates them weighted by their `coeff`, and backprops. Train
-    logging, checkpointing, and eval each fire on their own schedule.
-
-    Under DDP, the trainer wraps `ComponentModel` in `DistributedDataParallel` for
-    gradient sync. Every rank executes this function and every rank calls every `sink`
-    method — the `RunSink` implementation owns any rank-aware filtering it wants (e.g.
-    only writing files / wandb on `is_main_process()`).
-
-    Args:
-        target_model: The frozen model whose parameters are being decomposed. Mutated
-            in place: forced to `requires_grad=False` and put in `eval()` mode.
-        train_loader: Train data loader. Looped indefinitely until `pd_config.steps`
-            is reached.
-        run_batch: Callable that runs one batch through the wrapped target model and
-            returns its output tensor.
-        reconstruction_loss: Callable returning `(loss_sum, n_elements)` used by
-            recon-style loss metrics.
-        pd_config: Algorithm specification — CI fn, loss metrics, optimizers,
-            decomposition targets, seed, tied weights, warmup, etc.
-        runtime_config: Compute substrate — device, autocast, data-parallelism.
-        sink: Output destination. Metric keys handed to `sink.log` are pre-namespaced
-            (`train/...`, `eval/...`). See note above on rank semantics.
-        cadence: Train-log + checkpoint period. The final step always checkpoints
-            regardless of `cadence.save_every`.
-        eval_loop: Optional eval bundle. Pass `None` to skip eval entirely.
+    Thin wrapper over :class:`Trainer` for callers that don't need resumption
+    or interactive control. Identical signature to the pre-Trainer ``optimize``.
     """
-    dist_state = get_distributed_state()
-    device = runtime_config.device
-    validate_pgd_scope(
-        pd_config.loss_metrics,
-        batch_size=pd_config.batch_size,
-        world_size=dist_state.world_size if dist_state is not None else 1,
-    )
-
-    train_iterator = loop_dataloader(train_loader)
-    eval_iterator = loop_dataloader(eval_loop.loader) if eval_loop is not None else None
-
-    if pd_config.identity_decomposition_targets is not None:
-        insert_identity_operations_(
-            target_model,
-            identity_decomposition_targets=pd_config.identity_decomposition_targets,
-        )
-
-    target_model.requires_grad_(False)
-    target_model.eval()
-    decomposition_targets = resolve_decomposition_targets(
-        target_model, pd_config.all_decomposition_target_configs
-    )
-
-    seed_all_ranks(pd_config.seed)
-    model = ComponentModel(
+    trainer = Trainer(
         target_model=target_model,
         run_batch=run_batch,
-        decomposition_targets=decomposition_targets,
-        ci_config=pd_config.ci_config,
-        sigmoid_type=pd_config.sigmoid_type,
+        reconstruction_loss=reconstruction_loss,
+        pd_config=pd_config,
+        runtime_config=runtime_config,
     )
-    model.to(device)
-
-    # Diverge global RNG per rank so stochastic masks/sources differ across DP workers.
-    seed_per_rank(pd_config.seed)
-
-    wrapped_model: nn.Module = model
-    component_model: ComponentModel
-    if dist_state is not None:
-        if dist_state.backend == "nccl":
-            device_id = dist_state.local_rank
-            wrapped_model = torch.nn.parallel.DistributedDataParallel(
-                model, device_ids=[device_id], output_device=device_id
-            )
-        else:
-            wrapped_model = torch.nn.parallel.DistributedDataParallel(model)
-        component_model = cast(ComponentModel, wrapped_model.module)
-    else:
-        component_model = model
-    assert isinstance(component_model, ComponentModel), "component_model is not a ComponentModel"
-
-    if pd_config.tied_weights is not None:
-        tie_component_weights(component_model, pd_config.tied_weights)
-
-    component_params: list[torch.nn.Parameter] = []
-    for name in component_model.target_module_paths:
-        component_params.extend(component_model.components[name].parameters())
-    ci_fn_params = list(component_model.ci_fn.parameters())
-    assert len(component_params) > 0, "No parameters found in components to optimize"
-
-    components_optimizer = optim.AdamW(
-        component_params,
-        lr=pd_config.components_optimizer.lr_schedule.start_val,
-        betas=pd_config.components_optimizer.betas,
-        weight_decay=pd_config.components_optimizer.weight_decay,
-    )
-    ci_fn_optimizer = optim.AdamW(
-        ci_fn_params,
-        lr=pd_config.ci_fn_optimizer.lr_schedule.start_val,
-        betas=pd_config.ci_fn_optimizer.betas,
-        weight_decay=pd_config.ci_fn_optimizer.weight_decay,
-    )
-
-    if pd_config.faithfulness_warmup_steps > 0:
-        run_faithfulness_warmup(component_model, component_params, pd_config)
-
-    loss_instances, eval_instances = instantiate_metrics(
-        pd_config,
-        component_model,
-        device,
-        eval_metrics=eval_loop.metrics if eval_loop is not None else None,
-    )
-
-    for step in tqdm(range(pd_config.steps + 1), ncols=0, disable=not is_main_process()):
-        components_optimizer.zero_grad()
-        ci_fn_optimizer.zero_grad()
-
-        components_lr = get_scheduled_value(
-            step=step,
-            total_steps=pd_config.steps,
-            config=pd_config.components_optimizer.lr_schedule,
-        )
-        ci_fn_lr = get_scheduled_value(
-            step=step, total_steps=pd_config.steps, config=pd_config.ci_fn_optimizer.lr_schedule
-        )
-        for group in components_optimizer.param_groups:
-            group["lr"] = components_lr
-        for group in ci_fn_optimizer.param_groups:
-            group["lr"] = ci_fn_lr
-
-        batch_log_data: defaultdict[str, float] = defaultdict(float)
-
-        with bf16_autocast(enabled=runtime_config.autocast_bf16):
-            ctx = _build_metric_context(
-                next(train_iterator),
-                step=step,
-                is_eval=False,
-                device=device,
-                wrapped_model=wrapped_model,
-                component_model=component_model,
-                config=pd_config,
-                reconstruction_loss=reconstruction_loss,
-            )
-            losses = {name: m.update(ctx) for name, m in loss_instances.items()}
-
-        total_loss = torch.zeros((), device=device)
-        active_loss_names: list[str] = []
-        for metric_name, loss_val in losses.items():
-            if loss_val is None:
-                continue
-            active_loss_names.append(metric_name)
-            cfg = cast(LossMetricConfig, loss_instances[metric_name].cfg)
-            assert cfg.coeff is not None
-            total_loss = total_loss + cfg.coeff * loss_val
-            batch_log_data[f"loss/{type(loss_instances[metric_name]).__name__}"] = loss_val.item()
-        assert active_loss_names, (
-            f"No active loss metrics returned a loss at step {step}. "
-            f"Configured loss metrics: {list(loss_instances)}"
-        )
-        batch_log_data["loss/total"] = total_loss.item()
-
-        for metric_name, m in loss_instances.items():
-            m.before_backward(losses[metric_name])
-
-        total_loss.backward()
-
-        for m in loss_instances.values():
-            m.after_backward()
-
-        # --- Train Logging --- #
-        if cadence.should_log_train(step):
-            avg_metrics = avg_metrics_across_ranks(batch_log_data, device=device)
-            batch_log_data = cast(defaultdict[str, float], avg_metrics)
-
-            grad_norms = component_grad_norms(component_model, device)
-            grad_norm_log_data = {f"grad_norms/{k}": v for k, v in grad_norms.items()}
-            assert not set(batch_log_data) & set(grad_norm_log_data)
-            batch_log_data.update(grad_norm_log_data)
-            batch_log_data["schedules/lr/components"] = components_lr
-            batch_log_data["schedules/lr/ci_fn"] = ci_fn_lr
-
-            sink.console(
-                f"--- Step {step} ---",
-                f"LR[components]: {components_lr:.6f}",
-                f"LR[ci_fn]: {ci_fn_lr:.6f}",
-                *(f"train/{name}: {value:.15f}" for name, value in batch_log_data.items()),
-            )
-            sink.log({f"train/{k}": v for k, v in batch_log_data.items()}, step=step)
-
-        # --- Evaluation --- #
-        if eval_loop is not None and eval_loop.should_eval(step):
-            assert eval_iterator is not None
-            with torch.no_grad(), bf16_autocast(enabled=runtime_config.autocast_bf16):
-                slow_step = eval_loop.should_run_slow_eval(step)
-                active = [m for m in eval_instances.values() if not (m.slow and not slow_step)]
-                for m in active:
-                    m.reset()
-                for _ in range(eval_loop.n_steps):
-                    ctx = _build_metric_context(
-                        next(eval_iterator),
-                        step=step,
-                        is_eval=True,
-                        device=device,
-                        wrapped_model=wrapped_model,
-                        component_model=component_model,
-                        config=pd_config,
-                        reconstruction_loss=reconstruction_loss,
-                    )
-                    for m in active:
-                        m.update(ctx)
-                metrics = collect_metric_outputs(active)
-
-                sink.console(*(f"eval/{k}: {v}" for k, v in metrics.items()))
-                sink.log({f"eval/{k}": v for k, v in metrics.items()}, step=step)
-
-                del metrics
-                torch.cuda.empty_cache()
-                gc.collect()
-
-        # --- Saving Checkpoint --- #
-        if step == pd_config.steps or cadence.should_save(step):
-            sink.checkpoint(component_model.state_dict(), step=step)
-
-        # Skip gradient step at the very last step (last step is just for plotting/logging).
-        if step != pd_config.steps:
-            sync_across_processes()
-            if pd_config.components_optimizer.grad_clip_norm is not None:
-                clip_grad_norm_(component_params, pd_config.components_optimizer.grad_clip_norm)
-            if pd_config.ci_fn_optimizer.grad_clip_norm is not None:
-                clip_grad_norm_(ci_fn_params, pd_config.ci_fn_optimizer.grad_clip_norm)
-            components_optimizer.step()
-            ci_fn_optimizer.step()
-
-    if is_main_process():
-        logger.info("Finished training loop.")
+    trainer.run(train_loader, sink, cadence, eval_loop)

--- a/param_decomp/run_sink.py
+++ b/param_decomp/run_sink.py
@@ -2,6 +2,8 @@
 
 from typing import Any, Protocol, runtime_checkable
 
+from param_decomp.training_state import TrainingState
+
 
 @runtime_checkable
 class RunSink(Protocol):
@@ -27,12 +29,13 @@ class RunSink(Protocol):
         """Emit free-form lines (e.g. tqdm-friendly progress)."""
         ...
 
-    def checkpoint(self, state_dict: dict[str, Any], step: int) -> None:
-        """Persist a model state dict at `step`.
+    def checkpoint(self, snapshot: TrainingState) -> None:
+        """Persist a training state.
 
-        Args:
-            state_dict: Tensor state dict to serialise.
-            step: Training step used in the checkpoint identifier.
+        `snapshot.step` is the training step; sinks use it for naming. The lab
+        sink writes `snapshot.component_model` to `model_<step>.pth` and the
+        whole `snapshot` (cfgs, optimizer state, metric state, etc.) to
+        `training_<step>.pth`.
         """
         ...
 

--- a/param_decomp/tests/test_optimize.py
+++ b/param_decomp/tests/test_optimize.py
@@ -19,7 +19,7 @@ from param_decomp.configs import (
 from param_decomp.decomposition_targets import DecompositionTargetConfig
 from param_decomp.metrics.base import Metric, MetricResult
 from param_decomp.metrics.faithfulness import FaithfulnessLossConfig
-from param_decomp.optimize import EvalLoop, optimize
+from param_decomp.optimize import EvalLoop, Trainer, optimize
 from param_decomp.schedule import ScheduleConfig
 
 
@@ -60,10 +60,10 @@ class CaptureSink:
     def console(self, *lines: str) -> None:
         del lines
 
-    def checkpoint(self, state_dict: dict[str, Any], step: int) -> None:
-        del step
+    def checkpoint(self, snapshot: Any) -> None:
+        model_state = snapshot.component_model
         checkpoint: dict[str, Tensor] = {}
-        for key, value in state_dict.items():
+        for key, value in model_state.items():
             assert isinstance(value, Tensor)
             checkpoint[key] = value.detach().cpu().clone()
         self.checkpoints.append(checkpoint)
@@ -237,3 +237,93 @@ def run_with_external_seed(seed: int) -> dict[str, Tensor]:
     )
     assert len(sink.checkpoints) == 1
     return sink.checkpoints[0]
+
+
+def test_trainer_snapshot_round_trips() -> None:
+    """A trainer reconstructed via ``Trainer.from_snapshot`` produces matching state."""
+    pd_config = make_pd_config(steps=3)
+    runtime_config = RuntimeConfig(device="cpu", autocast_bf16=False)
+
+    trainer_a = Trainer(
+        target_model=TinyLinear(),
+        run_batch=run_batch_passthrough,
+        reconstruction_loss=recon_loss_mse,
+        pd_config=pd_config,
+        runtime_config=runtime_config,
+    )
+    trainer_a.run(make_loader(), CaptureSink(), make_cadence(), eval_loop=None)
+    snap = trainer_a.snapshot()
+
+    trainer_b = Trainer.from_snapshot(
+        snap,
+        target_model=TinyLinear(),
+        run_batch=run_batch_passthrough,
+        reconstruction_loss=recon_loss_mse,
+    )
+
+    assert trainer_b.step == trainer_a.step
+    sd_a = trainer_a.snapshot().component_model
+    sd_b = trainer_b.snapshot().component_model
+    assert sd_a.keys() == sd_b.keys()
+    for k in sd_a:
+        torch.testing.assert_close(sd_a[k], sd_b[k])
+
+    opt_a = trainer_a.components_optimizer.state_dict()
+    opt_b = trainer_b.components_optimizer.state_dict()
+    assert opt_a["param_groups"] == opt_b["param_groups"]
+    assert set(opt_a["state"].keys()) == set(opt_b["state"].keys())
+    for pid in opt_a["state"]:
+        for k, v in opt_a["state"][pid].items():
+            if isinstance(v, Tensor):
+                torch.testing.assert_close(v, opt_b["state"][pid][k])
+            else:
+                assert v == opt_b["state"][pid][k]
+
+
+def test_trainer_resumes_from_snapshot_and_matches_uninterrupted_run() -> None:
+    """Train K steps in one shot vs train K/2 → save → resume → train K/2;
+    the final model weights should match up to RNG drift (we accept some, but
+    on CPU with deterministic Adam the trajectory is bit-exact)."""
+    pd_config = make_pd_config(steps=4)
+    runtime_config = RuntimeConfig(device="cpu", autocast_bf16=False)
+
+    torch.manual_seed(7)
+    trainer_full = Trainer(
+        target_model=TinyLinear(),
+        run_batch=run_batch_passthrough,
+        reconstruction_loss=recon_loss_mse,
+        pd_config=pd_config,
+        runtime_config=runtime_config,
+    )
+    trainer_full.run(make_loader(), CaptureSink(), make_cadence(), eval_loop=None)
+    full_model = trainer_full.snapshot().component_model
+    final_full = {k: v.clone() for k, v in full_model.items()}
+
+    # Same fresh start, but save after step 2 and resume.
+    torch.manual_seed(7)
+    pd_config_half = make_pd_config(steps=2)
+    trainer_half = Trainer(
+        target_model=TinyLinear(),
+        run_batch=run_batch_passthrough,
+        reconstruction_loss=recon_loss_mse,
+        pd_config=pd_config_half,
+        runtime_config=runtime_config,
+    )
+    trainer_half.run(make_loader(), CaptureSink(), make_cadence(), eval_loop=None)
+    snap = trainer_half.snapshot()
+
+    # Resume — extend ``steps`` to 4 via cfg_overrides.
+    trainer_resumed = Trainer.from_snapshot(
+        snap,
+        target_model=TinyLinear(),
+        run_batch=run_batch_passthrough,
+        reconstruction_loss=recon_loss_mse,
+        cfg_overrides={"steps": 4},
+    )
+    assert trainer_resumed.step == 2
+    trainer_resumed.run(make_loader(), CaptureSink(), make_cadence(), eval_loop=None)
+
+    resumed_model = trainer_resumed.snapshot().component_model
+    assert final_full.keys() == resumed_model.keys()
+    for k in final_full:
+        torch.testing.assert_close(final_full[k], resumed_model[k])

--- a/param_decomp/training_state.py
+++ b/param_decomp/training_state.py
@@ -1,0 +1,34 @@
+"""`TrainingState`: the canonical persisted state of a 1-pool training run.
+
+Lives in its own module so both `param_decomp.optimize` (where `Trainer`
+produces it) and `param_decomp.run_sink` (where the `RunSink` Protocol
+consumes it) can import without a cycle.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+from torch import Tensor
+
+
+@dataclass(frozen=True)
+class TrainingState:
+    """Canonical 1-pool training state, persisted to `training_<step>.pth`.
+
+    Produced by `Trainer.snapshot()` and consumed by `Trainer.from_snapshot()`
+    to reconstruct the trainer. For DDP, every rank produces an identical
+    instance (model and optimizers are replicated); rank 0's write is the
+    canonical artifact.
+
+    Optimizer states are keyed by parameter name (e.g.
+    `components.h.0.attn.q_proj.V`, `ci_fn.embed.weight`) rather than the
+    optimizer's integer indices, so they survive a topology change on resume.
+    """
+
+    step: int
+    pd_config: dict[str, Any]
+    runtime_config: dict[str, Any]
+    component_model: dict[str, Tensor]
+    components_optimizer: dict[str, dict[str, Any]]
+    ci_fn_optimizer: dict[str, dict[str, Any]]
+    loss_metrics: dict[str, dict[str, Any]]

--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -1,9 +1,14 @@
-"""LM PD experiment: YAML -> `optimize()` glue, plus the `SavedLMRun` reload class.
+"""LM PD experiment: YAML -> `Trainer` glue + `SavedLMRun` reload + resumption.
 
-Both the fresh-run path (`main`) and the reload path share the module-level
-`build_target` / `build_lm_loader` / `make_run_batch`. Run via
-`pd-lm path/to/config.yaml`; pass `--dp N` to submit a single-node DDP SLURM job.
-For local DDP, invoke directly:
+Both the fresh-run path (`main`) and the reload path (`SavedLMRun`) share the
+module-level `build_target` / `build_lm_loader` / `make_run_batch`. The resume
+path (`main --resume <yaml>`) reads a parent run's `run_meta.yaml` plus
+`training_<step>.pth`, rebuilds a `Trainer` via `Trainer.from_snapshot`, and
+continues training.
+
+Run via `pd-lm path/to/config.yaml` (fresh) or `pd-lm --resume path/to/resume.yaml`
+(resume). Pass `--dp N` to submit a single-node DDP SLURM job; for local DDP,
+invoke directly via
 `torchrun --standalone --nproc_per_node=N -m param_decomp_lab.experiments.lm.run config.yaml`.
 """
 
@@ -24,7 +29,7 @@ from param_decomp.batch_and_loss_fns import RunBatch
 from param_decomp.component_model import ComponentModel
 from param_decomp.distributed import DistributedState, is_main_process
 from param_decomp.log import logger
-from param_decomp.optimize import EvalLoop, optimize
+from param_decomp.optimize import EvalLoop, Trainer
 from param_decomp_lab.batch_and_loss_fns import make_run_batch as _make_run_batch
 from param_decomp_lab.batch_and_loss_fns import recon_loss_kl
 from param_decomp_lab.component_model_io import load_component_model
@@ -52,6 +57,13 @@ from param_decomp_lab.infra.run_files import generate_run_id, resolve_run_files
 from param_decomp_lab.infra.settings import DEFAULT_PARTITION_NAME, REPO_ROOT
 from param_decomp_lab.infra.slurm import SlurmConfig, generate_script, submit_slurm_job
 from param_decomp_lab.infra.wandb import get_wandb_entity
+from param_decomp_lab.resumption import (
+    ResumeConfig,
+    ResumeProvenance,
+    read_training_snapshot,
+    resolve_step,
+    write_provenance,
+)
 from param_decomp_lab.seed import set_seed
 
 
@@ -185,8 +197,9 @@ class SavedLMRun:
 
 @with_distributed_cleanup
 def main(
-    config_path: str | Path,
+    config_path: str | Path | None = None,
     *,
+    resume: str | Path | None = None,
     group: str | None = None,
     tags: str | None = None,
     dp: int | None = None,
@@ -196,17 +209,24 @@ def main(
     no_snapshot: bool = False,
     run_id: str | None = None,
 ) -> None:
-    """Run an LM PD experiment end-to-end from a YAML config.
+    """Run an LM PD experiment end-to-end.
 
-    Parses the YAML, initialises DDP, builds the target / loaders / eval loop, writes
-    `run_meta.yaml`, and calls `optimize(...)`. Non-main ranks use a silent sink.
-    `group` / `tags` are wandb-only (no-ops without `wandb:`). Passing `--dp N`
-    outside torchrun submits a single-node SLURM job; for local DDP, invoke via
-    `torchrun --standalone --nproc_per_node=N -m param_decomp_lab.experiments.lm.run`.
+    Args:
+        config_path: YAML for a fresh run. Required when not resuming.
+        resume: Path to a `ResumeConfig` YAML pointing at a prior run. When set,
+            the parent's `run_meta.yaml` is the source of cfg truth (modulo
+            narrow `overrides`); a new `run_id` + sibling `resume_provenance.yaml`
+            are written.
+        group / tags: wandb-only (no-ops without `wandb:`).
+        dp / partition / time / job_name / no_snapshot / run_id: SLURM submission
+            knobs. Passing `--dp N` outside torchrun submits a single-node SLURM
+            job; for local DDP, invoke via
+            `torchrun --standalone --nproc_per_node=N -m param_decomp_lab.experiments.lm.run`.
     """
     if dp is not None and dp < 2:
         raise ValueError("--dp must be at least 2 for data parallelism")
     if dp is not None and os.environ.get("WORLD_SIZE") is None:
+        assert config_path is not None, "--dp SLURM submission requires a config_path"
         _submit_slurm(
             config_path,
             dp=dp,
@@ -220,6 +240,22 @@ def main(
         )
         return
 
+    if resume is not None:
+        assert config_path is None, "pass either config_path or --resume, not both"
+        _resume_main(Path(resume), group=group, tags=tags, run_id=run_id)
+    else:
+        assert config_path is not None, "must provide either config_path or --resume"
+        _fresh_main(Path(config_path), group=group, tags=tags, run_id=run_id)
+
+
+def _fresh_main(
+    config_path: Path,
+    *,
+    group: str | None,
+    tags: str | None,
+    run_id: str | None,
+) -> None:
+    """Fresh-run path: parse YAML, build everything, train from step 0."""
     cfg = LMExperimentConfig.from_file(config_path)
 
     dist_state = init_distributed()
@@ -254,17 +290,91 @@ def main(
     sink = init_pd_run(cfg, group=group, tags=tags, run_id=run_id)
 
     try:
-        optimize(
+        trainer = Trainer(
             target_model=target_model,
-            train_loader=train_loader,
             run_batch=make_run_batch(cfg.target),
             reconstruction_loss=recon_loss_kl,
             pd_config=cfg.pd,
             runtime_config=cfg.runtime,
-            sink=sink,
-            cadence=cfg.cadence,
-            eval_loop=eval_loop,
         )
+        trainer.run(train_loader, sink, cfg.cadence, eval_loop)
+    finally:
+        sink.finish()
+
+
+def _resume_main(
+    resume_cfg_path: Path,
+    *,
+    group: str | None,
+    tags: str | None,
+    run_id: str | None,
+) -> None:
+    """Resume-run path: read parent `run_meta.yaml` + `training_<step>.pth`,
+    rebuild trainer via `Trainer.from_snapshot`, continue training."""
+    resume_cfg = ResumeConfig.from_file(resume_cfg_path)
+    parent_cfg = LMExperimentConfig.from_file(resume_cfg.from_run / RUN_META_FILENAME)
+
+    dist_state = init_distributed()
+    if is_main_process():
+        logger.info(f"Distributed state: {dist_state}")
+        logger.info(f"Resuming from {resume_cfg.from_run} @ step {resume_cfg.step}")
+    set_seed(parent_cfg.pd.seed)
+    device = get_device()
+
+    cfg_overrides = (
+        resume_cfg.overrides.to_pd_config_patch() if resume_cfg.overrides is not None else None
+    )
+    effective_pd = (
+        parent_cfg.pd.model_copy(update=cfg_overrides)
+        if cfg_overrides is not None
+        else parent_cfg.pd
+    )
+    effective_cfg = parent_cfg.model_copy(
+        update={
+            "pd": effective_pd,
+            "runtime": parent_cfg.runtime.model_copy(
+                update={
+                    "device": device,
+                    "dp": dist_state.world_size if dist_state is not None else None,
+                }
+            ),
+        }
+    )
+
+    resolved_step = resolve_step(resume_cfg.from_run, resume_cfg.step)
+    snapshot = read_training_snapshot(resume_cfg.from_run, resolved_step)
+    # Override the saved device with the current resume environment. Mutating
+    # the dict (model_dump output) in place is fine even on a frozen dataclass;
+    # we're changing a value the dataclass references, not rebinding the field.
+    snapshot.runtime_config["device"] = device
+
+    target_model = build_target(effective_cfg.target)
+    train_loader = build_lm_loader(
+        effective_cfg.target,
+        effective_cfg.data,
+        split="train",
+        device=device,
+        batch_size=effective_cfg.pd.batch_size,
+        dist_state=dist_state,
+        seed=effective_cfg.pd.seed,
+    )
+    eval_loop = _build_eval_loop(effective_cfg, device, dist_state)
+    sink = init_pd_run(effective_cfg, group=group, tags=tags, run_id=run_id)
+    if sink.out_dir is not None:
+        write_provenance(
+            sink.out_dir,
+            ResumeProvenance(parent_run_dir=resume_cfg.from_run, parent_step=resolved_step),
+        )
+
+    try:
+        trainer = Trainer.from_snapshot(
+            snapshot,
+            target_model=target_model,
+            run_batch=make_run_batch(effective_cfg.target),
+            reconstruction_loss=recon_loss_kl,
+            cfg_overrides=cfg_overrides,
+        )
+        trainer.run(train_loader, sink, effective_cfg.cadence, eval_loop)
     finally:
         sink.finish()
 

--- a/param_decomp_lab/resumption/__init__.py
+++ b/param_decomp_lab/resumption/__init__.py
@@ -1,0 +1,35 @@
+"""Resumption: continue a prior PD run from one of its `training_<step>.pth` checkpoints.
+
+A resumption is a separate top-level concept from a fresh run, expressed via its own
+`ResumeConfig` YAML schema and dispatched from the `pd-lm --resume <path>` CLI flag.
+Resumption is *continuous*: the resumed run extends the parent's step axis, inheriting
+its config from `run_meta.yaml` and its training state from `training_<step>.pth`.
+
+The training state is canonical and topology-independent — a single file written by
+rank 0 carries everything needed to reconstruct the trainer for any compatible
+topology.
+"""
+
+from param_decomp_lab.resumption.config import (
+    ResumeConfig,
+    ResumeOverrides,
+    read_training_snapshot,
+    resolve_step,
+)
+from param_decomp_lab.resumption.provenance import (
+    RESUME_PROVENANCE_FILENAME,
+    ResumeProvenance,
+    read_provenance,
+    write_provenance,
+)
+
+__all__ = [
+    "RESUME_PROVENANCE_FILENAME",
+    "ResumeConfig",
+    "ResumeOverrides",
+    "ResumeProvenance",
+    "read_provenance",
+    "read_training_snapshot",
+    "resolve_step",
+    "write_provenance",
+]

--- a/param_decomp_lab/resumption/config.py
+++ b/param_decomp_lab/resumption/config.py
@@ -1,0 +1,88 @@
+"""YAML schema for resuming a prior PD run.
+
+A resume YAML is distinct from the run YAML: it doesn't define a run, it points
+at one. The schema is deliberately small — `from_run` + `step` + narrow
+`overrides`.
+"""
+
+from pathlib import Path
+from typing import Any, Literal
+
+import torch
+from pydantic import PositiveInt
+
+from param_decomp.base_config import BaseConfig
+from param_decomp.training_state import TrainingState
+
+
+class ResumeOverrides(BaseConfig):
+    """Narrow set of fields that may be overridden on resume.
+
+    Resumption is continuous with the parent's step axis, so most config fields
+    are inherited verbatim. The fields here are explicitly the ones we know
+    are safe to change mid-trajectory.
+    """
+
+    extend_to_step: PositiveInt | None = None
+    """Extend `pd_config.steps` so the resumed run trains further than the parent's
+    original target. Must be > `parent.pd_config.steps`; otherwise use the no-override
+    resume to finish the original."""
+
+    def to_pd_config_patch(self) -> dict[str, Any]:
+        """Convert to a flat dict patch applied to the saved `pd_config` dict before
+        pydantic re-validates it inside `Trainer.from_snapshot`."""
+        patch: dict[str, Any] = {}
+        if self.extend_to_step is not None:
+            patch["steps"] = self.extend_to_step
+        return patch
+
+
+class ResumeConfig(BaseConfig):
+    """A resumption YAML: which run to resume, which checkpoint, what to override."""
+
+    from_run: Path
+    """Path to the parent run directory (the one with `run_meta.yaml` and
+    `training_<step>.pth` files)."""
+
+    step: int | Literal["latest"] = "latest"
+    """Which checkpoint to load. `"latest"` picks the highest-numbered
+    `training_<step>.pth` under `from_run`."""
+
+    overrides: ResumeOverrides | None = None
+    """Optional narrow overrides applied to the saved `pd_config` before constructing
+    the resumed trainer."""
+
+
+def resolve_step(run_dir: Path, step: int | Literal["latest"]) -> int:
+    """Resolve `"latest"` to the highest-numbered `training_<step>.pth` under `run_dir`.
+
+    Errors loudly if no training checkpoints exist, or if a specific step was
+    requested that isn't on disk.
+    """
+    candidates: list[int] = []
+    for path in run_dir.glob("training_*.pth"):
+        try:
+            candidates.append(int(path.stem.removeprefix("training_")))
+        except ValueError:
+            continue
+    candidates.sort()
+    assert candidates, f"no training_*.pth checkpoints under {run_dir}"
+    if step == "latest":
+        return candidates[-1]
+    assert step in candidates, f"step {step} not on disk under {run_dir}; available: {candidates}"
+    return step
+
+
+def read_training_snapshot(run_dir: Path, step: int) -> TrainingState:
+    """Read `<run_dir>/training_<step>.pth` into a `TrainingState` dataclass.
+
+    `weights_only=False` because the payload contains arbitrary cfg dicts
+    (model_dump output) alongside tensors.
+    """
+    path = run_dir / f"training_{step}.pth"
+    assert path.is_file(), f"training checkpoint not found: {path}"
+    snapshot = torch.load(path, map_location="cpu", weights_only=False)
+    assert isinstance(snapshot, TrainingState), (
+        f"expected TrainingState in {path}, got {type(snapshot).__name__}"
+    )
+    return snapshot

--- a/param_decomp_lab/resumption/provenance.py
+++ b/param_decomp_lab/resumption/provenance.py
@@ -1,0 +1,41 @@
+"""Resume provenance: a small YAML sibling of ``run_meta.yaml`` recording
+which run a resumed run was forked from.
+
+Resumed runs get their own ``run_id`` and own ``run_meta.yaml`` (the effective
+config after overrides) — provenance is what makes them traceable back to
+the parent. A future reader can inspect ``resume_provenance.yaml`` to find
+the parent run dir + the step it was resumed from.
+
+A run without this file is a fresh run.
+"""
+
+from pathlib import Path
+
+from param_decomp.base_config import BaseConfig
+
+RESUME_PROVENANCE_FILENAME = "resume_provenance.yaml"
+
+
+class ResumeProvenance(BaseConfig):
+    """Sibling of ``run_meta.yaml`` recording where this resumed run came from."""
+
+    parent_run_dir: Path
+    """Path to the parent run's directory."""
+
+    parent_step: int
+    """The step at which we resumed (i.e. the step number in the parent's
+    ``resume/step_<N>/`` snapshot we loaded from)."""
+
+
+def write_provenance(out_dir: Path, provenance: ResumeProvenance) -> None:
+    """Persist ``provenance`` to ``{out_dir}/resume_provenance.yaml``."""
+    provenance.to_file(out_dir / RESUME_PROVENANCE_FILENAME)
+
+
+def read_provenance(run_dir: Path) -> ResumeProvenance | None:
+    """Read provenance from ``run_dir``. Returns ``None`` if the run is fresh
+    (no ``resume_provenance.yaml`` file present)."""
+    path = run_dir / RESUME_PROVENANCE_FILENAME
+    if not path.is_file():
+        return None
+    return ResumeProvenance.from_file(path)

--- a/param_decomp_lab/run_sink.py
+++ b/param_decomp_lab/run_sink.py
@@ -15,6 +15,7 @@ from tqdm import tqdm
 from param_decomp.base_config import BaseConfig
 from param_decomp.distributed import is_main_process
 from param_decomp.log import logger
+from param_decomp.training_state import TrainingState
 from param_decomp_lab.infra.run_files import save_file
 from param_decomp_lab.infra.wandb import init_wandb, try_wandb
 
@@ -131,18 +132,27 @@ class RunSink:
         for line in lines:
             tqdm.write(line)
 
-    def checkpoint(self, state_dict: dict[str, Any], step: int) -> None:
-        """Save `state_dict` to `{out_dir}/model_{step}.pth` and push to wandb.
+    def checkpoint(self, snapshot: TrainingState) -> None:
+        """Save the snapshot as two files: `model_<step>.pth` + `training_<step>.pth`.
 
-        No-op when `out_dir is None`; wandb upload only when wandb is active.
+        `model_<step>.pth` is just the component-model state dict — the artifact
+        downstream tools (`SavedRun.load_model`, postprocessing) consume.
+        `training_<step>.pth` is the full `TrainingState` (configs, optimizer
+        state, metric states, step) needed for resumption.
+
+        No-op when `out_dir is None` (silent sink / non-main rank); wandb upload
+        only when wandb is active.
         """
         if self.out_dir is None:
             return
-        path = self.out_dir / f"model_{step}.pth"
-        save_file(state_dict, path)
-        logger.info(f"Saved checkpoint to {path}")
+        model_path = self.out_dir / f"model_{snapshot.step}.pth"
+        save_file(snapshot.component_model, model_path)
+        training_path = self.out_dir / f"training_{snapshot.step}.pth"
+        save_file(snapshot, training_path)
+        logger.info(f"Saved checkpoint to {model_path} (+ {training_path.name})")
         if self._wandb_active:
-            try_wandb(wandb.save, str(path), base_path=str(self.out_dir), policy="now")
+            try_wandb(wandb.save, str(model_path), base_path=str(self.out_dir), policy="now")
+            try_wandb(wandb.save, str(training_path), base_path=str(self.out_dir), policy="now")
 
     def finish(self) -> None:
         """End-of-run cleanup."""

--- a/param_decomp_lab/tests/test_resumption.py
+++ b/param_decomp_lab/tests/test_resumption.py
@@ -1,0 +1,173 @@
+"""Lab-side resumption integration: canonical training state round-trips through a
+real `RunSink` into a tmp run_dir, then back through `read_training_snapshot` and
+`Trainer.from_snapshot`.
+
+Single-process / 1-pool only — exercises the wiring around the lab's resumption
+module without the cost of spinning up DDP.
+"""
+
+from pathlib import Path
+from typing import Any, override
+
+import torch
+from torch import Tensor, nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from param_decomp.ci_fns import LayerwiseCiConfig
+from param_decomp.configs import (
+    Cadence,
+    OptimizerConfig,
+    PDConfig,
+    RuntimeConfig,
+)
+from param_decomp.decomposition_targets import DecompositionTargetConfig
+from param_decomp.metrics.faithfulness import FaithfulnessLossConfig
+from param_decomp.optimize import Trainer
+from param_decomp.schedule import ScheduleConfig
+from param_decomp_lab.resumption import (
+    ResumeConfig,
+    read_training_snapshot,
+    resolve_step,
+)
+from param_decomp_lab.run_sink import RunSink
+
+
+class TinyLinear(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc = nn.Linear(2, 2, bias=False)
+        with torch.no_grad():
+            self.fc.weight.copy_(torch.tensor([[1.0, 2.0], [3.0, 4.0]]))
+
+    @override
+    def forward(self, x: Tensor) -> Tensor:
+        return self.fc(x)
+
+
+def _run_batch(model: nn.Module, batch: Any) -> Tensor:
+    if isinstance(batch, list | tuple):
+        batch = batch[0]
+    assert isinstance(batch, Tensor)
+    out = model(batch)
+    assert isinstance(out, Tensor)
+    return out
+
+
+def _recon_loss(pred: Tensor, target: Tensor) -> tuple[Tensor, int]:
+    assert pred.shape == target.shape
+    return ((pred - target) ** 2).sum(), pred.numel()
+
+
+def _pd_config(steps: int) -> PDConfig:
+    return PDConfig(
+        seed=123,
+        n_mask_samples=1,
+        ci_config=LayerwiseCiConfig(fn_type="mlp", hidden_dims=[2]),
+        decomposition_targets=[DecompositionTargetConfig(module_pattern="fc", C=2)],
+        components_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
+        ci_fn_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
+        steps=steps,
+        batch_size=2,
+        loss_metrics=[FaithfulnessLossConfig(coeff=1.0)],
+    )
+
+
+def _loader() -> DataLoader[Any]:
+    return DataLoader(TensorDataset(torch.ones(4, 2)), batch_size=2)
+
+
+def _runtime() -> RuntimeConfig:
+    return RuntimeConfig(device="cpu", autocast_bf16=False)
+
+
+def _cadence() -> Cadence:
+    return Cadence(train_log_every=10**9, save_every=2)
+
+
+def test_run_sink_writes_model_and_training_files(tmp_path: Path) -> None:
+    """A fresh run writes both `model_<step>.pth` and `training_<step>.pth` per save."""
+    run_dir = tmp_path / "run"
+    sink = RunSink.local(run_dir)
+
+    trainer = Trainer(
+        target_model=TinyLinear(),
+        run_batch=_run_batch,
+        reconstruction_loss=_recon_loss,
+        pd_config=_pd_config(steps=4),
+        runtime_config=_runtime(),
+    )
+    trainer.run(_loader(), sink, _cadence())
+
+    # Cadence.should_save skips step 0; final step always saves. So we expect 2 and 4.
+    expected_steps = [2, 4]
+    for step in expected_steps:
+        assert (run_dir / f"model_{step}.pth").is_file()
+        assert (run_dir / f"training_{step}.pth").is_file()
+
+
+def test_resume_round_trip_matches_uninterrupted_run(tmp_path: Path) -> None:
+    """Train K steps in one shot vs train K/2 -> write training_<step>.pth -> read it ->
+    Trainer.from_snapshot -> train K/2 more. Final weights match bit-for-bit on CPU.
+    """
+    # Reference: uninterrupted run.
+    torch.manual_seed(7)
+    trainer_full = Trainer(
+        target_model=TinyLinear(),
+        run_batch=_run_batch,
+        reconstruction_loss=_recon_loss,
+        pd_config=_pd_config(steps=4),
+        runtime_config=_runtime(),
+    )
+    full_sink_dir = tmp_path / "full"
+    trainer_full.run(_loader(), RunSink.local(full_sink_dir), _cadence())
+    final_full = {k: v.clone() for k, v in trainer_full.component_model.state_dict().items()}
+
+    # Phase 1: train 2 steps, the sink writes training_2.pth.
+    torch.manual_seed(7)
+    parent_dir = tmp_path / "parent"
+    trainer_half = Trainer(
+        target_model=TinyLinear(),
+        run_batch=_run_batch,
+        reconstruction_loss=_recon_loss,
+        pd_config=_pd_config(steps=2),
+        runtime_config=_runtime(),
+    )
+    trainer_half.run(_loader(), RunSink.local(parent_dir), _cadence())
+    assert (parent_dir / "training_2.pth").is_file()
+
+    # Phase 2: resume from parent's training_2.pth, train to step 4.
+    resume_cfg = ResumeConfig(from_run=parent_dir, step=2, overrides=None)
+    snapshot = read_training_snapshot(
+        resume_cfg.from_run, resolve_step(parent_dir, resume_cfg.step)
+    )
+    trainer_resumed = Trainer.from_snapshot(
+        snapshot,
+        target_model=TinyLinear(),
+        run_batch=_run_batch,
+        reconstruction_loss=_recon_loss,
+        cfg_overrides={"steps": 4},
+    )
+    assert trainer_resumed.step == 2
+    resumed_dir = tmp_path / "resumed"
+    trainer_resumed.run(_loader(), RunSink.local(resumed_dir), _cadence())
+
+    resumed_final = trainer_resumed.component_model.state_dict()
+    assert final_full.keys() == resumed_final.keys()
+    for k in final_full:
+        torch.testing.assert_close(final_full[k], resumed_final[k])
+
+
+def test_resolve_step_finds_latest(tmp_path: Path) -> None:
+    """`resolve_step('latest', ...)` returns the highest-numbered training file."""
+    parent_dir = tmp_path / "parent"
+    trainer = Trainer(
+        target_model=TinyLinear(),
+        run_batch=_run_batch,
+        reconstruction_loss=_recon_loss,
+        pd_config=_pd_config(steps=4),
+        runtime_config=_runtime(),
+    )
+    trainer.run(_loader(), RunSink.local(parent_dir), _cadence())
+
+    assert resolve_step(parent_dir, "latest") == 4
+    assert resolve_step(parent_dir, 2) == 2


### PR DESCRIPTION
## What this does

Training runs can now be paused and resumed. A run periodically saves enough state to disk that a separate process can pick it up and continue training as if nothing happened — bit-exact on the trainer side.

```bash
pd-lm config.yaml                   # fresh run (also saves resume checkpoints now)
pd-lm --resume my_resume.yaml       # continue from a saved checkpoint
```

Where `my_resume.yaml` is a tiny config pointing at the parent run + which step to resume from.

## Why

Long training jobs get preempted, slurm reservations expire, hyperparameters need tweaking mid-trajectory. The previous training loop had no notion of "where am I" beyond the live `optimize()` call — this lifts that into an explicit, snapshottable `Trainer`.

## The shape of the solution

**One canonical training-state file per checkpoint.** The persistence layer is deliberately topology-free: rank 0 writes a single `training_<step>.pth` containing everything needed to reconstruct the trainer (cfgs, model state, optimizer state, metric states, step). On resume, that one file rebuilds a trainer for whatever topology you're running — no per-rank shards, no layout fingerprint baked into the artifact.

For 1-pool DDP this is straightforward: every rank has the same state replicated, so rank 0's write captures all of it. For 2/3-pool ports later, the trainer's `snapshot()` does the cross-rank gathers needed to produce the same canonical artifact.

**`Trainer` class** (carved out of the old free-function `optimize()`). Holds the step counter, model, optimizer, and metric state. Exposes `snapshot()` to grab a point-in-time view and `from_snapshot(...)` to rebuild a trainer from one. `optimize()` survives as a thin wrapper for callers that don't care about resumption.

**`TrainerSnapshot`** is small: `step` + `state` (the canonical training-state dict). One field for everything, no rank-local/global mixing.

**`RunSink.checkpoint(snapshot)`** — Protocol method now takes a `TrainerSnapshot` instead of `(state_dict, step)`. The lab sink writes two files per checkpoint:

- `model_<step>.pth` — just the component-model state dict. This is what downstream tools (`SavedLMRun.load_model`, postprocessing, the app) already read; the shape is unchanged.
- `training_<step>.pth` — the rest: cfgs, optimizer state, metric states, step. Used only for resumption.

Splitting into two files keeps the "just give me the trained model" path cheap and unchanged for everything else in the codebase.

**Optimizer state is keyed by parameter name.** Rather than persisting PyTorch's integer-indexed optimizer state (where index 5 means "the 6th param the optimizer was constructed with" — topology-dependent), the canonical file stores `{param_name: state_entry}` (e.g. `components.h.0.attn.q_proj.V`, `ci_fn.embed.weight`). On resume, each rank looks up the state for the params it owns by name. Same shape on disk regardless of pool count or world size; resume can pick a different topology and the optimizer state still lands correctly.

**Metric state.** Most metrics are stateless across the optimizer trajectory (accumulators reset between eval passes), but `PersistentPGDReconLoss` carries adversarial sources + Adam moments that have to round-trip. `Metric` now has `state_dict` / `load_state_dict` mirroring the `nn.Module` / `Optimizer` convention; default is a no-op empty dict.

## Out of scope

2-pool and 3-pool resumption. Those subsystems live on a separate branch (`feature/resumption`) and aren't on `feature/modular` yet — they'll be ported onto this template when the time comes. The persistence shape (one canonical state, topology-free, name-keyed optimizer state) is the same; what they add is the cross-rank gather inside `snapshot()` and the scatter inside `from_snapshot()`.

## Breaking

- `RunSink.checkpoint(state_dict, step)` → `RunSink.checkpoint(snapshot: TrainerSnapshot)`. External Protocol implementations need to switch to reading `snapshot.state["component_model"]` (the model state) and `snapshot.step`.
- `optimize()` keeps its signature; existing callers are unchanged.

## Testing

- `test_trainer_snapshot_round_trips`: snapshot + from_snapshot produces matching trainer state including optimizer state.
- `test_trainer_resumes_from_snapshot_and_matches_uninterrupted_run`: resumed run matches an uninterrupted run bit-exact on CPU.
- `test_run_sink_writes_model_and_training_files`, `test_resume_round_trip_matches_uninterrupted_run`, `test_resolve_step_finds_latest`: lab-side integration through the real `RunSink`.
- Full suite: 415 passed, 5 skipped. basedpyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)