### PR TITLE
Support multi-node DDP for pd-lm

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,8 +93,8 @@ from param_decomp.batch_and_loss_fns import RunBatch, ReconstructionLoss
   — post-pipeline + app, each with its own CLAUDE.md.
 - `param_decomp_lab/postprocess/` — orchestrates the post-pipeline stages.
 - `param_decomp_lab/eval_metrics/` — batteries-included eval-metric set.
-- `param_decomp_lab/infra/` — settings, paths, slurm, wandb, sqlite, git, run_files,
-  markdown, pydantic helpers.
+- `param_decomp_lab/infra/` — settings, paths, slurm, ddp_launch (single-/multi-node
+  torchrun wrapper), wandb, sqlite, git, run_files, markdown, pydantic helpers.
 - `param_decomp_lab/{seed.py, distributed.py, batch_and_loss_fns.py, component_model_io.py, run_sink.py}`
   — lab-side helpers that aren't big enough to warrant their own subdir.
 

--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -2,9 +2,9 @@
 
 Both the fresh-run path (`main`) and the reload path share the module-level
 `build_target` / `build_lm_loader` / `make_run_batch`. Run via
-`pd-lm path/to/config.yaml`; pass `--dp N` to submit a single-node DDP SLURM job.
-For local DDP, invoke directly:
-`torchrun --standalone --nproc_per_node=N -m param_decomp_lab.experiments.lm.run config.yaml`.
+`pd-lm path/to/config.yaml`; pass `--dp N` to submit a DDP SLURM job (single-node for
+N <= 8, multi-node for N > 8 — N must then be a multiple of 8). For local DDP, invoke
+`torchrun --standalone --nproc_per_node=N -m param_decomp_lab.experiments.lm.run` directly.
 """
 
 import importlib
@@ -46,6 +46,7 @@ from param_decomp_lab.experiments.utils import (
     ExperimentConfig,
     init_pd_run,
 )
+from param_decomp_lab.infra.ddp_launch import build_ddp_launch
 from param_decomp_lab.infra.git import create_git_snapshot
 from param_decomp_lab.infra.paths import ModelPath
 from param_decomp_lab.infra.run_files import generate_run_id, resolve_run_files
@@ -200,12 +201,11 @@ def main(
 
     Parses the YAML, initialises DDP, builds the target / loaders / eval loop, writes
     `run_meta.yaml`, and calls `optimize(...)`. Non-main ranks use a silent sink.
-    `group` / `tags` are wandb-only (no-ops without `wandb:`). Passing `--dp N`
-    outside torchrun submits a single-node SLURM job; for local DDP, invoke via
+    `group` / `tags` are wandb-only (no-ops without `wandb:`). Passing `--dp N` outside
+    torchrun submits a SLURM job: single-node for N <= 8, multi-node for N > 8 (N must
+    be a multiple of 8). For local DDP, invoke
     `torchrun --standalone --nproc_per_node=N -m param_decomp_lab.experiments.lm.run`.
     """
