### PR TITLE
refactor: consolidate per-run artifacts under runs/<run_id>/

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,11 +120,21 @@ from param_decomp.batch_and_loss_fns import RunBatch, ReconstructionLoss
 
 ## Saved-run layout
 
+Every artifact for a decomposition lives under one dir per run:
+
 ```
-PARAM_DECOMP_OUT_DIR/decompositions/<run_id>/
+PARAM_DECOMP_OUT_DIR/runs/<run_id>/
+  experiment_config.yaml     # the full ExperimentConfig
   model_<step>.pth           # checkpoints (RunSink.checkpoint)
   metrics.jsonl              # local logs (RunSink.log)
+  harvest/h-*/...            # pd-harvest output
+  autointerp/a-*/...         # pd-autointerp output
+  dataset_attributions/da-*/...  # pd-attributions output
+  graph_interp/*/...         # pd-graph-interp output
 ```
+
+Both training output and the W&B download cache write here. Per-stage subdirs are
+populated by their respective pipelines.
 
 `PARAM_DECOMP_OUT_DIR` is `/mnt/polished-lake/artifacts/mechanisms/param-decomp/` on
 cluster, `~/param_decomp_out/` off cluster. Defined in

--- a/param_decomp_lab/app/CLAUDE.md
+++ b/param_decomp_lab/app/CLAUDE.md
@@ -355,7 +355,7 @@ StateManager.get() → AppState:
       - harvest: HarvestRepo       # Lazy-loaded pre-harvested data
   - dataset_search_state: DatasetSearchState | None  # Cached search results
 
-HarvestRepo:  # Lazy-loads from PARAM_DECOMP_OUT_DIR/harvest/<run_id>/
+HarvestRepo:  # Lazy-loads from PARAM_DECOMP_OUT_DIR/runs/<run_id>/harvest/
   - correlations: CorrelationStorage | None
   - token_stats: TokenStatsStorage | None
   - activation_contexts: dict[str, ComponentData] | None

--- a/param_decomp_lab/app/backend/routers/run_registry.py
+++ b/param_decomp_lab/app/backend/routers/run_registry.py
@@ -13,10 +13,13 @@ from pydantic import BaseModel
 from param_decomp.log import logger
 from param_decomp_lab.app.backend.routers.pretrain_info import _get_pretrain_info
 from param_decomp_lab.app.backend.utils import log_errors
+from param_decomp_lab.autointerp.schemas import get_autointerp_dir
+from param_decomp_lab.dataset_attributions.repo import get_attributions_dir
 from param_decomp_lab.experiments.lm.run import LMExperimentConfig
 from param_decomp_lab.experiments.utils import EXPERIMENT_CONFIG_FILENAME
+from param_decomp_lab.graph_interp.schemas import get_graph_interp_dir
+from param_decomp_lab.harvest.schemas import get_harvest_dir
 from param_decomp_lab.infra.run_files import resolve_config_path
-from param_decomp_lab.infra.settings import PARAM_DECOMP_OUT_DIR
 from param_decomp_lab.infra.wandb import parse_wandb_run_path
 
 router = APIRouter(prefix="/api/run_registry", tags=["run_registry"])
@@ -44,16 +47,11 @@ def _has_glob_match(pattern_dir: Path, glob_pattern: str) -> bool:
 
 def _check_availability(run_id: str) -> DataAvailability:
     """Lightweight filesystem checks for post-processing data availability."""
-    harvest_dir = PARAM_DECOMP_OUT_DIR / "harvest" / run_id
-    autointerp_dir = PARAM_DECOMP_OUT_DIR / "autointerp" / run_id
-    attributions_dir = PARAM_DECOMP_OUT_DIR / "dataset_attributions" / run_id
-    graph_interp_dir = PARAM_DECOMP_OUT_DIR / "graph_interp" / run_id
-
     return DataAvailability(
-        harvest=_has_glob_match(harvest_dir, "h-*/harvest.db"),
-        autointerp=_has_glob_match(autointerp_dir, "a-*/.done"),
-        attributions=_has_glob_match(attributions_dir, "da-*/dataset_attributions.pt"),
-        graph_interp=_has_glob_match(graph_interp_dir, "*/interp.db"),
+        harvest=_has_glob_match(get_harvest_dir(run_id), "h-*/harvest.db"),
+        autointerp=_has_glob_match(get_autointerp_dir(run_id), "a-*/.done"),
+        attributions=_has_glob_match(get_attributions_dir(run_id), "da-*/dataset_attributions.pt"),
+        graph_interp=_has_glob_match(get_graph_interp_dir(run_id), "*/interp.db"),
     )
 
 

