### PR TITLE
three_pool: relax cross-pool batch divisibility to bidirectional (BatchEdge)

### DIFF
--- a/param_decomp_lab/tests/test_three_pool_batch_edge.py
+++ b/param_decomp_lab/tests/test_three_pool_batch_edge.py
@@ -1,0 +1,97 @@
+"""Unit tests for ``BatchEdge`` — the cross-pool batch-slice geometry.
+
+CPU-only, no torch.distributed. Exercises both fan directions: CI-coarse
+(``n_ci`` divides ``n_down``) and CI-fine / inverted (``n_down`` divides
+``n_ci``), plus the square case. The invariant under test is that the
+``(ci_slice, down_slice)`` overlaps tile each pool's local batch tensor exactly
+once and agree on the global rows they cover from both sides — which is what
+makes the cross-pool sends/recvs stitch back to the single-pool batch.
+"""
+
+import pytest
+
+from param_decomp_lab.three_pool.layout import BatchEdge
+
+# (n_ci, n_down, batch_global), spanning coarse / square / inverted regimes.
+EDGE_CASES = [
+    (2, 4, 8),  # CI coarse (legacy forward path), fanout 2
+    (2, 2, 8),  # square
+    (4, 2, 8),  # CI fine (inverted), fanout 2
+    (4, 4, 8),  # square, all-equal
+    (8, 4, 8),  # CI fine, fanout 2, b_down > b_ci
+    (4, 8, 8),  # CI coarse, fanout 2
+    (1, 4, 8),  # single CI rank fans to all
+    (6, 6, 12),  # square non-power-of-two
+]
+
+
+@pytest.mark.parametrize(("n_ci", "n_down", "batch_global"), EDGE_CASES)
+def test_overlaps_tile_local_tensors_and_agree_globally(
+    n_ci: int, n_down: int, batch_global: int
+) -> None:
+    edge = BatchEdge(n_ci=n_ci, n_down=n_down, batch_global=batch_global)
+
+    # Every downstream slice is fully tiled by its CI overlaps (no gaps/overlaps).
+    for j in range(n_down):
+        covered = sorted(
+            (s.start, s.stop)
+            for s in (edge.overlap_within_down(i, j) for i in edge.ci_slices_for_down_slice(j))
+        )
+        cursor = 0
+        for start, stop in covered:
+            assert start == cursor, f"gap/overlap in down slice {j}: {covered}"
+            cursor = stop
+        assert cursor == edge.b_down
+
+    # Every CI slice is fully tiled by its downstream overlaps.
+    for i in range(n_ci):
+        covered = sorted(
+            (s.start, s.stop)
+            for s in (edge.overlap_within_ci(i, j) for j in edge.down_slices_for_ci_slice(i))
+        )
+        cursor = 0
+        for start, stop in covered:
+            assert start == cursor, f"gap/overlap in CI slice {i}: {covered}"
+            cursor = stop
+        assert cursor == edge.b_ci
+
+    # Each overlap covers the SAME global rows from both sides, with matching length.
+    for i in range(n_ci):
+        for j in edge.down_slices_for_ci_slice(i):
+            ci_sub = edge.overlap_within_ci(i, j)
+            down_sub = edge.overlap_within_down(i, j)
+            assert (ci_sub.stop - ci_sub.start) == (down_sub.stop - down_sub.start)
+            ci_global = (i * edge.b_ci + ci_sub.start, i * edge.b_ci + ci_sub.stop)
+            down_global = (j * edge.b_down + down_sub.start, j * edge.b_down + down_sub.stop)
+            assert ci_global == down_global
+
+
+@pytest.mark.parametrize(("n_ci", "n_down", "batch_global"), EDGE_CASES)
+def test_pairing_is_symmetric(n_ci: int, n_down: int, batch_global: int) -> None:
+    """``j in down_slices_for_ci_slice(i)`` iff ``i in ci_slices_for_down_slice(j)``."""
+    edge = BatchEdge(n_ci=n_ci, n_down=n_down, batch_global=batch_global)
+    for i in range(n_ci):
+        for j in edge.down_slices_for_ci_slice(i):
+            assert i in edge.ci_slices_for_down_slice(j)
+    for j in range(n_down):
+        for i in edge.ci_slices_for_down_slice(j):
+            assert j in edge.down_slices_for_ci_slice(i)
+
+
+def test_fanout_direction() -> None:
+    coarse = BatchEdge(n_ci=2, n_down=4, batch_global=8)
+    assert coarse.ci_is_coarse and coarse.fanout == 2
+    # One CI rank feeds 2 down ranks; each down rank reads from 1 CI rank.
+    assert coarse.down_slices_for_ci_slice(0) == (0, 1)
+    assert coarse.ci_slices_for_down_slice(3) == (1,)
+
+    fine = BatchEdge(n_ci=4, n_down=2, batch_global=8)
+    assert not fine.ci_is_coarse and fine.fanout == 2
+    # One down rank gathers from 2 CI ranks; each CI rank feeds 1 down rank.
+    assert fine.ci_slices_for_down_slice(0) == (0, 1)
+    assert fine.down_slices_for_ci_slice(3) == (1,)
+
+
+def test_rejects_non_cross_divisible() -> None:
+    with pytest.raises(AssertionError):
+        BatchEdge(n_ci=6, n_down=4, batch_global=12)

--- a/param_decomp_lab/three_pool/CLAUDE.md
+++ b/param_decomp_lab/three_pool/CLAUDE.md
@@ -8,7 +8,7 @@ docstring in `optimize.py` for the data-handling contract.
 | File | What it covers |
 |---|---|
 | `optimize.py` | `ThreePoolTrainer` + `optimize_three_pool`; the training loop, `snapshot`/`from_snapshot`, config validation |
-| `layout.py` | `World` topology; `build_world` constructs every process group (threading `pg_timeout` into each) |
+| `layout.py` | `World` topology; `build_world` constructs every process group (threading `pg_timeout` into each); `BatchEdge` — symmetric per-edge batch-slice geometry (CI↔LW, CI↔PPGD) answering routing for both fan directions |
 | `checkpoint.py` | `gather_full_state_dict_to_rank0` — rebuilds the full model state on rank 0 |
 | `config.py` | `ThreePoolConfig` + topology validation |
 | `role.py` | `PoolRole = CIRole \| LWRole \| PPGDRole` — this rank's pool role; per-pool fields are union variants, not optional attrs |
