### PR TITLE
Rename run_meta.yaml → experiment_config.yaml

### DIFF
--- a/param_decomp/optimize.py
+++ b/param_decomp/optimize.py
@@ -665,5 +665,3 @@ class Trainer:
 
         if is_main_process():
             logger.info("Finished training loop.")
-
-

--- a/param_decomp_lab/app/backend/routers/pretrain_info.py
+++ b/param_decomp_lab/app/backend/routers/pretrain_info.py
@@ -15,7 +15,7 @@ from param_decomp.log import logger
 from param_decomp_lab.app.backend.dependencies import DepLoadedRun
 from param_decomp_lab.app.backend.utils import log_errors
 from param_decomp_lab.experiments.lm.run import LMExperimentConfig, LMTargetConfig
-from param_decomp_lab.experiments.utils import RUN_META_FILENAME
+from param_decomp_lab.experiments.utils import EXPERIMENT_CONFIG_FILENAME
 from param_decomp_lab.infra.run_files import resolve_config_path
 from param_decomp_lab.infra.settings import PARAM_DECOMP_OUT_DIR
 from param_decomp_lab.infra.wandb import parse_wandb_run_path
@@ -216,7 +216,7 @@ def get_pretrain_info_for_run(wandb_path: str) -> PretrainInfoResponse:
     Fetches only config files (no checkpoints) for efficiency.
     """
     cfg = LMExperimentConfig.from_file(
-        resolve_config_path(wandb_path, config_filename=RUN_META_FILENAME)
+        resolve_config_path(wandb_path, config_filename=EXPERIMENT_CONFIG_FILENAME)
     )
     return _get_pretrain_info(cfg.target)
 

--- a/param_decomp_lab/app/backend/routers/run_registry.py
+++ b/param_decomp_lab/app/backend/routers/run_registry.py
@@ -14,7 +14,7 @@ from param_decomp.log import logger
 from param_decomp_lab.app.backend.routers.pretrain_info import _get_pretrain_info
 from param_decomp_lab.app.backend.utils import log_errors
 from param_decomp_lab.experiments.lm.run import LMExperimentConfig
-from param_decomp_lab.experiments.utils import RUN_META_FILENAME
+from param_decomp_lab.experiments.utils import EXPERIMENT_CONFIG_FILENAME
 from param_decomp_lab.infra.run_files import resolve_config_path
 from param_decomp_lab.infra.settings import PARAM_DECOMP_OUT_DIR
 from param_decomp_lab.infra.wandb import parse_wandb_run_path
@@ -61,7 +61,7 @@ def _get_architecture_summary(wandb_path: str) -> str | None:
     """Get a short architecture label for a run. Returns None on failure."""
     try:
         cfg = LMExperimentConfig.from_file(
-            resolve_config_path(wandb_path, config_filename=RUN_META_FILENAME)
+            resolve_config_path(wandb_path, config_filename=EXPERIMENT_CONFIG_FILENAME)
         )
         info = _get_pretrain_info(cfg.target)
         parts: list[str] = []

--- a/param_decomp_lab/experiments/CLAUDE.md
+++ b/param_decomp_lab/experiments/CLAUDE.md
@@ -12,7 +12,7 @@ the concrete reload class directly.
 ```
 experiments/
 ├── utils.py                 # ExperimentConfig[T,D] generic + EvalConfig + WandbConfig
-│                            # + init_pd_run + RUN_META_FILENAME
+│                            # + init_pd_run + EXPERIMENT_CONFIG_FILENAME
 ├── tms/run.py
 ├── resid_mlp/run.py
 └── lm/
@@ -102,7 +102,7 @@ the free function directly with `pd_run.cfg.target` / `pd_run.cfg.data`.
 to those same functions, so there's no duplication between "fresh run from YAML" and
 "reload from disk" paths.
 
-`main()` writes the resolved `<Name>ExperimentConfig` to `out_dir / RUN_META_FILENAME`
+`main()` writes the resolved `<Name>ExperimentConfig` to `out_dir / EXPERIMENT_CONFIG_FILENAME`
 via `cfg.to_file(...)`. There is no kind discriminator on disk — each post-processing
 caller imports the concrete `Saved<Name>Run` it expects:
 
@@ -153,7 +153,7 @@ Every `pd-*` run command accepts `--group <id>` and `--tags a,b,c` (no-ops when
 
 ```
 PARAM_DECOMP_OUT_DIR/decompositions/<run_id>/
-  run_meta.yaml              # the full ExperimentConfig
+  experiment_config.yaml     # the full ExperimentConfig
   model_<step>.pth           # checkpoints (RunSink.checkpoint)
   metrics.jsonl              # local logs (RunSink.log)
 ```

--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -2,7 +2,7 @@
 
 Both the fresh-run path (`main`) and the reload path (`SavedLMRun`) share the
 module-level `build_target` / `build_lm_loader` / `make_run_batch`. The resume
-path (`main --resume <yaml>`) reads a parent run's `run_meta.yaml` plus
+path (`main --resume <yaml>`) reads a parent run's `experiment_config.yaml` plus
 `training_<step>.pth`, rebuilds a `Trainer` via `Trainer.from_snapshot`, and
 continues training.
 
@@ -47,7 +47,7 @@ from param_decomp_lab.experiments.lm.data import (
     rank_batch_size,
 )
 from param_decomp_lab.experiments.utils import (
-    RUN_META_FILENAME,
+    EXPERIMENT_CONFIG_FILENAME,
     ExperimentConfig,
     init_pd_run,
 )
@@ -180,7 +180,7 @@ class SavedLMRun:
     def from_path(cls, path: ModelPath) -> "SavedLMRun":
         """Resolve a run directory or W&B path into a fully-validated `SavedLMRun`."""
         files = resolve_run_files(
-            path, config_filename=RUN_META_FILENAME, checkpoint_prefix="model"
+            path, config_filename=EXPERIMENT_CONFIG_FILENAME, checkpoint_prefix="model"
         )
         return cls(
             cfg=LMExperimentConfig.from_file(files.config_path),
@@ -215,7 +215,7 @@ def main(
     Args:
         config_path: YAML for a fresh run. Required when not resuming.
         resume: Path to a `ResumeConfig` YAML pointing at a prior run. When set,
-            the parent's `run_meta.yaml` is the source of cfg truth; a new
+            the parent's `experiment_config.yaml` is the source of cfg truth; a new
             `run_id` + sibling `resume_provenance.yaml` are written.
         group / tags: wandb-only (no-ops without `wandb:`).
         dp / partition / time / job_name / no_snapshot / run_id: SLURM submission
@@ -308,10 +308,10 @@ def _resume_main(
     tags: str | None,
     run_id: str | None,
 ) -> None:
-    """Resume-run path: read parent `run_meta.yaml` + `training_<step>.pth`,
+    """Resume-run path: read parent `experiment_config.yaml` + `training_<step>.pth`,
     rebuild trainer via `Trainer.from_snapshot`, continue training."""
     resume_cfg = ResumeConfig.from_file(resume_cfg_path)
