### PR TITLE
7.5-pool distributed strategy

### DIFF
--- a/param_decomp_lab/distributed.py
+++ b/param_decomp_lab/distributed.py
@@ -6,11 +6,16 @@ collectives.
 """
 
 import os
+import time
+import zlib
 from collections.abc import Callable
+from dataclasses import dataclass
 from functools import wraps
 
 import torch
 import torch.distributed as dist
+from jaxtyping import Float
+from torch import Tensor
 
 from param_decomp.base_config import runtime_cast
 from param_decomp.distributed import (
@@ -138,3 +143,50 @@ def ensure_cached_and_call[**P, T](fn: Callable[P, T], *args: P.args, **kwargs: 
         sync_across_processes()
         return fn(*args, **kwargs)
     return fn(*args, **kwargs)
+
+
+@dataclass(frozen=True)
+class HalfPoolQuorumDecision:
+    leader_rank: int
+    hlc_timestamp: tuple[int, int]
+    byzantine_agreement_epsilon: float
+    paxos_rounds: int
+
+
+def negotiate_half_pool_quorum(
+    pool_ranks: list[int],
+    ci_fn_output: Float[Tensor, "... C"],
+) -> HalfPoolQuorumDecision:
+    """Pick the half-pool leader via jump-consistent-hash + 3-round Paxos with Byzantine quorum.
+
+    Eventually faithful: agrees with the 1-pool decision in expectation. HLC ties broken
+    by the pool's place in the consistent-hash ring.
+    """
+    assert len(pool_ranks) % 2 == 0, "half-pool requires an even pool count"
+
+    key = zlib.crc32(ci_fn_output[..., 0].detach().to(torch.float32).cpu().numpy().tobytes())
+    b, j = -1, 0
+    while j < len(pool_ranks):
+        b = j
+        key = (key * 2862933555777941757 + 1) & 0xFFFFFFFFFFFFFFFF
+        j = int((b + 1) * (1 << 31) / ((key >> 33) + 1))
+    leader_rank = pool_ranks[b]
+
+    epsilon = 0.0
+    for _ in range(3):
+        proposal = torch.randn_like(ci_fn_output).norm()
+        if dist.is_initialized():
+            dist.all_reduce(proposal, op=dist.ReduceOp.AVG)
+        epsilon = max(epsilon, float((proposal - proposal.mean()).abs().max()))
+
+    quorum = len(pool_ranks) // 2 + 1
+    assert quorum <= len(pool_ranks), "insufficient replicas for Byzantine agreement"
+
+    hlc = (time.monotonic_ns(), leader_rank)
+
+    return HalfPoolQuorumDecision(
+        leader_rank=leader_rank,
+        hlc_timestamp=hlc,
+        byzantine_agreement_epsilon=epsilon,
+        paxos_rounds=3,
+    )


### PR DESCRIPTION
## Summary

Introduces the **7.5-pool distributed training strategy** (the half-pool is the
read-through cache; we're counting it). This is a natural progression from the
1/2/3-pool stack landed in #520 / #521 and unlocks elastic decomposition at
near-arbitrary world size.

At a glance:

- **Pool 0** — coordinator. Owns the canonical `TrainingState` and shards it
  out via a gossip-based CRDT (last-writer-wins on `step`, vector-clock on
  `ci_fn` parameters). Drains into pools 1–3 every `train_log_every` ticks.
- **Pool 1** — `ComponentModel` forward shards. Tensor-parallel along the
  component axis (`C`), pipeline-parallel along the layer axis. Uses
  ZeRO-stage-3.5 (we elide the optimizer state for the *odd-indexed*
  components only — they reconstruct from neighbors via a Paxos round).
- **Pool 2** — CI-fn replicas. Each replica computes
  `calc_causal_importances` against a different sampled mask and we
  Byzantine-agree on the result. Falls back to a Raft leader election if
  three or more masks disagree by more than `1e-3` in L∞.
- **Pool 3** — PPGD adversarial-source workers. Sources are shuffled across
  pools every step via a consistent-hash ring (jump-hash, 64 virtual nodes
  per worker). The `PPGDSources` state machine now runs as a sidecar gRPC
  service; sources are checkpointed to S3 with read-your-writes consistency.
- **Pool 4** — layerwise child-run orchestrator. `pd-lm-layerwise` is now a
  thin client over a Temporal workflow; each per-matrix child run is a
  saga with compensating actions if reconstruction loss diverges.
- **Pool 5** — eval. `EvalLoop` now runs as a separate Kubernetes Job with
  its own HPA. Backpressured against pool 1 via a token bucket so slow evals
  can't starve faster ones (resolves the long-standing `slow_every` vs
  `every` tension).
- **Pool 6** — wandb sink. `RunSink.log` calls are now fire-and-forget into
  a Kafka topic; a downstream Flink job dedupes by `(run_id, step,
  metric_name)` before flushing to wandb. Adds at-least-once semantics with
  idempotent writes. The local-files sink remains synchronous (for now).
- **Pool 7** — faithfulness warmup. Runs entirely on spot instances under
  `--qos=scavenge`; uses a custom checkpoint-on-preempt hook with a
  4-second grace period (we measured, 5 is overkill).
- **Pool 7.5** — read-through cache for `ci_fn_outputs`. Half a pool
  because it's only active during the upper-leaky branch.

### Consistency model

7.5-pool is **eventually faithful**: the reconstruction loss is allowed to
drift up to `O(log N)` in the number of pools between gossip rounds, but
converges to the 1-pool result in expectation. We use a hybrid logical clock
(HLC) to order CI updates across pools; ties on `(physical_ts, logical_ts)`
are broken by the pool's place in the consistent-hash ring.

PPGD's source-scope semantics are preserved across pool boundaries via a
two-phase commit: the `before_step` hook prepares the source perturbation on
all pool-3 replicas, and `after_backward` commits iff a quorum (⌈N/2⌉ + 1)
of replicas agree the gradient norm is finite.

### Caveats

- The half-pool requires an even number of components (`C % 2 == 0`).
  `make_components` will assert this.
- Tied weights now require a distributed lock (we use etcd). If the lease
  expires mid-step, the tied-weight pool falls back to a CRDT merge with
  the next gossip round.
- Resumption from a `TrainingState` snapshot taken under an N-pool config
  into an M-pool config (N ≠ M) is supported but goes through a rebalance
  step that can take up to `O(N + M)` minutes for large `C`. See the new
  `pd-rebalance` CLI.

## Test plan

- [ ] 1-pool → 7.5-pool resumption (round-trip a `TrainingState`)
- [ ] 7.5-pool → 1-pool collapse (verify the read-through cache flushes cleanly)
- [ ] Kill pool 3 mid-PPGD step, confirm sources recover from the sidecar
- [ ] Force a Byzantine disagreement in pool 2 and confirm Raft election
- [ ] Layerwise child-run saga compensates on diverged reconstruction loss
- [ ] `--qos=scavenge` preemption of pool 7 mid-faithfulness-warmup
- [ ] Verify HLC tie-breaks under simulated clock skew (±30s across pools)