@@ -64,3 +64,25 @@ Repro/fault-injection env knobs (never set in production):
 `PD_3POOL_PG_TIMEOUT_S`, `PD_3POOL_SNAPSHOT_RANK0_SLEEP_S` (inject a sleep into
 rank-0's read), `PD_3POOL_DISABLE_REJOIN_BARRIER` (reproduces the pre-fix race).
 Regression tests: `param_decomp_lab/tests/test_three_pool_pg_timeout.py`.
+
+## Cross-pool batch divisibility (bidirectional)
+
+Each cross-pool edge (CI↔LW, CI↔PPGD) requires the two batch arities to be
+**cross-divisible** — one divides the other, EITHER direction (`n_ci | n_down`
+OR `n_down | n_ci`). Ragged pairs where neither divides the other are rejected.
+The three "arity divides `pd.batch_size`" constraints still hold.
+
+`BatchEdge` (layout.py) owns the geometry for one edge and answers every routing
+question symmetrically:
+
+  * **CI coarse** (`n_ci <= n_down`): one CI rank fans a sub-slice to `fanout`
+    downstream ranks; grads stitch back fanout→one. One downstream rank ↔ one CI
+    rank.
+  * **CI fine / inverted** (`n_ci > n_down`): one downstream rank gathers CI
+    from `fanout` CI ranks (`PendingCiValues` holds the `fanout` packets and
+    stitches them) and scatters grads back to those CI ranks. One CI rank ↔ one
+    downstream rank.
+
+The six portal exchange methods + the eval CI ship consume `world.ci_lw_edge` /
+`world.ci_ppgd_edge` and never branch on the regime. Unit tests:
+`param_decomp_lab/tests/test_three_pool_batch_edge.py`.

--- a/param_decomp_lab/three_pool/config.py
+++ b/param_decomp_lab/three_pool/config.py
@@ -16,7 +16,7 @@ splitting the CI fn into its own pool (a dedicated unsharded CI pool enables
 global shared transformer CI fns that span all sites).
 
 Topology integrity checks (rank disjointness, uniform N_per_block, CI-pool
-divisibility into Layerwise/PPGD batch shards) run at validation time; checks
+cross-divisibility with Layerwise/PPGD arities) run at validation time; checks
 that depend on ``pd.batch_size`` (divisibility) run in
 ``_validate_pd_config_for_three_pool`` since they need the paired ``PDConfig``
 to evaluate.
@@ -54,21 +54,24 @@ class ThreePoolConfig(BaseConfig):
 
     Batch-split divisibility (see ``DESIGN.md`` open Q1):
 
-      * ``N_ci`` must divide ``N_per_block_layerwise`` so each Layerwise rank's
-        batch slice fits inside exactly one CI rank's slice (one-to-many
-        fan-out for CI values; many-to-one reduction for CI grads).
-      * ``N_ci`` must divide ``N_ppgd`` for the same reason on the CI↔PPGD
-        side.
+      * ``N_ci`` and ``N_per_block_layerwise`` must be cross-divisible — one
+        divides the other. Whichever is smaller owns the coarser batch slice;
+        the finer pool's shards each nest in exactly one coarse shard, so the
+        CI↔LW exchange is a clean one-to-K fan-out (and K-to-one reduction)
+        in either direction.
+      * ``N_ci`` and ``N_ppgd`` must be cross-divisible for the same reason on
+        the CI↔PPGD side.
 
-    These two constraints reduce the otherwise many-to-many batch routing to
-    the simpler one-to-many / many-to-one shape that the comms layer
-    implements. The validator rejects any other arrangement loudly.
+    These two constraints keep every batch-slice overlap a whole, aligned
+    sub-slice (uniform integer fan-in/out), avoiding ragged many-to-many
+    routing. The validator rejects any other arrangement loudly.
     """
 
     ci_ranks: list[int] = Field(
         ...,
         description="Ranks assigned to the CI pool (replicated CI fn, DP across batch). "
-        "Must divide both N_per_block_layerwise and N_ppgd (see class docstring).",
+        "Must be cross-divisible with both N_per_block_layerwise and N_ppgd "
+        "(see class docstring).",
     )
     layerwise_block_groups: list[LayerwiseBlockGroupSpec] = Field(
         ...,
@@ -132,17 +135,21 @@ class ThreePoolConfig(BaseConfig):
             f"Layerwise pool and PPGD pool must be rank-disjoint; overlap: {lw_pgd_overlap}"
         )
 
-        # Batch-split divisibility (MVP constraint — see DESIGN.md open Q1).
+        # Batch-split divisibility (see DESIGN.md open Q1). Each cross-pool edge
+        # (CI↔LW, CI↔PPGD) must be a clean one-to-K fan-out in EITHER direction:
+        # one arity divides the other, so every batch-slice overlap is a whole,
+        # aligned sub-slice. (The batch-divisibility of each arity itself is
+        # enforced against pd.batch_size in _validate_pd_config_for_three_pool.)
         n_ci = len(self.ci_ranks)
         n_ppgd = len(self.ppgd_ranks)
-        assert n_per_block % n_ci == 0, (
-            f"N_ci ({n_ci}) must divide N_per_block_layerwise ({n_per_block}) so each "
-            f"Layerwise rank's batch slice fits inside exactly one CI rank's slice. "
-            f"Tip: choose a smaller CI pool, or grow the layerwise block-DDP factor."
+        assert n_per_block % n_ci == 0 or n_ci % n_per_block == 0, (
+            f"N_ci ({n_ci}) and N_per_block_layerwise ({n_per_block}) must be "
+            f"cross-divisible (one divides the other) so each batch-slice overlap "
+            f"is a whole sub-slice. Tip: make one a multiple of the other."
         )
-        assert n_ppgd % n_ci == 0, (
-            f"N_ci ({n_ci}) must divide N_ppgd ({n_ppgd}) so each PPGD rank's batch "
-            f"slice fits inside exactly one CI rank's slice. "
-            f"Tip: choose a smaller CI pool, or grow the PPGD pool."
+        assert n_ppgd % n_ci == 0 or n_ci % n_ppgd == 0, (
+            f"N_ci ({n_ci}) and N_ppgd ({n_ppgd}) must be cross-divisible (one "
+            f"divides the other) so each batch-slice overlap is a whole sub-slice. "
+            f"Tip: make one a multiple of the other."
         )
         return self

--- a/param_decomp_lab/three_pool/layout.py
+++ b/param_decomp_lab/three_pool/layout.py
@@ -12,14 +12,15 @@ The per-rank view (which pool am I, what do I own) lives in ``role.py``
 
 The defining wrinkle is **3-way batch slicing**: CI/LW/PPGD each shard the
 global batch on their own axis. The constraint (enforced in
-``ThreePoolConfig.validate_topology``) is:
+``ThreePoolConfig.validate_topology``) is cross-divisibility per edge:
 
-    N_ci | N_per_block_layerwise
-    N_ci | N_ppgd
+    N_ci | N_per_block_layerwise   OR   N_per_block_layerwise | N_ci
+    N_ci | N_ppgd                  OR   N_ppgd | N_ci
 
-which reduces the otherwise many-to-many CI↔LW and CI↔PPGD routing to a
-one-to-many fan-out (CI rank → K downstream ranks) plus a many-to-one
-reduction (downstream ranks → one CI rank). See "Batch-split routing" below.
+so each CI↔LW / CI↔PPGD overlap is a whole, aligned sub-slice — a one-to-K
+fan-out (and K-to-one reduction) in EITHER direction. The geometry for one edge
+lives in ``BatchEdge``, which answers every routing question symmetrically for
+both fan directions (CI coarse vs CI fine). See "Batch-split routing" below.
 """
 
 # pyright: reportIndexIssue=false, reportArgumentType=false, reportOperatorIssue=false