--- a/param_decomp_lab/autointerp/CLAUDE.md
+++ b/param_decomp_lab/autointerp/CLAUDE.md
@@ -32,7 +32,7 @@ Requires the API key for your chosen provider (e.g. `OPENROUTER_API_KEY`, or `GE
 Each autointerp subrun has its own SQLite database:
 
 ```
-PARAM_DECOMP_OUT_DIR/autointerp/<spd_run_id>/
+PARAM_DECOMP_OUT_DIR/runs/<spd_run_id>/autointerp/
 └── <autointerp_run_id>/           # e.g. a-20260206_153040
     ├── interp.db                  # SQLite DB: interpretations + scores (WAL mode)
     └── config.yaml                # AutointerpConfig (for reproducibility)

--- a/param_decomp_lab/autointerp/schemas.py
+++ b/param_decomp_lab/autointerp/schemas.py
@@ -6,17 +6,14 @@ from typing import Literal
 
 from param_decomp_lab.infra.settings import PARAM_DECOMP_OUT_DIR
 
-# Base directory for autointerp data
-AUTOINTERP_DATA_DIR = PARAM_DECOMP_OUT_DIR / "autointerp"
-
 
 def get_autointerp_dir(decomposition_id: str) -> Path:
-    """Get the top-level autointerp directory for a PD run."""
-    return AUTOINTERP_DATA_DIR / decomposition_id
+    """Top-level autointerp directory for a decomposition."""
+    return PARAM_DECOMP_OUT_DIR / "runs" / decomposition_id / "autointerp"
 
 
 def get_autointerp_subrun_dir(decomposition_id: str, autointerp_run_id: str) -> Path:
-    """Get the directory for a specific autointerp run (timestamped subdirectory)."""
+    """Directory for a specific autointerp run (timestamped subdirectory)."""
     return get_autointerp_dir(decomposition_id) / autointerp_run_id
 
 

--- a/param_decomp_lab/dataset_attributions/CLAUDE.md
+++ b/param_decomp_lab/dataset_attributions/CLAUDE.md
@@ -42,7 +42,7 @@ python -m param_decomp_lab.dataset_attributions.scripts.run_merge --wandb_path <
 ## Data Storage
 
 ```
-PARAM_DECOMP_OUT_DIR/dataset_attributions/<run_id>/
+PARAM_DECOMP_OUT_DIR/runs/<run_id>/dataset_attributions/
 ├── da-20260223_183250/                    # sub-run (latest picked by repo)
 │   ├── dataset_attributions.pt            # merged result
 │   └── worker_states/

--- a/param_decomp_lab/dataset_attributions/repo.py
+++ b/param_decomp_lab/dataset_attributions/repo.py
@@ -1,10 +1,9 @@
 """Dataset attributions data repository.
 
-Owns PARAM_DECOMP_OUT_DIR/dataset_attributions/<run_id>/ and provides read access
-to the attribution matrix.
+Owns the per-decomposition attributions dir and provides read access to the attribution matrix.
 
 Use AttributionRepo.open() to construct — returns None if no attribution data exists.
-Layout: dataset_attributions/<run_id>/da-YYYYMMDD_HHMMSS/dataset_attributions.pt
+Layout: runs/<run_id>/dataset_attributions/da-YYYYMMDD_HHMMSS/dataset_attributions.pt
 """
 
 from pathlib import Path
@@ -12,11 +11,9 @@ from pathlib import Path
 from param_decomp_lab.dataset_attributions.storage import DatasetAttributionStorage
 from param_decomp_lab.infra.settings import PARAM_DECOMP_OUT_DIR
 
-DATASET_ATTRIBUTIONS_DIR = PARAM_DECOMP_OUT_DIR / "dataset_attributions"
-
 
 def get_attributions_dir(run_id: str) -> Path:
-    return DATASET_ATTRIBUTIONS_DIR / run_id
+    return PARAM_DECOMP_OUT_DIR / "runs" / run_id / "dataset_attributions"
 
 
 def get_attributions_subrun_dir(run_id: str, subrun_id: str) -> Path:

--- a/param_decomp_lab/experiments/CLAUDE.md
+++ b/param_decomp_lab/experiments/CLAUDE.md
@@ -152,11 +152,15 @@ Every `pd-*` run command accepts `--group <id>` and `--tags a,b,c` (no-ops when
 ## Saved-run layout
 
 ```
-PARAM_DECOMP_OUT_DIR/decompositions/<run_id>/
+PARAM_DECOMP_OUT_DIR/runs/<run_id>/
   experiment_config.yaml     # the full ExperimentConfig
   model_<step>.pth           # checkpoints (RunSink.checkpoint)
   metrics.jsonl              # local logs (RunSink.log)
 ```
+
+Post-decomposition pipelines (harvest, autointerp, attributions, graph_interp) nest
+their own sub-directories under this same `runs/<run_id>/` dir — see each module's
+CLAUDE.md.
 
 ## Canonical references
 

--- a/param_decomp_lab/experiments/utils.py
+++ b/param_decomp_lab/experiments/utils.py
@@ -74,7 +74,7 @@ def init_pd_run[T: BaseConfig, D: BaseConfig](
     if not is_main_process():
         return RunSink.silent()
     run_id = run_id or generate_run_id("param_decomp")
-    out_dir = PARAM_DECOMP_OUT_DIR / "decompositions" / run_id
+    out_dir = PARAM_DECOMP_OUT_DIR / "runs" / run_id
     cfg_path = out_dir / EXPERIMENT_CONFIG_FILENAME
     cfg.to_file(cfg_path)
     keep_last_n = cfg.cadence.keep_last_n_checkpoints

--- a/param_decomp_lab/graph_interp/CLAUDE.md
+++ b/param_decomp_lab/graph_interp/CLAUDE.md
@@ -28,7 +28,7 @@ All three phases run in a single invocation. Resume is per-phase via completed k
 ## Data Storage
 
 ```
-PARAM_DECOMP_OUT_DIR/graph_interp/<decomposition_id>/
+PARAM_DECOMP_OUT_DIR/runs/<decomposition_id>/graph_interp/
 └── ti-YYYYMMDD_HHMMSS/
     ├── interp.db       # SQLite: output_labels, input_labels, unified_labels, prompt_edges
     └── config.yaml

--- a/param_decomp_lab/graph_interp/schemas.py
+++ b/param_decomp_lab/graph_interp/schemas.py
@@ -6,11 +6,9 @@ from typing import Literal
 
 from param_decomp_lab.infra.settings import PARAM_DECOMP_OUT_DIR
 
-GRAPH_INTERP_DIR = PARAM_DECOMP_OUT_DIR / "graph_interp"
-
 
 def get_graph_interp_dir(decomposition_id: str) -> Path:
-    return GRAPH_INTERP_DIR / decomposition_id
+    return PARAM_DECOMP_OUT_DIR / "runs" / decomposition_id / "graph_interp"
 
 
 def get_graph_interp_subrun_dir(decomposition_id: str, subrun_id: str) -> Path:

--- a/param_decomp_lab/harvest/CLAUDE.md
+++ b/param_decomp_lab/harvest/CLAUDE.md
@@ -43,7 +43,7 @@ python -m param_decomp_lab.harvest.scripts.run_merge --subrun_id $SUBRUN --confi
 Each harvest invocation creates a timestamped sub-run directory. `HarvestRepo` automatically loads from the latest sub-run.
 
 ```
-PARAM_DECOMP_OUT_DIR/harvest/<run_id>/
+PARAM_DECOMP_OUT_DIR/runs/<run_id>/harvest/
 ├── h-20260211_120000/          # sub-run 1
 │   ├── harvest.db              # SQLite DB: components table + config table (WAL mode)
 │   ├── component_correlations.pt

--- a/param_decomp_lab/harvest/repo.py
+++ b/param_decomp_lab/harvest/repo.py
@@ -1,10 +1,10 @@
 """Harvest data repository.
 
-Owns PARAM_DECOMP_OUT_DIR/harvest/<decomposition_id>/ and provides read/write access to all
+Owns the per-decomposition harvest dir and provides read/write access to all
 harvest artifacts. No in-memory caching -- reads go through on every call.
 Component data backed by SQLite; correlations and token stats remain as .pt files.
 
-Layout: harvest/<decomposition_id>/h-YYYYMMDD_HHMMSS/{harvest.db, *.pt}
+Layout: runs/<decomposition_id>/harvest/h-YYYYMMDD_HHMMSS/{harvest.db, *.pt}
 """
 
 from pathlib import Path
@@ -17,6 +17,7 @@ from param_decomp_lab.harvest.schemas import (
     ComponentData,
     ComponentSummary,
     get_harvest_dir,
+    get_harvest_subrun_dir,
 )
 from param_decomp_lab.harvest.storage import CorrelationStorage, TokenStatsStorage
 
@@ -26,7 +27,7 @@ class HarvestRepo:
 
     def __init__(self, decomposition_id: str, subrun_id: str, readonly: bool) -> None:
         self.subrun_id = subrun_id
-        self._dir = get_harvest_dir(decomposition_id) / subrun_id
+        self._dir = get_harvest_subrun_dir(decomposition_id, subrun_id)
         self._db = HarvestDB(self._dir / "harvest.db", readonly=readonly)
 
     @classmethod
@@ -59,9 +60,7 @@ class HarvestRepo:
             return None
 
         logger.info(f"Opening harvest data for {decomposition_id} from {subrun_dir}")
-        subrun_id = subrun_dir.name
-
-        return cls(decomposition_id=decomposition_id, subrun_id=subrun_id, readonly=readonly)
+        return cls(decomposition_id=decomposition_id, subrun_id=subrun_dir.name, readonly=readonly)
 
     @staticmethod
     def save_results(harvester: Harvester, config: HarvestConfig, output_dir: Path) -> None:

--- a/param_decomp_lab/harvest/schemas.py
+++ b/param_decomp_lab/harvest/schemas.py
@@ -9,17 +9,14 @@ from torch import Tensor
 
 from param_decomp_lab.infra.settings import PARAM_DECOMP_OUT_DIR
 
-# Base directory for harvest data
-HARVEST_DATA_DIR = PARAM_DECOMP_OUT_DIR / "harvest"
 
-
-def get_harvest_dir(wandb_run_id: str) -> Path:
-    """Get the base harvest directory for a run."""
-    return HARVEST_DATA_DIR / wandb_run_id
+def get_harvest_dir(decomposition_id: str) -> Path:
+    """Base harvest dir for a decomposition."""
+    return PARAM_DECOMP_OUT_DIR / "runs" / decomposition_id / "harvest"
 
 
 def get_harvest_subrun_dir(decomposition_id: str, subrun_id: str) -> Path:
-    """Get the sub-run directory for a specific harvest invocation."""
+    """Subrun dir for a specific harvest invocation."""
     return get_harvest_dir(decomposition_id) / subrun_id
 
 

--- a/param_decomp_lab/infra/run_files.py
+++ b/param_decomp_lab/infra/run_files.py
@@ -283,8 +283,8 @@ class RunFiles:
     extras: dict[str, Path] = field(default_factory=dict)
 
 
-def _wandb_cache_dir(project: str, run_id: str) -> Path:
-    return PARAM_DECOMP_OUT_DIR / "runs" / f"{project}-{run_id}"
+def _wandb_cache_dir(run_id: str) -> Path:
+    return PARAM_DECOMP_OUT_DIR / "runs" / run_id
 
 
 def resolve_run_files(
@@ -317,7 +317,7 @@ def resolve_run_files(
         )
 
     wandb_path = f"{entity}/{project}/{run_id}"
-    run_dir = _wandb_cache_dir(project, run_id)
+    run_dir = _wandb_cache_dir(run_id)
 
     if run_dir.exists():
         logger.info(f"Loading run from {run_dir}")
@@ -356,7 +356,7 @@ def resolve_config_path(path: ModelPath, *, config_filename: str) -> Path:
         path_obj = Path(path)
         return (path_obj if path_obj.is_dir() else path_obj.parent) / config_filename
 
-    run_dir = _wandb_cache_dir(project, run_id)
+    run_dir = _wandb_cache_dir(run_id)
     config_path = run_dir / config_filename
     if config_path.exists():
         return config_path
@@ -400,8 +400,8 @@ def _download_run_files_from_wandb(
 ) -> RunFiles:
     api = wandb.Api()
     run: WandbRun = api.run(wandb_path)
-    _entity, project, run_id = parse_wandb_run_path(wandb_path)
-    run_dir = _wandb_cache_dir(project, run_id)
+    _entity, _project, run_id = parse_wandb_run_path(wandb_path)
+    run_dir = _wandb_cache_dir(run_id)
 
     config_path = download_wandb_file(run, run_dir, config_filename)
     if checkpoint_filename is not None:


### PR DESCRIPTION
## Summary

Training output, W&B download cache, and every postprocess stage (harvest, autointerp, dataset_attributions, graph_interp) now all write to `PARAM_DECOMP_OUT_DIR/runs/<run_id>/`, with stage data nested as `runs/<id>/<stage>/<subrun>/`. Drops the project-name prefix from the W&B cache.

Motivation: previously a single decomposition's artifacts were scattered across four top-level dirs (`decompositions/`, `runs/<project>-<id>/`, `harvest/`, `autointerp/`, etc.). Copying one run to another cluster meant tracking down each location. Now it's one directory per run.

## Layout

```
PARAM_DECOMP_OUT_DIR/runs/<run_id>/
  experiment_config.yaml
  model_<step>.pth
  metrics.jsonl
  figures/
  harvest/h-*/...
  autointerp/a-*/...
  dataset_attributions/da-*/...
  graph_interp/*/...
```

## Breaking change

**No legacy fallback in code** — readers point at the new layout only. Existing on-disk data at `decompositions/<id>/`, `harvest/<id>/`, `autointerp/<id>/`, `runs/<project>-<id>/` won't be auto-discovered after this change. Anyone with in-flight data should stay on a previous revision until they're ready to migrate their own data.

`p-73cf27e4` (the GPT2-XL test run in the app registry) has been migrated on `/mnt/data/artifacts/mechanisms/param-decomp/`. No other runs were touched.

## Files

- Path helpers (4 modules): `harvest/schemas.py`, `autointerp/schemas.py`, `dataset_attributions/repo.py`, `graph_interp/schemas.py` — each `get_<stage>_dir(id)` now returns `runs/<id>/<stage>/`.
- `infra/run_files.py` — `_wandb_cache_dir(run_id)` returns `runs/<run_id>/`; project arg dropped from signature and 3 call sites.
- `experiments/utils.py` — `init_pd_run` writes to `runs/<id>/` instead of `decompositions/<id>/`.
- `app/backend/routers/run_registry.py` — availability check now uses the per-module helpers directly instead of hardcoding paths.
- CLAUDE.md docs in root, experiments, harvest, autointerp, dataset_attributions, graph_interp, and app updated to reflect the new layout.

## Tested

- [x] `make check` — ruff + basedpyright clean
- [x] Python smoke test: `HarvestRepo.open_most_recent('p-73cf27e4')` and `InterpRepo.open('p-73cf27e4')` find the migrated data (8192 components, 3104 interpretations).
- [x] `resolve_config_path('goodfire/param-decomp/runs/p-73cf27e4', ...)` resolves to the new cache location without a W&B download.
- [ ] App end-to-end: relaunch `make app` on port 8000, confirm "GPT2-XL 0.mlp.up (test)" still shows the harvest/autointerp badges and labels render.

🤖 Generated with [Claude Code](https://claude.com/claude-code)