-    if dp is not None and dp < 2:
-        raise ValueError("--dp must be at least 2 for data parallelism")
     if dp is not None and os.environ.get("WORLD_SIZE") is None:
         _submit_slurm(
             config_path,
@@ -323,30 +323,30 @@ def _submit_slurm(
     else:
         config_arg = str(config_path)
 
-    command_parts = [
-        "torchrun",
-        "--standalone",
-        f"--nproc_per_node={dp}",
-        "-m",
-        "param_decomp_lab.experiments.lm.run",
-        config_arg,
-    ]
+    base_parts = ["-m", "param_decomp_lab.experiments.lm.run", config_arg, "--run_id", run_id]
     if group is not None:
-        command_parts.extend(["--group", group])
+        base_parts += ["--group", group]
     if tags is not None:
-        command_parts.extend(["--tags", tags])
-    command_parts.extend(["--run_id", run_id])
-    command = " ".join(shlex.quote(part) for part in command_parts)
+        base_parts += ["--tags", tags]
+    base_command = shlex.join(base_parts)
 
+    launch = build_ddp_launch(
+        base_command,
+        dp=dp,
+        job_name=job_name,
+        snapshot_ref=snapshot_ref,
+        port_seed=run_id,
+    )
     slurm_config = SlurmConfig(
         job_name=job_name,
         partition=partition,
-        n_gpus=dp,
+        n_gpus=launch.gpus_per_node,
+        n_nodes=launch.n_nodes,
         time=time,
         snapshot_ref=snapshot_ref,
         comment=run_id,
     )
-    script = generate_script(slurm_config, command)
+    script = generate_script(slurm_config, launch.command, env=launch.env)
     result = submit_slurm_job(script, "lm")
 
     wandb_url = _wandb_url_for_config(config_path, run_id)

--- a/param_decomp_lab/infra/ddp_launch.py
+++ b/param_decomp_lab/infra/ddp_launch.py
@@ -1,0 +1,97 @@
+"""Wrap a `-m <module> [args...]` invocation in a torchrun (single-node) or
+srun + torchrun (multi-node) launcher, and report the SLURM topology to feed
+into `SlurmConfig`.
+"""
+
+import shlex
+from dataclasses import dataclass
+from hashlib import sha256
+
+from param_decomp_lab.infra.slurm import (
+    SINGLETON_JOB_ID_BASH,
+    generate_git_snapshot_setup,
+)
+
+GPUS_PER_NODE = 8
+
+# Surface NCCL collective failures as Python exceptions instead of hanging the job —
+# matters for multi-node where a single stalled rank otherwise hangs everyone silently.
+DDP_ENV = {
+    "NCCL_DEBUG": "WARN",
+    "TORCH_NCCL_ASYNC_ERROR_HANDLING": "1",
+}
+
+
+@dataclass(frozen=True)
+class DDPLaunch:
+    """A torchrun/srun-wrapped command and the SLURM topology it expects."""
+
+    command: str
+    n_nodes: int
+    gpus_per_node: int
+    env: dict[str, str]
+
+
+def build_ddp_launch(
+    base_command: str,
+    *,
+    dp: int,
+    job_name: str,
+    snapshot_ref: str | None,
+    port_seed: str,
+) -> DDPLaunch:
+    """Wrap `base_command` (everything after `python`, e.g. `-m foo cfg.yaml`).
+
+    `dp <= GPUS_PER_NODE` → single-node `torchrun --standalone`.
+    `dp > GPUS_PER_NODE` → `srun bash -c '<setup>; torchrun --node_rank=$SLURM_PROCID ...'`.
+    Multi-node requires `dp % GPUS_PER_NODE == 0` and a `snapshot_ref`: `/tmp` is
+    node-local so each node clones its own workspace from the snapshot.
+
+    `port_seed` keys the master port deterministically — pass the run id so parallel
+    launches don't collide.
+    """
+    assert dp >= 2, f"dp must be at least 2 for DDP (got {dp})"
+    port = _choose_master_port(port_seed)
+
+    if dp <= GPUS_PER_NODE:
+        command = " ".join(
+            [
+                "torchrun",
+                "--standalone",
+                f"--nproc_per_node={dp}",
+                f"--master_port={port}",
+                base_command,
+            ]
+        )
+        return DDPLaunch(command=command, n_nodes=1, gpus_per_node=dp, env=DDP_ENV)
+
+    assert dp % GPUS_PER_NODE == 0, (
+        f"Multi-node DDP requires dp ({dp}) to be a multiple of {GPUS_PER_NODE}"
+    )
+    assert snapshot_ref is not None, "Multi-node DDP requires a snapshot ref"
+
+    n_nodes = dp // GPUS_PER_NODE
+    # /tmp is node-local, so each node clones the snapshot into its own workspace.
+    work_dir = (
+        f"/tmp/$USER/param-decomp/workspace-{job_name}-{SINGLETON_JOB_ID_BASH}-node$SLURM_PROCID"
+    )
+    setup = generate_git_snapshot_setup(work_dir, snapshot_ref)
+    torchrun_cmd = " ".join(
+        [
+            "torchrun",
+            f"--nnodes={n_nodes}",
+            "--node_rank=$SLURM_PROCID",
+            f"--nproc_per_node={GPUS_PER_NODE}",
+            '--master_addr=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | head -n 1)',
+            f"--master_port={port}",
+            base_command,
+        ]
+    )
+    srun_prefix = f"srun --nodes={n_nodes} --ntasks={n_nodes} --ntasks-per-node=1"
+    command = f"{srun_prefix} bash -c {shlex.quote(f'{setup}\n{torchrun_cmd}')}"
+    return DDPLaunch(command=command, n_nodes=n_nodes, gpus_per_node=GPUS_PER_NODE, env=DDP_ENV)
+
+
+def _choose_master_port(seed: str) -> int:
+    """Stable, unprivileged port in [20000, 40000)."""
+    return 20000 + (int(sha256(seed.encode()).hexdigest(), 16) % 20000)


### PR DESCRIPTION
## Description

Adds `param_decomp_lab/infra/ddp_launch.py` — a small helper that wraps a `-m <module> [args]` invocation in `torchrun` (single-node) or `srun + torchrun` (multi-node, with per-node `/tmp` workspace clone from the git snapshot) and returns the SLURM topology (`n_nodes`, `gpus_per_node`) plus DDP-friendly env vars. `pd-lm`'s `_submit_slurm` now calls it instead of hard-coding single-node `torchrun --standalone`.

`pd-lm --dp 16` lands 2 nodes × 8 GPUs; `pd-lm --dp 24` lands 3 nodes × 8 GPUs. `--dp <= 8` is unchanged.

## Motivation and Context

`pd-lm --dp 16` was producing `sbatch: Requested node configuration is not available` because the single-node code path requested `--gpus-per-node=16`, which no node satisfies (B200 nodes are 8 GPUs). The pre-#486 `compute_utils.py` had the right approach — derive `n_nodes` from total `dp`, fall through to `srun` for multi-node — so this PR re-introduces that split (`ddp_launch.py` ↔ `slurm.py`) in the lab `infra/` layout. The existing `slurm.py` already exposed the bash workspace-id strings for exactly this case.

## How Has This Been Tested?

Rendered the bash for both branches:

- `dp=4`: `torchrun --standalone --nproc_per_node=4 --master_port=… -m param_decomp_lab.experiments.lm.run cfg.yaml --run_id …`
- `dp=16`: `srun --nodes=2 --ntasks=2 --ntasks-per-node=1 bash -c '<git-snapshot setup>\ntorchrun --nnodes=2 --node_rank=\$SLURM_PROCID --nproc_per_node=8 --master_addr=\$(scontrol show hostnames "\$SLURM_JOB_NODELIST" | head -n 1) --master_port=… …'`

Asserts reject `dp < 2`, `dp > 8` not divisible by 8, and multi-node without a snapshot. `basedpyright`, `ruff`, and the existing test collection are all clean. End-to-end multi-node SLURM submission TBD by user.

## Does this PR introduce a breaking change?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)