@@ -210,67 +211,114 @@ class World:
     def block_leader_of_site(self, site: str) -> int:
         return self.layerwise_block_groups[self.block_idx_of_site(site)].leader
 
-    # ── Batch-split routing (the new wrinkle) ──
+    # ── Batch-split routing ──
+    #
+    # Each cross-pool edge's slice geometry is delegated to a ``BatchEdge`` (one
+    # per edge), which answers every routing question SYMMETRICALLY for both fan
+    # directions (CI coarse / CI fine). The portals call these edges so the
+    # exchange methods never branch on which arity is larger.
 
     @property
-    def k_lw_per_ci(self) -> int:
-        """How many LW batch shards (per block) fit inside one CI batch shard.
-
-        Validator guarantees N_ci | N_per_block_layerwise, so this is an integer.
-        """
-        assert self.n_per_block % self.n_ci == 0
-        return self.n_per_block // self.n_ci
+    def ci_lw_edge(self) -> "BatchEdge":
+        return BatchEdge(n_ci=self.n_ci, n_down=self.n_per_block, batch_global=self.batch_global)
 
     @property
-    def k_ppgd_per_ci(self) -> int:
-        """How many PPGD batch shards fit inside one CI batch shard.
+    def ci_ppgd_edge(self) -> "BatchEdge":
+        return BatchEdge(n_ci=self.n_ci, n_down=self.n_ppgd, batch_global=self.batch_global)
 
-        Validator guarantees N_ci | N_ppgd, so this is an integer.
+
+@dataclass(frozen=True)
+class BatchEdge:
+    """Symmetric batch-slice geometry for one cross-pool edge (CI ↔ downstream).
+
+    ``n_down`` is the downstream pool's batch arity (``n_per_block`` for LW,
+    ``n_ppgd`` for PPGD). The validator guarantees ``n_ci`` and ``n_down`` are
+    cross-divisible, so exactly one of two regimes holds:
+
+      * ``ci_is_coarse`` (``n_ci <= n_down``, ``n_ci | n_down``): each CI slice
+        contains ``fanout = n_down // n_ci`` whole downstream slices. CI fans a
+        sub-slice out to each; grads come back to be stitched. One downstream
+        rank pairs with exactly one CI rank.
+      * not ``ci_is_coarse`` (``n_ci > n_down``, ``n_down | n_ci``): each
+        downstream slice contains ``fanout = n_ci // n_down`` whole CI slices.
+        One downstream rank gathers from ``fanout`` CI ranks (concat) and
+        scatters grads back to those same ``fanout`` CI ranks. One CI rank pairs
+        with exactly one downstream rank.
+
+    All slice arithmetic is in units of the FINER pool's shard, so every overlap
+    is a whole, aligned sub-slice.
+    """
+
+    n_ci: int
+    n_down: int
+    batch_global: int
+
+    def __post_init__(self) -> None:
+        assert self.n_down % self.n_ci == 0 or self.n_ci % self.n_down == 0, (
+            f"n_ci ({self.n_ci}) and n_down ({self.n_down}) must be cross-divisible"
+        )
+        assert self.batch_global % self.n_ci == 0 and self.batch_global % self.n_down == 0
+
+    @property
+    def ci_is_coarse(self) -> bool:
+        return self.n_ci <= self.n_down
+
+    @property
+    def fanout(self) -> int:
+        """Number of finer-pool slices nested in one coarser-pool slice."""
+        return self.n_down // self.n_ci if self.ci_is_coarse else self.n_ci // self.n_down
+
+    @property
+    def b_ci(self) -> int:
+        return self.batch_global // self.n_ci
+
+    @property
+    def b_down(self) -> int:
+        return self.batch_global // self.n_down
+
+    # ── Pairing: which ranks talk to which ──
+
+    def ci_slices_for_down_slice(self, down_slice_idx: int) -> tuple[int, ...]:
+        """CI slice idxs whose batches overlap downstream slice `down_slice_idx`.
+
+        Coarse-CI regime: exactly one CI slice (the one containing it).
+        Fine-CI regime: the `fanout` CI slices nested in it.
         """
-        assert self.n_ppgd % self.n_ci == 0
-        return self.n_ppgd // self.n_ci
+        if self.ci_is_coarse:
+            return (down_slice_idx // self.fanout,)
+        return tuple(range(down_slice_idx * self.fanout, (down_slice_idx + 1) * self.fanout))
 
-    def ci_slice_of_lw_block_rank(self, block_rank_idx: int) -> int:
-        """Which CI rank's slice contains LW rank `block_rank_idx`'s batch shard."""
-        return block_rank_idx // self.k_lw_per_ci
+    def down_slices_for_ci_slice(self, ci_slice_idx: int) -> tuple[int, ...]:
+        """Downstream slice idxs whose batches overlap CI slice `ci_slice_idx`.
 
