### PR TITLE
Extract generic fresh + resume runners (ExperimentBundle)

### DIFF
--- a/BRANCH_NOTE.md
+++ b/BRANCH_NOTE.md
@@ -1,0 +1,70 @@
+# Shelved: `ExperimentBundle` + generic runner extraction
+
+This branch is **shelved as of 2026-05-27** — included here so a future
+maintainer can pick it back up.
+
+## What's on the branch
+
+One commit on top of `feature/resumption` (PR #520):
+
+- `542960fc` — lifts the per-experiment orchestration out of
+  `param_decomp_lab/experiments/lm/run.py` into a generic
+  `ExperimentBundle[CfgT]` + `run_fresh` / `run_resumed` drivers in
+  `param_decomp_lab/experiments/runner.py`. LM's `_fresh_main` /
+  `_resume_main` (~120 lines) collapse to a 17-line bundle literal and
+  3-line dispatch.
+
+## Why shelved
+
+PR #520's reviewer (Dan) flagged that resumption lived inside the
+lm-specific `run.py`. We tried the extraction (this branch + a follow-up
+`feature/resumption-bio-demo` that demoed migrating ESM2 / Carbon /
+GPN-MSA scaffolds onto the bundle). The migration worked cleanly across
+4 consumers, but with only LM actually needing resume today, we decided
+to keep things concrete: live with lm-specificity until a *second*
+experiment genuinely needs resume support.
+
+Dan's review explicitly said *"I'm OK with this for now, until we have
+another concrete experiment type that we care about, at which point we
+can worry about consolidating this stuff."* This matches that framing.
+
+## Open design questions when reviving
+
+1. **The lambda-adapter smell.** 4-of-4 bundles wrote identical lambda
+   shapes because the experiment-side build functions take sub-configs
+   (`cfg.target`, `cfg.data`) but the bundle wants the full `cfg`. Two
+   fixes on the table:
+   - (a) Change the experiment-side build function signatures to take
+     the full `cfg`. Then `build_target=build_target` works as a literal.
+     ~15 LOC across N experiments.
+   - (b) Switch the bundle to an ABC so methods take `self + cfg` and
+     the build logic can be inlined into methods (no wrapper around a
+     free function). ~200 LOC but unlocks inheritance (e.g.
+     `HFCausalLMExperiment` base for LM + Carbon) and naturally absorbs
+     the `Saved<X>Run` boilerplate.
+
+2. **Speculative fields to drop before shipping.** The bio-demo branch
+   already has these removals applied + verified under 4 consumers (418
+   tests pass):
+   - `refine_cfg` — added speculatively for TMS's `tied_weights`
+     post-build hook. TMS isn't migrating; drop it.
+   - `uses_distributed: bool` — redundant.
+     `init_distributed()` is already a no-op when `WORLD_SIZE` is unset.
+
+3. **`Saved<X>Run` duplication.** Every experiment has ~25 lines of
+   identical `from_path` + `load_model` boilerplate. Could become a
+   single generic `SavedRun[CfgT]` driven by the bundle. ~125 LOC of
+   dup to recover (5 experiments).
+
+## Reviving
+
+```bash
+git fetch origin feature/resumption-generic-runner
+git switch feature/resumption-generic-runner
+git rebase origin/main   # or the current resumption branch HEAD
+# Apply the cleanups from feature/resumption-bio-demo (commit 3ef96673).
+# Decide (a) signature fix vs (b) ABC for the lambda smell.
+```
+
+See also: `feature/resumption-bio-demo` for the 3-bio-experiment migration
+that stress-tested the bundle abstraction.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,23 +52,26 @@ Import names from where they're defined. No package-level re-exports — `__init
 files are bare. The canonical entrypoint and the protocols / configs it consumes:
 
 ```python
-from param_decomp.optimize import EvalLoop, optimize
+from param_decomp.optimize import EvalLoop, Trainer
 from param_decomp.configs import Cadence, PDConfig, RuntimeConfig
 from param_decomp.run_sink import RunSink
 from param_decomp.metrics.base import LossMetricConfig, Metric
 from param_decomp.batch_and_loss_fns import RunBatch, ReconstructionLoss
 ```
 
-- `optimize(target_model, train_loader, run_batch, reconstruction_loss, pd_config,
-  runtime_config, sink, cadence, eval_loop=None)` — the only entrypoint. Builds the
-  `ComponentModel`, binds eval metrics, runs the loop. Side effects all flow through `sink`.
+- `Trainer(target_model, run_batch, reconstruction_loss, pd_config, runtime_config)` +
+  `.run(train_loader, sink, cadence, eval_loop=None)` — the entrypoint. Construction
+  sets up the `ComponentModel`, the two optimizers, and the loss-metric instances;
+  `.run` advances the loop from `self.step` to `pd_config.steps`. Side effects flow
+  through `sink`. `Trainer.snapshot` / `Trainer.from_snapshot` round-trip a
+  `TrainingState` for resumption.
 - `PDConfig` — algorithm: seed, CI fn, loss metrics, optimizers, decomposition targets,
   tied weights, faithfulness warmup. Flipping a field here changes what algorithm runs.
 - `RuntimeConfig` — compute substrate: `autocast_bf16`, `device`, `dp`. Perturbs numerics
   without changing the algorithm.
 - `Cadence` — train-log / save period predicates. Train-log fires every
   `train_log_every` steps; `save_every` is optional and `should_save` is false at
-  step 0. `optimize()` always checkpoints at the final step regardless of `save_every`.
+  step 0. `Trainer.run` always checkpoints at the final step regardless of `save_every`.
 - `EvalLoop` — frozen dataclass in `param_decomp/optimize.py` bundling the eval-loop
   triple (`loader`, `metrics`, `n_steps`) with its timing (`every`, `slow_every`,
   `slow_on_first_step`). Atomic optional: pass `None` to disable eval. `slow_every` must
@@ -88,7 +91,7 @@ from param_decomp.batch_and_loss_fns import RunBatch, ReconstructionLoss
   describe each file.
 - `param_decomp/metrics/` — loss `Metric` classes and dispatch.
 - `param_decomp_lab/experiments/{tms,resid_mlp,lm}/run.py` — composition roots; each
-  parses a YAML, builds objects, calls `optimize()`.
+  parses a YAML, builds objects, runs a `Trainer`.
 - `param_decomp_lab/{harvest,autointerp,clustering,dataset_attributions,graph_interp,investigate,app}/`
   — post-pipeline + app, each with its own CLAUDE.md.
 - `param_decomp_lab/postprocess/` — orchestrates the post-pipeline stages.
@@ -285,8 +288,9 @@ Docstrings carry information the signature doesn't.
 
 **Load-bearing public entrypoints in `param_decomp/` are an exception** — there, a full
 Google-style `Args:` block is worth the bookkeeping, because IDE hover surfaces it and
-the callers are external. Concretely: `optimize`, `ComponentModel.__init__` / `forward`
-/ `calc_causal_importances`, `RunSink` protocol methods, `Metric.bind` / `update` /
+the callers are external. Concretely: `Trainer.__init__` / `run` /
+`snapshot` / `from_snapshot`, `ComponentModel.__init__` / `forward` /
+`calc_causal_importances`, `RunSink` protocol methods, `Metric.bind` / `update` /
 `reset` / `compute`, `make_components`, `make_ci_fn_wrapper`. For everything else,
 *including internal helpers in `param_decomp/`*, prefer better parameter names and
 clearer parameterisation over docstrings — name parameters by their role inside the

--- a/param_decomp/batch_and_loss_fns.py
+++ b/param_decomp/batch_and_loss_fns.py
@@ -1,4 +1,4 @@
-"""Protocols for the callbacks `optimize()` invokes once per batch.
+"""Protocols for the callbacks `Trainer.run` invokes once per batch.
 
 The lab ships concrete implementations in `param_decomp_lab.batch_and_loss_fns`.
 """

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -222,6 +222,13 @@ class Cadence(BaseConfig):
 
     train_log_every: PositiveInt
     save_every: PositiveInt | None = None
+    keep_last_n_checkpoints: PositiveInt | None = None
+    """How many of the most-recent ``training_<step>.pth`` / ``model_<step>.pth`` pairs
+    to keep on disk after each checkpoint write. ``None`` (the default) keeps all
+    checkpoints — the conservative choice for research where prior steps may matter.
+    Opt in to e.g. ``3`` for long jobs where disk pressure outweighs the value of
+    intermediate checkpoints; the final-step checkpoint is always included in the
+    retained set."""
 
     def should_log_train(self, step: int) -> bool:
         return step % self.train_log_every == 0

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -216,7 +216,7 @@ class Cadence(BaseConfig):
 
     Held separately from `RunSink` so the sink only owns *where* output goes; `Cadence`
     owns *when* train logs and checkpoints fire. Eval timing lives on `EvalLoop`,
-    alongside the runtime objects it depends on. `optimize()` always checkpoints at the
+    alongside the runtime objects it depends on. `Trainer.run` always checkpoints at the
     final step regardless of `save_every`.
     """
 

--- a/param_decomp/metrics/base.py
+++ b/param_decomp/metrics/base.py
@@ -114,3 +114,22 @@ class Metric[TConfig: BaseConfig](ABC):
         Override when a metric needs to step internal state coupled to the outer
         backward — e.g. `PersistentPGDReconLoss` steps its adversarial sources here.
         """
+
+    def state_dict(self) -> dict[str, Any]:
+        """Return persistent metric state for round-tripping across a training restart.
+
+        Default is an empty dict: most metrics are stateless w.r.t. the optimizer
+        trajectory (their accumulators reset between eval passes). Override when a
+        metric carries trajectory-dependent state — e.g. `PersistentPGDReconLoss`
+        round-trips its adversarial sources here. Mirrors the `nn.Module` / `Optimizer`
+        convention; the parent `Trainer` composes these into its own state blob.
+        """
+        return {}
+
+    def load_state_dict(self, state: dict[str, Any]) -> None:  # noqa: B027 — intentional no-op default
+        """Load persistent state produced by a prior :meth:`state_dict` call.
+
+        Default is a no-op (matches the default empty `state_dict`). Override
+        alongside `state_dict` for any metric carrying trajectory-dependent state.
+        """
+        del state

--- a/param_decomp/metrics/persistent_pgd_recon.py
+++ b/param_decomp/metrics/persistent_pgd_recon.py
@@ -7,7 +7,7 @@ state + optimizer state machine live in `persistent_pgd_state`.
 """
 
 from collections.abc import Iterable
-from typing import Annotated, ClassVar, Literal, override
+from typing import Annotated, Any, ClassVar, Literal, override
 
 import torch
 from jaxtyping import Float
@@ -128,6 +128,9 @@ class _PersistentPGDReconBase[
         super().__init__(cfg)
         self.state: PersistentPGDState | None = None
         self._pending_source_grads: PPGDSources | None = None
+        # Stash from `load_state_dict` if called before the first `update()` —
+        # `PersistentPGDState` needs batch_dims, which we only learn from a live ctx.
+        self._pending_resume_state: dict[str, Any] | None = None
 
     def _ensure_state(self, ctx: MetricContext) -> None:
         if self.state is not None:
@@ -146,6 +149,9 @@ class _PersistentPGDReconBase[
             router=_router_for_cfg(self.cfg, self.device),
             reconstruction_loss=ctx.reconstruction_loss,
         )
+        if self._pending_resume_state is not None:
+            self.state.load_state_dict(self._pending_resume_state)
+            self._pending_resume_state = None
 
     @override
     def reset(self) -> None:
@@ -246,6 +252,24 @@ class _PersistentPGDReconBase[
         assert self.state is not None
         self.state.step(self._pending_source_grads)
         self._pending_source_grads = None
+
+    @override
+    def state_dict(self) -> dict[str, Any]:
+        if self.state is None:
+            return {}
+        return self.state.state_dict()
+
+    @override
+    def load_state_dict(self, state: dict[str, Any]) -> None:
+        if not state:
+            self._pending_resume_state = None
+            return
+        if self.state is None:
+            # `PersistentPGDState` needs batch_dims, which only arrives with the first
+            # `update()` ctx. Defer the load until `_ensure_state` constructs the state.
+            self._pending_resume_state = state
+        else:
+            self.state.load_state_dict(state)
 
 
 class PersistentPGDReconLoss(_PersistentPGDReconBase[PersistentPGDReconLossConfig]):

--- a/param_decomp/metrics/persistent_pgd_state.py
+++ b/param_decomp/metrics/persistent_pgd_state.py
@@ -6,7 +6,7 @@ these primitives.
 """
 
 from abc import ABC, abstractmethod
-from typing import Annotated, Literal, override
+from typing import Annotated, Any, Literal, override
 
 import torch
 from jaxtyping import Float, Int
@@ -105,6 +105,18 @@ class PPGDOptimizer(ABC):
     @abstractmethod
     def set_lr(self, lr: float) -> None: ...
 
+    def state_dict(self) -> dict[str, Any]:
+        """Return trajectory-dependent optimizer state.
+
+        Default empty — stateless optimizers (e.g. SignPGD) need nothing. Override
+        in optimizers that carry momentum or step counts across training steps.
+        """
+        return {}
+
+    def load_state_dict(self, state: dict[str, Any]) -> None:  # noqa: B027 — intentional no-op default
+        """Restore optimizer state produced by a prior :meth:`state_dict` call."""
+        del state
+
 
 class SignPGDOptimizer(PPGDOptimizer):
     def __init__(self, cfg: SignPGDConfig) -> None:
@@ -159,6 +171,23 @@ class AdamPGDOptimizer(PPGDOptimizer):
     @override
     def set_lr(self, lr: float) -> None:
         self._lr = lr
+
+    @override
+    def state_dict(self) -> dict[str, Any]:
+        return {
+            "step_count": self._step_count,
+            "m": dict(self._m),
+            "v": dict(self._v),
+        }
+
+    @override
+    def load_state_dict(self, state: dict[str, Any]) -> None:
+        self._step_count = state["step_count"]
+        with torch.no_grad():
+            for k, t in state["m"].items():
+                self._m[k].copy_(t.to(self._m[k].device))
+            for k, t in state["v"].items():
+                self._v[k].copy_(t.to(self._v[k].device))
 
 
 def make_ppgd_optimizer(cfg: PGDOptimizerConfig) -> PPGDOptimizer:
@@ -264,6 +293,20 @@ class PersistentPGDState:
     def update_lr(self, step: int, total_steps: int) -> None:
         lr = get_scheduled_value(step, total_steps, self._lr_schedule)
         self.optimizer.set_lr(lr)
+
+    def state_dict(self) -> dict[str, Any]:
+        """Round-trip the persistent adversary trajectory: sources + optimizer state."""
+        return {
+            "sources": {k: v.detach() for k, v in self.sources.items()},
+            "optimizer": self.optimizer.state_dict(),
+        }
+
+    def load_state_dict(self, state: dict[str, Any]) -> None:
+        """Restore sources + optimizer state in-place. Shapes must already match."""
+        with torch.no_grad():
+            for k, src in self.sources.items():
+                src.copy_(state["sources"][k].to(src.device))
+        self.optimizer.load_state_dict(state["optimizer"])
 
     def warmup(
         self,

--- a/param_decomp/optimize.py
+++ b/param_decomp/optimize.py
@@ -1,13 +1,25 @@
-"""PD optimization loop.
+"""The PD trainer.
 
-`optimize()` is the sole core entrypoint; `EvalLoop` bundles the eval runtime objects
-with their timing.
+Two entry points:
+
+- :class:`Trainer` — stateful training class. Construction sets up the
+  `ComponentModel`, the two optimizers, and the loss-metric instances from
+  ``pd_config``. :meth:`Trainer.run` advances the training loop from
+  ``self.step`` to ``pd_config.steps``. :meth:`Trainer.snapshot` and
+  :meth:`Trainer.from_snapshot` round-trip an atomic
+  :class:`~param_decomp.trainer_snapshot.TrainerSnapshot` that lets a caller
+  persist and restore the full training state (used by resumption).
+- :func:`optimize` — thin convenience wrapper that constructs a `Trainer` and
+  calls :meth:`Trainer.run`. Preserves the original function-style entry point
+  for callers that don't need resumption.
+
+Both go through the same code path.
 """
 
 import gc
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Self, cast
 
 import torch
 import torch.nn as nn
@@ -47,19 +59,28 @@ from param_decomp.metrics.persistent_pgd_recon import validate_pgd_scope
 from param_decomp.run_sink import RunSink
 from param_decomp.schedule import get_scheduled_value
 from param_decomp.torch_helpers import bf16_autocast, loop_dataloader
+from param_decomp.training_state import TrainingState
 
 
 @dataclass(frozen=True)
 class EvalLoop:
     """Eval-loop runtime objects bundled with their timing.
 
-    Pass `eval_loop=None` to `optimize` to skip eval entirely. When set, the trainer
-    evaluates every `every` steps; on steps that are also multiples of `slow_every`,
-    slow metrics fire too. `slow_every` must be a multiple of `every` — `should_run_slow_eval`
-    is only checked on steps where `should_eval` already fired.
+    Pass ``eval_loop=None`` to :meth:`Trainer.run` (or :func:`optimize`) to skip
+    eval entirely. When set, the trainer evaluates every ``every`` steps; on steps
+    that are also multiples of ``slow_every``, slow metrics fire too. ``slow_every``
+    must be a multiple of ``every`` — the trainer only checks :meth:`should_run_slow_eval`
+    on steps where :meth:`should_eval` already fired.
 
-    `optimize` calls `Metric.bind(model, device)` on every entry of `metrics` before the
-    loop starts.
+    Attributes:
+        loader: Eval data loader. Looped for the lifetime of training.
+        metrics: Caller-instantiated eval ``Metric``s. ``optimize`` calls
+            ``Metric.bind(model, device)`` on each before the loop.
+        n_steps: Number of eval batches per eval pass.
+        every: Period (in train steps) between eval passes.
+        slow_every: Period (in train steps) between *slow* eval passes. Must
+            be a multiple of ``every``.
+        slow_on_first_step: Whether slow eval fires at step 0.
     """
 
     loader: DataLoader[Any]
@@ -75,13 +96,14 @@ class EvalLoop:
         )
 
     def should_eval(self, step: int) -> bool:
+        """Whether a (regular) eval pass should fire at ``step``."""
         return step % self.every == 0
 
     def should_run_slow_eval(self, step: int) -> bool:
-        """Whether slow eval should fire at `step`.
+        """Whether slow eval metrics should fire at ``step``.
 
-        Slow eval is gated on top of `should_eval`; only call this on steps where
-        `should_eval` is already true.
+        Slow eval is gated on top of ``should_eval``; callers are expected to
+        only call this on steps where ``should_eval`` is already true.
         """
         if step == 0:
             return self.slow_on_first_step
@@ -126,6 +148,29 @@ def _build_metric_context(
     )
 
 
+def _assert_ctx_invariants(ctx: MetricContext, device: str, step: int) -> None:
+    """Fail loudly if anything is off about the metric context handed to the
+    loss metrics — wrong device, non-finite target output, empty ci dict, etc.
+    These would otherwise propagate silently through the loss + backward path.
+    """
+    assert isinstance(ctx.target_out, torch.Tensor)
+    device_prefix = str(device).split(":")[0]
+    assert str(ctx.target_out.device).startswith(device_prefix), (
+        f"ctx.target_out device mismatch at step {step}: target_out on "
+        f"{ctx.target_out.device}, trainer on {device}"
+    )
+    assert torch.isfinite(ctx.target_out).all(), f"non-finite values in target_out at step {step}"
+    assert ctx.ci.lower_leaky, f"empty ci.lower_leaky dict at step {step}"
+    assert ctx.ci.upper_leaky.keys() == ctx.ci.lower_leaky.keys(), (
+        f"ci upper/lower leaky key mismatch at step {step}"
+    )
+    for name, t in ctx.ci.lower_leaky.items():
+        assert torch.isfinite(t).all(), f"non-finite ci.lower_leaky[{name!r}] at step {step}"
+        assert str(t.device).startswith(device_prefix), (
+            f"ci.lower_leaky[{name!r}] device mismatch at step {step}: {t.device} vs {device}"
+        )
+
+
 def tie_component_weights(
     component_model: ComponentModel, tied_weights: list[tuple[str, str]]
 ) -> None:
@@ -137,6 +182,457 @@ def tie_component_weights(
         )
         tgt.U.data = src.V.data.T
         tgt.V.data = src.U.data.T
+
+
+def optimizer_state_by_name(
+    optimizer: torch.optim.Optimizer,
+    named_params: list[tuple[str, nn.Parameter]],
+) -> dict[str, dict[str, Any]]:
+    """Convert ``optimizer.state_dict()["state"]`` from integer-indexed to name-keyed.
+
+    PyTorch optimizers key their internal per-parameter state (Adam moments, step
+    counter, etc.) by the integer position of each parameter in
+    ``param_groups[*]["params"]``. That position is topology-dependent: a rank
+    holding a subset of sites indexes them 0..N for *its own* sites, in the
+    order they were added. To make optimizer state survive a topology change,
+    the caller passes the ``(name, param)`` pairs in the same order they were
+    added to the optimizer, and this returns ``{name: state_entry}``.
+
+    Names that have no optimizer state yet (e.g. fresh param, no step taken)
+    are simply omitted.
+    """
+    raw_state: dict[int, dict[str, Any]] = optimizer.state_dict()["state"]
+    by_name: dict[str, dict[str, Any]] = {}
+    for i, (name, _) in enumerate(named_params):
+        if i in raw_state:
+            by_name[name] = raw_state[i]
+    return by_name
+
+
+def load_optimizer_state_by_name(
+    optimizer: torch.optim.Optimizer,
+    named_params: list[tuple[str, nn.Parameter]],
+    by_name: dict[str, dict[str, Any]],
+) -> None:
+    """Inverse of :func:`optimizer_state_by_name`.
+
+    Each ``(name, param)`` pair in ``named_params`` matches its position in
+    the live optimizer's ``param_groups[*]["params"]``. For each name present
+    in ``by_name``, install the saved entry under the matching integer index
+    in ``optimizer.state``. Param groups (lr, betas, etc.) are taken from the
+    live optimizer — they're hyperparameters configured at construction time,
+    not state to be round-tripped.
+    """
+    current = optimizer.state_dict()
+    new_state: dict[int, dict[str, Any]] = {}
+    for i, (name, _) in enumerate(named_params):
+        if name in by_name:
+            new_state[i] = by_name[name]
+    current["state"] = new_state
+    optimizer.load_state_dict(current)
+
+
+class Trainer:
+    """Stateful PD trainer.
+
+    Construction wires up the `ComponentModel`, both AdamW optimizers, and the
+    loss-metric instances declared in ``pd_config.loss_metrics``. :meth:`run`
+    advances the training loop from ``self.step`` to ``pd_config.steps``.
+    :meth:`snapshot` and :meth:`from_snapshot` round-trip a
+    :class:`~param_decomp.trainer_snapshot.TrainerSnapshot` that a caller can
+    persist and restore.
+
+    All ranks construct a `Trainer`. Sink output and the loader-replay skip on
+    resume are governed by ``self.step`` (advanced by :meth:`run`,
+    overwritten by :meth:`_load_state`).
+    """
+
+    pd_config: PDConfig
+    runtime_config: RuntimeConfig
+    reconstruction_loss: ReconstructionLoss
+    component_model: ComponentModel
+    components_optimizer: optim.Optimizer
+    ci_fn_optimizer: optim.Optimizer
+    loss_metrics: dict[str, Metric[Any]]
+    step: int
+
+    def __init__(
+        self,
+        *,
+        target_model: nn.Module,
+        run_batch: RunBatch,
+        reconstruction_loss: ReconstructionLoss,
+        pd_config: PDConfig,
+        runtime_config: RuntimeConfig,
+    ) -> None:
+        self.pd_config = pd_config
+        self.runtime_config = runtime_config
+        self.reconstruction_loss = reconstruction_loss
+        self.step = 0
+
+        dist_state = get_distributed_state()
+        device = runtime_config.device
+        validate_pgd_scope(
+            pd_config.loss_metrics,
+            batch_size=pd_config.batch_size,
+            world_size=dist_state.world_size if dist_state is not None else 1,
+        )
+
+        if pd_config.identity_decomposition_targets is not None:
+            insert_identity_operations_(
+                target_model,
+                identity_decomposition_targets=pd_config.identity_decomposition_targets,
+            )
+
+        target_model.requires_grad_(False)
+        target_model.eval()
+        decomposition_targets = resolve_decomposition_targets(
+            target_model, pd_config.all_decomposition_target_configs
+        )
+
+        seed_all_ranks(pd_config.seed)
+        model = ComponentModel(
+            target_model=target_model,
+            run_batch=run_batch,
+            decomposition_targets=decomposition_targets,
+            ci_config=pd_config.ci_config,
+            sigmoid_type=pd_config.sigmoid_type,
+        )
+        model.to(device)
+
+        # Diverge global RNG per rank so stochastic masks/sources differ across DP workers.
+        seed_per_rank(pd_config.seed)
+
+        if dist_state is not None:
+            if dist_state.backend == "nccl":
+                device_id = dist_state.local_rank
+                self._wrapped_model: nn.Module = torch.nn.parallel.DistributedDataParallel(
+                    model, device_ids=[device_id], output_device=device_id
+                )
+            else:
+                self._wrapped_model = torch.nn.parallel.DistributedDataParallel(model)
+            component_model = cast(ComponentModel, self._wrapped_model.module)
+        else:
+            self._wrapped_model = model
+            component_model = model
+        assert isinstance(component_model, ComponentModel)
+        self.component_model = component_model
+
+        if pd_config.tied_weights is not None:
+            tie_component_weights(component_model, pd_config.tied_weights)
+
+        self._component_params: list[torch.nn.Parameter] = []
+        for name in component_model.target_module_paths:
+            self._component_params.extend(component_model.components[name].parameters())
+        assert component_model.ci_fn is not None, (
+            "single-pool Trainer assumes a ComponentModel with the CI fn intact"
+        )
+        self._ci_fn_params = list(component_model.ci_fn.parameters())
+        assert len(self._component_params) > 0, "No parameters found in components to optimize"
+
+        self.components_optimizer = optim.AdamW(
+            self._component_params,
+            lr=pd_config.components_optimizer.lr_schedule.start_val,
+            betas=pd_config.components_optimizer.betas,
+            weight_decay=pd_config.components_optimizer.weight_decay,
+        )
+        self.ci_fn_optimizer = optim.AdamW(
+            self._ci_fn_params,
+            lr=pd_config.ci_fn_optimizer.lr_schedule.start_val,
+            betas=pd_config.ci_fn_optimizer.betas,
+            weight_decay=pd_config.ci_fn_optimizer.weight_decay,
+        )
+
+        self.loss_metrics, _ = instantiate_metrics(pd_config, component_model, device)
+
+    # ============================ Named-param accessors for optimizer state ============================
+
+    def _components_optimizer_named_params(self) -> list[tuple[str, nn.Parameter]]:
+        """The ``(name, param)`` pairs in the order they were added to ``components_optimizer``.
+
+        Names follow ``components.<module_path>.<param_name_inside_component>`` so they're
+        topology-independent (a sharded trainer holding only a subset of sites produces
+        the same names for those sites as a 1-pool trainer holding all of them).
+        """
+        out: list[tuple[str, nn.Parameter]] = []
+        for module_path in self.component_model.target_module_paths:
+            for pname, p in self.component_model.components[module_path].named_parameters():
+                out.append((f"components.{module_path}.{pname}", p))
+        return out
+
+    def _ci_fn_optimizer_named_params(self) -> list[tuple[str, nn.Parameter]]:
+        """The ``(name, param)`` pairs for ``ci_fn_optimizer``."""
+        assert self.component_model.ci_fn is not None
+        return [(f"ci_fn.{n}", p) for n, p in self.component_model.ci_fn.named_parameters()]
+
+    # ============================ Atomic cfg + state ============================
+
+    def snapshot(self) -> TrainingState:
+        """Canonical point-in-time view of this trainer.
+
+        Returns a :class:`TrainingState` carrying configs (model_dump'd), model
+        state dict, both optimizer states (keyed by parameter NAME so they
+        survive topology changes), and every loss metric's ``state_dict()``.
+        For 1-pool DDP this state is identical across ranks (the model and
+        optimizers are replicated); the lab sink writes from rank 0 only.
+        """
+        return TrainingState(
+            step=self.step,
+            pd_config=self.pd_config.model_dump(),
+            runtime_config=self.runtime_config.model_dump(),
+            component_model=self.component_model.state_dict(),
+            components_optimizer=optimizer_state_by_name(
+                self.components_optimizer, self._components_optimizer_named_params()
+            ),
+            ci_fn_optimizer=optimizer_state_by_name(
+                self.ci_fn_optimizer, self._ci_fn_optimizer_named_params()
+            ),
+            loss_metrics={n: m.state_dict() for n, m in self.loss_metrics.items()},
+        )
+
+    @classmethod
+    def from_snapshot(
+        cls,
+        snapshot: TrainingState,
+        *,
+        target_model: nn.Module,
+        run_batch: RunBatch,
+        reconstruction_loss: ReconstructionLoss,
+        cfg_overrides: dict[str, Any] | None = None,
+    ) -> Self:
+        """Reconstruct a Trainer from a :class:`TrainingState`.
+
+        ``cfg_overrides`` is a flat patch applied to the saved ``pd_config``
+        dict before pydantic validation — used for narrow resume-time
+        overrides such as extending ``steps``.
+        """
+        pd_dict = snapshot.pd_config
+        if cfg_overrides is not None:
+            pd_dict = {**pd_dict, **cfg_overrides}
+        pd_config = PDConfig.model_validate(pd_dict)
+        runtime_config = RuntimeConfig.model_validate(snapshot.runtime_config)
+        trainer = cls(
+            target_model=target_model,
+            run_batch=run_batch,
+            reconstruction_loss=reconstruction_loss,
+            pd_config=pd_config,
+            runtime_config=runtime_config,
+        )
+        trainer._load_state(snapshot)
+        return trainer
+
+    def _load_state(self, state: TrainingState) -> None:
+        """In-place load of the trainer's runtime state. Caller's responsibility
+        to have constructed self with a matching cfg (use :meth:`from_snapshot`
+        to guarantee this).
+        """
+        self.step = state.step
+        self.component_model.load_state_dict(state.component_model)
+        load_optimizer_state_by_name(
+            self.components_optimizer,
+            self._components_optimizer_named_params(),
+            state.components_optimizer,
+        )
+        load_optimizer_state_by_name(
+            self.ci_fn_optimizer,
+            self._ci_fn_optimizer_named_params(),
+            state.ci_fn_optimizer,
+        )
+        for name, m in self.loss_metrics.items():
+            m.load_state_dict(state.loss_metrics[name])
+
+    # ============================ Training loop ============================
+
+    def run(
+        self,
+        train_loader: DataLoader[Any],
+        sink: RunSink,
+        cadence: Cadence,
+        eval_loop: EvalLoop | None = None,
+    ) -> None:
+        """Advance training from ``self.step`` to ``self.pd_config.steps``.
+
+        When ``self.step == 0`` and ``pd_config.faithfulness_warmup_steps > 0``,
+        faithfulness warmup runs once before the loop. When ``self.step > 0``
+        (i.e. resumed mid-trajectory), warmup is skipped and the train loader is
+        skip-advanced by ``self.step`` batches to reproduce the corresponding
+        position in the data stream.
+        """
+        pd_config = self.pd_config
+        runtime_config = self.runtime_config
+        device = runtime_config.device
+
+        train_iterator = loop_dataloader(train_loader)
+        eval_iterator = loop_dataloader(eval_loop.loader) if eval_loop is not None else None
+
+        # Loader replay: if we're starting from non-zero step, advance the iterator to
+        # the matching position. Deterministic given the loader's seed.
+        for _ in range(self.step):
+            next(train_iterator)
+
+        if self.step == 0 and pd_config.faithfulness_warmup_steps > 0:
+            run_faithfulness_warmup(self.component_model, self._component_params, pd_config)
+
+        eval_only_instances: dict[str, Metric[Any]] = {}
+        if eval_loop is not None:
+            for m in eval_loop.metrics:
+                m.bind(model=self.component_model, device=device)
+
+            # Loss metrics are auto-evaluated alongside dedicated eval metrics. We disallow
+            # duplicate registry names across the two pools because `evaluate()` keys metrics
+            # by class name.
+            for m in eval_loop.metrics:
+                metric_name = type(m).__name__
+                assert metric_name not in eval_only_instances, (
+                    f"duplicate eval metric {metric_name!r}"
+                )
+                eval_only_instances[metric_name] = m
+            overlap = sorted(set(self.loss_metrics) & set(eval_only_instances))
+            assert not overlap, (
+                f"eval_loop.metrics overlap with pd_config.loss_metrics: {overlap}. Loss "
+                "metrics are automatically evaluated; remove the duplicates from "
+                "eval_loop.metrics."
+            )
+        all_instances = {**self.loss_metrics, **eval_only_instances}
+
+        for step in tqdm(
+            range(self.step, pd_config.steps + 1), ncols=0, disable=not is_main_process()
+        ):
+            self.step = step
+            self.components_optimizer.zero_grad()
+            self.ci_fn_optimizer.zero_grad()
+
+            components_lr = get_scheduled_value(
+                step=step,
+                total_steps=pd_config.steps,
+                config=pd_config.components_optimizer.lr_schedule,
+            )
+            ci_fn_lr = get_scheduled_value(
+                step=step,
+                total_steps=pd_config.steps,
+                config=pd_config.ci_fn_optimizer.lr_schedule,
+            )
+            for group in self.components_optimizer.param_groups:
+                group["lr"] = components_lr
+            for group in self.ci_fn_optimizer.param_groups:
+                group["lr"] = ci_fn_lr
+
+            batch_log_data: defaultdict[str, float] = defaultdict(float)
+
+            with bf16_autocast(enabled=runtime_config.autocast_bf16):
+                ctx = _build_metric_context(
+                    next(train_iterator),
+                    step=step,
+                    is_eval=False,
+                    device=device,
+                    wrapped_model=self._wrapped_model,
+                    component_model=self.component_model,
+                    config=pd_config,
+                    reconstruction_loss=self.reconstruction_loss,
+                )
+                _assert_ctx_invariants(ctx, device, step)
+                losses = {name: m.update(ctx) for name, m in self.loss_metrics.items()}
+
+            total_loss = torch.zeros((), device=device)
+            active_loss_names: list[str] = []
+            for metric_name, loss_val in losses.items():
+                if loss_val is None:
+                    continue
+                active_loss_names.append(metric_name)
+                assert torch.isfinite(loss_val).all(), (
+                    f"non-finite loss from metric {metric_name!r} at step {step}: {loss_val}"
+                )
+                cfg = cast(LossMetricConfig, self.loss_metrics[metric_name].cfg)
+                assert cfg.coeff is not None
+                total_loss = total_loss + cfg.coeff * loss_val
+                batch_log_data[f"loss/{type(self.loss_metrics[metric_name]).__name__}"] = (
+                    loss_val.item()
+                )
+            assert active_loss_names, (
+                f"No active loss metrics returned a loss at step {step}. "
+                f"Configured loss metrics: {list(self.loss_metrics)}"
+            )
+            assert torch.isfinite(total_loss).all(), (
+                f"total_loss is non-finite at step {step}: {total_loss}"
+            )
+            batch_log_data["loss/total"] = total_loss.item()
+
+            for metric_name, m in self.loss_metrics.items():
+                m.before_backward(losses[metric_name])
+
+            total_loss.backward()
+
+            for m in self.loss_metrics.values():
+                m.after_backward()
+
+            # --- Train Logging --- #
+            if cadence.should_log_train(step):
+                avg_metrics = avg_metrics_across_ranks(batch_log_data, device=device)
+                batch_log_data = cast(defaultdict[str, float], avg_metrics)
+
+                grad_norms = component_grad_norms(self.component_model, device)
+                grad_norm_log_data = {f"grad_norms/{k}": v for k, v in grad_norms.items()}
+                assert not set(batch_log_data) & set(grad_norm_log_data)
+                batch_log_data.update(grad_norm_log_data)
+                batch_log_data["schedules/lr/components"] = components_lr
+                batch_log_data["schedules/lr/ci_fn"] = ci_fn_lr
+
+                sink.console(
+                    f"--- Step {step} ---",
+                    f"LR[components]: {components_lr:.6f}",
+                    f"LR[ci_fn]: {ci_fn_lr:.6f}",
+                    *(f"train/{name}: {value:.15f}" for name, value in batch_log_data.items()),
+                )
+                sink.log({f"train/{k}": v for k, v in batch_log_data.items()}, step=step)
+
+            # --- Evaluation --- #
+            if eval_loop is not None and eval_loop.should_eval(step):
+                assert eval_iterator is not None
+                with torch.no_grad(), bf16_autocast(enabled=runtime_config.autocast_bf16):
+                    slow_step = eval_loop.should_run_slow_eval(step)
+                    active = [m for m in all_instances.values() if not (m.slow and not slow_step)]
+                    for m in active:
+                        m.reset()
+                    for _ in range(eval_loop.n_steps):
+                        ctx = _build_metric_context(
+                            next(eval_iterator),
+                            step=step,
+                            is_eval=True,
+                            device=device,
+                            wrapped_model=self._wrapped_model,
+                            component_model=self.component_model,
+                            config=pd_config,
+                            reconstruction_loss=self.reconstruction_loss,
+                        )
+                        for m in active:
+                            m.update(ctx)
+                    metrics = collect_metric_outputs(active)
+
+                    sink.console(*(f"eval/{k}: {v}" for k, v in metrics.items()))
+                    sink.log({f"eval/{k}": v for k, v in metrics.items()}, step=step)
+
+                    del metrics
+                    torch.cuda.empty_cache()
+                    gc.collect()
+
+            # --- Saving Checkpoint --- #
+            if step == pd_config.steps or cadence.should_save(step):
+                sink.checkpoint(self.snapshot())
+
+            # Skip gradient step at the very last step (last step is just for plotting/logging).
+            if step != pd_config.steps:
+                sync_across_processes()
+                if pd_config.components_optimizer.grad_clip_norm is not None:
+                    clip_grad_norm_(
+                        self._component_params, pd_config.components_optimizer.grad_clip_norm
+                    )
+                if pd_config.ci_fn_optimizer.grad_clip_norm is not None:
+                    clip_grad_norm_(self._ci_fn_params, pd_config.ci_fn_optimizer.grad_clip_norm)
+                self.components_optimizer.step()
+                self.ci_fn_optimizer.step()
+
+        if is_main_process():
+            logger.info("Finished training loop.")
 
 
 def optimize(
@@ -152,237 +648,14 @@ def optimize(
 ) -> None:
     """Run the PD optimization loop.
 
-    Builds the `ComponentModel` internally, instantiates loss metrics from
-    `pd_config.loss_metrics`, optionally runs a faithfulness warmup, then loops for
-    `pd_config.steps + 1` training steps. Every step computes losses from
-    `loss_metrics`, accumulates them weighted by their `coeff`, and backprops. Train
-    logging, checkpointing, and eval each fire on their own schedule.
-
-    Under DDP, the trainer wraps `ComponentModel` in `DistributedDataParallel` for
-    gradient sync. Every rank executes this function and every rank calls every `sink`
-    method — the `RunSink` implementation owns any rank-aware filtering it wants (e.g.
-    only writing files / wandb on `is_main_process()`).
-
-    Args:
-        target_model: The frozen model whose parameters are being decomposed. Mutated
-            in place: forced to `requires_grad=False` and put in `eval()` mode.
-        train_loader: Train data loader. Looped indefinitely until `pd_config.steps`
-            is reached.
-        run_batch: Callable that runs one batch through the wrapped target model and
-            returns its output tensor.
-        reconstruction_loss: Callable returning `(loss_sum, n_elements)` used by
-            recon-style loss metrics.
-        pd_config: Algorithm specification — CI fn, loss metrics, optimizers,
-            decomposition targets, seed, tied weights, warmup, etc.
-        runtime_config: Compute substrate — device, autocast, data-parallelism.
-        sink: Output destination. Metric keys handed to `sink.log` are pre-namespaced
-            (`train/...`, `eval/...`). See note above on rank semantics.
-        cadence: Train-log + checkpoint period. The final step always checkpoints
-            regardless of `cadence.save_every`.
-        eval_loop: Optional eval bundle. Pass `None` to skip eval entirely.
+    Thin wrapper over :class:`Trainer` for callers that don't need resumption
+    or interactive control. Identical signature to the pre-Trainer ``optimize``.
     """
-    dist_state = get_distributed_state()
-    device = runtime_config.device
-    validate_pgd_scope(
-        pd_config.loss_metrics,
-        batch_size=pd_config.batch_size,
-        world_size=dist_state.world_size if dist_state is not None else 1,
-    )
-
-    train_iterator = loop_dataloader(train_loader)
-    eval_iterator = loop_dataloader(eval_loop.loader) if eval_loop is not None else None
-
-    if pd_config.identity_decomposition_targets is not None:
-        insert_identity_operations_(
-            target_model,
-            identity_decomposition_targets=pd_config.identity_decomposition_targets,
-        )
-
-    target_model.requires_grad_(False)
-    target_model.eval()
-    decomposition_targets = resolve_decomposition_targets(
-        target_model, pd_config.all_decomposition_target_configs
-    )
-
-    seed_all_ranks(pd_config.seed)
-    model = ComponentModel(
+    trainer = Trainer(
         target_model=target_model,
         run_batch=run_batch,
-        decomposition_targets=decomposition_targets,
-        ci_config=pd_config.ci_config,
-        sigmoid_type=pd_config.sigmoid_type,
+        reconstruction_loss=reconstruction_loss,
+        pd_config=pd_config,
+        runtime_config=runtime_config,
     )
-    model.to(device)
-
-    # Diverge global RNG per rank so stochastic masks/sources differ across DP workers.
-    seed_per_rank(pd_config.seed)
-
-    wrapped_model: nn.Module = model
-    component_model: ComponentModel
-    if dist_state is not None:
-        if dist_state.backend == "nccl":
-            device_id = dist_state.local_rank
-            wrapped_model = torch.nn.parallel.DistributedDataParallel(
-                model, device_ids=[device_id], output_device=device_id
-            )
-        else:
-            wrapped_model = torch.nn.parallel.DistributedDataParallel(model)
-        component_model = cast(ComponentModel, wrapped_model.module)
-    else:
-        component_model = model
-    assert isinstance(component_model, ComponentModel), "component_model is not a ComponentModel"
-
-    if pd_config.tied_weights is not None:
-        tie_component_weights(component_model, pd_config.tied_weights)
-
-    component_params: list[torch.nn.Parameter] = []
-    for name in component_model.target_module_paths:
-        component_params.extend(component_model.components[name].parameters())
-    ci_fn_params = list(component_model.ci_fn.parameters())
-    assert len(component_params) > 0, "No parameters found in components to optimize"
-
-    components_optimizer = optim.AdamW(
-        component_params,
-        lr=pd_config.components_optimizer.lr_schedule.start_val,
-        betas=pd_config.components_optimizer.betas,
-        weight_decay=pd_config.components_optimizer.weight_decay,
-    )
-    ci_fn_optimizer = optim.AdamW(
-        ci_fn_params,
-        lr=pd_config.ci_fn_optimizer.lr_schedule.start_val,
-        betas=pd_config.ci_fn_optimizer.betas,
-        weight_decay=pd_config.ci_fn_optimizer.weight_decay,
-    )
-
-    if pd_config.faithfulness_warmup_steps > 0:
-        run_faithfulness_warmup(component_model, component_params, pd_config)
-
-    loss_instances, eval_instances = instantiate_metrics(
-        pd_config,
-        component_model,
-        device,
-        eval_metrics=eval_loop.metrics if eval_loop is not None else None,
-    )
-
-    for step in tqdm(range(pd_config.steps + 1), ncols=0, disable=not is_main_process()):
-        components_optimizer.zero_grad()
-        ci_fn_optimizer.zero_grad()
-
-        components_lr = get_scheduled_value(
-            step=step,
-            total_steps=pd_config.steps,
-            config=pd_config.components_optimizer.lr_schedule,
-        )
-        ci_fn_lr = get_scheduled_value(
-            step=step, total_steps=pd_config.steps, config=pd_config.ci_fn_optimizer.lr_schedule
-        )
-        for group in components_optimizer.param_groups:
-            group["lr"] = components_lr
-        for group in ci_fn_optimizer.param_groups:
-            group["lr"] = ci_fn_lr
-
-        batch_log_data: defaultdict[str, float] = defaultdict(float)
-
-        with bf16_autocast(enabled=runtime_config.autocast_bf16):
-            ctx = _build_metric_context(
-                next(train_iterator),
-                step=step,
-                is_eval=False,
-                device=device,
-                wrapped_model=wrapped_model,
-                component_model=component_model,
-                config=pd_config,
-                reconstruction_loss=reconstruction_loss,
-            )
-            losses = {name: m.update(ctx) for name, m in loss_instances.items()}
-
-        total_loss = torch.zeros((), device=device)
-        active_loss_names: list[str] = []
-        for metric_name, loss_val in losses.items():
-            if loss_val is None:
-                continue
-            active_loss_names.append(metric_name)
-            cfg = cast(LossMetricConfig, loss_instances[metric_name].cfg)
-            assert cfg.coeff is not None
-            total_loss = total_loss + cfg.coeff * loss_val
-            batch_log_data[f"loss/{type(loss_instances[metric_name]).__name__}"] = loss_val.item()
-        assert active_loss_names, (
-            f"No active loss metrics returned a loss at step {step}. "
-            f"Configured loss metrics: {list(loss_instances)}"
-        )
-        batch_log_data["loss/total"] = total_loss.item()
-
-        for metric_name, m in loss_instances.items():
-            m.before_backward(losses[metric_name])
-
-        total_loss.backward()
-
-        for m in loss_instances.values():
-            m.after_backward()
-
-        # --- Train Logging --- #
-        if cadence.should_log_train(step):
-            avg_metrics = avg_metrics_across_ranks(batch_log_data, device=device)
-            batch_log_data = cast(defaultdict[str, float], avg_metrics)
-
-            grad_norms = component_grad_norms(component_model, device)
-            grad_norm_log_data = {f"grad_norms/{k}": v for k, v in grad_norms.items()}
-            assert not set(batch_log_data) & set(grad_norm_log_data)
-            batch_log_data.update(grad_norm_log_data)
-            batch_log_data["schedules/lr/components"] = components_lr
-            batch_log_data["schedules/lr/ci_fn"] = ci_fn_lr
-
-            sink.console(
-                f"--- Step {step} ---",
-                f"LR[components]: {components_lr:.6f}",
-                f"LR[ci_fn]: {ci_fn_lr:.6f}",
-                *(f"train/{name}: {value:.15f}" for name, value in batch_log_data.items()),
-            )
-            sink.log({f"train/{k}": v for k, v in batch_log_data.items()}, step=step)
-
-        # --- Evaluation --- #
-        if eval_loop is not None and eval_loop.should_eval(step):
-            assert eval_iterator is not None
-            with torch.no_grad(), bf16_autocast(enabled=runtime_config.autocast_bf16):
-                slow_step = eval_loop.should_run_slow_eval(step)
-                active = [m for m in eval_instances.values() if not (m.slow and not slow_step)]
-                for m in active:
-                    m.reset()
-                for _ in range(eval_loop.n_steps):
-                    ctx = _build_metric_context(
-                        next(eval_iterator),
-                        step=step,
-                        is_eval=True,
-                        device=device,
-                        wrapped_model=wrapped_model,
-                        component_model=component_model,
-                        config=pd_config,
-                        reconstruction_loss=reconstruction_loss,
-                    )
-                    for m in active:
-                        m.update(ctx)
-                metrics = collect_metric_outputs(active)
-
-                sink.console(*(f"eval/{k}: {v}" for k, v in metrics.items()))
-                sink.log({f"eval/{k}": v for k, v in metrics.items()}, step=step)
-
-                del metrics
-                torch.cuda.empty_cache()
-                gc.collect()
-
-        # --- Saving Checkpoint --- #
-        if step == pd_config.steps or cadence.should_save(step):
-            sink.checkpoint(component_model.state_dict(), step=step)
-
-        # Skip gradient step at the very last step (last step is just for plotting/logging).
-        if step != pd_config.steps:
-            sync_across_processes()
-            if pd_config.components_optimizer.grad_clip_norm is not None:
-                clip_grad_norm_(component_params, pd_config.components_optimizer.grad_clip_norm)
-            if pd_config.ci_fn_optimizer.grad_clip_norm is not None:
-                clip_grad_norm_(ci_fn_params, pd_config.ci_fn_optimizer.grad_clip_norm)
-            components_optimizer.step()
-            ci_fn_optimizer.step()
-
-    if is_main_process():
-        logger.info("Finished training loop.")
+    trainer.run(train_loader, sink, cadence, eval_loop)

--- a/param_decomp/optimize.py
+++ b/param_decomp/optimize.py
@@ -1,19 +1,11 @@
 """The PD trainer.
 
-Two entry points:
-
-- :class:`Trainer` — stateful training class. Construction sets up the
-  `ComponentModel`, the two optimizers, and the loss-metric instances from
-  ``pd_config``. :meth:`Trainer.run` advances the training loop from
-  ``self.step`` to ``pd_config.steps``. :meth:`Trainer.snapshot` and
-  :meth:`Trainer.from_snapshot` round-trip an atomic
-  :class:`~param_decomp.trainer_snapshot.TrainerSnapshot` that lets a caller
-  persist and restore the full training state (used by resumption).
-- :func:`optimize` — thin convenience wrapper that constructs a `Trainer` and
-  calls :meth:`Trainer.run`. Preserves the original function-style entry point
-  for callers that don't need resumption.
-
-Both go through the same code path.
+:class:`Trainer` is the one entry point: construction sets up the
+`ComponentModel`, the two optimizers, and the loss-metric instances from
+``pd_config``; :meth:`Trainer.run` advances the training loop from
+``self.step`` to ``pd_config.steps``; :meth:`Trainer.snapshot` and
+:meth:`Trainer.from_snapshot` round-trip an atomic :class:`TrainingState`
+that lets a caller persist and restore the full training state (resumption).
 """
 
 import gc
@@ -675,27 +667,3 @@ class Trainer:
             logger.info("Finished training loop.")
 
 
-def optimize(
-    target_model: nn.Module,
-    train_loader: DataLoader[Any],
-    run_batch: RunBatch,
-    reconstruction_loss: ReconstructionLoss,
-    pd_config: PDConfig,
-    runtime_config: RuntimeConfig,
-    sink: RunSink,
-    cadence: Cadence,
-    eval_loop: EvalLoop | None = None,
-) -> None:
-    """Run the PD optimization loop.
-
-    Thin wrapper over :class:`Trainer` for callers that don't need resumption
-    or interactive control.
-    """
-    trainer = Trainer(
-        target_model=target_model,
-        run_batch=run_batch,
-        reconstruction_loss=reconstruction_loss,
-        pd_config=pd_config,
-        runtime_config=runtime_config,
-    )
-    trainer.run(train_loader, sink, cadence, eval_loop)

--- a/param_decomp/optimize.py
+++ b/param_decomp/optimize.py
@@ -17,6 +17,7 @@ Both go through the same code path.
 """
 
 import gc
+import signal
 from collections import defaultdict
 from dataclasses import dataclass
 from typing import Any, Self, cast
@@ -60,6 +61,33 @@ from param_decomp.run_sink import RunSink
 from param_decomp.schedule import get_scheduled_value
 from param_decomp.torch_helpers import bf16_autocast, loop_dataloader
 from param_decomp.training_state import TrainingState
+
+
+@dataclass
+class _SigtermFlag:
+    """Mutable flag flipped by a SIGTERM handler so the train loop can react."""
+
+    received: bool = False
+
+
+def _install_sigterm_flag() -> _SigtermFlag:
+    """Install a SIGTERM handler that flips a flag, and return the flag.
+
+    SLURM sends SIGTERM to all ranks at job-kill / preemption time. The handler
+    is intentionally minimal (set a flag, return) — Python's signal handlers
+    aren't strictly async-signal-safe, and we want the actual checkpoint save
+    to happen at a known-safe point in the train loop. No teardown: ``Trainer.run``
+    owns the process for its lifetime and the next SIGTERM after ``run`` returns
+    can take the default action.
+    """
+    flag = _SigtermFlag()
+
+    def _handler(signum: int, frame: Any) -> None:
+        del signum, frame
+        flag.received = True
+
+    signal.signal(signal.SIGTERM, _handler)
+    return flag
 
 
 @dataclass(frozen=True)
@@ -365,6 +393,35 @@ class Trainer:
         assert self.component_model.ci_fn is not None
         return [(f"ci_fn.{n}", p) for n, p in self.component_model.ci_fn.named_parameters()]
 
+    def _build_all_metric_instances(
+        self,
+        eval_loop: "EvalLoop | None",
+        device: str,
+    ) -> dict[str, "Metric[Any]"]:
+        """Merge loss + eval-only metric instances keyed by class name.
+
+        Binds each eval-only metric, rejects duplicate names within eval_loop, and
+        rejects overlap between eval-only and loss metrics (loss metrics are
+        auto-evaluated; duplicating them as eval metrics is a config error since
+        ``evaluate()`` keys by class name).
+        """
+        eval_only_instances: dict[str, Metric[Any]] = {}
+        if eval_loop is not None:
+            for m in eval_loop.metrics:
+                m.bind(model=self.component_model, device=device)
+                metric_name = type(m).__name__
+                assert metric_name not in eval_only_instances, (
+                    f"duplicate eval metric {metric_name!r}"
+                )
+                eval_only_instances[metric_name] = m
+            overlap = sorted(set(self.loss_metrics) & set(eval_only_instances))
+            assert not overlap, (
+                f"eval_loop.metrics overlap with pd_config.loss_metrics: {overlap}. Loss "
+                "metrics are automatically evaluated; remove the duplicates from "
+                "eval_loop.metrics."
+            )
+        return {**self.loss_metrics, **eval_only_instances}
+
     # ============================ Atomic cfg + state ============================
 
     def snapshot(self) -> TrainingState:
@@ -398,18 +455,14 @@ class Trainer:
         target_model: nn.Module,
         run_batch: RunBatch,
         reconstruction_loss: ReconstructionLoss,
-        cfg_overrides: dict[str, Any] | None = None,
     ) -> Self:
         """Reconstruct a Trainer from a :class:`TrainingState`.
 
-        ``cfg_overrides`` is a flat patch applied to the saved ``pd_config``
-        dict before pydantic validation — used for narrow resume-time
-        overrides such as extending ``steps``.
+        For mid-trajectory edits to the saved config (e.g. extending ``steps``
+        on a finished run), mutate ``snapshot.pd_config`` in place before this
+        call.
         """
-        pd_dict = snapshot.pd_config
-        if cfg_overrides is not None:
-            pd_dict = {**pd_dict, **cfg_overrides}
-        pd_config = PDConfig.model_validate(pd_dict)
+        pd_config = PDConfig.model_validate(snapshot.pd_config)
         runtime_config = RuntimeConfig.model_validate(snapshot.runtime_config)
         trainer = cls(
             target_model=target_model,
@@ -473,27 +526,8 @@ class Trainer:
         if self.step == 0 and pd_config.faithfulness_warmup_steps > 0:
             run_faithfulness_warmup(self.component_model, self._component_params, pd_config)
 
-        eval_only_instances: dict[str, Metric[Any]] = {}
-        if eval_loop is not None:
-            for m in eval_loop.metrics:
-                m.bind(model=self.component_model, device=device)
-
-            # Loss metrics are auto-evaluated alongside dedicated eval metrics. We disallow
-            # duplicate registry names across the two pools because `evaluate()` keys metrics
-            # by class name.
-            for m in eval_loop.metrics:
-                metric_name = type(m).__name__
-                assert metric_name not in eval_only_instances, (
-                    f"duplicate eval metric {metric_name!r}"
-                )
-                eval_only_instances[metric_name] = m
-            overlap = sorted(set(self.loss_metrics) & set(eval_only_instances))
-            assert not overlap, (
-                f"eval_loop.metrics overlap with pd_config.loss_metrics: {overlap}. Loss "
-                "metrics are automatically evaluated; remove the duplicates from "
-                "eval_loop.metrics."
-            )
-        all_instances = {**self.loss_metrics, **eval_only_instances}
+        all_instances = self._build_all_metric_instances(eval_loop, device)
+        sigterm = _install_sigterm_flag()
 
         for step in tqdm(
             range(self.step, pd_config.steps + 1), ncols=0, disable=not is_main_process()
@@ -616,8 +650,14 @@ class Trainer:
                     gc.collect()
 
             # --- Saving Checkpoint --- #
-            if step == pd_config.steps or cadence.should_save(step):
+            if step == pd_config.steps or cadence.should_save(step) or sigterm.received:
                 sink.checkpoint(self.snapshot())
+            if sigterm.received:
+                if is_main_process():
+                    logger.info(
+                        f"SIGTERM received; saved checkpoint at step {step}, exiting train loop"
+                    )
+                break
 
             # Skip gradient step at the very last step (last step is just for plotting/logging).
             if step != pd_config.steps:
@@ -649,7 +689,7 @@ def optimize(
     """Run the PD optimization loop.
 
     Thin wrapper over :class:`Trainer` for callers that don't need resumption
-    or interactive control. Identical signature to the pre-Trainer ``optimize``.
+    or interactive control.
     """
     trainer = Trainer(
         target_model=target_model,

--- a/param_decomp/run_sink.py
+++ b/param_decomp/run_sink.py
@@ -2,6 +2,8 @@
 
 from typing import Any, Protocol, runtime_checkable
 
+from param_decomp.training_state import TrainingState
+
 
 @runtime_checkable
 class RunSink(Protocol):
@@ -27,12 +29,13 @@ class RunSink(Protocol):
         """Emit free-form lines (e.g. tqdm-friendly progress)."""
         ...
 
-    def checkpoint(self, state_dict: dict[str, Any], step: int) -> None:
-        """Persist a model state dict at `step`.
+    def checkpoint(self, snapshot: TrainingState) -> None:
+        """Persist a training state.
 
-        Args:
-            state_dict: Tensor state dict to serialise.
-            step: Training step used in the checkpoint identifier.
+        `snapshot.step` is the training step; sinks use it for naming. The lab
+        sink writes `snapshot.component_model` to `model_<step>.pth` and the
+        whole `snapshot` (cfgs, optimizer state, metric state, etc.) to
+        `training_<step>.pth`.
         """
         ...
 

--- a/param_decomp/run_sink.py
+++ b/param_decomp/run_sink.py
@@ -1,4 +1,4 @@
-"""`RunSink` Protocol: where `optimize()` sends its output (metrics, console lines, checkpoints)."""
+"""`RunSink` Protocol: where `Trainer.run` sends its output (metrics, console lines, checkpoints)."""
 
 from typing import Any, Protocol, runtime_checkable
 

--- a/param_decomp/schedule.py
+++ b/param_decomp/schedule.py
@@ -1,4 +1,4 @@
-"""Schedule config and value lookup used by `optimize()` and PGD metrics."""
+"""Schedule config and value lookup used by `Trainer.run` and PGD metrics."""
 
 from typing import Literal, Self
 

--- a/param_decomp/tests/test_optimize.py
+++ b/param_decomp/tests/test_optimize.py
@@ -312,13 +312,13 @@ def test_trainer_resumes_from_snapshot_and_matches_uninterrupted_run() -> None:
     trainer_half.run(make_loader(), CaptureSink(), make_cadence(), eval_loop=None)
     snap = trainer_half.snapshot()
 
-    # Resume — extend ``steps`` to 4 via cfg_overrides.
+    # Resume — extend ``steps`` to 4 by mutating the saved pd_config dict.
+    snap.pd_config["steps"] = 4
     trainer_resumed = Trainer.from_snapshot(
         snap,
         target_model=TinyLinear(),
         run_batch=run_batch_passthrough,
         reconstruction_loss=recon_loss_mse,
-        cfg_overrides={"steps": 4},
     )
     assert trainer_resumed.step == 2
     trainer_resumed.run(make_loader(), CaptureSink(), make_cadence(), eval_loop=None)

--- a/param_decomp/tests/test_optimize.py
+++ b/param_decomp/tests/test_optimize.py
@@ -19,7 +19,7 @@ from param_decomp.configs import (
 from param_decomp.decomposition_targets import DecompositionTargetConfig
 from param_decomp.metrics.base import Metric, MetricResult
 from param_decomp.metrics.faithfulness import FaithfulnessLossConfig
-from param_decomp.optimize import EvalLoop, optimize
+from param_decomp.optimize import EvalLoop, Trainer, optimize
 from param_decomp.schedule import ScheduleConfig
 
 
@@ -60,10 +60,10 @@ class CaptureSink:
     def console(self, *lines: str) -> None:
         del lines
 
-    def checkpoint(self, state_dict: dict[str, Any], step: int) -> None:
-        del step
+    def checkpoint(self, snapshot: Any) -> None:
+        model_state = snapshot.component_model
         checkpoint: dict[str, Tensor] = {}
-        for key, value in state_dict.items():
+        for key, value in model_state.items():
             assert isinstance(value, Tensor)
             checkpoint[key] = value.detach().cpu().clone()
         self.checkpoints.append(checkpoint)
@@ -237,3 +237,93 @@ def run_with_external_seed(seed: int) -> dict[str, Tensor]:
     )
     assert len(sink.checkpoints) == 1
     return sink.checkpoints[0]
+
+
+def test_trainer_snapshot_round_trips() -> None:
+    """A trainer reconstructed via ``Trainer.from_snapshot`` produces matching state."""
+    pd_config = make_pd_config(steps=3)
+    runtime_config = RuntimeConfig(device="cpu", autocast_bf16=False)
+
+    trainer_a = Trainer(
+        target_model=TinyLinear(),
+        run_batch=run_batch_passthrough,
+        reconstruction_loss=recon_loss_mse,
+        pd_config=pd_config,
+        runtime_config=runtime_config,
+    )
+    trainer_a.run(make_loader(), CaptureSink(), make_cadence(), eval_loop=None)
+    snap = trainer_a.snapshot()
+
+    trainer_b = Trainer.from_snapshot(
+        snap,
+        target_model=TinyLinear(),
+        run_batch=run_batch_passthrough,
+        reconstruction_loss=recon_loss_mse,
+    )
+
+    assert trainer_b.step == trainer_a.step
+    sd_a = trainer_a.snapshot().component_model
+    sd_b = trainer_b.snapshot().component_model
+    assert sd_a.keys() == sd_b.keys()
+    for k in sd_a:
+        torch.testing.assert_close(sd_a[k], sd_b[k])
+
+    opt_a = trainer_a.components_optimizer.state_dict()
+    opt_b = trainer_b.components_optimizer.state_dict()
+    assert opt_a["param_groups"] == opt_b["param_groups"]
+    assert set(opt_a["state"].keys()) == set(opt_b["state"].keys())
+    for pid in opt_a["state"]:
+        for k, v in opt_a["state"][pid].items():
+            if isinstance(v, Tensor):
+                torch.testing.assert_close(v, opt_b["state"][pid][k])
+            else:
+                assert v == opt_b["state"][pid][k]
+
+
+def test_trainer_resumes_from_snapshot_and_matches_uninterrupted_run() -> None:
+    """Train K steps in one shot vs train K/2 → save → resume → train K/2;
+    the final model weights should match up to RNG drift (we accept some, but
+    on CPU with deterministic Adam the trajectory is bit-exact)."""
+    pd_config = make_pd_config(steps=4)
+    runtime_config = RuntimeConfig(device="cpu", autocast_bf16=False)
+
+    torch.manual_seed(7)
+    trainer_full = Trainer(
+        target_model=TinyLinear(),
+        run_batch=run_batch_passthrough,
+        reconstruction_loss=recon_loss_mse,
+        pd_config=pd_config,
+        runtime_config=runtime_config,
+    )
+    trainer_full.run(make_loader(), CaptureSink(), make_cadence(), eval_loop=None)
+    full_model = trainer_full.snapshot().component_model
+    final_full = {k: v.clone() for k, v in full_model.items()}
+
+    # Same fresh start, but save after step 2 and resume.
+    torch.manual_seed(7)
+    pd_config_half = make_pd_config(steps=2)
+    trainer_half = Trainer(
+        target_model=TinyLinear(),
+        run_batch=run_batch_passthrough,
+        reconstruction_loss=recon_loss_mse,
+        pd_config=pd_config_half,
+        runtime_config=runtime_config,
+    )
+    trainer_half.run(make_loader(), CaptureSink(), make_cadence(), eval_loop=None)
+    snap = trainer_half.snapshot()
+
+    # Resume — extend ``steps`` to 4 via cfg_overrides.
+    trainer_resumed = Trainer.from_snapshot(
+        snap,
+        target_model=TinyLinear(),
+        run_batch=run_batch_passthrough,
+        reconstruction_loss=recon_loss_mse,
+        cfg_overrides={"steps": 4},
+    )
+    assert trainer_resumed.step == 2
+    trainer_resumed.run(make_loader(), CaptureSink(), make_cadence(), eval_loop=None)
+
+    resumed_model = trainer_resumed.snapshot().component_model
+    assert final_full.keys() == resumed_model.keys()
+    for k in final_full:
+        torch.testing.assert_close(final_full[k], resumed_model[k])

--- a/param_decomp/tests/test_optimize.py
+++ b/param_decomp/tests/test_optimize.py
@@ -19,7 +19,7 @@ from param_decomp.configs import (
 from param_decomp.decomposition_targets import DecompositionTargetConfig
 from param_decomp.metrics.base import Metric, MetricResult
 from param_decomp.metrics.faithfulness import FaithfulnessLossConfig
-from param_decomp.optimize import EvalLoop, Trainer, optimize
+from param_decomp.optimize import EvalLoop, Trainer
 from param_decomp.schedule import ScheduleConfig
 
 
@@ -130,17 +130,14 @@ def test_pd_config_requires_positive_steps() -> None:
 def test_optimize_logs_missing_grad_norms_as_nan() -> None:
     sink = CaptureSink()
     loader = make_loader()
-    optimize(
+    trainer = Trainer(
         target_model=TinyLinear(),
-        train_loader=loader,
         run_batch=run_batch_passthrough,
         reconstruction_loss=recon_loss_mse,
         pd_config=make_pd_config(),
         runtime_config=RuntimeConfig(device="cpu", autocast_bf16=False),
-        sink=sink,
-        cadence=make_cadence(train_log_every=1),
-        eval_loop=None,
     )
+    trainer.run(loader, sink, make_cadence(train_log_every=1), eval_loop=None)
 
     train_logs = [
         metrics for _, metrics in sink.logged if any(k.startswith("train/") for k in metrics)
@@ -179,15 +176,17 @@ class DummyEvalMetric(Metric[DummyEvalConfig]):
 def test_optimize_rejects_duplicate_eval_metric_names() -> None:
     loader = make_loader()
     with pytest.raises(AssertionError, match="duplicate eval metric 'DummyEvalMetric'"):
-        optimize(
+        trainer = Trainer(
             target_model=TinyLinear(),
-            train_loader=loader,
             run_batch=run_batch_passthrough,
             reconstruction_loss=recon_loss_mse,
             pd_config=make_pd_config(),
             runtime_config=RuntimeConfig(device="cpu", autocast_bf16=False),
-            sink=CaptureSink(),
-            cadence=make_cadence(),
+        )
+        trainer.run(
+            loader,
+            CaptureSink(),
+            make_cadence(),
             eval_loop=make_eval_loop(
                 loader,
                 metrics=[DummyEvalMetric(DummyEvalConfig()), DummyEvalMetric(DummyEvalConfig())],
@@ -198,17 +197,14 @@ def test_optimize_rejects_duplicate_eval_metric_names() -> None:
 def test_optimize_runs_without_eval_loop() -> None:
     sink = CaptureSink()
     loader = make_loader()
-    optimize(
+    trainer = Trainer(
         target_model=TinyLinear(),
-        train_loader=loader,
         run_batch=run_batch_passthrough,
         reconstruction_loss=recon_loss_mse,
         pd_config=make_pd_config(steps=2),
         runtime_config=RuntimeConfig(device="cpu", autocast_bf16=False),
-        sink=sink,
-        cadence=make_cadence(train_log_every=1),
-        eval_loop=None,
     )
+    trainer.run(loader, sink, make_cadence(train_log_every=1), eval_loop=None)
     assert not any(any(k.startswith("eval/") for k in metrics) for _, metrics in sink.logged)
 
 
@@ -224,17 +220,14 @@ def run_with_external_seed(seed: int) -> dict[str, Tensor]:
     torch.manual_seed(seed)
     sink = CaptureSink()
     loader = make_loader()
-    optimize(
+    trainer = Trainer(
         target_model=TinyLinear(),
-        train_loader=loader,
         run_batch=run_batch_passthrough,
         reconstruction_loss=recon_loss_mse,
         pd_config=make_pd_config(),
         runtime_config=RuntimeConfig(device="cpu", autocast_bf16=False),
-        sink=sink,
-        cadence=make_cadence(),
-        eval_loop=None,
     )
+    trainer.run(loader, sink, make_cadence(), eval_loop=None)
     assert len(sink.checkpoints) == 1
     return sink.checkpoints[0]
 

--- a/param_decomp/training_state.py
+++ b/param_decomp/training_state.py
@@ -1,0 +1,34 @@
+"""`TrainingState`: the canonical persisted state of a 1-pool training run.
+
+Lives in its own module so both `param_decomp.optimize` (where `Trainer`
+produces it) and `param_decomp.run_sink` (where the `RunSink` Protocol
+consumes it) can import without a cycle.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+from torch import Tensor
+
+
+@dataclass(frozen=True)
+class TrainingState:
+    """Canonical 1-pool training state, persisted to `training_<step>.pth`.
+
+    Produced by `Trainer.snapshot()` and consumed by `Trainer.from_snapshot()`
+    to reconstruct the trainer. For DDP, every rank produces an identical
+    instance (model and optimizers are replicated); rank 0's write is the
+    canonical artifact.
+
+    Optimizer states are keyed by parameter name (e.g.
+    `components.h.0.attn.q_proj.V`, `ci_fn.embed.weight`) rather than the
+    optimizer's integer indices, so they survive a topology change on resume.
+    """
+
+    step: int
+    pd_config: dict[str, Any]
+    runtime_config: dict[str, Any]
+    component_model: dict[str, Tensor]
+    components_optimizer: dict[str, dict[str, Any]]
+    ci_fn_optimizer: dict[str, dict[str, Any]]
+    loss_metrics: dict[str, dict[str, Any]]

--- a/param_decomp_lab/batch_and_loss_fns.py
+++ b/param_decomp_lab/batch_and_loss_fns.py
@@ -1,6 +1,6 @@
 """Lab-side `RunBatch` / `ReconstructionLoss` helpers.
 
-Passed to `optimize(run_batch=..., reconstruction_loss=...)`.
+Passed to `Trainer(run_batch=..., reconstruction_loss=...)`.
 """
 
 from typing import Any

--- a/param_decomp_lab/experiments/CLAUDE.md
+++ b/param_decomp_lab/experiments/CLAUDE.md
@@ -1,7 +1,7 @@
 # `param_decomp_lab/experiments/`
 
 Composition roots for the in-repo experiments. Each experiment is a plain Python script
-that parses a YAML, builds the target / loaders / metrics, and calls `optimize(...)`.
+that parses a YAML, builds the target / loaders / metrics, and runs a `Trainer`.
 
 There is no central registry — each `run.py` declares its own `<Name>ExperimentConfig`
 + build functions + `Saved<Name>Run` reload class, and post-processing callers import

--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -1,9 +1,14 @@
-"""LM PD experiment: YAML -> `optimize()` glue, plus the `SavedLMRun` reload class.
+"""LM PD experiment: YAML -> `Trainer` glue + `SavedLMRun` reload + resumption.
 
-Both the fresh-run path (`main`) and the reload path share the module-level
-`build_target` / `build_lm_loader` / `make_run_batch`. Run via
-`pd-lm path/to/config.yaml`; pass `--dp N` to submit a single-node DDP SLURM job.
-For local DDP, invoke directly:
+Both the fresh-run path (`main`) and the reload path (`SavedLMRun`) share the
+module-level `build_target` / `build_lm_loader` / `make_run_batch`. The resume
+path (`main --resume <yaml>`) reads a parent run's `run_meta.yaml` plus
+`training_<step>.pth`, rebuilds a `Trainer` via `Trainer.from_snapshot`, and
+continues training.
+
+Run via `pd-lm path/to/config.yaml` (fresh) or `pd-lm --resume path/to/resume.yaml`
+(resume). Pass `--dp N` to submit a single-node DDP SLURM job; for local DDP,
+invoke directly via
 `torchrun --standalone --nproc_per_node=N -m param_decomp_lab.experiments.lm.run config.yaml`.
 """
 
@@ -24,7 +29,7 @@ from param_decomp.batch_and_loss_fns import RunBatch
 from param_decomp.component_model import ComponentModel
 from param_decomp.distributed import DistributedState, is_main_process
 from param_decomp.log import logger
-from param_decomp.optimize import EvalLoop, optimize
+from param_decomp.optimize import EvalLoop, Trainer
 from param_decomp_lab.batch_and_loss_fns import make_run_batch as _make_run_batch
 from param_decomp_lab.batch_and_loss_fns import recon_loss_kl
 from param_decomp_lab.component_model_io import load_component_model
@@ -52,6 +57,13 @@ from param_decomp_lab.infra.run_files import generate_run_id, resolve_run_files
 from param_decomp_lab.infra.settings import DEFAULT_PARTITION_NAME, REPO_ROOT
 from param_decomp_lab.infra.slurm import SlurmConfig, generate_script, submit_slurm_job
 from param_decomp_lab.infra.wandb import get_wandb_entity
+from param_decomp_lab.resumption import (
+    ResumeConfig,
+    ResumeProvenance,
+    read_training_snapshot,
+    resolve_step,
+    write_provenance,
+)
 from param_decomp_lab.seed import set_seed
 
 
@@ -185,8 +197,9 @@ class SavedLMRun:
 
 @with_distributed_cleanup
 def main(
-    config_path: str | Path,
+    config_path: str | Path | None = None,
     *,
+    resume: str | Path | None = None,
     group: str | None = None,
     tags: str | None = None,
     dp: int | None = None,
@@ -196,17 +209,24 @@ def main(
     no_snapshot: bool = False,
     run_id: str | None = None,
 ) -> None:
-    """Run an LM PD experiment end-to-end from a YAML config.
+    """Run an LM PD experiment end-to-end.
 
-    Parses the YAML, initialises DDP, builds the target / loaders / eval loop, writes
-    `run_meta.yaml`, and calls `optimize(...)`. Non-main ranks use a silent sink.
-    `group` / `tags` are wandb-only (no-ops without `wandb:`). Passing `--dp N`
-    outside torchrun submits a single-node SLURM job; for local DDP, invoke via
-    `torchrun --standalone --nproc_per_node=N -m param_decomp_lab.experiments.lm.run`.
+    Args:
+        config_path: YAML for a fresh run. Required when not resuming.
+        resume: Path to a `ResumeConfig` YAML pointing at a prior run. When set,
+            the parent's `run_meta.yaml` is the source of cfg truth (modulo
+            narrow `overrides`); a new `run_id` + sibling `resume_provenance.yaml`
+            are written.
+        group / tags: wandb-only (no-ops without `wandb:`).
+        dp / partition / time / job_name / no_snapshot / run_id: SLURM submission
+            knobs. Passing `--dp N` outside torchrun submits a single-node SLURM
+            job; for local DDP, invoke via
+            `torchrun --standalone --nproc_per_node=N -m param_decomp_lab.experiments.lm.run`.
     """
     if dp is not None and dp < 2:
         raise ValueError("--dp must be at least 2 for data parallelism")
     if dp is not None and os.environ.get("WORLD_SIZE") is None:
+        assert config_path is not None, "--dp SLURM submission requires a config_path"
         _submit_slurm(
             config_path,
             dp=dp,
@@ -220,6 +240,22 @@ def main(
         )
         return
 
+    if resume is not None:
+        assert config_path is None, "pass either config_path or --resume, not both"
+        _resume_main(Path(resume), group=group, tags=tags, run_id=run_id)
+    else:
+        assert config_path is not None, "must provide either config_path or --resume"
+        _fresh_main(Path(config_path), group=group, tags=tags, run_id=run_id)
+
+
+def _fresh_main(
+    config_path: Path,
+    *,
+    group: str | None,
+    tags: str | None,
+    run_id: str | None,
+) -> None:
+    """Fresh-run path: parse YAML, build everything, train from step 0."""
     cfg = LMExperimentConfig.from_file(config_path)
 
     dist_state = init_distributed()
@@ -254,17 +290,91 @@ def main(
     sink = init_pd_run(cfg, group=group, tags=tags, run_id=run_id)
 
     try:
-        optimize(
+        trainer = Trainer(
             target_model=target_model,
-            train_loader=train_loader,
             run_batch=make_run_batch(cfg.target),
             reconstruction_loss=recon_loss_kl,
             pd_config=cfg.pd,
             runtime_config=cfg.runtime,
-            sink=sink,
-            cadence=cfg.cadence,
-            eval_loop=eval_loop,
         )
+        trainer.run(train_loader, sink, cfg.cadence, eval_loop)
+    finally:
+        sink.finish()
+
+
+def _resume_main(
+    resume_cfg_path: Path,
+    *,
+    group: str | None,
+    tags: str | None,
+    run_id: str | None,
+) -> None:
+    """Resume-run path: read parent `run_meta.yaml` + `training_<step>.pth`,
+    rebuild trainer via `Trainer.from_snapshot`, continue training."""
+    resume_cfg = ResumeConfig.from_file(resume_cfg_path)
+    parent_cfg = LMExperimentConfig.from_file(resume_cfg.from_run / RUN_META_FILENAME)
+
+    dist_state = init_distributed()
+    if is_main_process():
+        logger.info(f"Distributed state: {dist_state}")
+        logger.info(f"Resuming from {resume_cfg.from_run} @ step {resume_cfg.step}")
+    set_seed(parent_cfg.pd.seed)
+    device = get_device()
+
+    cfg_overrides = (
+        resume_cfg.overrides.to_pd_config_patch() if resume_cfg.overrides is not None else None
+    )
+    effective_pd = (
+        parent_cfg.pd.model_copy(update=cfg_overrides)
+        if cfg_overrides is not None
+        else parent_cfg.pd
+    )
+    effective_cfg = parent_cfg.model_copy(
+        update={
+            "pd": effective_pd,
+            "runtime": parent_cfg.runtime.model_copy(
+                update={
+                    "device": device,
+                    "dp": dist_state.world_size if dist_state is not None else None,
+                }
+            ),
+        }
+    )
+
+    resolved_step = resolve_step(resume_cfg.from_run, resume_cfg.step)
+    snapshot = read_training_snapshot(resume_cfg.from_run, resolved_step)
+    # Override the saved device with the current resume environment. Mutating
+    # the dict (model_dump output) in place is fine even on a frozen dataclass;
+    # we're changing a value the dataclass references, not rebinding the field.
+    snapshot.runtime_config["device"] = device
+
+    target_model = build_target(effective_cfg.target)
+    train_loader = build_lm_loader(
+        effective_cfg.target,
+        effective_cfg.data,
+        split="train",
+        device=device,
+        batch_size=effective_cfg.pd.batch_size,
+        dist_state=dist_state,
+        seed=effective_cfg.pd.seed,
+    )
+    eval_loop = _build_eval_loop(effective_cfg, device, dist_state)
+    sink = init_pd_run(effective_cfg, group=group, tags=tags, run_id=run_id)
+    if sink.out_dir is not None:
+        write_provenance(
+            sink.out_dir,
+            ResumeProvenance(parent_run_dir=resume_cfg.from_run, parent_step=resolved_step),
+        )
+
+    try:
+        trainer = Trainer.from_snapshot(
+            snapshot,
+            target_model=target_model,
+            run_batch=make_run_batch(effective_cfg.target),
+            reconstruction_loss=recon_loss_kl,
+            cfg_overrides=cfg_overrides,
+        )
+        trainer.run(train_loader, sink, effective_cfg.cadence, eval_loop)
     finally:
         sink.finish()
 

--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -214,9 +214,8 @@ def main(
     Args:
         config_path: YAML for a fresh run. Required when not resuming.
         resume: Path to a `ResumeConfig` YAML pointing at a prior run. When set,
-            the parent's `run_meta.yaml` is the source of cfg truth (modulo
-            narrow `overrides`); a new `run_id` + sibling `resume_provenance.yaml`
-            are written.
+            the parent's `run_meta.yaml` is the source of cfg truth; a new
+            `run_id` + sibling `resume_provenance.yaml` are written.
         group / tags: wandb-only (no-ops without `wandb:`).
         dp / partition / time / job_name / no_snapshot / run_id: SLURM submission
             knobs. Passing `--dp N` outside torchrun submits a single-node SLURM
@@ -321,17 +320,8 @@ def _resume_main(
     set_seed(parent_cfg.pd.seed)
     device = get_device()
 
-    cfg_overrides = (
-        resume_cfg.overrides.to_pd_config_patch() if resume_cfg.overrides is not None else None
-    )
-    effective_pd = (
-        parent_cfg.pd.model_copy(update=cfg_overrides)
-        if cfg_overrides is not None
-        else parent_cfg.pd
-    )
     effective_cfg = parent_cfg.model_copy(
         update={
-            "pd": effective_pd,
             "runtime": parent_cfg.runtime.model_copy(
                 update={
                     "device": device,
@@ -372,7 +362,6 @@ def _resume_main(
             target_model=target_model,
             run_batch=make_run_batch(effective_cfg.target),
             reconstruction_loss=recon_loss_kl,
-            cfg_overrides=cfg_overrides,
         )
         trainer.run(train_loader, sink, effective_cfg.cadence, eval_loop)
     finally:

--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -1,10 +1,10 @@
-"""LM PD experiment: YAML -> `Trainer` glue + `SavedLMRun` reload + resumption.
+"""LM PD experiment: YAML -> generic runner glue + `SavedLMRun` reload.
 
-Both the fresh-run path (`main`) and the reload path (`SavedLMRun`) share the
-module-level `build_target` / `build_lm_loader` / `make_run_batch`. The resume
-path (`main --resume <yaml>`) reads a parent run's `run_meta.yaml` plus
-`training_<step>.pth`, rebuilds a `Trainer` via `Trainer.from_snapshot`, and
-continues training.
+`main` packages the per-experiment callables (`build_target`, `build_lm_loader`,
+`make_run_batch`, `_build_eval_loop`, `recon_loss_kl`) into an `ExperimentBundle`
+and dispatches to `run_fresh` / `run_resumed` in `experiments.runner`. The
+generic orchestration (distributed setup, snapshot read, sink, trainer build,
+provenance write) lives there.
 
 Run via `pd-lm path/to/config.yaml` (fresh) or `pd-lm --resume path/to/resume.yaml`
 (resume). Pass `--dp N` to submit a single-node DDP SLURM job; for local DDP,
@@ -27,16 +27,14 @@ from torch.utils.data import DataLoader
 from param_decomp.base_config import BaseConfig
 from param_decomp.batch_and_loss_fns import RunBatch
 from param_decomp.component_model import ComponentModel
-from param_decomp.distributed import DistributedState, is_main_process
+from param_decomp.distributed import DistributedState
 from param_decomp.log import logger
-from param_decomp.optimize import EvalLoop, Trainer
+from param_decomp.optimize import EvalLoop
 from param_decomp_lab.batch_and_loss_fns import make_run_batch as _make_run_batch
 from param_decomp_lab.batch_and_loss_fns import recon_loss_kl
 from param_decomp_lab.component_model_io import load_component_model
 from param_decomp_lab.distributed import (
     ensure_cached_and_call,
-    get_device,
-    init_distributed,
     with_distributed_cleanup,
 )
 from param_decomp_lab.eval_metrics import EVAL_METRIC_CLASSES
@@ -46,25 +44,14 @@ from param_decomp_lab.experiments.lm.data import (
     create_lm_data_loader,
     rank_batch_size,
 )
-from param_decomp_lab.experiments.utils import (
-    RUN_META_FILENAME,
-    ExperimentConfig,
-    init_pd_run,
-)
+from param_decomp_lab.experiments.runner import ExperimentBundle, run_fresh, run_resumed
+from param_decomp_lab.experiments.utils import RUN_META_FILENAME, ExperimentConfig
 from param_decomp_lab.infra.git import create_git_snapshot
 from param_decomp_lab.infra.paths import ModelPath
 from param_decomp_lab.infra.run_files import generate_run_id, resolve_run_files
 from param_decomp_lab.infra.settings import DEFAULT_PARTITION_NAME, REPO_ROOT
 from param_decomp_lab.infra.slurm import SlurmConfig, generate_script, submit_slurm_job
 from param_decomp_lab.infra.wandb import get_wandb_entity
-from param_decomp_lab.resumption import (
-    ResumeConfig,
-    ResumeProvenance,
-    read_training_snapshot,
-    resolve_step,
-    write_provenance,
-)
-from param_decomp_lab.seed import set_seed
 
 
 def _resolve_class(fqn: str) -> type:
@@ -241,131 +228,12 @@ def main(
 
     if resume is not None:
         assert config_path is None, "pass either config_path or --resume, not both"
-        _resume_main(Path(resume), group=group, tags=tags, run_id=run_id)
+        run_resumed(_LM_BUNDLE, Path(resume), group=group, tags=tags, run_id=run_id)
     else:
         assert config_path is not None, "must provide either config_path or --resume"
-        _fresh_main(Path(config_path), group=group, tags=tags, run_id=run_id)
+        run_fresh(_LM_BUNDLE, Path(config_path), group=group, tags=tags, run_id=run_id)
 
 
-def _fresh_main(
-    config_path: Path,
-    *,
-    group: str | None,
-    tags: str | None,
-    run_id: str | None,
-) -> None:
-    """Fresh-run path: parse YAML, build everything, train from step 0."""
-    cfg = LMExperimentConfig.from_file(config_path)
-
-    dist_state = init_distributed()
-    if is_main_process():
-        logger.info(f"Distributed state: {dist_state}")
-    set_seed(cfg.pd.seed)
-    device = get_device()
-    cfg = cfg.model_copy(
-        update={
-            "runtime": cfg.runtime.model_copy(
-                update={
-                    "device": device,
-                    "dp": dist_state.world_size if dist_state is not None else None,
-                }
-            )
-        }
-    )
-
-    target_model = build_target(cfg.target)
-
-    train_loader = build_lm_loader(
-        cfg.target,
-        cfg.data,
-        split="train",
-        device=device,
-        batch_size=cfg.pd.batch_size,
-        dist_state=dist_state,
-        seed=cfg.pd.seed,
-    )
-    eval_loop = _build_eval_loop(cfg, device, dist_state)
-
-    sink = init_pd_run(cfg, group=group, tags=tags, run_id=run_id)
-
-    try:
-        trainer = Trainer(
-            target_model=target_model,
-            run_batch=make_run_batch(cfg.target),
-            reconstruction_loss=recon_loss_kl,
-            pd_config=cfg.pd,
-            runtime_config=cfg.runtime,
-        )
-        trainer.run(train_loader, sink, cfg.cadence, eval_loop)
-    finally:
-        sink.finish()
-
-
-def _resume_main(
-    resume_cfg_path: Path,
-    *,
-    group: str | None,
-    tags: str | None,
-    run_id: str | None,
-) -> None:
-    """Resume-run path: read parent `run_meta.yaml` + `training_<step>.pth`,
-    rebuild trainer via `Trainer.from_snapshot`, continue training."""
-    resume_cfg = ResumeConfig.from_file(resume_cfg_path)
-    parent_cfg = LMExperimentConfig.from_file(resume_cfg.from_run / RUN_META_FILENAME)
-
-    dist_state = init_distributed()
-    if is_main_process():
-        logger.info(f"Distributed state: {dist_state}")
-        logger.info(f"Resuming from {resume_cfg.from_run} @ step {resume_cfg.step}")
-    set_seed(parent_cfg.pd.seed)
-    device = get_device()
-
-    effective_cfg = parent_cfg.model_copy(
-        update={
-            "runtime": parent_cfg.runtime.model_copy(
-                update={
-                    "device": device,
-                    "dp": dist_state.world_size if dist_state is not None else None,
-                }
-            ),
-        }
-    )
-
-    resolved_step = resolve_step(resume_cfg.from_run, resume_cfg.step)
-    snapshot = read_training_snapshot(resume_cfg.from_run, resolved_step)
-    # Override the saved device with the current resume environment. Mutating
-    # the dict (model_dump output) in place is fine even on a frozen dataclass;
-    # we're changing a value the dataclass references, not rebinding the field.
-    snapshot.runtime_config["device"] = device
-
-    target_model = build_target(effective_cfg.target)
-    train_loader = build_lm_loader(
-        effective_cfg.target,
-        effective_cfg.data,
-        split="train",
-        device=device,
-        batch_size=effective_cfg.pd.batch_size,
-        dist_state=dist_state,
-        seed=effective_cfg.pd.seed,
-    )
-    eval_loop = _build_eval_loop(effective_cfg, device, dist_state)
-    sink = init_pd_run(effective_cfg, group=group, tags=tags, run_id=run_id)
-    if sink.out_dir is not None:
-        write_provenance(
-            sink.out_dir,
-            ResumeProvenance(parent_run_dir=resume_cfg.from_run, parent_step=resolved_step),
-        )
-
-    try:
-        trainer = Trainer.from_snapshot(
-            snapshot,
-            target_model=target_model,
-            run_batch=make_run_batch(effective_cfg.target),
-            reconstruction_loss=recon_loss_kl,
-        )
-        trainer.run(train_loader, sink, effective_cfg.cadence, eval_loop)
-    finally:
-        sink.finish()
 
 
 def _build_eval_loop(
@@ -393,6 +261,25 @@ def _build_eval_loop(
         slow_every=cfg.eval.slow_every,
         slow_on_first_step=cfg.eval.slow_on_first_step,
     )
+
+
+_LM_BUNDLE = ExperimentBundle[LMExperimentConfig](
+    config_cls=LMExperimentConfig,
+    build_target=lambda cfg: build_target(cfg.target),
+    build_train_loader=lambda cfg, device, dist_state: build_lm_loader(
+        cfg.target,
+        cfg.data,
+        split="train",
+        device=device,
+        batch_size=cfg.pd.batch_size,
+        dist_state=dist_state,
+        seed=cfg.pd.seed,
+    ),
+    build_eval_loop=_build_eval_loop,
+    make_run_batch=lambda cfg: make_run_batch(cfg.target),
+    reconstruction_loss=recon_loss_kl,
+    uses_distributed=True,
+)
 
 
 def _submit_slurm(

--- a/param_decomp_lab/experiments/resid_mlp/run.py
+++ b/param_decomp_lab/experiments/resid_mlp/run.py
@@ -1,4 +1,4 @@
-"""ResidMLP PD experiment: YAML -> `optimize()` glue, plus the `SavedResidMLPRun` reload class.
+"""ResidMLP PD experiment: YAML -> `Trainer` glue, plus the `SavedResidMLPRun` reload class.
 
 Run via `pd-resid-mlp path/to/config.yaml`.
 """
@@ -16,7 +16,7 @@ from param_decomp.batch_and_loss_fns import RunBatch
 from param_decomp.component_model import ComponentModel
 from param_decomp.distributed import DistributedState
 from param_decomp.log import logger
-from param_decomp.optimize import EvalLoop, optimize
+from param_decomp.optimize import EvalLoop, Trainer
 from param_decomp_lab.batch_and_loss_fns import recon_loss_mse, run_batch_first_element
 from param_decomp_lab.component_model_io import load_component_model
 from param_decomp_lab.distributed import get_device
@@ -151,17 +151,14 @@ def main(
     sink = init_pd_run(cfg, group=group, tags=tags)
 
     try:
-        optimize(
+        trainer = Trainer(
             target_model=target_model,
-            train_loader=train_loader,
             run_batch=make_run_batch(cfg.target),
             reconstruction_loss=recon_loss_mse,
             pd_config=cfg.pd,
             runtime_config=cfg.runtime,
-            sink=sink,
-            cadence=cfg.cadence,
-            eval_loop=eval_loop,
         )
+        trainer.run(train_loader, sink, cfg.cadence, eval_loop)
     finally:
         sink.finish()
 

--- a/param_decomp_lab/experiments/runner.py
+++ b/param_decomp_lab/experiments/runner.py
@@ -1,0 +1,188 @@
+"""Generic experiment orchestration: fresh-run and resume-from-snapshot drivers.
+
+Each experiment (`lm`, `tms`, `resid_mlp`) packages its per-experiment callables
+into an :class:`ExperimentBundle` and dispatches to :func:`run_fresh` /
+:func:`run_resumed` from its own ``run.py::main``. The generic surface — config
+load, distributed init, device + seed, runtime cfg refresh, sink construction,
+trainer build, train loop, sink finish, plus resume-specific snapshot read and
+provenance write — lives here.
+
+The bundle defines a uniform signature for the per-experiment build callables
+so the runner doesn't need to know which experiment it's serving. Non-DDP
+experiments (TMS, ResidMLP) simply set ``uses_distributed=False`` and accept
+``dist_state=None`` in their build callables.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import torch.nn as nn
+from torch.utils.data import DataLoader
+
+from param_decomp.batch_and_loss_fns import ReconstructionLoss, RunBatch
+from param_decomp.distributed import DistributedState, is_main_process
+from param_decomp.log import logger
+from param_decomp.optimize import EvalLoop, Trainer
+from param_decomp_lab.distributed import get_device, init_distributed
+from param_decomp_lab.experiments.utils import RUN_META_FILENAME, ExperimentConfig, init_pd_run
+from param_decomp_lab.resumption import (
+    ResumeConfig,
+    ResumeProvenance,
+    read_training_snapshot,
+    resolve_step,
+    write_provenance,
+)
+from param_decomp_lab.seed import set_seed
+
+
+@dataclass(frozen=True)
+class ExperimentBundle[CfgT: ExperimentConfig[Any, Any]]:
+    """Per-experiment callables that the generic runner needs.
+
+    Each experiment constructs one of these in its ``run.py`` and passes it to
+    :func:`run_fresh` / :func:`run_resumed`. The build callables take the full
+    config (so they can reach ``cfg.target`` / ``cfg.data`` themselves) and the
+    runtime context (``device``, ``dist_state``) the runner has set up. Bundle
+    is generic over the experiment's config type so callers stay type-checked.
+
+    Attributes:
+        config_cls: The pydantic ``ExperimentConfig`` subclass for this experiment.
+            Used by the resume path to ``.from_file`` the parent's
+            ``run_meta.yaml``.
+        build_target: Construct the (frozen) target model.
+        build_train_loader: Construct the training data loader.
+        build_eval_loop: Construct the eval loop, or return ``None`` to skip.
+        make_run_batch: Construct the per-experiment ``RunBatch`` adapter.
+        reconstruction_loss: The recon loss closure for this experiment.
+        uses_distributed: Whether to run ``init_distributed`` at the top of the
+            runner. ``False`` for single-process experiments (TMS, ResidMLP);
+            ``True`` for LM.
+        refine_cfg: Optional hook called after ``build_target`` to return a
+            refined cfg (e.g. TMS's ``tied_weights`` depend on the constructed
+            target model). Default ``None`` means no refinement.
+    """
+
+    config_cls: type[CfgT]
+    build_target: Callable[[CfgT], nn.Module]
+    build_train_loader: Callable[[CfgT, str, DistributedState | None], DataLoader[Any]]
+    build_eval_loop: Callable[[CfgT, str, DistributedState | None], EvalLoop | None]
+    make_run_batch: Callable[[CfgT], RunBatch]
+    reconstruction_loss: ReconstructionLoss
+    uses_distributed: bool = False
+    refine_cfg: Callable[[CfgT, nn.Module], CfgT] | None = None
+
+
+def _setup_runtime[CfgT: ExperimentConfig[Any, Any]](
+    cfg: CfgT, bundle: ExperimentBundle[CfgT]
+) -> tuple[CfgT, str, DistributedState | None]:
+    """Init distributed (if requested), seed RNG, derive device, refresh cfg.runtime.
+
+    Returns the refreshed cfg, the device string, and the dist state (or ``None``).
+    The returned cfg has ``runtime.device`` and ``runtime.dp`` updated for the
+    current resume / submission environment so downstream consumers see truth.
+    """
+    dist_state = init_distributed() if bundle.uses_distributed else None
+    if bundle.uses_distributed and is_main_process():
+        logger.info(f"Distributed state: {dist_state}")
+    set_seed(cfg.pd.seed)
+    device = get_device()
+    refreshed = cfg.model_copy(
+        update={
+            "runtime": cfg.runtime.model_copy(
+                update={
+                    "device": device,
+                    "dp": dist_state.world_size if dist_state is not None else None,
+                }
+            )
+        }
+    )
+    return refreshed, device, dist_state
+
+
+def run_fresh[CfgT: ExperimentConfig[Any, Any]](
+    bundle: ExperimentBundle[CfgT],
+    config_path: Path,
+    *,
+    group: str | None = None,
+    tags: str | None = None,
+    run_id: str | None = None,
+) -> None:
+    """Fresh-run driver: parse YAML, build everything via the bundle, train from step 0."""
+    cfg = bundle.config_cls.from_file(config_path)
+    cfg, device, dist_state = _setup_runtime(cfg, bundle)
+
+    target_model = bundle.build_target(cfg)
+    if bundle.refine_cfg is not None:
+        cfg = bundle.refine_cfg(cfg, target_model)
+    train_loader = bundle.build_train_loader(cfg, device, dist_state)
+    eval_loop = bundle.build_eval_loop(cfg, device, dist_state)
+    sink = init_pd_run(cfg, group=group, tags=tags, run_id=run_id)
+
+    try:
+        trainer = Trainer(
+            target_model=target_model,
+            run_batch=bundle.make_run_batch(cfg),
+            reconstruction_loss=bundle.reconstruction_loss,
+            pd_config=cfg.pd,
+            runtime_config=cfg.runtime,
+        )
+        trainer.run(train_loader, sink, cfg.cadence, eval_loop)
+    finally:
+        sink.finish()
+
+
+def run_resumed[CfgT: ExperimentConfig[Any, Any]](
+    bundle: ExperimentBundle[CfgT],
+    resume_cfg_path: Path,
+    *,
+    group: str | None = None,
+    tags: str | None = None,
+    run_id: str | None = None,
+) -> None:
+    """Resume-run driver: read parent ``run_meta.yaml`` + ``training_<step>.pth``,
+    rebuild experiment via the bundle, continue training.
+
+    The parent's saved config is the source of cfg truth; only the runtime fields
+    (``device``, ``dp``) are refreshed for the resume environment. For mid-trajectory
+    edits to the saved ``pd_config`` (e.g. extending ``steps``), the caller should
+    use ``read_training_snapshot`` directly and call ``Trainer.from_snapshot`` —
+    this generic driver is the "continue with original config" path.
+    """
+    resume_cfg = ResumeConfig.from_file(resume_cfg_path)
+    parent_cfg = bundle.config_cls.from_file(resume_cfg.from_run / RUN_META_FILENAME)
+
+    if is_main_process():
+        logger.info(f"Resuming from {resume_cfg.from_run} @ step {resume_cfg.step}")
+
+    cfg, device, dist_state = _setup_runtime(parent_cfg, bundle)
+
+    resolved_step = resolve_step(resume_cfg.from_run, resume_cfg.step)
+    snapshot = read_training_snapshot(resume_cfg.from_run, resolved_step)
+    # Override the saved device with the current resume environment. The dict
+    # field is mutable even on a frozen dataclass.
+    snapshot.runtime_config["device"] = device
+
+    target_model = bundle.build_target(cfg)
+    if bundle.refine_cfg is not None:
+        cfg = bundle.refine_cfg(cfg, target_model)
+    train_loader = bundle.build_train_loader(cfg, device, dist_state)
+    eval_loop = bundle.build_eval_loop(cfg, device, dist_state)
+    sink = init_pd_run(cfg, group=group, tags=tags, run_id=run_id)
+    if sink.out_dir is not None:
+        write_provenance(
+            sink.out_dir,
+            ResumeProvenance(parent_run_dir=resume_cfg.from_run, parent_step=resolved_step),
+        )
+
+    try:
+        trainer = Trainer.from_snapshot(
+            snapshot,
+            target_model=target_model,
+            run_batch=bundle.make_run_batch(cfg),
+            reconstruction_loss=bundle.reconstruction_loss,
+        )
+        trainer.run(train_loader, sink, cfg.cadence, eval_loop)
+    finally:
+        sink.finish()

--- a/param_decomp_lab/experiments/tms/run.py
+++ b/param_decomp_lab/experiments/tms/run.py
@@ -1,4 +1,4 @@
-"""TMS PD experiment: YAML -> `optimize()` glue, plus the `SavedTMSRun` reload class.
+"""TMS PD experiment: YAML -> `Trainer` glue, plus the `SavedTMSRun` reload class.
 
 Run via `pd-tms path/to/config.yaml`.
 """
@@ -16,7 +16,7 @@ from param_decomp.batch_and_loss_fns import RunBatch
 from param_decomp.component_model import ComponentModel
 from param_decomp.distributed import DistributedState
 from param_decomp.log import logger
-from param_decomp.optimize import EvalLoop, optimize
+from param_decomp.optimize import EvalLoop, Trainer
 from param_decomp_lab.batch_and_loss_fns import recon_loss_mse, run_batch_first_element
 from param_decomp_lab.component_model_io import load_component_model
 from param_decomp_lab.distributed import get_device
@@ -153,17 +153,14 @@ def main(
     sink = init_pd_run(cfg, group=group, tags=tags)
 
     try:
-        optimize(
+        trainer = Trainer(
             target_model=target_model,
-            train_loader=train_loader,
             run_batch=make_run_batch(cfg.target),
             reconstruction_loss=recon_loss_mse,
             pd_config=cfg.pd,
             runtime_config=cfg.runtime,
-            sink=sink,
-            cadence=cfg.cadence,
-            eval_loop=eval_loop,
         )
+        trainer.run(train_loader, sink, cfg.cadence, eval_loop)
     finally:
         sink.finish()
 

--- a/param_decomp_lab/experiments/utils.py
+++ b/param_decomp_lab/experiments/utils.py
@@ -77,8 +77,9 @@ def init_pd_run[T: BaseConfig, D: BaseConfig](
     out_dir = PARAM_DECOMP_OUT_DIR / "decompositions" / run_id
     meta_path = out_dir / RUN_META_FILENAME
     cfg.to_file(meta_path)
+    keep_last_n = cfg.cadence.keep_last_n_checkpoints
     if cfg.wandb is None:
-        return RunSink.local(out_dir)
+        return RunSink.local(out_dir, keep_last_n_checkpoints=keep_last_n)
     parsed_tags = [s.strip() for s in tags.split(",") if s.strip()] if tags else None
     sink = RunSink.with_wandb(
         out_dir,
@@ -88,6 +89,7 @@ def init_pd_run[T: BaseConfig, D: BaseConfig](
         config=cfg,
         group=group,
         tags=parsed_tags,
+        keep_last_n_checkpoints=keep_last_n,
     )
     try_wandb(wandb.save, str(meta_path), base_path=str(out_dir), policy="now")
     return sink

--- a/param_decomp_lab/resumption/__init__.py
+++ b/param_decomp_lab/resumption/__init__.py
@@ -12,7 +12,6 @@ topology.
 
 from param_decomp_lab.resumption.config import (
     ResumeConfig,
-    ResumeOverrides,
     read_training_snapshot,
     resolve_step,
 )
@@ -26,7 +25,6 @@ from param_decomp_lab.resumption.provenance import (
 __all__ = [
     "RESUME_PROVENANCE_FILENAME",
     "ResumeConfig",
-    "ResumeOverrides",
     "ResumeProvenance",
     "read_provenance",
     "read_training_snapshot",

--- a/param_decomp_lab/resumption/__init__.py
+++ b/param_decomp_lab/resumption/__init__.py
@@ -1,0 +1,35 @@
+"""Resumption: continue a prior PD run from one of its `training_<step>.pth` checkpoints.
+
+A resumption is a separate top-level concept from a fresh run, expressed via its own
+`ResumeConfig` YAML schema and dispatched from the `pd-lm --resume <path>` CLI flag.
+Resumption is *continuous*: the resumed run extends the parent's step axis, inheriting
+its config from `run_meta.yaml` and its training state from `training_<step>.pth`.
+
+The training state is canonical and topology-independent — a single file written by
+rank 0 carries everything needed to reconstruct the trainer for any compatible
+topology.
+"""
+
+from param_decomp_lab.resumption.config import (
+    ResumeConfig,
+    ResumeOverrides,
+    read_training_snapshot,
+    resolve_step,
+)
+from param_decomp_lab.resumption.provenance import (
+    RESUME_PROVENANCE_FILENAME,
+    ResumeProvenance,
+    read_provenance,
+    write_provenance,
+)
+
+__all__ = [
+    "RESUME_PROVENANCE_FILENAME",
+    "ResumeConfig",
+    "ResumeOverrides",
+    "ResumeProvenance",
+    "read_provenance",
+    "read_training_snapshot",
+    "resolve_step",
+    "write_provenance",
+]

--- a/param_decomp_lab/resumption/config.py
+++ b/param_decomp_lab/resumption/config.py
@@ -1,44 +1,23 @@
 """YAML schema for resuming a prior PD run.
 
 A resume YAML is distinct from the run YAML: it doesn't define a run, it points
-at one. The schema is deliberately small — `from_run` + `step` + narrow
-`overrides`.
+at one. The schema is deliberately small — `from_run` + `step`. The standard
+resume case is "continue with the original config"; mid-trajectory edits to the
+saved config (e.g. extending `steps`) are out-of-band — mutate the snapshot's
+`pd_config` dict in Python and pass it to `Trainer.from_snapshot` directly.
 """
 
 from pathlib import Path
-from typing import Any, Literal
+from typing import Literal
 
 import torch
-from pydantic import PositiveInt
 
 from param_decomp.base_config import BaseConfig
 from param_decomp.training_state import TrainingState
 
 
-class ResumeOverrides(BaseConfig):
-    """Narrow set of fields that may be overridden on resume.
-
-    Resumption is continuous with the parent's step axis, so most config fields
-    are inherited verbatim. The fields here are explicitly the ones we know
-    are safe to change mid-trajectory.
-    """
-
-    extend_to_step: PositiveInt | None = None
-    """Extend `pd_config.steps` so the resumed run trains further than the parent's
-    original target. Must be > `parent.pd_config.steps`; otherwise use the no-override
-    resume to finish the original."""
-
-    def to_pd_config_patch(self) -> dict[str, Any]:
-        """Convert to a flat dict patch applied to the saved `pd_config` dict before
-        pydantic re-validates it inside `Trainer.from_snapshot`."""
-        patch: dict[str, Any] = {}
-        if self.extend_to_step is not None:
-            patch["steps"] = self.extend_to_step
-        return patch
-
-
 class ResumeConfig(BaseConfig):
-    """A resumption YAML: which run to resume, which checkpoint, what to override."""
+    """A resumption YAML: which run to resume, which checkpoint."""
 
     from_run: Path
     """Path to the parent run directory (the one with `run_meta.yaml` and
@@ -47,10 +26,6 @@ class ResumeConfig(BaseConfig):
     step: int | Literal["latest"] = "latest"
     """Which checkpoint to load. `"latest"` picks the highest-numbered
     `training_<step>.pth` under `from_run`."""
-
-    overrides: ResumeOverrides | None = None
-    """Optional narrow overrides applied to the saved `pd_config` before constructing
-    the resumed trainer."""
 
 
 def resolve_step(run_dir: Path, step: int | Literal["latest"]) -> int:

--- a/param_decomp_lab/resumption/config.py
+++ b/param_decomp_lab/resumption/config.py
@@ -1,0 +1,88 @@
+"""YAML schema for resuming a prior PD run.
+
+A resume YAML is distinct from the run YAML: it doesn't define a run, it points
+at one. The schema is deliberately small — `from_run` + `step` + narrow
+`overrides`.
+"""
+
+from pathlib import Path
+from typing import Any, Literal
+
+import torch
+from pydantic import PositiveInt
+
+from param_decomp.base_config import BaseConfig
+from param_decomp.training_state import TrainingState
+
+
+class ResumeOverrides(BaseConfig):
+    """Narrow set of fields that may be overridden on resume.
+
+    Resumption is continuous with the parent's step axis, so most config fields
+    are inherited verbatim. The fields here are explicitly the ones we know
+    are safe to change mid-trajectory.
+    """
+
+    extend_to_step: PositiveInt | None = None
+    """Extend `pd_config.steps` so the resumed run trains further than the parent's
+    original target. Must be > `parent.pd_config.steps`; otherwise use the no-override
+    resume to finish the original."""
+
+    def to_pd_config_patch(self) -> dict[str, Any]:
+        """Convert to a flat dict patch applied to the saved `pd_config` dict before
+        pydantic re-validates it inside `Trainer.from_snapshot`."""
+        patch: dict[str, Any] = {}
+        if self.extend_to_step is not None:
+            patch["steps"] = self.extend_to_step
+        return patch
+
+
+class ResumeConfig(BaseConfig):
+    """A resumption YAML: which run to resume, which checkpoint, what to override."""
+
+    from_run: Path
+    """Path to the parent run directory (the one with `run_meta.yaml` and
+    `training_<step>.pth` files)."""
+
+    step: int | Literal["latest"] = "latest"
+    """Which checkpoint to load. `"latest"` picks the highest-numbered
+    `training_<step>.pth` under `from_run`."""
+
+    overrides: ResumeOverrides | None = None
+    """Optional narrow overrides applied to the saved `pd_config` before constructing
+    the resumed trainer."""
+
+
+def resolve_step(run_dir: Path, step: int | Literal["latest"]) -> int:
+    """Resolve `"latest"` to the highest-numbered `training_<step>.pth` under `run_dir`.
+
+    Errors loudly if no training checkpoints exist, or if a specific step was
+    requested that isn't on disk.
+    """
+    candidates: list[int] = []
+    for path in run_dir.glob("training_*.pth"):
+        try:
+            candidates.append(int(path.stem.removeprefix("training_")))
+        except ValueError:
+            continue
+    candidates.sort()
+    assert candidates, f"no training_*.pth checkpoints under {run_dir}"
+    if step == "latest":
+        return candidates[-1]
+    assert step in candidates, f"step {step} not on disk under {run_dir}; available: {candidates}"
+    return step
+
+
+def read_training_snapshot(run_dir: Path, step: int) -> TrainingState:
+    """Read `<run_dir>/training_<step>.pth` into a `TrainingState` dataclass.
+
+    `weights_only=False` because the payload contains arbitrary cfg dicts
+    (model_dump output) alongside tensors.
+    """
+    path = run_dir / f"training_{step}.pth"
+    assert path.is_file(), f"training checkpoint not found: {path}"
+    snapshot = torch.load(path, map_location="cpu", weights_only=False)
+    assert isinstance(snapshot, TrainingState), (
+        f"expected TrainingState in {path}, got {type(snapshot).__name__}"
+    )
+    return snapshot

--- a/param_decomp_lab/resumption/provenance.py
+++ b/param_decomp_lab/resumption/provenance.py
@@ -1,0 +1,41 @@
+"""Resume provenance: a small YAML sibling of ``run_meta.yaml`` recording
+which run a resumed run was forked from.
+
+Resumed runs get their own ``run_id`` and own ``run_meta.yaml`` (the effective
+config after overrides) — provenance is what makes them traceable back to
+the parent. A future reader can inspect ``resume_provenance.yaml`` to find
+the parent run dir + the step it was resumed from.
+
+A run without this file is a fresh run.
+"""
+
+from pathlib import Path
+
+from param_decomp.base_config import BaseConfig
+
+RESUME_PROVENANCE_FILENAME = "resume_provenance.yaml"
+
+
+class ResumeProvenance(BaseConfig):
+    """Sibling of ``run_meta.yaml`` recording where this resumed run came from."""
+
+    parent_run_dir: Path
+    """Path to the parent run's directory."""
+
+    parent_step: int
+    """The step at which we resumed (i.e. the step number in the parent's
+    ``resume/step_<N>/`` snapshot we loaded from)."""
+
+
+def write_provenance(out_dir: Path, provenance: ResumeProvenance) -> None:
+    """Persist ``provenance`` to ``{out_dir}/resume_provenance.yaml``."""
+    provenance.to_file(out_dir / RESUME_PROVENANCE_FILENAME)
+
+
+def read_provenance(run_dir: Path) -> ResumeProvenance | None:
+    """Read provenance from ``run_dir``. Returns ``None`` if the run is fresh
+    (no ``resume_provenance.yaml`` file present)."""
+    path = run_dir / RESUME_PROVENANCE_FILENAME
+    if not path.is_file():
+        return None
+    return ResumeProvenance.from_file(path)

--- a/param_decomp_lab/resumption/provenance.py
+++ b/param_decomp_lab/resumption/provenance.py
@@ -1,10 +1,10 @@
 """Resume provenance: a small YAML sibling of ``run_meta.yaml`` recording
 which run a resumed run was forked from.
 
-Resumed runs get their own ``run_id`` and own ``run_meta.yaml`` (the effective
-config after overrides) — provenance is what makes them traceable back to
-the parent. A future reader can inspect ``resume_provenance.yaml`` to find
-the parent run dir + the step it was resumed from.
+Resumed runs get their own ``run_id`` and own ``run_meta.yaml`` — provenance
+is what makes them traceable back to the parent. A future reader can inspect
+``resume_provenance.yaml`` to find the parent run dir + the step it was
+resumed from.
 
 A run without this file is a fresh run.
 """

--- a/param_decomp_lab/run_sink.py
+++ b/param_decomp_lab/run_sink.py
@@ -61,17 +61,22 @@ class RunSink:
 
     out_dir: Path | None
     _wandb_active: bool
+    keep_last_n_checkpoints: int | None = None
 
     # =========================== Constructors ===========================
 
     @classmethod
-    def local(cls, out_dir: Path) -> "RunSink":
+    def local(cls, out_dir: Path, *, keep_last_n_checkpoints: int | None = None) -> "RunSink":
         """Sink that writes to local files only (no wandb)."""
         if not is_main_process():
             return cls(out_dir=None, _wandb_active=False)
         out_dir.mkdir(parents=True, exist_ok=True)
         logger.info(f"Train+eval logs saved to directory: {out_dir}")
-        return cls(out_dir=out_dir, _wandb_active=False)
+        return cls(
+            out_dir=out_dir,
+            _wandb_active=False,
+            keep_last_n_checkpoints=keep_last_n_checkpoints,
+        )
 
     @classmethod
     def with_wandb(
@@ -86,6 +91,7 @@ class RunSink:
         tags: list[str] | None = None,
         group: str | None = None,
         view_meta: dict[str, Any] | None = None,
+        keep_last_n_checkpoints: int | None = None,
     ) -> "RunSink":
         """Sink that writes to local files and a wandb run.
 
@@ -106,7 +112,11 @@ class RunSink:
             group=group,
             view_meta=view_meta,
         )
-        return cls(out_dir=out_dir, _wandb_active=True)
+        return cls(
+            out_dir=out_dir,
+            _wandb_active=True,
+            keep_last_n_checkpoints=keep_last_n_checkpoints,
+        )
 
     @classmethod
     def silent(cls) -> "RunSink":
@@ -141,7 +151,8 @@ class RunSink:
         state, metric states, step) needed for resumption.
 
         No-op when `out_dir is None` (silent sink / non-main rank); wandb upload
-        only when wandb is active.
+        only when wandb is active. Prunes older (model, training) pairs after the
+        write when ``keep_last_n_checkpoints`` is set.
         """
         if self.out_dir is None:
             return
@@ -153,6 +164,8 @@ class RunSink:
         if self._wandb_active:
             try_wandb(wandb.save, str(model_path), base_path=str(self.out_dir), policy="now")
             try_wandb(wandb.save, str(training_path), base_path=str(self.out_dir), policy="now")
+        if self.keep_last_n_checkpoints is not None:
+            _prune_old_checkpoints(self.out_dir, keep_last_n=self.keep_last_n_checkpoints)
 
     def finish(self) -> None:
         """End-of-run cleanup."""
@@ -165,3 +178,32 @@ def _wandb_value(v: Any) -> Any:
     if isinstance(v, Image.Image):
         return wandb.Image(v)
     return v
+
+
+def _prune_old_checkpoints(out_dir: Path, *, keep_last_n: int) -> None:
+    """Delete (``model_<step>.pth``, ``training_<step>.pth``) pairs except for the
+    top ``keep_last_n`` by step number.
+
+    A "pair" is the two files written together by :meth:`RunSink.checkpoint`; we
+    glob each independently and prune by step rather than assuming both must
+    exist, since a future caller might write only one of them.
+    """
+
+    def steps(prefix: str) -> list[int]:
+        out: list[int] = []
+        for p in out_dir.glob(f"{prefix}_*.pth"):
+            try:
+                out.append(int(p.stem.removeprefix(f"{prefix}_")))
+            except ValueError:
+                continue
+        return out
+
+    all_steps = sorted(set(steps("model")) | set(steps("training")))
+    if len(all_steps) <= keep_last_n:
+        return
+    to_delete = all_steps[: len(all_steps) - keep_last_n]
+    for step in to_delete:
+        for prefix in ("model", "training"):
+            path = out_dir / f"{prefix}_{step}.pth"
+            if path.is_file():
+                path.unlink()

--- a/param_decomp_lab/run_sink.py
+++ b/param_decomp_lab/run_sink.py
@@ -15,6 +15,7 @@ from tqdm import tqdm
 from param_decomp.base_config import BaseConfig
 from param_decomp.distributed import is_main_process
 from param_decomp.log import logger
+from param_decomp.training_state import TrainingState
 from param_decomp_lab.infra.run_files import save_file
 from param_decomp_lab.infra.wandb import init_wandb, try_wandb
 
@@ -131,18 +132,27 @@ class RunSink:
         for line in lines:
             tqdm.write(line)
 
-    def checkpoint(self, state_dict: dict[str, Any], step: int) -> None:
-        """Save `state_dict` to `{out_dir}/model_{step}.pth` and push to wandb.
+    def checkpoint(self, snapshot: TrainingState) -> None:
+        """Save the snapshot as two files: `model_<step>.pth` + `training_<step>.pth`.
 
-        No-op when `out_dir is None`; wandb upload only when wandb is active.
+        `model_<step>.pth` is just the component-model state dict — the artifact
+        downstream tools (`SavedRun.load_model`, postprocessing) consume.
+        `training_<step>.pth` is the full `TrainingState` (configs, optimizer
+        state, metric states, step) needed for resumption.
+
+        No-op when `out_dir is None` (silent sink / non-main rank); wandb upload
+        only when wandb is active.
         """
         if self.out_dir is None:
             return
-        path = self.out_dir / f"model_{step}.pth"
-        save_file(state_dict, path)
-        logger.info(f"Saved checkpoint to {path}")
+        model_path = self.out_dir / f"model_{snapshot.step}.pth"
+        save_file(snapshot.component_model, model_path)
+        training_path = self.out_dir / f"training_{snapshot.step}.pth"
+        save_file(snapshot, training_path)
+        logger.info(f"Saved checkpoint to {model_path} (+ {training_path.name})")
         if self._wandb_active:
-            try_wandb(wandb.save, str(path), base_path=str(self.out_dir), policy="now")
+            try_wandb(wandb.save, str(model_path), base_path=str(self.out_dir), policy="now")
+            try_wandb(wandb.save, str(training_path), base_path=str(self.out_dir), policy="now")
 
     def finish(self) -> None:
         """End-of-run cleanup."""

--- a/param_decomp_lab/tests/test_gpt2.py
+++ b/param_decomp_lab/tests/test_gpt2.py
@@ -17,7 +17,7 @@ from param_decomp.metrics.stochastic_recon import StochasticReconLossConfig
 from param_decomp.metrics.stochastic_recon_layerwise import (
     StochasticReconLayerwiseLossConfig,
 )
-from param_decomp.optimize import EvalLoop, optimize
+from param_decomp.optimize import EvalLoop, Trainer
 from param_decomp.schedule import ScheduleConfig
 from param_decomp_lab.batch_and_loss_fns import make_run_batch, recon_loss_kl
 from param_decomp_lab.eval_metrics.ci_l0 import CI_L0, CI_L0Config
@@ -112,14 +112,11 @@ def test_gpt_2_decomposition_happy_path(tmp_path: Path) -> None:
         slow_on_first_step=False,
     )
 
-    optimize(
+    trainer = Trainer(
         target_model=target_model,
-        train_loader=train_loader,
         run_batch=make_run_batch("logits"),
         reconstruction_loss=recon_loss_kl,
         pd_config=pd_config,
         runtime_config=RuntimeConfig(device=device),
-        sink=sink,
-        cadence=cadence,
-        eval_loop=eval_loop,
     )
+    trainer.run(train_loader, sink, cadence, eval_loop)

--- a/param_decomp_lab/tests/test_resid_mlp.py
+++ b/param_decomp_lab/tests/test_resid_mlp.py
@@ -11,7 +11,7 @@ from param_decomp.decomposition_targets import (
 from param_decomp.metrics.faithfulness import FaithfulnessLossConfig
 from param_decomp.metrics.importance_minimality import ImportanceMinimalityLossConfig
 from param_decomp.metrics.stochastic_recon import StochasticReconLossConfig
-from param_decomp.optimize import EvalLoop, optimize
+from param_decomp.optimize import EvalLoop, Trainer
 from param_decomp.schedule import ScheduleConfig
 from param_decomp_lab.batch_and_loss_fns import recon_loss_mse, run_batch_first_element
 from param_decomp_lab.experiments.resid_mlp.data import ResidMLPDataset
@@ -114,14 +114,11 @@ def test_resid_mlp_decomposition_happy_path(tmp_path: Path) -> None:
         slow_on_first_step=False,
     )
 
-    optimize(
+    trainer = Trainer(
         target_model=target_model,
-        train_loader=train_loader,
         run_batch=run_batch_first_element,
         reconstruction_loss=recon_loss_mse,
         pd_config=pd_config,
         runtime_config=RuntimeConfig(device=device),
-        sink=sink,
-        cadence=cadence,
-        eval_loop=eval_loop,
     )
+    trainer.run(train_loader, sink, cadence, eval_loop)

--- a/param_decomp_lab/tests/test_resumption.py
+++ b/param_decomp_lab/tests/test_resumption.py
@@ -136,16 +136,16 @@ def test_resume_round_trip_matches_uninterrupted_run(tmp_path: Path) -> None:
     assert (parent_dir / "training_2.pth").is_file()
 
     # Phase 2: resume from parent's training_2.pth, train to step 4.
-    resume_cfg = ResumeConfig(from_run=parent_dir, step=2, overrides=None)
+    resume_cfg = ResumeConfig(from_run=parent_dir, step=2)
     snapshot = read_training_snapshot(
         resume_cfg.from_run, resolve_step(parent_dir, resume_cfg.step)
     )
+    snapshot.pd_config["steps"] = 4
     trainer_resumed = Trainer.from_snapshot(
         snapshot,
         target_model=TinyLinear(),
         run_batch=_run_batch,
         reconstruction_loss=_recon_loss,
-        cfg_overrides={"steps": 4},
     )
     assert trainer_resumed.step == 2
     resumed_dir = tmp_path / "resumed"

--- a/param_decomp_lab/tests/test_resumption.py
+++ b/param_decomp_lab/tests/test_resumption.py
@@ -171,3 +171,29 @@ def test_resolve_step_finds_latest(tmp_path: Path) -> None:
 
     assert resolve_step(parent_dir, "latest") == 4
     assert resolve_step(parent_dir, 2) == 2
+
+
+def test_keep_last_n_checkpoints_prunes_older_pairs(tmp_path: Path) -> None:
+    """With ``keep_last_n_checkpoints=1``, only the most recent (model, training)
+    pair survives. Earlier saves get deleted right after the next write.
+
+    Default (``None``) keeps everything — covered by every other test in this file.
+    """
+    run_dir = tmp_path / "run"
+    sink = RunSink.local(run_dir, keep_last_n_checkpoints=1)
+
+    # save_every=2 + steps=4 → saves at step 2 and step 4 (final).
+    trainer = Trainer(
+        target_model=TinyLinear(),
+        run_batch=_run_batch,
+        reconstruction_loss=_recon_loss,
+        pd_config=_pd_config(steps=4),
+        runtime_config=_runtime(),
+    )
+    trainer.run(_loader(), sink, Cadence(train_log_every=1, save_every=2))
+
+    # Step-2 pair must be gone; step-4 pair must remain.
+    assert not (run_dir / "model_2.pth").exists()
+    assert not (run_dir / "training_2.pth").exists()
+    assert (run_dir / "model_4.pth").is_file()
+    assert (run_dir / "training_4.pth").is_file()

--- a/param_decomp_lab/tests/test_resumption.py
+++ b/param_decomp_lab/tests/test_resumption.py
@@ -1,0 +1,173 @@
+"""Lab-side resumption integration: canonical training state round-trips through a
+real `RunSink` into a tmp run_dir, then back through `read_training_snapshot` and
+`Trainer.from_snapshot`.
+
+Single-process / 1-pool only — exercises the wiring around the lab's resumption
+module without the cost of spinning up DDP.
+"""
+
+from pathlib import Path
+from typing import Any, override
+
+import torch
+from torch import Tensor, nn
+from torch.utils.data import DataLoader, TensorDataset
+
+from param_decomp.ci_fns import LayerwiseCiConfig
+from param_decomp.configs import (
+    Cadence,
+    OptimizerConfig,
+    PDConfig,
+    RuntimeConfig,
+)
+from param_decomp.decomposition_targets import DecompositionTargetConfig
+from param_decomp.metrics.faithfulness import FaithfulnessLossConfig
+from param_decomp.optimize import Trainer
+from param_decomp.schedule import ScheduleConfig
+from param_decomp_lab.resumption import (
+    ResumeConfig,
+    read_training_snapshot,
+    resolve_step,
+)
+from param_decomp_lab.run_sink import RunSink
+
+
+class TinyLinear(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.fc = nn.Linear(2, 2, bias=False)
+        with torch.no_grad():
+            self.fc.weight.copy_(torch.tensor([[1.0, 2.0], [3.0, 4.0]]))
+
+    @override
+    def forward(self, x: Tensor) -> Tensor:
+        return self.fc(x)
+
+
+def _run_batch(model: nn.Module, batch: Any) -> Tensor:
+    if isinstance(batch, list | tuple):
+        batch = batch[0]
+    assert isinstance(batch, Tensor)
+    out = model(batch)
+    assert isinstance(out, Tensor)
+    return out
+
+
+def _recon_loss(pred: Tensor, target: Tensor) -> tuple[Tensor, int]:
+    assert pred.shape == target.shape
+    return ((pred - target) ** 2).sum(), pred.numel()
+
+
+def _pd_config(steps: int) -> PDConfig:
+    return PDConfig(
+        seed=123,
+        n_mask_samples=1,
+        ci_config=LayerwiseCiConfig(fn_type="mlp", hidden_dims=[2]),
+        decomposition_targets=[DecompositionTargetConfig(module_pattern="fc", C=2)],
+        components_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
+        ci_fn_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
+        steps=steps,
+        batch_size=2,
+        loss_metrics=[FaithfulnessLossConfig(coeff=1.0)],
+    )
+
+
+def _loader() -> DataLoader[Any]:
+    return DataLoader(TensorDataset(torch.ones(4, 2)), batch_size=2)
+
+
+def _runtime() -> RuntimeConfig:
+    return RuntimeConfig(device="cpu", autocast_bf16=False)
+
+
+def _cadence() -> Cadence:
+    return Cadence(train_log_every=10**9, save_every=2)
+
+
+def test_run_sink_writes_model_and_training_files(tmp_path: Path) -> None:
+    """A fresh run writes both `model_<step>.pth` and `training_<step>.pth` per save."""
+    run_dir = tmp_path / "run"
+    sink = RunSink.local(run_dir)
+
+    trainer = Trainer(
+        target_model=TinyLinear(),
+        run_batch=_run_batch,
+        reconstruction_loss=_recon_loss,
+        pd_config=_pd_config(steps=4),
+        runtime_config=_runtime(),
+    )
+    trainer.run(_loader(), sink, _cadence())
+
+    # Cadence.should_save skips step 0; final step always saves. So we expect 2 and 4.
+    expected_steps = [2, 4]
+    for step in expected_steps:
+        assert (run_dir / f"model_{step}.pth").is_file()
+        assert (run_dir / f"training_{step}.pth").is_file()
+
+
+def test_resume_round_trip_matches_uninterrupted_run(tmp_path: Path) -> None:
+    """Train K steps in one shot vs train K/2 -> write training_<step>.pth -> read it ->
+    Trainer.from_snapshot -> train K/2 more. Final weights match bit-for-bit on CPU.
+    """
+    # Reference: uninterrupted run.
+    torch.manual_seed(7)
+    trainer_full = Trainer(
+        target_model=TinyLinear(),
+        run_batch=_run_batch,
+        reconstruction_loss=_recon_loss,
+        pd_config=_pd_config(steps=4),
+        runtime_config=_runtime(),
+    )
+    full_sink_dir = tmp_path / "full"
+    trainer_full.run(_loader(), RunSink.local(full_sink_dir), _cadence())
+    final_full = {k: v.clone() for k, v in trainer_full.component_model.state_dict().items()}
+
+    # Phase 1: train 2 steps, the sink writes training_2.pth.
+    torch.manual_seed(7)
+    parent_dir = tmp_path / "parent"
+    trainer_half = Trainer(
+        target_model=TinyLinear(),
+        run_batch=_run_batch,
+        reconstruction_loss=_recon_loss,
+        pd_config=_pd_config(steps=2),
+        runtime_config=_runtime(),
+    )
+    trainer_half.run(_loader(), RunSink.local(parent_dir), _cadence())
+    assert (parent_dir / "training_2.pth").is_file()
+
+    # Phase 2: resume from parent's training_2.pth, train to step 4.
+    resume_cfg = ResumeConfig(from_run=parent_dir, step=2, overrides=None)
+    snapshot = read_training_snapshot(
+        resume_cfg.from_run, resolve_step(parent_dir, resume_cfg.step)
+    )
+    trainer_resumed = Trainer.from_snapshot(
+        snapshot,
+        target_model=TinyLinear(),
+        run_batch=_run_batch,
+        reconstruction_loss=_recon_loss,
+        cfg_overrides={"steps": 4},
+    )
+    assert trainer_resumed.step == 2
+    resumed_dir = tmp_path / "resumed"
+    trainer_resumed.run(_loader(), RunSink.local(resumed_dir), _cadence())
+
+    resumed_final = trainer_resumed.component_model.state_dict()
+    assert final_full.keys() == resumed_final.keys()
+    for k in final_full:
+        torch.testing.assert_close(final_full[k], resumed_final[k])
+
+
+def test_resolve_step_finds_latest(tmp_path: Path) -> None:
+    """`resolve_step('latest', ...)` returns the highest-numbered training file."""
+    parent_dir = tmp_path / "parent"
+    trainer = Trainer(
+        target_model=TinyLinear(),
+        run_batch=_run_batch,
+        reconstruction_loss=_recon_loss,
+        pd_config=_pd_config(steps=4),
+        runtime_config=_runtime(),
+    )
+    trainer.run(_loader(), RunSink.local(parent_dir), _cadence())
+
+    assert resolve_step(parent_dir, "latest") == 4
+    assert resolve_step(parent_dir, 2) == 2

--- a/param_decomp_lab/tests/test_tms.py
+++ b/param_decomp_lab/tests/test_tms.py
@@ -17,7 +17,7 @@ from param_decomp.metrics.stochastic_recon import StochasticReconLossConfig
 from param_decomp.metrics.stochastic_recon_layerwise import (
     StochasticReconLayerwiseLossConfig,
 )
-from param_decomp.optimize import EvalLoop, optimize
+from param_decomp.optimize import EvalLoop, Trainer
 from param_decomp.schedule import ScheduleConfig
 from param_decomp_lab.batch_and_loss_fns import recon_loss_mse, run_batch_first_element
 from param_decomp_lab.experiments.tms.data import SparseFeatureDataset
@@ -109,17 +109,14 @@ def test_tms_decomposition_happy_path(tmp_path: Path) -> None:
         slow_on_first_step=False,
     )
 
-    optimize(
+    trainer = Trainer(
         target_model=target_model,
-        train_loader=train_loader,
         run_batch=run_batch_first_element,
         reconstruction_loss=recon_loss_mse,
         pd_config=pd_config,
         runtime_config=RuntimeConfig(device=device),
-        sink=sink,
-        cadence=cadence,
-        eval_loop=eval_loop,
     )
+    trainer.run(train_loader, sink, cadence, eval_loop)
 
     print("TMS PD optimization completed successfully")
 


### PR DESCRIPTION
## What this does

Stacked on top of #520. Lifts the generic experiment orchestration out of `lm/run.py` into `param_decomp_lab/experiments/runner.py`, addressing Dan's inline comment on `lm/run.py:1` that the resume functionality should not be lm-specific.

```python
# Before — lm/run.py had two ~60-line orchestrators with mostly identical
# distributed init / cfg refresh / sink wiring code, differing only in the
# LM-specific build callables.
def _fresh_main(config_path, ...):    # 54 lines
def _resume_main(resume_cfg_path, ...):  # 65 lines

# After — lm/run.py packages the LM-specific callables into an ExperimentBundle
# and dispatches to a generic runner.
_LM_BUNDLE = ExperimentBundle[LMExperimentConfig](
    config_cls=LMExperimentConfig,
    build_target=lambda cfg: build_target(cfg.target),
    build_train_loader=lambda cfg, device, dist_state: build_lm_loader(...),
    build_eval_loop=_build_eval_loop,
    make_run_batch=lambda cfg: make_run_batch(cfg.target),
    reconstruction_loss=recon_loss_kl,
    uses_distributed=True,
)
# inside main():
if resume is not None:
    run_resumed(_LM_BUNDLE, Path(resume), ...)
else:
    run_fresh(_LM_BUNDLE, Path(config_path), ...)
```

## Why

Dan's comment on PR #520:

> I don't like that the resume functionality is specific to the lm experiment. I think the majority of it should be generic.

The fresh + resume orchestration (~120 lines) was structurally generic — every line except the build-callable invocations works the same across experiments. The bundle abstracts the per-experiment callables behind a uniform signature.

## The shape

**`ExperimentBundle[CfgT]`** — frozen dataclass parameterized on the experiment's config type. Fields:
- `config_cls: type[CfgT]` — for `from_file` on the parent `run_meta.yaml`
- `build_target`, `build_train_loader`, `build_eval_loop`, `make_run_batch`, `reconstruction_loss` — the per-experiment callables, all taking the full cfg + runtime context (`device`, `dist_state`)
- `uses_distributed: bool` — whether to `init_distributed` (LM: yes; TMS/ResidMLP: no)
- `refine_cfg: Callable | None` — optional hook for post-build cfg refinement (e.g. TMS uses this for `tied_weights` derived from the constructed target model)

**`run_fresh(bundle, config_path, ...)`** and **`run_resumed(bundle, resume_cfg_path, ...)`** — the generic drivers.

## Scope

LM only. TMS and ResidMLP are unchanged — they have no resume support today, and forcing them through the generic runner just for fresh-run paths is churn for no immediate benefit. They can opt in later by building their own bundles (TMS would use the `refine_cfg` hook). Once both are on the bundle, `_submit_slurm` in `lm/run.py` (Dan's other concern, #522) can move to the runner module too.

## Testing

- All resumption tests pass (4 in `test_resumption.py`).
- All trainer tests pass (8 in `test_optimize.py`).
- Full suite: 417 passed, 5 skipped, basedpyright clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)