-    parent_cfg = LMExperimentConfig.from_file(resume_cfg.from_run / RUN_META_FILENAME)
+    parent_cfg = LMExperimentConfig.from_file(resume_cfg.from_run / EXPERIMENT_CONFIG_FILENAME)
 
     dist_state = init_distributed()
     if is_main_process():

--- a/param_decomp_lab/experiments/resid_mlp/run.py
+++ b/param_decomp_lab/experiments/resid_mlp/run.py
@@ -24,7 +24,7 @@ from param_decomp_lab.eval_metrics import EVAL_METRIC_CLASSES
 from param_decomp_lab.experiments.resid_mlp.data import ResidMLPDataset
 from param_decomp_lab.experiments.resid_mlp.models import ResidMLP, ResidMLPTargetRunInfo
 from param_decomp_lab.experiments.utils import (
-    RUN_META_FILENAME,
+    EXPERIMENT_CONFIG_FILENAME,
     ExperimentConfig,
     init_pd_run,
 )
@@ -108,7 +108,7 @@ class SavedResidMLPRun:
     def from_path(cls, path: ModelPath) -> "SavedResidMLPRun":
         """Resolve a run directory or W&B path into a fully-validated `SavedResidMLPRun`."""
         files = resolve_run_files(
-            path, config_filename=RUN_META_FILENAME, checkpoint_prefix="model"
+            path, config_filename=EXPERIMENT_CONFIG_FILENAME, checkpoint_prefix="model"
         )
         return cls(
             cfg=ResidMLPExperimentConfig.from_file(files.config_path),

--- a/param_decomp_lab/experiments/tms/run.py
+++ b/param_decomp_lab/experiments/tms/run.py
@@ -24,7 +24,7 @@ from param_decomp_lab.eval_metrics import EVAL_METRIC_CLASSES
 from param_decomp_lab.experiments.tms.data import SparseFeatureDataset
 from param_decomp_lab.experiments.tms.models import TMSModel, TMSTargetRunInfo
 from param_decomp_lab.experiments.utils import (
-    RUN_META_FILENAME,
+    EXPERIMENT_CONFIG_FILENAME,
     ExperimentConfig,
     init_pd_run,
 )
@@ -108,7 +108,7 @@ class SavedTMSRun:
     def from_path(cls, path: ModelPath) -> "SavedTMSRun":
         """Resolve a run directory or W&B path into a fully-validated `SavedTMSRun`."""
         files = resolve_run_files(
-            path, config_filename=RUN_META_FILENAME, checkpoint_prefix="model"
+            path, config_filename=EXPERIMENT_CONFIG_FILENAME, checkpoint_prefix="model"
         )
         return cls(
             cfg=TMSExperimentConfig.from_file(files.config_path),

--- a/param_decomp_lab/experiments/utils.py
+++ b/param_decomp_lab/experiments/utils.py
@@ -16,7 +16,7 @@ from param_decomp_lab.infra.settings import PARAM_DECOMP_OUT_DIR
 from param_decomp_lab.infra.wandb import try_wandb
 from param_decomp_lab.run_sink import RunSink
 
-RUN_META_FILENAME = "run_meta.yaml"
+EXPERIMENT_CONFIG_FILENAME = "experiment_config.yaml"
 
 
 class WandbConfig(BaseConfig):
@@ -46,7 +46,7 @@ class ExperimentConfig[T: BaseConfig, D: BaseConfig](BaseConfig):
             pass
 
     Omit the `eval:` block to skip eval entirely; omit `wandb:` to skip wandb (the run
-    still writes `run_meta.yaml` + checkpoints locally).
+    still writes `experiment_config.yaml` + checkpoints locally).
     """
 
     pd: PDConfig
@@ -65,7 +65,7 @@ def init_pd_run[T: BaseConfig, D: BaseConfig](
     tags: str | None,
     run_id: str | None = None,
 ) -> RunSink:
-    """Allocate `run_id` + `out_dir`, write `run_meta.yaml`, return a sink.
+    """Allocate `run_id` + `out_dir`, write `experiment_config.yaml`, return a sink.
 
     Local-only when `cfg.wandb is None`, else wandb-backed. Non-main DDP ranks get a
     silent no-op sink without touching disk or wandb. `group` is a "launched together"
@@ -75,8 +75,8 @@ def init_pd_run[T: BaseConfig, D: BaseConfig](
         return RunSink.silent()
     run_id = run_id or generate_run_id("param_decomp")
     out_dir = PARAM_DECOMP_OUT_DIR / "decompositions" / run_id
-    meta_path = out_dir / RUN_META_FILENAME
-    cfg.to_file(meta_path)
+    cfg_path = out_dir / EXPERIMENT_CONFIG_FILENAME
+    cfg.to_file(cfg_path)
     keep_last_n = cfg.cadence.keep_last_n_checkpoints
     if cfg.wandb is None:
         return RunSink.local(out_dir, keep_last_n_checkpoints=keep_last_n)
@@ -91,5 +91,5 @@ def init_pd_run[T: BaseConfig, D: BaseConfig](
         tags=parsed_tags,
         keep_last_n_checkpoints=keep_last_n,
     )
-    try_wandb(wandb.save, str(meta_path), base_path=str(out_dir), policy="now")
+    try_wandb(wandb.save, str(cfg_path), base_path=str(out_dir), policy="now")
     return sink

--- a/param_decomp_lab/resumption/__init__.py
+++ b/param_decomp_lab/resumption/__init__.py
@@ -3,7 +3,7 @@
 A resumption is a separate top-level concept from a fresh run, expressed via its own
 `ResumeConfig` YAML schema and dispatched from the `pd-lm --resume <path>` CLI flag.
 Resumption is *continuous*: the resumed run extends the parent's step axis, inheriting
-its config from `run_meta.yaml` and its training state from `training_<step>.pth`.
+its config from `experiment_config.yaml` and its training state from `training_<step>.pth`.
 
 The training state is canonical and topology-independent — a single file written by
 rank 0 carries everything needed to reconstruct the trainer for any compatible

--- a/param_decomp_lab/resumption/config.py
+++ b/param_decomp_lab/resumption/config.py
@@ -20,7 +20,7 @@ class ResumeConfig(BaseConfig):
     """A resumption YAML: which run to resume, which checkpoint."""
 
     from_run: Path
-    """Path to the parent run directory (the one with `run_meta.yaml` and
+    """Path to the parent run directory (the one with `experiment_config.yaml` and
     `training_<step>.pth` files)."""
 
     step: int | Literal["latest"] = "latest"

--- a/param_decomp_lab/resumption/provenance.py
+++ b/param_decomp_lab/resumption/provenance.py
@@ -1,7 +1,7 @@
-"""Resume provenance: a small YAML sibling of ``run_meta.yaml`` recording
+"""Resume provenance: a small YAML sibling of ``experiment_config.yaml`` recording
 which run a resumed run was forked from.
 
-Resumed runs get their own ``run_id`` and own ``run_meta.yaml`` — provenance
+Resumed runs get their own ``run_id`` and own ``experiment_config.yaml`` — provenance
 is what makes them traceable back to the parent. A future reader can inspect
 ``resume_provenance.yaml`` to find the parent run dir + the step it was
 resumed from.
@@ -17,7 +17,7 @@ RESUME_PROVENANCE_FILENAME = "resume_provenance.yaml"
 
 
 class ResumeProvenance(BaseConfig):
-    """Sibling of ``run_meta.yaml`` recording where this resumed run came from."""
+    """Sibling of ``experiment_config.yaml`` recording where this resumed run came from."""
 
     parent_run_dir: Path
     """Path to the parent run's directory."""


### PR DESCRIPTION
## Description

Renames the per-run config file written by `init_pd_run`:

- Constant: `RUN_META_FILENAME` → `EXPERIMENT_CONFIG_FILENAME`
- Filename on disk + wandb: `run_meta.yaml` → `experiment_config.yaml`

Cascaded through the three experiment `run.py`s (lm, tms, resid_mlp), the two app routers that read it (`pretrain_info`, `run_registry`), and docstrings in `resumption/` + `experiments/CLAUDE.md`. The unrelated `final_config.yaml` written by the target-model pretraining flow (`experiments/lm/pretrain/`) is untouched.

Also picked up a stray trailing-newline cleanup in `param_decomp/optimize.py` from the pre-commit hook.

## Motivation and Context

`run_meta.yaml` is mildly misleading — the file contains the serialized `ExperimentConfig`, not arbitrary metadata. `experiment_config.yaml` names what's actually inside. (The pre-sexy-refactor name was `final_config.yaml`, which had its own "final vs what?" ambiguity.)

## How Has This Been Tested?

- `basedpyright` clean on touched files
- Smoke-imported `EXPERIMENT_CONFIG_FILENAME` from every call site

## Does this PR introduce a breaking change?

Yes — existing runs on disk with `run_meta.yaml` won't be readable by `SavedLMRun.from_path` / resumption until renamed. No migration shim included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)