-    def ci_slice_of_ppgd_slice(self, ppgd_slice_idx: int) -> int:
-        """Which CI rank's slice contains PPGD rank `ppgd_slice_idx`'s batch shard."""
-        return ppgd_slice_idx // self.k_ppgd_per_ci
-
-    def lw_sub_slice_within_ci(self, block_rank_idx: int) -> slice:
-        """Within a CI rank's local batch tensor [B_ci, ...], the sub-slice
-        that corresponds to LW rank `block_rank_idx`.
-
-        Assumes the caller is the CI rank with
-        `ci_slice_idx == ci_slice_of_lw_block_rank(block_rank_idx)`.
+        Coarse-CI regime: the `fanout` downstream slices nested in it.
+        Fine-CI regime: exactly one downstream slice (the one containing it).
         """
-        b_lw = self.batch_local_lw
-        ci_slice_idx = self.ci_slice_of_lw_block_rank(block_rank_idx)
-        global_start = block_rank_idx * b_lw
-        ci_global_start = ci_slice_idx * self.batch_local_ci
-        local_start = global_start - ci_global_start
-        return slice(local_start, local_start + b_lw)
+        if self.ci_is_coarse:
+            return tuple(range(ci_slice_idx * self.fanout, (ci_slice_idx + 1) * self.fanout))
+        return (ci_slice_idx // self.fanout,)
 
-    def ppgd_sub_slice_within_ci(self, ppgd_slice_idx: int) -> slice:
-        """Within a CI rank's local batch tensor [B_ci, ...], the sub-slice
-        that corresponds to PPGD rank `ppgd_slice_idx`."""
-        b_pp = self.batch_local_ppgd
-        ci_slice_idx = self.ci_slice_of_ppgd_slice(ppgd_slice_idx)
-        global_start = ppgd_slice_idx * b_pp
-        ci_global_start = ci_slice_idx * self.batch_local_ci
-        local_start = global_start - ci_global_start
-        return slice(local_start, local_start + b_pp)
+    # ── Sub-slices: the overlap, expressed in each rank's local batch tensor ──
 
-    def lw_block_ranks_for_ci_slice(self, ci_slice_idx: int) -> tuple[int, ...]:
-        """LW block_rank_idxs whose batch shards sit inside CI rank `ci_slice_idx`'s slice."""
-        k = self.k_lw_per_ci
-        return tuple(range(ci_slice_idx * k, (ci_slice_idx + 1) * k))
+    def overlap_within_ci(self, ci_slice_idx: int, down_slice_idx: int) -> slice:
+        """The CI↔downstream overlap as a sub-slice of CI rank `ci_slice_idx`'s
+        local ``[B_ci, ...]`` tensor. Spans the FINER pool's shard."""
+        return self._overlap(ci_slice_idx, down_slice_idx, base_is_ci=True)
 
-    def ppgd_slice_idxs_for_ci_slice(self, ci_slice_idx: int) -> tuple[int, ...]:
-        """PPGD slice idxs whose batch shards sit inside CI rank `ci_slice_idx`'s slice."""
-        k = self.k_ppgd_per_ci
-        return tuple(range(ci_slice_idx * k, (ci_slice_idx + 1) * k))
+    def overlap_within_down(self, ci_slice_idx: int, down_slice_idx: int) -> slice:
+        """The CI↔downstream overlap as a sub-slice of downstream rank
+        `down_slice_idx`'s local ``[B_down, ...]`` tensor."""
+        return self._overlap(ci_slice_idx, down_slice_idx, base_is_ci=False)
+
+    def _overlap(self, ci_slice_idx: int, down_slice_idx: int, *, base_is_ci: bool) -> slice:
+        ci_global_start = ci_slice_idx * self.b_ci
+        down_global_start = down_slice_idx * self.b_down
+        overlap_global_start = max(ci_global_start, down_global_start)
+        overlap_len = min(self.b_ci, self.b_down)
+        base_start = ci_global_start if base_is_ci else down_global_start
+        local_start = overlap_global_start - base_start
+        assert local_start >= 0, f"non-overlapping slices: ci={ci_slice_idx} down={down_slice_idx}"
+        return slice(local_start, local_start + overlap_len)
 
 
 def build_world(

--- a/param_decomp_lab/three_pool/portals.py
+++ b/param_decomp_lab/three_pool/portals.py
@@ -63,34 +63,55 @@ WIRE_DTYPE: torch.dtype = torch.bfloat16
 
 
 @dataclass(frozen=True)
-class PendingCiValues:
-    """A coalesced CI-values irecv, held until ``wait()``.
+class _CiRecvPacket:
+    """One in-flight CI-values irecv from a single CI rank, plus the sub-slice
+    of the downstream rank's local batch tensor it fills."""
 
-    The packed buffer carries ``sites`` worth of CI values (in order) as
-    ``b * seq_len * c_s`` ``WIRE_DTYPE`` elements each. ``wait`` blocks on the
-    ``dist.Work`` then materializes per-site ``[b, seq_len, c_s]`` views into
-    the packed buffer (no copy).
+    work: "dist.Work"
+    packed: Tensor
+    overlap: slice
+    overlap_len: int
+
+
+@dataclass(frozen=True)
+class PendingCiValues:
+    """One or more coalesced CI-values irecvs, held until ``wait()``.
+
+    Coarse-CI regime: a single packet covering this downstream rank's whole
+    local batch. Fine-CI regime: ``fanout`` packets, each from a different CI
+    rank, covering disjoint ``overlap`` sub-slices that tile the local batch.
+    ``wait`` blocks on every packet then stitches them into per-site
+    ``[b_down, seq_len, c_s]`` tensors.
     """
 
-    packed: Tensor
-    work: "dist.Work"
+    packets: tuple[_CiRecvPacket, ...]
     sites: tuple[str, ...]
     site_to_c: dict[str, int]
-    b: int
+    b_down: int
     seq_len: int
+    device: torch.device
 
     def wait(self) -> dict[str, Tensor]:
-        self.work.wait()
-        out: dict[str, Tensor] = {}
-        offset = 0
-        for s in self.sites:
-            c_s = self.site_to_c[s]
-            numel = self.b * self.seq_len * c_s
-            out[s] = self.packed[offset : offset + numel].view(self.b, self.seq_len, c_s)
-            offset += numel
-        assert offset == self.packed.numel(), (
-            f"unpack size mismatch: consumed {offset} of {self.packed.numel()}"
-        )
+        out: dict[str, Tensor] = {
+            s: torch.empty(
+                self.b_down, self.seq_len, self.site_to_c[s], device=self.device, dtype=WIRE_DTYPE
+            )
+            for s in self.sites
+        }
+        for packet in self.packets:
+            packet.work.wait()
+            offset = 0
+            for s in self.sites:
+                c_s = self.site_to_c[s]
+                numel = packet.overlap_len * self.seq_len * c_s
+                view = packet.packed[offset : offset + numel].view(
+                    packet.overlap_len, self.seq_len, c_s
+                )
+                out[s][packet.overlap].copy_(view)
+                offset += numel
+            assert offset == packet.packed.numel(), (
+                f"unpack size mismatch: consumed {offset} of {packet.packed.numel()}"
+            )
         return out
 
 
@@ -150,17 +171,21 @@ class CiValuesToLayerwise:
     world: World
 
     def send(self, role: CIRole, ci_full: dict[str, Tensor]) -> InFlightSends:
-        """For each site and each LW rank whose batch shard sits in my CI slice,
-        isend the corresponding sub-slice. ``ci_full`` is keyed by site (the CI
-        fn is global) with values ``[B_local_ci, S, C_s]``."""
+        """For each site and each LW rank my CI slice overlaps, isend the
+        overlapping sub-slice. ``ci_full`` is keyed by site (the CI fn is global)
+        with values ``[B_local_ci, S, C_s]``.
+
+        Coarse-CI: I overlap ``fanout`` whole LW slices, each a sub-slice of my
+        CI tensor. Fine-CI: I overlap exactly one LW slice, sending my whole
+        (smaller) CI tensor into the right offset of that LW rank."""
+        edge = self.world.ci_lw_edge
         works: list[dist.Work] = []
         buffers: list[Tensor] = []
-        my_lw_block_ranks = self.world.lw_block_ranks_for_ci_slice(role.slice_idx)
         with time_nccl_op("CiValuesToLayerwise.send"):
             for bg in self.world.layerwise_block_groups:
-                for block_rank_idx in my_lw_block_ranks:
-                    target = bg.ranks[block_rank_idx]
-                    sub = self.world.lw_sub_slice_within_ci(block_rank_idx)
+                for down_slice_idx in edge.down_slices_for_ci_slice(role.slice_idx):
+                    target = bg.ranks[down_slice_idx]
+                    sub = edge.overlap_within_ci(role.slice_idx, down_slice_idx)
                     packed = _pack_sites(ci_full, bg.owned_sites, sub)
                     works.append(
                         dist.isend(packed, dst=target, group=self.world.cross_pool_p2p_group)
@@ -171,23 +196,34 @@ class CiValuesToLayerwise:
     def post_recv(
         self, role: LWRole, site_to_c: dict[str, int], seq_len: int, device: torch.device
     ) -> PendingCiValues:
-        """irecv one coalesced packet of CI values for all of this LW rank's
-        owned sites, from the CI rank whose slice contains my LW batch shard."""
-        src_ci_slice = self.world.ci_slice_of_lw_block_rank(role.within_block_idx)
-        src = self.world.ci_ranks[src_ci_slice]
+        """irecv CI values for this LW rank's owned sites. Coarse-CI: one packet
+        from the single CI rank whose slice contains my LW shard. Fine-CI:
+        ``fanout`` packets from the CI ranks nested in my LW shard, each filling
+        a disjoint sub-slice of my local batch."""
+        edge = self.world.ci_lw_edge
         b_lw = self.world.batch_local_lw
-        packed_numel = sum(b_lw * seq_len * site_to_c[s] for s in role.owned_sites)
-        packed = torch.empty(packed_numel, device=device, dtype=WIRE_DTYPE)
+        packets: list[_CiRecvPacket] = []
         with time_nccl_op("CiValuesToLayerwise.recv"):
-            work = dist.irecv(packed, src=src, group=self.world.cross_pool_p2p_group)
-            assert work is not None
+            for ci_slice_idx in edge.ci_slices_for_down_slice(role.within_block_idx):
+                src = self.world.ci_ranks[ci_slice_idx]
+                overlap = edge.overlap_within_down(ci_slice_idx, role.within_block_idx)
+                overlap_len = overlap.stop - overlap.start
+                packed_numel = sum(overlap_len * seq_len * site_to_c[s] for s in role.owned_sites)
+                packed = torch.empty(packed_numel, device=device, dtype=WIRE_DTYPE)
+                work = dist.irecv(packed, src=src, group=self.world.cross_pool_p2p_group)
+                assert work is not None
+                packets.append(
+                    _CiRecvPacket(
+                        work=work, packed=packed, overlap=overlap, overlap_len=overlap_len
+                    )
+                )
         return PendingCiValues(
-            packed=packed,
-            work=work,
+            packets=tuple(packets),
             sites=role.owned_sites,
             site_to_c=site_to_c,
-            b=b_lw,
+            b_down=b_lw,
             seq_len=seq_len,
+            device=device,
         )
 
 
@@ -201,13 +237,13 @@ class CiValuesToPPGD:
     world: World
 
     def send(self, role: CIRole, ci_full: dict[str, Tensor]) -> InFlightSends:
+        edge = self.world.ci_ppgd_edge
         works: list[dist.Work] = []
         buffers: list[Tensor] = []
-        my_ppgd_slice_idxs = self.world.ppgd_slice_idxs_for_ci_slice(role.slice_idx)
         with time_nccl_op("CiValuesToPPGD.send"):
-            for ppgd_slice_idx in my_ppgd_slice_idxs:
+            for ppgd_slice_idx in edge.down_slices_for_ci_slice(role.slice_idx):
                 target = self.world.ppgd_ranks[ppgd_slice_idx]
-                sub = self.world.ppgd_sub_slice_within_ci(ppgd_slice_idx)
+                sub = edge.overlap_within_ci(role.slice_idx, ppgd_slice_idx)
                 packed = _pack_sites(ci_full, self.world.all_sites, sub)
                 works.append(dist.isend(packed, dst=target, group=self.world.cross_pool_p2p_group))
                 buffers.append(packed)
@@ -216,21 +252,32 @@ class CiValuesToPPGD:
     def post_recv(
         self, role: PPGDRole, site_to_c: dict[str, int], seq_len: int, device: torch.device
     ) -> PendingCiValues:
-        src_ci_slice = self.world.ci_slice_of_ppgd_slice(role.slice_idx)
-        src = self.world.ci_ranks[src_ci_slice]
+        edge = self.world.ci_ppgd_edge
         b_pp = self.world.batch_local_ppgd
-        packed_numel = sum(b_pp * seq_len * site_to_c[s] for s in self.world.all_sites)
-        packed = torch.empty(packed_numel, device=device, dtype=WIRE_DTYPE)
+        packets: list[_CiRecvPacket] = []
         with time_nccl_op("CiValuesToPPGD.recv"):
-            work = dist.irecv(packed, src=src, group=self.world.cross_pool_p2p_group)
-            assert work is not None
+            for ci_slice_idx in edge.ci_slices_for_down_slice(role.slice_idx):
+                src = self.world.ci_ranks[ci_slice_idx]
+                overlap = edge.overlap_within_down(ci_slice_idx, role.slice_idx)
+                overlap_len = overlap.stop - overlap.start
+                packed_numel = sum(
+                    overlap_len * seq_len * site_to_c[s] for s in self.world.all_sites
+                )
+                packed = torch.empty(packed_numel, device=device, dtype=WIRE_DTYPE)
+                work = dist.irecv(packed, src=src, group=self.world.cross_pool_p2p_group)
+                assert work is not None
+                packets.append(
+                    _CiRecvPacket(
+                        work=work, packed=packed, overlap=overlap, overlap_len=overlap_len
+                    )
+                )
         return PendingCiValues(
-            packed=packed,
-            work=work,
+            packets=tuple(packets),
             sites=self.world.all_sites,
             site_to_c=site_to_c,
-            b=b_pp,
+            b_down=b_pp,
             seq_len=seq_len,
+            device=device,
         )
 
 
@@ -244,33 +291,41 @@ class GradCiFromLayerwise:
     world: World
 
     def send(self, role: LWRole, g_ci_owned: dict[str, Tensor]) -> None:
-        """Send per-owned-site CI grads (full LW batch slice) to the CI rank
-        that owns my slice. Owned sites coalesced into one packed send."""
-        dst_ci_slice = self.world.ci_slice_of_lw_block_rank(role.within_block_idx)
-        dst = self.world.ci_ranks[dst_ci_slice]
-        packed = _pack_sites(g_ci_owned, role.owned_sites, sub=None)
+        """Send per-owned-site CI grads to the CI rank(s) my LW slice overlaps.
+
+        Coarse-CI: one CI rank contains my whole slice — send all of it. Fine-CI:
+        my slice spans ``fanout`` CI ranks — send each the overlapping sub-slice
+        of my LW grad. One coalesced send per destination."""
+        edge = self.world.ci_lw_edge
         with time_nccl_op("GradCiFromLayerwise.send"):
-            dist.send(packed, dst=dst, group=self.world.cross_pool_p2p_group)
+            for ci_slice_idx in edge.ci_slices_for_down_slice(role.within_block_idx):
+                dst = self.world.ci_ranks[ci_slice_idx]
+                sub = edge.overlap_within_down(ci_slice_idx, role.within_block_idx)
+                packed = _pack_sites(g_ci_owned, role.owned_sites, sub)
+                dist.send(packed, dst=dst, group=self.world.cross_pool_p2p_group)
 
     def recv(
         self, role: CIRole, site_to_c: dict[str, int], seq_len: int, device: torch.device
     ) -> dict[str, Tensor]:
-        """Recv per-site CI grads, one coalesced buffer per (LW block, LW rank
-        index), stitched into per-site ``[B_local_ci, S, C_s]`` fp32 dests."""
-        my_lw_block_ranks = self.world.lw_block_ranks_for_ci_slice(role.slice_idx)
-        b_lw = self.world.batch_local_lw
+        """Recv per-site CI grads from the LW rank(s) my CI slice overlaps,
+        stitched into per-site ``[B_local_ci, S, C_s]`` fp32 dests. Coarse-CI:
+        ``fanout`` LW ranks tile my slice. Fine-CI: one LW rank, my slice a
+        sub-slice of it (I fill only my overlap)."""
+        edge = self.world.ci_lw_edge
 
-        pending: list[tuple[int, Tensor, dist.Work, tuple[str, ...]]] = []
+        pending: list[tuple[slice, int, Tensor, dist.Work, tuple[str, ...]]] = []
         with time_nccl_op("GradCiFromLayerwise.recv:post_irecvs"):
             for bg in self.world.layerwise_block_groups:
                 owned = bg.owned_sites
-                packed_numel = sum(b_lw * seq_len * site_to_c[s] for s in owned)
-                for block_rank_idx in my_lw_block_ranks:
-                    src = bg.ranks[block_rank_idx]
+                for down_slice_idx in edge.down_slices_for_ci_slice(role.slice_idx):
+                    src = bg.ranks[down_slice_idx]
+                    overlap = edge.overlap_within_ci(role.slice_idx, down_slice_idx)
+                    overlap_len = overlap.stop - overlap.start
+                    packed_numel = sum(overlap_len * seq_len * site_to_c[s] for s in owned)
                     buf = torch.empty(packed_numel, device=device, dtype=WIRE_DTYPE)
                     w = dist.irecv(buf, src=src, group=self.world.cross_pool_p2p_group)
                     assert w is not None
-                    pending.append((block_rank_idx, buf, w, owned))
+                    pending.append((overlap, overlap_len, buf, w, owned))
 
         b_ci = self.world.batch_local_ci
         out: dict[str, Tensor] = {
@@ -278,15 +333,14 @@ class GradCiFromLayerwise:
             for s in self.world.all_sites
         }
         with time_nccl_op("GradCiFromLayerwise.recv:wait"):
-            for block_rank_idx, buf, w, owned in pending:
+            for overlap, overlap_len, buf, w, owned in pending:
                 w.wait()
-                sub = self.world.lw_sub_slice_within_ci(block_rank_idx)
                 offset = 0
                 for site in owned:
                     c_s = site_to_c[site]
-                    n = b_lw * seq_len * c_s
-                    site_view = buf[offset : offset + n].view(b_lw, seq_len, c_s)
-                    out[site][sub].copy_(site_view.to(torch.float32))
+                    n = overlap_len * seq_len * c_s
+                    site_view = buf[offset : offset + n].view(overlap_len, seq_len, c_s)
+                    out[site][overlap].copy_(site_view.to(torch.float32))
                     offset += n
         return out
 
@@ -301,30 +355,36 @@ class GradCiFromPPGD:
     world: World
 
     def send(self, role: PPGDRole, g_ci_full: dict[str, Tensor]) -> None:
-        """Send full-model CI grads (PPGD batch slice) to the CI rank that owns
-        my slice. All sites coalesced into a single packed buffer."""
-        dst_ci_slice = self.world.ci_slice_of_ppgd_slice(role.slice_idx)
-        dst = self.world.ci_ranks[dst_ci_slice]
-        packed = _pack_sites(g_ci_full, self.world.all_sites, sub=None)
+        """Send full-model CI grads to the CI rank(s) my PPGD slice overlaps.
+
+        Coarse-CI: one CI rank — send my whole slice. Fine-CI: ``fanout`` CI
+        ranks — send each its overlapping sub-slice."""
+        edge = self.world.ci_ppgd_edge
         with time_nccl_op("GradCiFromPPGD.send"):
-            dist.send(packed, dst=dst, group=self.world.cross_pool_p2p_group)
+            for ci_slice_idx in edge.ci_slices_for_down_slice(role.slice_idx):
+                dst = self.world.ci_ranks[ci_slice_idx]
+                sub = edge.overlap_within_down(ci_slice_idx, role.slice_idx)
+                packed = _pack_sites(g_ci_full, self.world.all_sites, sub)
+                dist.send(packed, dst=dst, group=self.world.cross_pool_p2p_group)
 
     def recv(
         self, role: CIRole, site_to_c: dict[str, int], seq_len: int, device: torch.device
     ) -> dict[str, Tensor]:
-        my_ppgd_slice_idxs = self.world.ppgd_slice_idxs_for_ci_slice(role.slice_idx)
-        b_pp = self.world.batch_local_ppgd
-        site_numels = {s: b_pp * seq_len * site_to_c[s] for s in self.world.all_sites}
-        packed_numel = sum(site_numels.values())
+        edge = self.world.ci_ppgd_edge
 
-        pending: list[tuple[int, Tensor, dist.Work]] = []
+        pending: list[tuple[slice, int, Tensor, dist.Work]] = []
         with time_nccl_op("GradCiFromPPGD.recv:post_irecvs"):
-            for ppgd_slice_idx in my_ppgd_slice_idxs:
+            for ppgd_slice_idx in edge.down_slices_for_ci_slice(role.slice_idx):
                 src = self.world.ppgd_ranks[ppgd_slice_idx]
+                overlap = edge.overlap_within_ci(role.slice_idx, ppgd_slice_idx)
+                overlap_len = overlap.stop - overlap.start
+                packed_numel = sum(
+                    overlap_len * seq_len * site_to_c[s] for s in self.world.all_sites
+                )
                 packed = torch.empty(packed_numel, device=device, dtype=WIRE_DTYPE)
                 w = dist.irecv(packed, src=src, group=self.world.cross_pool_p2p_group)
                 assert w is not None
-                pending.append((ppgd_slice_idx, packed, w))
+                pending.append((overlap, overlap_len, packed, w))
 
         b_ci = self.world.batch_local_ci
         out: dict[str, Tensor] = {
@@ -332,14 +392,13 @@ class GradCiFromPPGD:
             for s in self.world.all_sites
         }
         with time_nccl_op("GradCiFromPPGD.recv:wait"):
-            for ppgd_slice_idx, packed, w in pending:
+            for overlap, overlap_len, packed, w in pending:
                 w.wait()
-                sub = self.world.ppgd_sub_slice_within_ci(ppgd_slice_idx)
                 offset = 0
                 for site in self.world.all_sites:
-                    n = site_numels[site]
-                    buf = packed[offset : offset + n].view(b_pp, seq_len, site_to_c[site])
-                    out[site][sub].copy_(buf.to(torch.float32))
+                    n = overlap_len * seq_len * site_to_c[site]
+                    buf = packed[offset : offset + n].view(overlap_len, seq_len, site_to_c[site])
+                    out[site][overlap].copy_(buf.to(torch.float32))
                     offset += n
         return out
 
@@ -478,16 +537,17 @@ class CiOutputsEvalToPPGD:
     world: World
 
     def send(self, role: CIRole, ci: CIOutputs) -> None:
-        """Synchronous send of full CIOutputs (all three dicts) sliced to each
-        PPGD rank within my CI slice. Eval is rare; overlap has no value here.
+        """Synchronous send of full CIOutputs (all three dicts) to the PPGD
+        rank(s) my CI slice overlaps. Eval is rare; overlap has no value here.
 
         Pack layout (must match ``recv``): three contiguous blocks in order
-        (lower_leaky, upper_leaky, pre_sigmoid)."""
-        my_ppgd_slice_idxs = self.world.ppgd_slice_idxs_for_ci_slice(role.slice_idx)
+        (lower_leaky, upper_leaky, pre_sigmoid), each carrying the overlapping
+        sub-slice of my CI tensor for the destination PPGD rank."""
+        edge = self.world.ci_ppgd_edge
         with time_nccl_op("CiOutputsEvalToPPGD.send"):
-            for ppgd_slice_idx in my_ppgd_slice_idxs:
+            for ppgd_slice_idx in edge.down_slices_for_ci_slice(role.slice_idx):
                 target = self.world.ppgd_ranks[ppgd_slice_idx]
-                sub = self.world.ppgd_sub_slice_within_ci(ppgd_slice_idx)
+                sub = edge.overlap_within_ci(role.slice_idx, ppgd_slice_idx)
                 parts: list[Tensor] = []
                 for d in (ci.lower_leaky, ci.upper_leaky, ci.pre_sigmoid):
                     parts.append(_pack_sites(d, self.world.all_sites, sub))
@@ -497,23 +557,36 @@ class CiOutputsEvalToPPGD:
     def recv(
         self, role: PPGDRole, site_to_c: dict[str, int], seq_len: int, device: torch.device
     ) -> CIOutputs:
-        src_ci_slice = self.world.ci_slice_of_ppgd_slice(role.slice_idx)
-        src = self.world.ci_ranks[src_ci_slice]
+        """Recv full CIOutputs from the CI rank(s) my PPGD slice overlaps,
+        stitched into per-site ``[B_local_ppgd, S, C_s]`` tensors (three dicts)."""
+        edge = self.world.ci_ppgd_edge
         b_pp = self.world.batch_local_ppgd
-        per_block_numel = sum(b_pp * seq_len * site_to_c[s] for s in self.world.all_sites)
-        packed = torch.empty(3 * per_block_numel, device=device, dtype=WIRE_DTYPE)
+        out: list[dict[str, Tensor]] = [
+            {
+                s: torch.empty(b_pp, seq_len, site_to_c[s], device=device, dtype=WIRE_DTYPE)
+                for s in self.world.all_sites
+            }
+            for _ in range(3)
+        ]
         with time_nccl_op("CiOutputsEvalToPPGD.recv"):
-            dist.recv(packed, src=src, group=self.world.cross_pool_p2p_group)
-
-        out: list[dict[str, Tensor]] = [{}, {}, {}]
-        offset = 0
-        for block_idx in range(3):
-            for site in self.world.all_sites:
-                c_s = site_to_c[site]
-                numel = b_pp * seq_len * c_s
-                out[block_idx][site] = packed[offset : offset + numel].view(b_pp, seq_len, c_s)
-                offset += numel
-        assert offset == packed.numel(), f"unpack mismatch: {offset} of {packed.numel()}"
+            for ci_slice_idx in edge.ci_slices_for_down_slice(role.slice_idx):
+                src = self.world.ci_ranks[ci_slice_idx]
+                overlap = edge.overlap_within_down(ci_slice_idx, role.slice_idx)
+                overlap_len = overlap.stop - overlap.start
+                per_block_numel = sum(
+                    overlap_len * seq_len * site_to_c[s] for s in self.world.all_sites
+                )
+                packed = torch.empty(3 * per_block_numel, device=device, dtype=WIRE_DTYPE)
+                dist.recv(packed, src=src, group=self.world.cross_pool_p2p_group)
+                offset = 0
+                for block_idx in range(3):
+                    for site in self.world.all_sites:
+                        c_s = site_to_c[site]
+                        numel = overlap_len * seq_len * c_s
+                        view = packed[offset : offset + numel].view(overlap_len, seq_len, c_s)
+                        out[block_idx][site][overlap].copy_(view)
+                        offset += numel
+                assert offset == packed.numel(), f"unpack mismatch: {offset} of {packed.numel()}"
         return CIOutputs(lower_leaky=out[0], upper_leaky=out[1], pre_sigmoid=out[2])
 
 


### PR DESCRIPTION
## What

Relaxes the cross-pool batch-divisibility constraint from one-way to **bidirectional**, ported onto the #534 typed-DAG (`portals.py` / `ctx`) structure. This is the equivalent of #535, which was built on the older `layout.py`-centric structure.

Each cross-pool edge (CI↔LW, CI↔PPGD) previously required the CI arity to **divide** the downstream arity (`n_per_block % n_ci == 0`, `n_ppgd % n_ci == 0`). Now both edges only need to be **cross-divisible** — one divides the other, either direction. The three "arity divides `pd.batch_size`" constraints are kept; ragged pairs (neither divides) stay rejected.

## How

New `BatchEdge` (`layout.py`): symmetric per-edge batch-slice geometry that answers every routing question for both fan directions, so the portal methods never branch on the regime:

- **CI coarse** (`n_ci ≤ n_down`): one CI rank fans a sub-slice to `fanout` downstream ranks; grads stitch back fanout→one. (Original path.)
- **CI fine / inverted** (`n_ci > n_down`): one downstream rank gathers CI from `fanout` CI ranks (`PendingCiValues` now holds the `fanout` packets and stitches them) and scatters grads back to those CI ranks.

The six portal exchange methods + the eval CI ship are rewritten against `world.ci_lw_edge` / `world.ci_ppgd_edge`; the coarse-only `World` helpers (`k_*_per_ci` / `*_slice_of_*` / `*_sub_slice_within_ci`) are removed.

## Validation

- **CPU unit tests** (`param_decomp_lab/tests/test_three_pool_batch_edge.py`, 18 cases): overlaps tile each pool's local batch exactly once and agree on global rows from both sides, across coarse/square/inverted regimes; pairing is symmetric; ragged rejected.
- **`make check` clean** (basedpyright + ruff).
- **Real CI-fn gradient check** (the diagnostic from #538) on 8×B200:
  - **Inverted topology** `n_ci=4, n_per_block=2, n_ppgd=2` (CI finer than both downstream — old validator *rejected* `2 % 4`; needs this relaxation): runs end-to-end with correct shapes; the CI-fn grad direction matches single-pool **cosine = 1.000**, proving the fine-CI routing assembles the gradient correctly across the fanout.
  - **Current-legal coarse topology** `n_ci=2, n_per_block=4`: the relaxed `BatchEdge` code produces a **byte-identical** CI-fn grad dump to the original coarse-only code → **zero regression**.

(The inverted run surfaced a pre-existing `n_per_block/n_ci` stoch-grad scaling characteristic — 3p grad 0.5× single-pool without the stoch fix; that's the subject of #538, orthogonal to this routing refactor.)

## Test plan
- `python -m pytest param_decomp_lab/tests/test_three_pool_batch_edge.py`
- `make check`
- Inverted + coarse grad checks via the #538 diagnostic (above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)