### PR TITLE
three_pool: Option C config fork — standalone ThreePoolLMExperimentConfig + pd-lm-3pool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,8 @@ All declared in `param_decomp_lab/pyproject.toml`.
 |---|---|---|
 | `pd-tms` | `experiments/tms/run.py` | Run TMS experiment from a YAML |
 | `pd-resid-mlp` | `experiments/resid_mlp/run.py` | Run ResidMLP from a YAML |
-| `pd-lm` | `experiments/lm/run.py` | Run LM from a YAML |
+| `pd-lm` | `experiments/lm/run.py` | Run single-pool LM from a YAML |
+| `pd-lm-3pool` | `experiments/lm/three_pool_run.py` | Run 3-pool LM from a `ThreePoolLMExperimentConfig` YAML |
 | `pd-lm-layerwise` | `experiments/lm/layerwise.py` | Split an LM YAML into per-matrix configs, submit as a SLURM array |
 | `pd-pretrain` | `experiments/lm/pretrain/cli.py` | Pretrain target models |
 | `pd-harvest` | `harvest/scripts/run_slurm_cli.py` | Submit harvest SLURM job |

--- a/param_decomp_lab/experiments/CLAUDE.md
+++ b/param_decomp_lab/experiments/CLAUDE.md
@@ -12,15 +12,41 @@ the concrete reload class directly.
 ```
 experiments/
 ├── utils.py                 # ExperimentConfig[T,D] generic + EvalConfig + WandbConfig
-│                            # + init_pd_run + RUN_META_FILENAME
+│                            # + init_pd_run + RUN_META_FILENAME + resume_provenance field
 ├── tms/run.py
 ├── resid_mlp/run.py
 └── lm/
-    ├── run.py
+    ├── run.py               # single-pool LM (pd-lm)
+    ├── three_pool_run.py    # 3-pool LM (pd-lm-3pool): ThreePoolLMExperimentConfig
+    ├── three_pool_pd.py     # ThreePoolConstrainedPDConfig + ThreePoolLosses
     ├── layerwise.py         # split LM YAML into per-matrix configs + SLURM-array submit
     ├── data.py
     └── pretrain/            # see lm/pretrain/CLAUDE.md
 ```
+
+## 3-pool config fork (`pd-lm-3pool`)
+
+The 3-pool training path is a standalone sibling of `pd-lm`, not a flag on it. Dispatch
+is by entry point (the repo idiom — no discriminator). `ThreePoolLMExperimentConfig`
+(in `lm/three_pool_run.py`) is a standalone `BaseConfig` with `pd:
+ThreePoolConstrainedPDConfig`, `runtime: ThreePoolRuntimeConfig` (core `RuntimeConfig`
+scalars + `topology: ThreePoolConfig`), and the usual `cadence`/`target`/`data`/`eval`/
+`wandb`. `LMExperimentConfig` is purely single-pool (no `three_pool` field).
+
+`ThreePoolConstrainedPDConfig` (in `lm/three_pool_pd.py`) subclasses core `PDConfig` and
+bakes the 3-pool's invariants into the types — `sampling`/`n_mask_samples`/
+`use_delta_component`/`identity_decomposition_targets` are frozen `Literal` defaults, and
+the generic `loss_metrics` list is replaced by a typed `ThreePoolLosses(faith, imp,
+stoch, ppgd)` struct (it derives the inherited `loss_metrics` list from the struct via a
+before-validator and excludes it from serialization). `ThreePoolTrainer` reads
+`pd.losses.faith` / `.imp` / `.stoch` / `.ppgd` directly — no `by_type` dict, no
+`isinstance` asserts. Cross-field checks coupling `pd` to `runtime.topology` (batch
+divisibility, rank-0 convention) run as a `@model_validator` on
+`ThreePoolLMExperimentConfig`, so 3-pool misconfigs fail at YAML parse, not minutes into
+a multi-node launch. (Site coverage — owned sites ∈ decomposition_targets after pattern
+expansion — stays in `ThreePoolTrainer._build_runtime` since it needs the loaded model.)
+
+Reload: `SavedThreePoolLMRun` (in `three_pool_run.py`) mirrors `SavedLMRun`.
 
 ## YAML schema
 

--- a/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_save_repro.yaml
+++ b/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_save_repro.yaml
@@ -1,6 +1,5 @@
 pd:
   seed: 0
-  n_mask_samples: 1
   ci_config:
     mode: global
     fn_type: global_shared_transformer
@@ -13,15 +12,12 @@ pd:
         n_heads: 12
         max_len: 128
         rope_base: 10000.0
-  sampling: continuous
   sigmoid_type: leaky_hard
   decomposition_targets:
   - module_pattern: h.*.attn.q_proj
     C: 64
   - module_pattern: h.*.attn.k_proj
     C: 64
-  identity_decomposition_targets: null
-  use_delta_component: true
   batch_size: 2
   steps: 25
   components_optimizer:
@@ -40,36 +36,36 @@ pd:
   faithfulness_warmup_steps: 2
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_weight_decay: 0.0
-  loss_metrics:
-  - type: FaithfulnessLoss
-    coeff: 100000000.0
-  - type: StochasticReconLayerwiseLoss
-    coeff: 100.0
-  - type: ImportanceMinimalityLoss
-    coeff: 3.2e-05
-    pnorm: 2.0
-    beta: 0.5
-    p_anneal_start_frac: 0.0
-    p_anneal_final_p: 0.3
-    p_anneal_end_frac: 1.0
-    eps: 1.0e-12
-  - type: PersistentPGDReconLoss
-    coeff: 1.0
-    optimizer:
-      type: adam
-      beta1: 0.5
-      beta2: 0.99
-      eps: 1.0e-08
-      lr_schedule:
-        start_val: 0.01
-        warmup_pct: 0.025
-        final_val_frac: 1.0
-        fn_type: constant
-    scope:
-      type: per_batch_per_position
-    use_sigmoid_parameterization: false
-    n_warmup_steps: 2
-    n_samples: 1
+  losses:
+    faith:
+      coeff: 100000000.0
+    imp:
+      coeff: 3.2e-05
+      pnorm: 2.0
+      beta: 0.5
+      p_anneal_start_frac: 0.0
+      p_anneal_final_p: 0.3
+      p_anneal_end_frac: 1.0
+      eps: 1.0e-12
+    stoch:
+      coeff: 100.0
+    ppgd:
+      coeff: 1.0
+      optimizer:
+        type: adam
+        beta1: 0.5
+        beta2: 0.99
+        eps: 1.0e-08
+        lr_schedule:
+          start_val: 0.01
+          warmup_pct: 0.025
+          final_val_frac: 1.0
+          fn_type: constant
+      scope:
+        type: per_batch_per_position
+      use_sigmoid_parameterization: false
+      n_warmup_steps: 2
+      n_samples: 1
 cadence:
   train_log_every: 5
   save_every: 10
@@ -90,6 +86,49 @@ runtime:
   autocast_bf16: true
   device: cuda
   dp: null
+  topology:
+    use_fused_kl: true
+    ci_ranks:
+    - 6
+    ppgd_ranks:
+    - 7
+    layerwise_block_groups:
+    - ranks:
+      - 0
+      - 1
+      owned_sites:
+      - h.0.attn.q_proj
+      - h.0.attn.k_proj
+      - h.1.attn.q_proj
+      - h.1.attn.k_proj
+      - h.2.attn.q_proj
+      - h.2.attn.k_proj
+      - h.3.attn.q_proj
+      - h.3.attn.k_proj
+    - ranks:
+      - 2
+      - 3
+      owned_sites:
+      - h.4.attn.q_proj
+      - h.4.attn.k_proj
+      - h.5.attn.q_proj
+      - h.5.attn.k_proj
+      - h.6.attn.q_proj
+      - h.6.attn.k_proj
+      - h.7.attn.q_proj
+      - h.7.attn.k_proj
+    - ranks:
+      - 4
+      - 5
+      owned_sites:
+      - h.8.attn.q_proj
+      - h.8.attn.k_proj
+      - h.9.attn.q_proj
+      - h.9.attn.k_proj
+      - h.10.attn.q_proj
+      - h.10.attn.k_proj
+      - h.11.attn.q_proj
+      - h.11.attn.k_proj
 target:
   spec:
     kind: hf_weights_in_vendored
@@ -108,46 +147,3 @@ data:
   streaming: true
   buffer_size: 1000
   shuffle_each_epoch: true
-three_pool:
-  use_fused_kl: true
-  ci_ranks:
-  - 6
-  ppgd_ranks:
-  - 7
-  layerwise_block_groups:
-  - ranks:
-    - 0
-    - 1
-    owned_sites:
-    - h.0.attn.q_proj
-    - h.0.attn.k_proj
-    - h.1.attn.q_proj
-    - h.1.attn.k_proj
-    - h.2.attn.q_proj
-    - h.2.attn.k_proj
-    - h.3.attn.q_proj
-    - h.3.attn.k_proj
-  - ranks:
-    - 2
-    - 3
-    owned_sites:
-    - h.4.attn.q_proj
-    - h.4.attn.k_proj
-    - h.5.attn.q_proj
-    - h.5.attn.k_proj
-    - h.6.attn.q_proj
-    - h.6.attn.k_proj
-    - h.7.attn.q_proj
-    - h.7.attn.k_proj
-  - ranks:
-    - 4
-    - 5
-    owned_sites:
-    - h.8.attn.q_proj
-    - h.8.attn.k_proj
-    - h.9.attn.q_proj
-    - h.9.attn.k_proj
-    - h.10.attn.q_proj
-    - h.10.attn.k_proj
-    - h.11.attn.q_proj
-    - h.11.attn.k_proj

--- a/param_decomp_lab/experiments/lm/_xl_production/gpt2_xl_qk_b48_sqrtlr.yaml
+++ b/param_decomp_lab/experiments/lm/_xl_production/gpt2_xl_qk_b48_sqrtlr.yaml
@@ -1,6 +1,5 @@
 pd:
   seed: 0
-  n_mask_samples: 1
   ci_config:
     mode: global
     fn_type: global_shared_transformer
@@ -13,15 +12,12 @@ pd:
         n_heads: 32
         max_len: 1024
         rope_base: 10000.0
-  sampling: continuous
   sigmoid_type: leaky_hard
   decomposition_targets:
   - module_pattern: h.*.attn.q_proj
     C: 1024
   - module_pattern: h.*.attn.k_proj
     C: 1024
-  identity_decomposition_targets: null
-  use_delta_component: true
   batch_size: 48
   steps: 50000
   components_optimizer:
@@ -40,36 +36,36 @@ pd:
   faithfulness_warmup_steps: 400
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_weight_decay: 0.0
-  loss_metrics:
-  - type: FaithfulnessLoss
-    coeff: 100000000.0
-  - type: StochasticReconLayerwiseLoss
-    coeff: 100.0
-  - type: ImportanceMinimalityLoss
-    coeff: 3.2e-05
-    pnorm: 2.0
-    beta: 0.5
-    p_anneal_start_frac: 0.0
-    p_anneal_final_p: 0.3
-    p_anneal_end_frac: 1.0
-    eps: 1.0e-12
-  - type: PersistentPGDReconLoss
-    coeff: 1.0
-    optimizer:
-      type: adam
-      beta1: 0.5
-      beta2: 0.99
-      eps: 1.0e-08
-      lr_schedule:
-        start_val: 0.01
-        warmup_pct: 0.025
-        final_val_frac: 1.0
-        fn_type: constant
-    scope:
-      type: per_batch_per_position
-    use_sigmoid_parameterization: false
-    n_warmup_steps: 2
-    n_samples: 1
+  losses:
+    faith:
+      coeff: 100000000.0
+    imp:
+      coeff: 3.2e-05
+      pnorm: 2.0
+      beta: 0.5
+      p_anneal_start_frac: 0.0
+      p_anneal_final_p: 0.3
+      p_anneal_end_frac: 1.0
+      eps: 1.0e-12
+    stoch:
+      coeff: 100.0
+    ppgd:
+      coeff: 1.0
+      optimizer:
+        type: adam
+        beta1: 0.5
+        beta2: 0.99
+        eps: 1.0e-08
+        lr_schedule:
+          start_val: 0.01
+          warmup_pct: 0.025
+          final_val_frac: 1.0
+          fn_type: constant
+      scope:
+        type: per_batch_per_position
+      use_sigmoid_parameterization: false
+      n_warmup_steps: 2
+      n_samples: 1
 cadence:
   train_log_every: 100
   save_every: 5000
@@ -111,6 +107,259 @@ runtime:
   autocast_bf16: true
   device: cuda
   dp: null
+  topology:
+    use_fused_kl: true
+    ci_ranks:
+    - 96
+    - 97
+    - 98
+    - 99
+    - 100
+    - 101
+    - 102
+    - 103
+    - 104
+    - 105
+    - 106
+    - 107
+    - 108
+    - 109
+    - 110
+    - 111
+    - 112
+    - 113
+    - 114
+    - 115
+    - 116
+    - 117
+    - 118
+    - 119
+    ppgd_ranks:
+    - 120
+    - 121
+    - 122
+    - 123
+    - 124
+    - 125
+    - 126
+    - 127
+    - 128
+    - 129
+    - 130
+    - 131
+    - 132
+    - 133
+    - 134
+    - 135
+    - 136
+    - 137
+    - 138
+    - 139
+    - 140
+    - 141
+    - 142
+    - 143
+    layerwise_block_groups:
+    - ranks:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+      - 8
+      - 9
+      - 10
+      - 11
+      - 12
+      - 13
+      - 14
+      - 15
+      - 16
+      - 17
+      - 18
+      - 19
+      - 20
+      - 21
+      - 22
+      - 23
+      owned_sites:
+      - h.0.attn.q_proj
+      - h.0.attn.k_proj
+      - h.1.attn.q_proj
+      - h.1.attn.k_proj
+      - h.2.attn.q_proj
+      - h.2.attn.k_proj
+      - h.3.attn.q_proj
+      - h.3.attn.k_proj
+      - h.4.attn.q_proj
+      - h.4.attn.k_proj
+      - h.5.attn.q_proj
+      - h.5.attn.k_proj
+      - h.6.attn.q_proj
+      - h.6.attn.k_proj
+      - h.7.attn.q_proj
+      - h.7.attn.k_proj
+      - h.8.attn.q_proj
+      - h.8.attn.k_proj
+      - h.9.attn.q_proj
+      - h.9.attn.k_proj
+      - h.10.attn.q_proj
+      - h.10.attn.k_proj
+      - h.11.attn.q_proj
+      - h.11.attn.k_proj
+    - ranks:
+      - 24
+      - 25
+      - 26
+      - 27
+      - 28
+      - 29
+      - 30
+      - 31
+      - 32
+      - 33
+      - 34
+      - 35
+      - 36
+      - 37
+      - 38
+      - 39
+      - 40
+      - 41
+      - 42
+      - 43
+      - 44
+      - 45
+      - 46
+      - 47
+      owned_sites:
+      - h.12.attn.q_proj
+      - h.12.attn.k_proj
+      - h.13.attn.q_proj
+      - h.13.attn.k_proj
+      - h.14.attn.q_proj
+      - h.14.attn.k_proj
+      - h.15.attn.q_proj
+      - h.15.attn.k_proj
+      - h.16.attn.q_proj
+      - h.16.attn.k_proj
+      - h.17.attn.q_proj
+      - h.17.attn.k_proj
+      - h.18.attn.q_proj
+      - h.18.attn.k_proj
+      - h.19.attn.q_proj
+      - h.19.attn.k_proj
+      - h.20.attn.q_proj
+      - h.20.attn.k_proj
+      - h.21.attn.q_proj
+      - h.21.attn.k_proj
+      - h.22.attn.q_proj
+      - h.22.attn.k_proj
+      - h.23.attn.q_proj
+      - h.23.attn.k_proj
+    - ranks:
+      - 48
+      - 49
+      - 50
+      - 51
+      - 52
+      - 53
+      - 54
+      - 55
+      - 56
+      - 57
+      - 58
+      - 59
+      - 60
+      - 61
+      - 62
+      - 63
+      - 64
+      - 65
+      - 66
+      - 67
+      - 68
+      - 69
+      - 70
+      - 71
+      owned_sites:
+      - h.24.attn.q_proj
+      - h.24.attn.k_proj
+      - h.25.attn.q_proj
+      - h.25.attn.k_proj
+      - h.26.attn.q_proj
+      - h.26.attn.k_proj
+      - h.27.attn.q_proj
+      - h.27.attn.k_proj
+      - h.28.attn.q_proj
+      - h.28.attn.k_proj
+      - h.29.attn.q_proj
+      - h.29.attn.k_proj
+      - h.30.attn.q_proj
+      - h.30.attn.k_proj
+      - h.31.attn.q_proj
+      - h.31.attn.k_proj
+      - h.32.attn.q_proj
+      - h.32.attn.k_proj
+      - h.33.attn.q_proj
+      - h.33.attn.k_proj
+      - h.34.attn.q_proj
+      - h.34.attn.k_proj
+      - h.35.attn.q_proj
+      - h.35.attn.k_proj
+    - ranks:
+      - 72
+      - 73
+      - 74
+      - 75
+      - 76
+      - 77
+      - 78
+      - 79
+      - 80
+      - 81
+      - 82
+      - 83
+      - 84
+      - 85
+      - 86
+      - 87
+      - 88
+      - 89
+      - 90
+      - 91
+      - 92
+      - 93
+      - 94
+      - 95
+      owned_sites:
+      - h.36.attn.q_proj
+      - h.36.attn.k_proj
+      - h.37.attn.q_proj
+      - h.37.attn.k_proj
+      - h.38.attn.q_proj
+      - h.38.attn.k_proj
+      - h.39.attn.q_proj
+      - h.39.attn.k_proj
+      - h.40.attn.q_proj
+      - h.40.attn.k_proj
+      - h.41.attn.q_proj
+      - h.41.attn.k_proj
+      - h.42.attn.q_proj
+      - h.42.attn.k_proj
+      - h.43.attn.q_proj
+      - h.43.attn.k_proj
+      - h.44.attn.q_proj
+      - h.44.attn.k_proj
+      - h.45.attn.q_proj
+      - h.45.attn.k_proj
+      - h.46.attn.q_proj
+      - h.46.attn.k_proj
+      - h.47.attn.q_proj
+      - h.47.attn.k_proj
 wandb:
   project: param-decomp
   entity: goodfire
@@ -132,256 +381,3 @@ data:
   streaming: true
   buffer_size: 1000
   shuffle_each_epoch: true
-three_pool:
-  use_fused_kl: true
-  ci_ranks:
-  - 96
-  - 97
-  - 98
-  - 99
-  - 100
-  - 101
-  - 102
-  - 103
-  - 104
-  - 105
-  - 106
-  - 107
-  - 108
-  - 109
-  - 110
-  - 111
-  - 112
-  - 113
-  - 114
-  - 115
-  - 116
-  - 117
-  - 118
-  - 119
-  ppgd_ranks:
-  - 120
-  - 121
-  - 122
-  - 123
-  - 124
-  - 125
-  - 126
-  - 127
-  - 128
-  - 129
-  - 130
-  - 131
-  - 132
-  - 133
-  - 134
-  - 135
-  - 136
-  - 137
-  - 138
-  - 139
-  - 140
-  - 141
-  - 142
-  - 143
-  layerwise_block_groups:
-  - ranks:
-    - 0
-    - 1
-    - 2
-    - 3
-    - 4
-    - 5
-    - 6
-    - 7
-    - 8
-    - 9
-    - 10
-    - 11
-    - 12
-    - 13
-    - 14
-    - 15
-    - 16
-    - 17
-    - 18
-    - 19
-    - 20
-    - 21
-    - 22
-    - 23
-    owned_sites:
-    - h.0.attn.q_proj
-    - h.0.attn.k_proj
-    - h.1.attn.q_proj
-    - h.1.attn.k_proj
-    - h.2.attn.q_proj
-    - h.2.attn.k_proj
-    - h.3.attn.q_proj
-    - h.3.attn.k_proj
-    - h.4.attn.q_proj
-    - h.4.attn.k_proj
-    - h.5.attn.q_proj
-    - h.5.attn.k_proj
-    - h.6.attn.q_proj
-    - h.6.attn.k_proj
-    - h.7.attn.q_proj
-    - h.7.attn.k_proj
-    - h.8.attn.q_proj
-    - h.8.attn.k_proj
-    - h.9.attn.q_proj
-    - h.9.attn.k_proj
-    - h.10.attn.q_proj
-    - h.10.attn.k_proj
-    - h.11.attn.q_proj
-    - h.11.attn.k_proj
-  - ranks:
-    - 24
-    - 25
-    - 26
-    - 27
-    - 28
-    - 29
-    - 30
-    - 31
-    - 32
-    - 33
-    - 34
-    - 35
-    - 36
-    - 37
-    - 38
-    - 39
-    - 40
-    - 41
-    - 42
-    - 43
-    - 44
-    - 45
-    - 46
-    - 47
-    owned_sites:
-    - h.12.attn.q_proj
-    - h.12.attn.k_proj
-    - h.13.attn.q_proj
-    - h.13.attn.k_proj
-    - h.14.attn.q_proj
-    - h.14.attn.k_proj
-    - h.15.attn.q_proj
-    - h.15.attn.k_proj
-    - h.16.attn.q_proj
-    - h.16.attn.k_proj
-    - h.17.attn.q_proj
-    - h.17.attn.k_proj
-    - h.18.attn.q_proj
-    - h.18.attn.k_proj
-    - h.19.attn.q_proj
-    - h.19.attn.k_proj
-    - h.20.attn.q_proj
-    - h.20.attn.k_proj
-    - h.21.attn.q_proj
-    - h.21.attn.k_proj
-    - h.22.attn.q_proj
-    - h.22.attn.k_proj
-    - h.23.attn.q_proj
-    - h.23.attn.k_proj
-  - ranks:
-    - 48
-    - 49
-    - 50
-    - 51
-    - 52
-    - 53
-    - 54
-    - 55
-    - 56
-    - 57
-    - 58
-    - 59
-    - 60
-    - 61
-    - 62
-    - 63
-    - 64
-    - 65
-    - 66
-    - 67
-    - 68
-    - 69
-    - 70
-    - 71
-    owned_sites:
-    - h.24.attn.q_proj
-    - h.24.attn.k_proj
-    - h.25.attn.q_proj
-    - h.25.attn.k_proj
-    - h.26.attn.q_proj
-    - h.26.attn.k_proj
-    - h.27.attn.q_proj
-    - h.27.attn.k_proj
-    - h.28.attn.q_proj
-    - h.28.attn.k_proj
-    - h.29.attn.q_proj
-    - h.29.attn.k_proj
-    - h.30.attn.q_proj
-    - h.30.attn.k_proj
-    - h.31.attn.q_proj
-    - h.31.attn.k_proj
-    - h.32.attn.q_proj
-    - h.32.attn.k_proj
-    - h.33.attn.q_proj
-    - h.33.attn.k_proj
-    - h.34.attn.q_proj
-    - h.34.attn.k_proj
-    - h.35.attn.q_proj
-    - h.35.attn.k_proj
-  - ranks:
-    - 72
-    - 73
-    - 74
-    - 75
-    - 76
-    - 77
-    - 78
-    - 79
-    - 80
-    - 81
-    - 82
-    - 83
-    - 84
-    - 85
-    - 86
-    - 87
-    - 88
-    - 89
-    - 90
-    - 91
-    - 92
-    - 93
-    - 94
-    - 95
-    owned_sites:
-    - h.36.attn.q_proj
-    - h.36.attn.k_proj
-    - h.37.attn.q_proj
-    - h.37.attn.k_proj
-    - h.38.attn.q_proj
-    - h.38.attn.k_proj
-    - h.39.attn.q_proj
-    - h.39.attn.k_proj
-    - h.40.attn.q_proj
-    - h.40.attn.k_proj
-    - h.41.attn.q_proj
-    - h.41.attn.k_proj
-    - h.42.attn.q_proj
-    - h.42.attn.k_proj
-    - h.43.attn.q_proj
-    - h.43.attn.k_proj
-    - h.44.attn.q_proj
-    - h.44.attn.k_proj
-    - h.45.attn.q_proj
-    - h.45.attn.k_proj
-    - h.46.attn.q_proj
-    - h.46.attn.k_proj
-    - h.47.attn.q_proj
-    - h.47.attn.k_proj

--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -1,5 +1,11 @@
 """LM PD experiment: YAML -> `Trainer` glue + `SavedLMRun` reload + resumption.
 
+Single-pool only — the 3-pool path is its own composition root
+(`experiments.lm.three_pool_run`, entry point `pd-lm-3pool`). This module keeps the
+pure, pool-agnostic builders (`build_target`, `build_lm_loader`, `make_run_batch`,
+`_build_eval_loop`, `_split_metrics_by_slow`, `_resolve_train_run_id`) that both paths
+import.
+
 Both the fresh-run path (`main`) and the reload path (`SavedLMRun`) share the
 module-level `build_target` / `build_lm_loader` / `make_run_batch`. The resume
 path (`main --resume <yaml>`) reads a parent run's `run_meta.yaml` plus
@@ -11,28 +17,16 @@ Run via `pd-lm path/to/config.yaml` (fresh) or `pd-lm --resume path/to/resume.ya
 multi-node for N > 8 — N must then be a multiple of 8). For local DDP, invoke
 directly via
 `torchrun --standalone --nproc_per_node=N -m param_decomp_lab.experiments.lm.run config.yaml`.
-
-Async slow-eval of saved checkpoints lives in
-``param_decomp_lab.experiments.lm.async_eval``; the helper
-:func:`submit_slurm_async_slow_eval` below filters the parent's slow metrics into
-a temp YAML and submits an sbatch job that invokes that module.
 """
 
-import atexit
-import datetime
 import importlib
-import json
 import os
 import shlex
-import sys
-import traceback
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Protocol
 
 import fire
-import torch
-import torch.distributed as dist
 import torch.nn as nn
 from pydantic import Discriminator
 from torch.utils.data import DataLoader
@@ -40,10 +34,11 @@ from torch.utils.data import DataLoader
 from param_decomp.base_config import BaseConfig
 from param_decomp.batch_and_loss_fns import RunBatch
 from param_decomp.component_model import ComponentModel
+from param_decomp.configs import PDConfig
 from param_decomp.distributed import DistributedState, is_main_process
 from param_decomp.log import logger
 from param_decomp.optimize import EvalLoop, Trainer
-from param_decomp.training_state import ThreePoolTrainingState, TrainingState
+from param_decomp.training_state import TrainingState
 from param_decomp_lab.batch_and_loss_fns import make_run_batch as _make_run_batch
 from param_decomp_lab.batch_and_loss_fns import recon_loss_kl
 from param_decomp_lab.component_model_io import load_component_model
@@ -62,6 +57,7 @@ from param_decomp_lab.experiments.lm.data import (
 )
 from param_decomp_lab.experiments.utils import (
     RUN_META_FILENAME,
+    EvalConfig,
     ExperimentConfig,
     init_pd_run,
 )
@@ -69,11 +65,7 @@ from param_decomp_lab.infra.ddp_launch import build_ddp_launch
 from param_decomp_lab.infra.git import create_git_snapshot
 from param_decomp_lab.infra.paths import ModelPath
 from param_decomp_lab.infra.run_files import generate_run_id, resolve_run_files
-from param_decomp_lab.infra.settings import (
-    DEFAULT_PARTITION_NAME,
-    PARAM_DECOMP_OUT_DIR,
-    REPO_ROOT,
-)
+from param_decomp_lab.infra.settings import DEFAULT_PARTITION_NAME, REPO_ROOT
 from param_decomp_lab.infra.slurm import SlurmConfig, generate_script, submit_slurm_job
 from param_decomp_lab.infra.wandb import get_wandb_entity, parse_wandb_run_path
 from param_decomp_lab.resumption import (
@@ -81,11 +73,9 @@ from param_decomp_lab.resumption import (
     ResumeProvenance,
     read_training_snapshot,
     resolve_step,
-    write_provenance,
 )
-from param_decomp_lab.run_sink import OnePoolSink, ThreePoolSink
+from param_decomp_lab.run_sink import OnePoolSink
 from param_decomp_lab.seed import set_seed
-from param_decomp_lab.three_pool import ThreePoolConfig, ThreePoolTrainer
 
 
 def _resolve_class(fqn: str) -> type:
@@ -152,10 +142,7 @@ class LMTargetConfig(BaseConfig):
 
 
 class LMExperimentConfig(ExperimentConfig[LMTargetConfig, LMDataConfig]):
-    three_pool: ThreePoolConfig | None = None
-    """When set, training runs under the 3-pool strategy
-    (:class:`param_decomp_lab.three_pool.ThreePoolTrainer`) instead of single-process
-    :class:`param_decomp.optimize.Trainer`."""
+    pass
 
 
 def build_target(target_cfg: LMTargetConfig) -> nn.Module:
@@ -268,8 +255,9 @@ def main(
     Args:
         config_path: YAML for a fresh run. Required when not resuming.
         resume: Path to a `ResumeConfig` YAML pointing at a prior run. When set,
-            the parent's `run_meta.yaml` is the source of cfg truth; a new
-            `run_id` + sibling `resume_provenance.yaml` are written.
+            the parent's `run_meta.yaml` is the source of cfg truth; a new `run_id` is
+            allocated and `resume_provenance` (parent dir + step) is stamped onto the
+            effective config so it lands in `run_meta.yaml` + `wandb.config`.
         group / tags: wandb-only (no-ops without `wandb:`).
         dp / partition / time / job_name / no_snapshot / run_id: SLURM submission
             knobs. Passing `--dp N` outside torchrun submits a SLURM job: single-node
@@ -303,168 +291,6 @@ def main(
         _fresh_main(Path(config_path), group=group, tags=tags, run_id=run_id)
 
 
-def _agree_on_run_id_three_pool(run_id: str | None, dist_state: DistributedState | None) -> str:
-    """Broadcast (or generate-then-broadcast) a single run id across all ranks.
-
-    3-pool snapshot uses a file-based gather under
-    ``PARAM_DECOMP_OUT_DIR/decompositions/<run_id>/.snapshot_scratch/``; every
-    rank must compute the same path.
-    """
-    if is_main_process() and run_id is None:
-        run_id = generate_run_id("param_decomp")
-    if dist_state is not None:
-        objs: list[str | None] = [run_id]
-        dist.broadcast_object_list(objs, src=0)
-        run_id = objs[0]
-    assert run_id is not None
-    return run_id
-
-
-def _install_first_fail_marker(rank: int) -> None:
-    """On uncaught exception, write a structured marker to shared FS so a
-    debugger can identify which rank died and what hit it without grepping
-    through GB of NCCL log noise across N ranks. Always-on; cost is one
-    excepthook registration.
-
-    Writes ``$HOME/pd_first_fail/$SLURM_JOB_ID/rank<R>.json`` containing
-    ``{rank, exception_type, exception_message, traceback, timestamp_utc,
-    pid}``. Chains to the previous excepthook so behavior is otherwise
-    unchanged.
-
-    Open follow-up (#11 in the task list): once any rank writes its marker,
-    the rest of the world will block in their next collective for up to
-    30 min before monitoredBarrier times out. A future change should
-    ``dist.destroy_process_group()`` + ``os._exit(1)`` here so siblings
-    fast-fail in seconds via ``TORCH_NCCL_ASYNC_ERROR_HANDLING``. Skipped
-    for now because doing that wrong can hang siblings *worse*.
-    """
-    job_id = os.environ.get("SLURM_JOB_ID", "local")
-    out_dir = Path.home() / "pd_first_fail" / job_id
-    out_dir.mkdir(parents=True, exist_ok=True)
-    out_path = out_dir / f"rank{rank}.json"
-
-    prev_excepthook = sys.excepthook
-
-    def _excepthook(exctype: type[BaseException], value: BaseException, tb: Any) -> None:
-        try:
-            payload = {
-                "rank": rank,
-                "exception_type": exctype.__name__,
-                "exception_message": str(value),
-                "traceback": "".join(traceback.format_exception(exctype, value, tb)),
-                "timestamp_utc": datetime.datetime.now(datetime.UTC).isoformat(),
-                "pid": os.getpid(),
-            }
-            out_path.write_text(json.dumps(payload, indent=2))
-            print(f"[first-fail] rank={rank} wrote {out_path}", file=sys.stderr, flush=True)
-        except Exception as e:
-            print(f"[first-fail] failed to write marker: {e}", file=sys.stderr, flush=True)
-        prev_excepthook(exctype, value, tb)
-
-    sys.excepthook = _excepthook
-
-
-def _maybe_enable_memory_profile(rank: int) -> None:
-    """Opt-in CUDA memory-history recorder for offline ``memory_viz`` analysis.
-
-    Activated by env vars:
-      * ``PD_MEMORY_PROFILE_RANKS=0,32,96`` — comma-separated ranks to profile.
-      * ``PD_MEMORY_PROFILE_OUT=/abs/path/to/dir`` — dump directory.
-
-    Dumps to ``<dir>/mem_rank<R>.pickle`` on normal exit and on uncaught
-    exception. Load the pickle at https://pytorch.org/memory_viz.
-    """
-    prof_ranks_env = os.environ.get("PD_MEMORY_PROFILE_RANKS")
-    if not prof_ranks_env:
-        return
-    if rank not in {int(r) for r in prof_ranks_env.split(",") if r.strip()}:
-        return
-    out_dir = Path(os.environ["PD_MEMORY_PROFILE_OUT"])
-    out_dir.mkdir(parents=True, exist_ok=True)
-    out_path = out_dir / f"mem_rank{rank}.pickle"
-    logger.info(f"[mem-profile] recording rank={rank} → {out_path}")
-    torch.cuda.memory._record_memory_history(max_entries=200_000)
-
-    def _dump() -> None:
-        torch.cuda.memory._dump_snapshot(str(out_path))
-        logger.info(f"[mem-profile] dumped rank={rank} → {out_path}")
-
-    atexit.register(_dump)
-    prev_excepthook = sys.excepthook
-
-    def _excepthook(exctype: type[BaseException], value: BaseException, tb: Any) -> None:
-        _dump()
-        prev_excepthook(exctype, value, tb)
-
-    sys.excepthook = _excepthook
-
-
-def _maybe_build_torch_profiler(trainer: ThreePoolTrainer) -> torch.profiler.profile | None:
-    """Opt-in ``torch.profiler.profile`` for the listed ranks.
-
-    Activated by env vars:
-      * ``PD_TORCH_PROFILE_RANKS=0,96,100`` — ranks to profile. Typically one
-        per pool (LW block-0 leader, CI leader, PPGD leader).
-      * ``PD_TORCH_PROFILE_OUT=/abs/path/to/dir`` — trace dump directory.
-      * ``PD_TORCH_PROFILE_SKIP_FIRST`` (default 20) and
-        ``PD_TORCH_PROFILE_ACTIVE`` (default 3) — schedule knobs.
-      * ``PD_TORCH_PROFILE_MEMORY=0`` — disable profile_memory (CUPTI memory
-        instrumentation is the heaviest subsystem; toggle if you suspect
-        it's confounding measurements).
-      * ``PD_TORCH_PROFILE_STACK=1`` — Python source location per op
-        (~25% step-time hit, much larger traces, but huge readability win).
-      * ``PD_TORCH_PROFILE_MODULES=1`` — nn.Module hierarchy labels (cheap;
-        useful for per-site decomposition labels).
-      * ``PD_TORCH_PROFILE_SHAPES=1`` — per-op input tensor shapes.
-
-    Returns the profile context (caller passes it to ``trainer.run(profiler=
-    ...)`` which enters it) or ``None`` if this rank isn't profiled.
-
-    Verified at production scale (104 ranks, gpt2-xl, 3 profiled ranks one
-    per pool) on 2026-05-28 after commit 497e1542 removed a cosmetic pre-step
-    barrier that was the previously-suspected CUPTI deadlock.
-    """
-    prof_ranks_env = os.environ.get("PD_TORCH_PROFILE_RANKS", "").strip()
-    if not prof_ranks_env:
-        return None
-    prof_ranks = {int(r) for r in prof_ranks_env.split(",") if r.strip()}
-    my_rank = trainer.ctx.role.rank
-    if my_rank not in prof_ranks:
-        return None
-    out_dir = Path(os.environ["PD_TORCH_PROFILE_OUT"])
-    out_dir.mkdir(parents=True, exist_ok=True)
-    skip_first = int(os.environ.get("PD_TORCH_PROFILE_SKIP_FIRST", "20"))
-    active = int(os.environ.get("PD_TORCH_PROFILE_ACTIVE", "3"))
-    profile_memory = os.environ.get("PD_TORCH_PROFILE_MEMORY", "1") != "0"
-    with_stack = os.environ.get("PD_TORCH_PROFILE_STACK", "0") == "1"
-    with_modules = os.environ.get("PD_TORCH_PROFILE_MODULES", "0") == "1"
-    record_shapes = os.environ.get("PD_TORCH_PROFILE_SHAPES", "0") == "1"
-
-    pool = trainer.ctx.kind
-    trace_path = out_dir / f"trace_{pool}_rank{my_rank}.json"
-    logger.info(
-        f"[torch-profile] rank={my_rank} pool={pool} → {trace_path} "
-        f"(skip_first={skip_first}, active={active}, profile_memory={profile_memory}, "
-        f"with_stack={with_stack}, with_modules={with_modules}, record_shapes={record_shapes})"
-    )
-
-    def on_trace_ready(prof: torch.profiler.profile) -> None:
-        prof.export_chrome_trace(str(trace_path))
-        logger.info(f"[torch-profile] rank={my_rank} wrote {trace_path}")
-
-    return torch.profiler.profile(
-        activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA],
-        schedule=torch.profiler.schedule(
-            skip_first=skip_first, wait=0, warmup=1, active=active, repeat=1
-        ),
-        on_trace_ready=on_trace_ready,
-        record_shapes=record_shapes,
-        profile_memory=profile_memory,
-        with_stack=with_stack,
-        with_modules=with_modules,
-    )
-
-
 def _fresh_main(
     config_path: Path,
     *,
@@ -472,14 +298,12 @@ def _fresh_main(
     tags: str | None,
     run_id: str | None,
 ) -> None:
-    """Fresh-run path: parse YAML, dispatch on pool config, train from step 0."""
+    """Fresh-run path: parse YAML, build everything, train from step 0."""
     cfg = LMExperimentConfig.from_file(config_path)
 
     dist_state = init_distributed()
     if is_main_process():
         logger.info(f"Distributed state: {dist_state}")
-    _install_first_fail_marker(dist_state.rank if dist_state is not None else 0)
-    _maybe_enable_memory_profile(dist_state.rank if dist_state is not None else 0)
     set_seed(cfg.pd.seed)
     device = get_device()
     cfg = cfg.model_copy(
@@ -494,57 +318,17 @@ def _fresh_main(
     )
 
     target_model = build_target(cfg.target)
-    is_three_pool = cfg.three_pool is not None
     train_loader = build_lm_loader(
         cfg.target,
         cfg.data,
         split="train",
         device=device,
         batch_size=cfg.pd.batch_size,
-        # 3-pool requires the full global batch on every rank — each pool
-        # slices it locally. Single-pool uses standard DistributedSampler.
-        dist_state=None if is_three_pool else dist_state,
+        dist_state=dist_state,
         seed=cfg.pd.seed,
     )
 
-    if cfg.three_pool is not None:
-        run_id = _agree_on_run_id_three_pool(run_id, dist_state)
-        out_dir = PARAM_DECOMP_OUT_DIR / "decompositions" / run_id
-        scratch_dir = out_dir / ".snapshot_scratch"
-        three_sink = init_pd_run(
-            cfg,
-            sink_class=ThreePoolSink,
-            group=group,
-            tags=tags,
-            run_id=run_id,
-            on_save=lambda step: submit_slurm_async_slow_eval(out_dir, step=step, parent_cfg=cfg),
-        )
-        # Multi-pool eval mirrors the train data-handling contract: full eval
-        # batch on every rank, sliced internally by each pool. So we pass
-        # dist_state=None.
-        three_eval_loop = _build_eval_loop(cfg, device, dist_state=None)
-        try:
-            three_trainer = ThreePoolTrainer(
-                target_model=target_model,
-                run_batch=make_run_batch(cfg.target),
-                reconstruction_loss=recon_loss_kl,
-                pd_config=cfg.pd,
-                runtime_config=cfg.runtime,
-                three_pool_config=cfg.three_pool,
-            )
-            three_trainer.run(
-                train_loader,
-                three_sink,
-                cfg.cadence,
-                scratch_dir=scratch_dir,
-                eval_loop=three_eval_loop,
-                profiler=_maybe_build_torch_profiler(three_trainer),
-            )
-        finally:
-            three_sink.finish()
-        return
-
-    one_sink = init_pd_run(cfg, sink_class=OnePoolSink, group=group, tags=tags, run_id=run_id)
+    sink = init_pd_run(cfg, sink_class=OnePoolSink, group=group, tags=tags, run_id=run_id)
     eval_loop = _build_eval_loop(cfg, device, dist_state)
     try:
         trainer = Trainer(
@@ -554,9 +338,9 @@ def _fresh_main(
             pd_config=cfg.pd,
             runtime_config=cfg.runtime,
         )
-        trainer.run(train_loader, one_sink, cfg.cadence, eval_loop)
+        trainer.run(train_loader, sink, cfg.cadence, eval_loop)
     finally:
-        one_sink.finish()
+        sink.finish()
 
 
 def _resume_main(
@@ -575,11 +359,10 @@ def _resume_main(
     if is_main_process():
         logger.info(f"Distributed state: {dist_state}")
         logger.info(f"Resuming from {resume_cfg.from_run} @ step {resume_cfg.step}")
-    _install_first_fail_marker(dist_state.rank if dist_state is not None else 0)
-    _maybe_enable_memory_profile(dist_state.rank if dist_state is not None else 0)
     set_seed(parent_cfg.pd.seed)
     device = get_device()
 
+    resolved_step = resolve_step(resume_cfg.from_run, resume_cfg.step)
     effective_cfg = parent_cfg.model_copy(
         update={
             "runtime": parent_cfg.runtime.model_copy(
@@ -588,90 +371,42 @@ def _resume_main(
                     "dp": dist_state.world_size if dist_state is not None else None,
                 }
             ),
+            "resume_provenance": ResumeProvenance(
+                parent_run_dir=resume_cfg.from_run, parent_step=resolved_step
+            ),
         }
     )
 
-    resolved_step = resolve_step(resume_cfg.from_run, resume_cfg.step)
     snapshot = read_training_snapshot(resume_cfg.from_run, resolved_step)
+    assert isinstance(snapshot, TrainingState), (
+        f"1-pool resume needs TrainingState; got {type(snapshot).__name__}"
+    )
     snapshot.runtime_config["device"] = device
 
     target_model = build_target(effective_cfg.target)
-    is_three_pool = effective_cfg.three_pool is not None
     train_loader = build_lm_loader(
         effective_cfg.target,
         effective_cfg.data,
         split="train",
         device=device,
         batch_size=effective_cfg.pd.batch_size,
-        dist_state=None if is_three_pool else dist_state,
+        dist_state=dist_state,
         seed=effective_cfg.pd.seed,
     )
     run_batch = make_run_batch(effective_cfg.target)
 
-    if effective_cfg.three_pool is not None:
-        run_id = _agree_on_run_id_three_pool(run_id, dist_state)
-        out_dir = PARAM_DECOMP_OUT_DIR / "decompositions" / run_id
-        scratch_dir = out_dir / ".snapshot_scratch"
-        three_sink = init_pd_run(
-            effective_cfg,
-            sink_class=ThreePoolSink,
-            group=group,
-            tags=tags,
-            run_id=run_id,
-            on_save=lambda step: submit_slurm_async_slow_eval(
-                out_dir, step=step, parent_cfg=effective_cfg
-            ),
-        )
-        if three_sink.out_dir is not None:
-            write_provenance(
-                three_sink.out_dir,
-                ResumeProvenance(parent_run_dir=resume_cfg.from_run, parent_step=resolved_step),
-            )
-        three_eval_loop = _build_eval_loop(effective_cfg, device, dist_state=None)
-        try:
-            assert isinstance(snapshot, ThreePoolTrainingState), (
-                f"3-pool resume needs ThreePoolTrainingState; got {type(snapshot).__name__}"
-            )
-            three_trainer = ThreePoolTrainer.from_snapshot(
-                snapshot,
-                target_model=target_model,
-                run_batch=run_batch,
-                reconstruction_loss=recon_loss_kl,
-            )
-            three_trainer.run(
-                train_loader,
-                three_sink,
-                effective_cfg.cadence,
-                scratch_dir=scratch_dir,
-                eval_loop=three_eval_loop,
-                profiler=_maybe_build_torch_profiler(three_trainer),
-            )
-        finally:
-            three_sink.finish()
-        return
-
-    one_sink = init_pd_run(
-        effective_cfg, sink_class=OnePoolSink, group=group, tags=tags, run_id=run_id
-    )
-    if one_sink.out_dir is not None:
-        write_provenance(
-            one_sink.out_dir,
-            ResumeProvenance(parent_run_dir=resume_cfg.from_run, parent_step=resolved_step),
-        )
+    sink = init_pd_run(effective_cfg, sink_class=OnePoolSink, group=group, tags=tags, run_id=run_id)
     eval_loop = _build_eval_loop(effective_cfg, device, dist_state)
     try:
-        assert isinstance(snapshot, TrainingState), (
-            f"1-pool resume needs TrainingState; got {type(snapshot).__name__}"
-        )
         trainer = Trainer.from_snapshot(
             snapshot,
             target_model=target_model,
             run_batch=run_batch,
             reconstruction_loss=recon_loss_kl,
         )
-        trainer.run(train_loader, one_sink, effective_cfg.cadence, eval_loop)
+        trainer.run(train_loader, sink, effective_cfg.cadence, eval_loop)
     finally:
-        one_sink.finish()
+        sink.finish()
 
 
 def _split_metrics_by_slow(
@@ -695,8 +430,11 @@ def _split_metrics_by_slow(
     return slow_metrics, fast_metrics
 
 
-def _resolve_train_run_id(run_path: str | Path) -> str:
+def _resolve_train_run_id(run_path: str | Path) -> str:  # pyright: ignore[reportUnusedFunction]
     """Extract the parent run id from a `SavedLMRun.from_path`-compatible reference.
+
+    Shared helper imported by `experiments.lm.async_eval` and
+    `experiments.lm.three_pool_run` (basedpyright can't see the cross-module uses).
 
     Accepts wandb URL / `entity/project/runId` / bare `p-xxxxxxxx` / local directory
     whose final name is the run id (i.e. `PARAM_DECOMP_OUT_DIR/decompositions/<run_id>/`).
@@ -711,8 +449,25 @@ def _resolve_train_run_id(run_path: str | Path) -> str:
     return (p if p.is_dir() else p.parent).name
 
 
+class _EvalLoopInputs(Protocol):
+    """The slice of an experiment config `_build_eval_loop` reads.
+
+    Lets the single-pool `LMExperimentConfig` and the 3-pool
+    `ThreePoolLMExperimentConfig` share one eval-loop builder without a common base.
+    """
+
+    @property
+    def eval(self) -> EvalConfig | None: ...
+    @property
+    def target(self) -> LMTargetConfig: ...
+    @property
+    def data(self) -> LMDataConfig: ...
+    @property
+    def pd(self) -> PDConfig: ...
+
+
 def _build_eval_loop(
-    cfg: LMExperimentConfig,
+    cfg: _EvalLoopInputs,
     device: str,
     dist_state: DistributedState | None,
 ) -> EvalLoop | None:
@@ -721,7 +476,7 @@ def _build_eval_loop(
     Slow metrics (class-attr ``slow=True``) are filtered out — in-train eval is
     fast-only. Slow metrics are picked up later by the async eval-only job (which
     receives the slow subset via a temp ``EvalConfig`` YAML, see
-    :func:`_submit_slurm_async_slow_eval`).
+    ``submit_slurm_async_slow_eval`` in ``experiments.lm.three_pool_run``).
     """
     if cfg.eval is None:
         return None
@@ -832,96 +587,6 @@ def _wandb_url_for_config(config_path: str | Path, run_id: str) -> str | None:
         return None
     entity = cfg.wandb.entity or get_wandb_entity()
     return f"https://wandb.ai/{entity}/{cfg.wandb.project}/runs/{run_id}"
-
-
-def submit_slurm_async_slow_eval(
-    run_path: str | Path,
-    *,
-    step: int,
-    parent_cfg: "LMExperimentConfig",
-    dp: int = 8,
-    time: str = "2:00:00",
-    partition: str | None = DEFAULT_PARTITION_NAME,
-    job_name: str = "pd-lm-eval-slow",
-    group: str | None = None,
-    tags: str | None = None,
-    no_snapshot: bool = False,
-) -> None:
-    """Filter the parent's slow eval metrics into a temp YAML, submit a SLURM job.
-
-    Called from training right after a save: emits an async SLURM job that runs
-    *only* the slow metrics against ``model_<step>.pth`` via
-    ``python -m param_decomp_lab.experiments.lm.async_eval``, logging into the
-    parent's wandb run at the same step. No-op when the parent has no eval block
-    or no slow metrics.
-    """
-    from param_decomp_lab.experiments.utils import EvalConfig
-
-    if parent_cfg.eval is None:
-        return
-    slow_metrics, _fast = _split_metrics_by_slow(parent_cfg.eval.metrics)
-    if not slow_metrics:
-        return
-
-    slow_eval_cfg = EvalConfig(
-        batch_size=parent_cfg.eval.batch_size,
-        n_steps=parent_cfg.eval.n_steps,
-        every=parent_cfg.eval.every,
-        slow_every=parent_cfg.eval.every,  # any value; not consumed by async_eval
-        slow_on_first_step=True,
-        metrics=slow_metrics,
-    )
-    train_run_id = _resolve_train_run_id(run_path)
-    scratch = PARAM_DECOMP_OUT_DIR / "decompositions" / train_run_id / ".async_eval_configs"
-    scratch.mkdir(parents=True, exist_ok=True)
-    cfg_path = scratch / f"slow_eval_step_{step}.yaml"
-    slow_eval_cfg.to_file(cfg_path)
-
-    # Reuse the training run's snapshot ref. The training was launched from
-    # $HOME/param-decomp and the snapshot already exists there. Creating a new
-    # snapshot here would operate on whatever git repo this process happens to
-    # be in — when called from inside a training job, that's the node-local
-    # /tmp/.../workspace-* clone, which other nodes can't see. Plus, async eval
-    # should run the same code as the training that produced the checkpoint.
-    eval_run_id = generate_run_id("param_decomp")
-    snapshot_ref: str | None = f"refs/runs/snapshot/{train_run_id}" if not no_snapshot else None
-
-    base_command = shlex.join(
-        [
-            "-m",
-            "param_decomp_lab.experiments.lm.async_eval",
-            "--run",
-            str(run_path),
-            "--step",
-            str(step),
-            "--eval-config",
-            str(cfg_path),
-            *(["--group", group] if group is not None else []),
-            *(["--tags", tags] if tags is not None else []),
-        ]
-    )
-    launch = build_ddp_launch(
-        base_command,
-        dp=dp,
-        job_name=job_name,
-        snapshot_ref=snapshot_ref,
-        port_seed=eval_run_id,
-    )
-    slurm_config = SlurmConfig(
-        job_name=job_name,
-        partition=partition,
-        n_gpus=launch.gpus_per_node,
-        n_nodes=launch.n_nodes,
-        time=time,
-        snapshot_ref=snapshot_ref,
-        comment=f"async-slow-eval:{train_run_id}@{step}",
-    )
-    script = generate_script(slurm_config, launch.command, env=launch.env)
-    result = submit_slurm_job(script, "lm")
-    logger.info(
-        f"Async slow-eval submitted: parent={train_run_id} step={step} "
-        f"job_id={result.job_id} log={result.log_pattern}"
-    )
 
 
 def cli() -> None:

--- a/param_decomp_lab/experiments/lm/three_pool_pd.py
+++ b/param_decomp_lab/experiments/lm/three_pool_pd.py
@@ -1,0 +1,117 @@
+"""3-pool-constrained `PDConfig` subclass + the typed `ThreePoolLosses` struct.
+
+The 3-pool training path implements exactly one algorithm: continuous sampling, a
+single stochastic mask, a delta component, no identity ops, and exactly the four
+loss terms (faithfulness, importance-minimality, layerwise stoch recon, persistent
+PGD recon). On the generic `PDConfig` those facts were enforced by ~60 lines of
+runtime asserts inside `ThreePoolTrainer.__init__`
+(`_validate_pd_config_for_three_pool`), firing only after a multi-node launch
+reached construction.
+
+`ThreePoolConstrainedPDConfig` lifts those into the type: the fixed scalars become
+frozen `Literal` defaults, and `loss_metrics` (a generic ordered list) is replaced
+by the `ThreePoolLosses(faith, imp, stoch, ppgd)` struct so "exactly these four,
+each with a coeff" is unrepresentable-if-wrong. A `model_validator` derives the
+inherited `loss_metrics` list from the struct so everything that still consumes a
+`list[AnyLossMetricConfig]` (`ComponentModel` wiring, `validate_pgd_scope`,
+snapshot serialization, eval) keeps working unchanged.
+
+The residual cross-field checks (batch divisibility, rank-0 convention, site
+coverage) that couple `pd` to the topology live on `ThreePoolLMExperimentConfig`
+(see `three_pool_run.py`), since only there are both `pd` and `runtime.topology`
+visible at load time.
+"""
+
+from typing import Any, Literal, Self
+
+from pydantic import Field, model_validator
+
+from param_decomp.base_config import BaseConfig
+from param_decomp.configs import AnyLossMetricConfig, PDConfig
+from param_decomp.metrics.faithfulness import FaithfulnessLossConfig
+from param_decomp.metrics.importance_minimality import ImportanceMinimalityLossConfig
+from param_decomp.metrics.persistent_pgd_recon import PersistentPGDReconLossConfig
+from param_decomp.metrics.stochastic_recon_layerwise import StochasticReconLayerwiseLossConfig
+
+
+class ThreePoolLosses(BaseConfig):
+    """The exactly-these-four loss set the 3-pool path implements.
+
+    Replaces `PDConfig.loss_metrics`'s generic `list[AnyLossMetricConfig]` so a
+    missing / extra / wrong-typed loss is a parse error, not a runtime assert. Each
+    field carries the metric's own params (`imp.pnorm`/`beta`, `ppgd.optimizer`/
+    `scope`/`n_warmup_steps`, …) plus its `coeff`. The trainer reads
+    `pd.losses.faith` / `.imp` / `.stoch` / `.ppgd` directly — no `by_type` dict, no
+    `isinstance` narrowing.
+    """
+
+    faith: FaithfulnessLossConfig
+    imp: ImportanceMinimalityLossConfig
+    stoch: StochasticReconLayerwiseLossConfig
+    ppgd: PersistentPGDReconLossConfig
+
+    @model_validator(mode="after")
+    def validate_coeffs_present(self) -> Self:
+        for name, cfg in (
+            ("faith", self.faith),
+            ("imp", self.imp),
+            ("stoch", self.stoch),
+            ("ppgd", self.ppgd),
+        ):
+            assert cfg.coeff is not None, f"losses.{name}.coeff is required for 3-pool training"
+        assert self.ppgd.start_frac == 0.0, (
+            "3-pool path does not implement PersistentPGDReconLoss.start_frac > 0; "
+            "PPGD always runs from step 0."
+        )
+        return self
+
+
+class ThreePoolConstrainedPDConfig(PDConfig):
+    """`PDConfig` narrowed to what the 3-pool path can honour.
+
+    Substitutable for `PDConfig` everywhere (`ThreePoolTrainer`, `load_component_model`
+    consume inherited fields), but the fixed scalars are frozen `Literal` defaults and
+    the loss set is the typed `ThreePoolLosses` struct. The inherited `loss_metrics`
+    list is derived from `losses` so list-consuming code keeps working.
+    """
+
+    # These narrow inherited `PDConfig` fields to the single value the 3-pool path
+    # honours. basedpyright flags the narrowing as an incompatible variable override
+    # (pydantic class attrs read as mutable/invariant); the narrowing is the point.
+    sampling: Literal["continuous"] = "continuous"  # pyright: ignore[reportIncompatibleVariableOverride]
+    n_mask_samples: Literal[1] = 1  # pyright: ignore[reportIncompatibleVariableOverride]
+    use_delta_component: Literal[True] = True  # pyright: ignore[reportIncompatibleVariableOverride]
+    identity_decomposition_targets: None = None  # pyright: ignore[reportIncompatibleVariableOverride]
+
+    losses: ThreePoolLosses
+
+    # Derived from `losses` (see `derive_loss_metrics`); excluded from serialization
+    # so a round-trip through `model_dump()` re-derives it rather than re-supplying it.
+    loss_metrics: list[AnyLossMetricConfig] = Field(default_factory=list, exclude=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def derive_loss_metrics(cls, data: Any) -> Any:
+        # `loss_metrics` is the inherited generic list consumed by ComponentModel
+        # wiring, validate_pgd_scope, snapshot serialization, and eval. It's not
+        # authored on this config (the struct is) — derive it from `losses` in the
+        # canonical order before field validation, so the parent's
+        # `validate_loss_metrics_have_coeff` (which runs on the populated list) and
+        # downstream list consumers both see the four metrics. Authoring
+        # `loss_metrics` directly is rejected — the struct is the single source.
+        if not isinstance(data, dict):
+            return data
+        assert "loss_metrics" not in data, (
+            "ThreePoolConstrainedPDConfig derives `loss_metrics` from `losses`; "
+            "do not author `loss_metrics` directly."
+        )
+        assert "losses" in data, "ThreePoolConstrainedPDConfig requires a `losses` block"
+        losses = ThreePoolLosses.model_validate(data["losses"])
+        data = dict(data)
+        data["loss_metrics"] = [
+            losses.faith.model_dump(),
+            losses.imp.model_dump(),
+            losses.stoch.model_dump(),
+            losses.ppgd.model_dump(),
+        ]
+        return data

--- a/param_decomp_lab/experiments/lm/three_pool_run.py
+++ b/param_decomp_lab/experiments/lm/three_pool_run.py
@@ -1,0 +1,699 @@
+"""3-pool LM PD experiment: YAML -> `ThreePoolTrainer` glue + reload + resumption.
+
+The 3-pool sibling of `experiments.lm.run`. Its config — `ThreePoolLMExperimentConfig`
+— bakes the 3-pool's constraints into the types (`ThreePoolConstrainedPDConfig`'s fixed
+scalars + typed `ThreePoolLosses` struct; `ThreePoolRuntimeConfig`'s authored
+`topology`), so misconfigurations fail at YAML parse on the login node rather than
+minutes into a multi-node launch.
+
+Dispatch is by entry point, not a discriminator: `pd-lm-3pool` selects this composition
+root (single-pool `pd-lm` -> `experiments.lm.run`), matching the repo's per-experiment
+idiom. The pure, pool-agnostic builders (`build_target`, `build_lm_loader`,
+`make_run_batch`, `_build_eval_loop`, `_split_metrics_by_slow`, `_resolve_train_run_id`)
+are imported from `experiments.lm.run` — only the 3-pool-specific scaffolding (full-batch
+loader, run-id agreement, `ThreePoolSink`, scratch dir, profiler / mem-profile /
+first-fail debug hooks, async slow-eval) lives here.
+
+Run via `pd-lm-3pool path/to/config.yaml` (fresh) or
+`pd-lm-3pool --resume path/to/resume.yaml` (resume). Pass `--dp N` to submit a DDP SLURM
+job (single-node for N <= 8, multi-node for N > 8 — N must then be a multiple of 8). For
+local DDP, invoke directly via
+`torchrun --standalone --nproc_per_node=N -m param_decomp_lab.experiments.lm.three_pool_run config.yaml`.
+"""
+
+import atexit
+import datetime
+import json
+import os
+import shlex
+import sys
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Self
+
+import fire
+import torch
+import torch.distributed as dist
+import torch.profiler
+from pydantic import model_validator
+
+from param_decomp.base_config import BaseConfig
+from param_decomp.component_model import ComponentModel
+from param_decomp.configs import Cadence, RuntimeConfig
+from param_decomp.distributed import DistributedState, is_main_process
+from param_decomp.log import logger
+from param_decomp.training_state import ThreePoolTrainingState
+from param_decomp_lab.batch_and_loss_fns import recon_loss_kl
+from param_decomp_lab.component_model_io import load_component_model
+from param_decomp_lab.distributed import (
+    get_device,
+    init_distributed,
+    with_distributed_cleanup,
+)
+from param_decomp_lab.experiments.lm.data import LMDataConfig
+from param_decomp_lab.experiments.lm.run import (
+    LMTargetConfig,
+    _build_eval_loop,
+    _resolve_train_run_id,
+    _split_metrics_by_slow,
+    build_lm_loader,
+    build_target,
+    make_run_batch,
+)
+from param_decomp_lab.experiments.lm.three_pool_pd import ThreePoolConstrainedPDConfig
+from param_decomp_lab.experiments.utils import (
+    RUN_META_FILENAME,
+    EvalConfig,
+    WandbConfig,
+    init_pd_run,
+)
+from param_decomp_lab.infra.ddp_launch import build_ddp_launch
+from param_decomp_lab.infra.git import create_git_snapshot
+from param_decomp_lab.infra.paths import ModelPath
+from param_decomp_lab.infra.run_files import generate_run_id, resolve_run_files
+from param_decomp_lab.infra.settings import (
+    DEFAULT_PARTITION_NAME,
+    PARAM_DECOMP_OUT_DIR,
+    REPO_ROOT,
+)
+from param_decomp_lab.infra.slurm import SlurmConfig, generate_script, submit_slurm_job
+from param_decomp_lab.infra.wandb import get_wandb_entity
+from param_decomp_lab.resumption import (
+    ResumeConfig,
+    ResumeProvenance,
+    read_training_snapshot,
+    resolve_step,
+)
+from param_decomp_lab.run_sink import ThreePoolSink
+from param_decomp_lab.seed import set_seed
+from param_decomp_lab.three_pool import ThreePoolConfig, ThreePoolTrainer
+
+
+class ThreePoolRuntimeConfig(RuntimeConfig):
+    """Core's substrate scalars (`autocast_bf16` / `device` / `dp`) + the authored
+    rank->pool `topology`.
+
+    Subclasses `RuntimeConfig` so it's substitutable wherever a `RuntimeConfig` is
+    expected (`ThreePoolTrainer.__init__`, snapshot serialization) and reuses the three
+    scalars rather than duplicating them. `dp` is the launch-derived world readout
+    (overwritten from the torchrun world at launch); `topology` is the authored rank
+    assignment that pairs with `ThreePoolConstrainedPDConfig`. Core's `RuntimeConfig`
+    itself stays pool-blind — the topology is added only here, in lab.
+    """
+
+    topology: ThreePoolConfig
+
+
+class ThreePoolLMExperimentConfig(BaseConfig):
+    """Full YAML schema for a 3-pool LM PD run. Standalone sibling of
+    `LMExperimentConfig` (not a variant of it).
+
+    The cross-field checks that couple `pd` to `runtime.topology` (batch divisibility,
+    rank-0 convention, site coverage) run here at load time — the only place both are
+    visible — so they fail at parse rather than inside `ThreePoolTrainer.__init__`.
+    """
+
+    pd: ThreePoolConstrainedPDConfig
+    runtime: ThreePoolRuntimeConfig
+    cadence: Cadence
+    target: LMTargetConfig
+    data: LMDataConfig
+    eval: EvalConfig | None = None
+    wandb: WandbConfig | None = None
+    resume_provenance: ResumeProvenance | None = None
+    """Set on resumed runs (parent run dir + step); `None` for fresh runs. Lives on the
+    config so it flows into `run_meta.yaml` and `wandb.config` via `init_pd_run`, making a
+    resumed run's lineage visible in the wandb UI."""
+
+    @model_validator(mode="after")
+    def validate_pd_against_topology(self) -> Self:
+        topology = self.runtime.topology
+        n_per_block = len(topology.layerwise_block_groups[0].ranks)
+        n_ci = len(topology.ci_ranks)
+        n_ppgd = len(topology.ppgd_ranks)
+        bs = self.pd.batch_size
+        assert bs % n_per_block == 0, (
+            f"pd.batch_size ({bs}) must be divisible by N_per_block ({n_per_block}) "
+            f"= len(topology.layerwise_block_groups[0].ranks)"
+        )
+        assert bs % n_ci == 0, (
+            f"pd.batch_size ({bs}) must be divisible by N_ci ({n_ci}) = len(topology.ci_ranks)"
+        )
+        assert bs % n_ppgd == 0, (
+            f"pd.batch_size ({bs}) must be divisible by N_ppgd ({n_ppgd}) "
+            f"= len(topology.ppgd_ranks)"
+        )
+        assert topology.layerwise_block_groups[0].ranks[0] == 0, (
+            "Convention: rank 0 must be the LW pool's block 0 leader (so reductions can "
+            "ship CI/PPGD pool losses to rank 0). Reorder layerwise_block_groups so the "
+            "first group starts with rank 0."
+        )
+        # Site coverage (every LW-owned site is in decomposition_targets after pattern
+        # expansion) needs the loaded target model and stays in `_build_runtime`.
+        return self
+
+
+@dataclass(frozen=True)
+class SavedThreePoolLMRun:
+    """Handle to a completed 3-pool LM PD run on disk or in W&B.
+
+    Sibling of `SavedLMRun` for the 3-pool config type. `load_model` consumes only
+    inherited `PDConfig` fields, so inference / inspection of a 3-pool decomposition
+    works identically to a single-pool one.
+    """
+
+    cfg: ThreePoolLMExperimentConfig
+    checkpoint_path: Path
+
+    @classmethod
+    def from_path(cls, path: ModelPath) -> "SavedThreePoolLMRun":
+        files = resolve_run_files(
+            path, config_filename=RUN_META_FILENAME, checkpoint_prefix="model"
+        )
+        return cls(
+            cfg=ThreePoolLMExperimentConfig.from_file(files.config_path),
+            checkpoint_path=files.checkpoint_path,
+        )
+
+    def load_model(self) -> ComponentModel:
+        return load_component_model(
+            pd_config=self.cfg.pd,
+            checkpoint_path=self.checkpoint_path,
+            target_model=build_target(self.cfg.target),
+            run_batch=make_run_batch(self.cfg.target),
+        )
+
+
+def _agree_on_run_id(run_id: str | None, dist_state: DistributedState | None) -> str:
+    """Broadcast (or generate-then-broadcast) a single run id across all ranks.
+
+    3-pool snapshot uses a file-based gather under
+    `PARAM_DECOMP_OUT_DIR/decompositions/<run_id>/.snapshot_scratch/`; every rank must
+    compute the same path.
+    """
+    if is_main_process() and run_id is None:
+        run_id = generate_run_id("param_decomp")
+    if dist_state is not None:
+        objs: list[str | None] = [run_id]
+        dist.broadcast_object_list(objs, src=0)
+        run_id = objs[0]
+    assert run_id is not None
+    return run_id
+
+
+def _install_first_fail_marker(rank: int) -> None:
+    """On uncaught exception, write a structured marker to shared FS so a debugger can
+    identify which rank died and what hit it without grepping GB of NCCL log noise.
+
+    Writes `$HOME/pd_first_fail/$SLURM_JOB_ID/rank<R>.json`. Chains to the previous
+    excepthook so behavior is otherwise unchanged.
+    """
+    job_id = os.environ.get("SLURM_JOB_ID", "local")
+    out_dir = Path.home() / "pd_first_fail" / job_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"rank{rank}.json"
+
+    prev_excepthook = sys.excepthook
+
+    def _excepthook(exctype: type[BaseException], value: BaseException, tb: Any) -> None:
+        try:
+            payload = {
+                "rank": rank,
+                "exception_type": exctype.__name__,
+                "exception_message": str(value),
+                "traceback": "".join(traceback.format_exception(exctype, value, tb)),
+                "timestamp_utc": datetime.datetime.now(datetime.UTC).isoformat(),
+                "pid": os.getpid(),
+            }
+            out_path.write_text(json.dumps(payload, indent=2))
+            print(f"[first-fail] rank={rank} wrote {out_path}", file=sys.stderr, flush=True)
+        except Exception as e:
+            print(f"[first-fail] failed to write marker: {e}", file=sys.stderr, flush=True)
+        prev_excepthook(exctype, value, tb)
+
+    sys.excepthook = _excepthook
+
+
+def _maybe_enable_memory_profile(rank: int) -> None:
+    """Opt-in CUDA memory-history recorder for offline `memory_viz` analysis.
+
+    Env: `PD_MEMORY_PROFILE_RANKS=0,32,96` (ranks) + `PD_MEMORY_PROFILE_OUT=/abs/dir`.
+    Dumps `<dir>/mem_rank<R>.pickle` on normal exit and on uncaught exception. Load at
+    https://pytorch.org/memory_viz.
+    """
+    prof_ranks_env = os.environ.get("PD_MEMORY_PROFILE_RANKS")
+    if not prof_ranks_env:
+        return
+    if rank not in {int(r) for r in prof_ranks_env.split(",") if r.strip()}:
+        return
+    out_dir = Path(os.environ["PD_MEMORY_PROFILE_OUT"])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"mem_rank{rank}.pickle"
+    logger.info(f"[mem-profile] recording rank={rank} -> {out_path}")
+    torch.cuda.memory._record_memory_history(max_entries=200_000)
+
+    def _dump() -> None:
+        torch.cuda.memory._dump_snapshot(str(out_path))
+        logger.info(f"[mem-profile] dumped rank={rank} -> {out_path}")
+
+    atexit.register(_dump)
+    prev_excepthook = sys.excepthook
+
+    def _excepthook(exctype: type[BaseException], value: BaseException, tb: Any) -> None:
+        _dump()
+        prev_excepthook(exctype, value, tb)
+
+    sys.excepthook = _excepthook
+
+
+def _maybe_build_torch_profiler(trainer: ThreePoolTrainer) -> "torch.profiler.profile | None":
+    """Opt-in `torch.profiler.profile` for the listed ranks (typically one per pool).
+
+    Env: `PD_TORCH_PROFILE_RANKS=0,96,100` + `PD_TORCH_PROFILE_OUT=/abs/dir`, plus
+    schedule / instrumentation knobs (`PD_TORCH_PROFILE_SKIP_FIRST` default 20,
+    `_ACTIVE` default 3, `_MEMORY` default on, `_STACK` / `_MODULES` / `_SHAPES` off).
+    Returns the profile context (caller passes it to `trainer.run(profiler=...)`) or
+    `None` if this rank isn't profiled. Verified at 104 ranks (gpt2-xl) 2026-05-28.
+    """
+    prof_ranks_env = os.environ.get("PD_TORCH_PROFILE_RANKS", "").strip()
+    if not prof_ranks_env:
+        return None
+    prof_ranks = {int(r) for r in prof_ranks_env.split(",") if r.strip()}
+    my_rank = trainer.ctx.role.rank
+    if my_rank not in prof_ranks:
+        return None
+    out_dir = Path(os.environ["PD_TORCH_PROFILE_OUT"])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    skip_first = int(os.environ.get("PD_TORCH_PROFILE_SKIP_FIRST", "20"))
+    active = int(os.environ.get("PD_TORCH_PROFILE_ACTIVE", "3"))
+    profile_memory = os.environ.get("PD_TORCH_PROFILE_MEMORY", "1") != "0"
+    with_stack = os.environ.get("PD_TORCH_PROFILE_STACK", "0") == "1"
+    with_modules = os.environ.get("PD_TORCH_PROFILE_MODULES", "0") == "1"
+    record_shapes = os.environ.get("PD_TORCH_PROFILE_SHAPES", "0") == "1"
+
+    pool = trainer.ctx.kind
+    trace_path = out_dir / f"trace_{pool}_rank{my_rank}.json"
+    logger.info(
+        f"[torch-profile] rank={my_rank} pool={pool} -> {trace_path} "
+        f"(skip_first={skip_first}, active={active}, profile_memory={profile_memory}, "
+        f"with_stack={with_stack}, with_modules={with_modules}, record_shapes={record_shapes})"
+    )
+
+    def on_trace_ready(prof: "torch.profiler.profile") -> None:
+        prof.export_chrome_trace(str(trace_path))
+        logger.info(f"[torch-profile] rank={my_rank} wrote {trace_path}")
+
+    return torch.profiler.profile(
+        activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA],
+        schedule=torch.profiler.schedule(
+            skip_first=skip_first, wait=0, warmup=1, active=active, repeat=1
+        ),
+        on_trace_ready=on_trace_ready,
+        record_shapes=record_shapes,
+        profile_memory=profile_memory,
+        with_stack=with_stack,
+        with_modules=with_modules,
+    )
+
+
+@with_distributed_cleanup
+def main(
+    config_path: str | Path | None = None,
+    *,
+    resume: str | Path | None = None,
+    group: str | None = None,
+    tags: str | None = None,
+    dp: int | None = None,
+    partition: str | None = DEFAULT_PARTITION_NAME,
+    time: str = "72:00:00",
+    job_name: str = "pd-lm-3pool",
+    no_snapshot: bool = False,
+    run_id: str | None = None,
+) -> None:
+    """Run a 3-pool LM PD experiment end-to-end.
+
+    Args:
+        config_path: YAML for a fresh run. Required when not resuming.
+        resume: Path to a `ResumeConfig` YAML pointing at a prior 3-pool run.
+        group / tags: wandb-only (no-ops without `wandb:`).
+        dp / partition / time / job_name / no_snapshot / run_id: SLURM submission knobs.
+            Passing `--dp N` outside torchrun submits a SLURM job: single-node for
+            N <= 8, multi-node for N > 8 (N must be a multiple of 8).
+    """
+    if dp is not None and os.environ.get("WORLD_SIZE") is None:
+        assert (config_path is not None) != (resume is not None), (
+            "--dp SLURM submission requires exactly one of config_path or --resume"
+        )
+        _submit_slurm(
+            config_path,
+            resume=resume,
+            dp=dp,
+            group=group,
+            tags=tags,
+            partition=partition,
+            time=time,
+            job_name=job_name,
+            no_snapshot=no_snapshot,
+            run_id=run_id,
+        )
+        return
+
+    if resume is not None:
+        assert config_path is None, "pass either config_path or --resume, not both"
+        _resume_main(Path(resume), group=group, tags=tags, run_id=run_id)
+    else:
+        assert config_path is not None, "must provide either config_path or --resume"
+        _fresh_main(Path(config_path), group=group, tags=tags, run_id=run_id)
+
+
+def _fresh_main(
+    config_path: Path,
+    *,
+    group: str | None,
+    tags: str | None,
+    run_id: str | None,
+) -> None:
+    """Fresh-run path: parse YAML, build everything, train from step 0."""
+    cfg = ThreePoolLMExperimentConfig.from_file(config_path)
+
+    dist_state = init_distributed()
+    if is_main_process():
+        logger.info(f"Distributed state: {dist_state}")
+    rank = dist_state.rank if dist_state is not None else 0
+    _install_first_fail_marker(rank)
+    _maybe_enable_memory_profile(rank)
+    set_seed(cfg.pd.seed)
+    device = get_device()
+    cfg = cfg.model_copy(
+        update={
+            "runtime": cfg.runtime.model_copy(
+                update={
+                    "device": device,
+                    "dp": dist_state.world_size if dist_state is not None else None,
+                }
+            )
+        }
+    )
+
+    target_model = build_target(cfg.target)
+    # 3-pool requires the full global batch on every rank — each pool slices it
+    # locally. So the loader is built with dist_state=None (no DistributedSampler).
+    train_loader = build_lm_loader(
+        cfg.target,
+        cfg.data,
+        split="train",
+        device=device,
+        batch_size=cfg.pd.batch_size,
+        dist_state=None,
+        seed=cfg.pd.seed,
+    )
+
+    run_id = _agree_on_run_id(run_id, dist_state)
+    out_dir = PARAM_DECOMP_OUT_DIR / "decompositions" / run_id
+    scratch_dir = out_dir / ".snapshot_scratch"
+    sink = init_pd_run(
+        cfg,
+        sink_class=ThreePoolSink,
+        group=group,
+        tags=tags,
+        run_id=run_id,
+        on_save=lambda step: submit_slurm_async_slow_eval(out_dir, step=step, parent_cfg=cfg),
+    )
+    eval_loop = _build_eval_loop(cfg, device, dist_state=None)
+    try:
+        trainer = ThreePoolTrainer(
+            target_model=target_model,
+            run_batch=make_run_batch(cfg.target),
+            reconstruction_loss=recon_loss_kl,
+            pd_config=cfg.pd,
+            runtime_config=cfg.runtime,
+            three_pool_config=cfg.runtime.topology,
+        )
+        trainer.run(
+            train_loader,
+            sink,
+            cfg.cadence,
+            scratch_dir=scratch_dir,
+            eval_loop=eval_loop,
+            profiler=_maybe_build_torch_profiler(trainer),
+        )
+    finally:
+        sink.finish()
+
+
+def _resume_main(
+    resume_cfg_path: Path,
+    *,
+    group: str | None,
+    tags: str | None,
+    run_id: str | None,
+) -> None:
+    """Resume-run path: read parent `run_meta.yaml` + `training_<step>.pth`, rebuild via
+    `ThreePoolTrainer.from_snapshot`, continue training."""
+    resume_cfg = ResumeConfig.from_file(resume_cfg_path)
+    parent_cfg = ThreePoolLMExperimentConfig.from_file(resume_cfg.from_run / RUN_META_FILENAME)
+
+    dist_state = init_distributed()
+    if is_main_process():
+        logger.info(f"Distributed state: {dist_state}")
+        logger.info(f"Resuming from {resume_cfg.from_run} @ step {resume_cfg.step}")
+    rank = dist_state.rank if dist_state is not None else 0
+    _install_first_fail_marker(rank)
+    _maybe_enable_memory_profile(rank)
+    set_seed(parent_cfg.pd.seed)
+    device = get_device()
+
+    resolved_step = resolve_step(resume_cfg.from_run, resume_cfg.step)
+    effective_cfg = parent_cfg.model_copy(
+        update={
+            "runtime": parent_cfg.runtime.model_copy(
+                update={
+                    "device": device,
+                    "dp": dist_state.world_size if dist_state is not None else None,
+                }
+            ),
+            "resume_provenance": ResumeProvenance(
+                parent_run_dir=resume_cfg.from_run, parent_step=resolved_step
+            ),
+        }
+    )
+
+    snapshot = read_training_snapshot(resume_cfg.from_run, resolved_step)
+    assert isinstance(snapshot, ThreePoolTrainingState), (
+        f"3-pool resume needs ThreePoolTrainingState; got {type(snapshot).__name__}"
+    )
+    snapshot.runtime_config["device"] = device
+
+    target_model = build_target(effective_cfg.target)
+    train_loader = build_lm_loader(
+        effective_cfg.target,
+        effective_cfg.data,
+        split="train",
+        device=device,
+        batch_size=effective_cfg.pd.batch_size,
+        dist_state=None,
+        seed=effective_cfg.pd.seed,
+    )
+
+    run_id = _agree_on_run_id(run_id, dist_state)
+    out_dir = PARAM_DECOMP_OUT_DIR / "decompositions" / run_id
+    scratch_dir = out_dir / ".snapshot_scratch"
+    sink = init_pd_run(
+        effective_cfg,
+        sink_class=ThreePoolSink,
+        group=group,
+        tags=tags,
+        run_id=run_id,
+        on_save=lambda step: submit_slurm_async_slow_eval(
+            out_dir, step=step, parent_cfg=effective_cfg
+        ),
+    )
+    eval_loop = _build_eval_loop(effective_cfg, device, dist_state=None)
+    try:
+        trainer = ThreePoolTrainer.from_snapshot(
+            snapshot,
+            target_model=target_model,
+            run_batch=make_run_batch(effective_cfg.target),
+            reconstruction_loss=recon_loss_kl,
+        )
+        trainer.run(
+            train_loader,
+            sink,
+            effective_cfg.cadence,
+            scratch_dir=scratch_dir,
+            eval_loop=eval_loop,
+            profiler=_maybe_build_torch_profiler(trainer),
+        )
+    finally:
+        sink.finish()
+
+
+def _submit_slurm(
+    config_path: str | Path | None,
+    *,
+    resume: str | Path | None,
+    dp: int,
+    group: str | None,
+    tags: str | None,
+    partition: str | None,
+    time: str,
+    job_name: str,
+    no_snapshot: bool,
+    run_id: str | None,
+) -> None:
+    run_id = run_id or generate_run_id("param_decomp")
+    snapshot_ref: str | None = None
+    commit_hash = "no-snapshot"
+    if not no_snapshot:
+        snapshot_ref, commit_hash = create_git_snapshot(snapshot_id=run_id)
+        logger.info(f"Created git snapshot: {snapshot_ref} ({commit_hash[:8]})")
+
+    yaml_target = resume if resume is not None else config_path
+    assert yaml_target is not None
+    path = Path(yaml_target)
+    if path.is_absolute() and path.is_relative_to(REPO_ROOT):
+        yaml_arg = path.relative_to(REPO_ROOT).as_posix()
+    else:
+        yaml_arg = str(yaml_target)
+
+    module = "param_decomp_lab.experiments.lm.three_pool_run"
+    if resume is not None:
+        base_parts = ["-m", module, "--resume", yaml_arg, "--run_id", run_id]
+    else:
+        base_parts = ["-m", module, yaml_arg, "--run_id", run_id]
+    if group is not None:
+        base_parts += ["--group", group]
+    if tags is not None:
+        base_parts += ["--tags", tags]
+    base_command = shlex.join(base_parts)
+
+    launch = build_ddp_launch(
+        base_command,
+        dp=dp,
+        job_name=job_name,
+        snapshot_ref=snapshot_ref,
+        port_seed=run_id,
+    )
+    slurm_config = SlurmConfig(
+        job_name=job_name,
+        partition=partition,
+        n_gpus=launch.gpus_per_node,
+        n_nodes=launch.n_nodes,
+        time=time,
+        snapshot_ref=snapshot_ref,
+        comment=run_id,
+    )
+    script = generate_script(slurm_config, launch.command, env=launch.env)
+    result = submit_slurm_job(script, "lm")
+
+    wandb_url = _wandb_url_for_config(config_path, run_id) if config_path is not None else None
+
+    logger.section("3-pool LM PD job submitted!")
+    summary: dict[str, str | None] = {
+        "Run ID": run_id,
+        "Job ID": result.job_id,
+        "Log file": result.log_pattern,
+        "Script": str(result.script_path),
+        "Snapshot": f"{snapshot_ref} ({commit_hash[:8]})" if snapshot_ref else "(none)",
+    }
+    if wandb_url is not None:
+        summary["WandB run URL"] = wandb_url
+    logger.values(summary)
+
+
+def _wandb_url_for_config(config_path: str | Path, run_id: str) -> str | None:
+    cfg = ThreePoolLMExperimentConfig.from_file(config_path)
+    if cfg.wandb is None:
+        return None
+    entity = cfg.wandb.entity or get_wandb_entity()
+    return f"https://wandb.ai/{entity}/{cfg.wandb.project}/runs/{run_id}"
+
+
+def submit_slurm_async_slow_eval(
+    run_path: str | Path,
+    *,
+    step: int,
+    parent_cfg: ThreePoolLMExperimentConfig,
+    dp: int = 8,
+    time: str = "2:00:00",
+    partition: str | None = DEFAULT_PARTITION_NAME,
+    job_name: str = "pd-lm-eval-slow",
+    group: str | None = None,
+    tags: str | None = None,
+    no_snapshot: bool = False,
+) -> None:
+    """Filter the parent's slow eval metrics into a temp YAML, submit a SLURM job.
+
+    Called from training right after a save: emits an async SLURM job that runs only the
+    slow metrics against `model_<step>.pth` via
+    `python -m param_decomp_lab.experiments.lm.async_eval`, logging into the parent's
+    wandb run at the same step. No-op when the parent has no eval block or no slow metrics.
+    """
+    if parent_cfg.eval is None:
+        return
+    slow_metrics, _fast = _split_metrics_by_slow(parent_cfg.eval.metrics)
+    if not slow_metrics:
+        return
+
+    slow_eval_cfg = EvalConfig(
+        batch_size=parent_cfg.eval.batch_size,
+        n_steps=parent_cfg.eval.n_steps,
+        every=parent_cfg.eval.every,
+        slow_every=parent_cfg.eval.every,  # any value; not consumed by async_eval
+        slow_on_first_step=True,
+        metrics=slow_metrics,
+    )
+    train_run_id = _resolve_train_run_id(run_path)
+    scratch = PARAM_DECOMP_OUT_DIR / "decompositions" / train_run_id / ".async_eval_configs"
+    scratch.mkdir(parents=True, exist_ok=True)
+    cfg_path = scratch / f"slow_eval_step_{step}.yaml"
+    slow_eval_cfg.to_file(cfg_path)
+
+    eval_run_id = generate_run_id("param_decomp")
+    snapshot_ref: str | None = f"refs/runs/snapshot/{train_run_id}" if not no_snapshot else None
+
+    base_command = shlex.join(
+        [
+            "-m",
+            "param_decomp_lab.experiments.lm.async_eval",
+            "--run",
+            str(run_path),
+            "--step",
+            str(step),
+            "--eval-config",
+            str(cfg_path),
+            *(["--group", group] if group is not None else []),
+            *(["--tags", tags] if tags is not None else []),
+        ]
+    )
+    launch = build_ddp_launch(
+        base_command,
+        dp=dp,
+        job_name=job_name,
+        snapshot_ref=snapshot_ref,
+        port_seed=eval_run_id,
+    )
+    slurm_config = SlurmConfig(
+        job_name=job_name,
+        partition=partition,
+        n_gpus=launch.gpus_per_node,
+        n_nodes=launch.n_nodes,
+        time=time,
+        snapshot_ref=snapshot_ref,
+        comment=f"async-slow-eval:{train_run_id}@{step}",
+    )
+    script = generate_script(slurm_config, launch.command, env=launch.env)
+    result = submit_slurm_job(script, "lm")
+    logger.info(
+        f"Async slow-eval submitted: parent={train_run_id} step={step} "
+        f"job_id={result.job_id} log={result.log_pattern}"
+    )
+
+
+def cli() -> None:
+    fire.Fire(main)
+
+
+if __name__ == "__main__":
+    cli()

--- a/param_decomp_lab/experiments/utils.py
+++ b/param_decomp_lab/experiments/utils.py
@@ -5,17 +5,20 @@ types.
 """
 
 from collections.abc import Callable
+from pathlib import Path
+from typing import Protocol
 
 import wandb
 from pydantic import Field, PositiveInt
 
-from param_decomp.base_config import BaseConfig
+from param_decomp.base_config import BaseConfig, runtime_cast
 from param_decomp.configs import Cadence, PDConfig, RuntimeConfig
 from param_decomp.distributed import is_main_process
 from param_decomp_lab.eval_metrics import AnyEvalMetricConfig
 from param_decomp_lab.infra.run_files import generate_run_id
 from param_decomp_lab.infra.settings import PARAM_DECOMP_OUT_DIR
 from param_decomp_lab.infra.wandb import try_wandb
+from param_decomp_lab.resumption.provenance import ResumeProvenance
 from param_decomp_lab.run_sink import OnePoolSink, ThreePoolSink
 
 RUN_META_FILENAME = "run_meta.yaml"
@@ -58,10 +61,29 @@ class ExperimentConfig[T: BaseConfig, D: BaseConfig](BaseConfig):
     data: D
     eval: EvalConfig | None = None
     wandb: WandbConfig | None = None
+    resume_provenance: ResumeProvenance | None = None
+    """Set on resumed runs (parent run dir + step); `None` for fresh runs. Lives on the
+    config so it flows into `run_meta.yaml` and `wandb.config` via `init_pd_run`, making a
+    resumed run's lineage visible in the wandb UI."""
 
 
-def init_pd_run[T: BaseConfig, D: BaseConfig, S: OnePoolSink | ThreePoolSink](
-    cfg: ExperimentConfig[T, D],
+class _PdRunInputs(Protocol):
+    """The slice of an experiment config `init_pd_run` reads.
+
+    Lets the single-pool `ExperimentConfig` and the standalone 3-pool
+    `ThreePoolLMExperimentConfig` share one sink builder without a common base — it
+    only touches `cadence`, `wandb`, and `to_file`, never `pd` / `runtime`.
+    """
+
+    @property
+    def cadence(self) -> Cadence: ...
+    @property
+    def wandb(self) -> "WandbConfig | None": ...
+    def to_file(self, path: Path | str) -> None: ...
+
+
+def init_pd_run[S: OnePoolSink | ThreePoolSink](
+    cfg: _PdRunInputs,
     *,
     sink_class: type[S],
     group: str | None,
@@ -95,7 +117,7 @@ def init_pd_run[T: BaseConfig, D: BaseConfig, S: OnePoolSink | ThreePoolSink](
         project=cfg.wandb.project,
         entity=cfg.wandb.entity,
         run_id=run_id,
-        config=cfg,
+        config=runtime_cast(BaseConfig, cfg),
         group=group,
         tags=parsed_tags,
         keep_last_n_checkpoints=keep_last_n,

--- a/param_decomp_lab/pyproject.toml
+++ b/param_decomp_lab/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 pd-tms = "param_decomp_lab.experiments.tms.run:cli"
 pd-resid-mlp = "param_decomp_lab.experiments.resid_mlp.run:cli"
 pd-lm = "param_decomp_lab.experiments.lm.run:cli"
+pd-lm-3pool = "param_decomp_lab.experiments.lm.three_pool_run:cli"
 pd-lm-layerwise = "param_decomp_lab.experiments.lm.layerwise:cli"
 pd-pretrain = "param_decomp_lab.experiments.lm.pretrain.cli:cli"
 # Post-processing pipeline CLIs (SLURM-driven; lab subtrees).

--- a/param_decomp_lab/resumption/__init__.py
+++ b/param_decomp_lab/resumption/__init__.py
@@ -15,19 +15,11 @@ from param_decomp_lab.resumption.config import (
     read_training_snapshot,
     resolve_step,
 )
-from param_decomp_lab.resumption.provenance import (
-    RESUME_PROVENANCE_FILENAME,
-    ResumeProvenance,
-    read_provenance,
-    write_provenance,
-)
+from param_decomp_lab.resumption.provenance import ResumeProvenance
 
 __all__ = [
-    "RESUME_PROVENANCE_FILENAME",
     "ResumeConfig",
     "ResumeProvenance",
-    "read_provenance",
     "read_training_snapshot",
     "resolve_step",
-    "write_provenance",
 ]

--- a/param_decomp_lab/resumption/provenance.py
+++ b/param_decomp_lab/resumption/provenance.py
@@ -1,41 +1,23 @@
-"""Resume provenance: a small YAML sibling of ``run_meta.yaml`` recording
-which run a resumed run was forked from.
+"""Resume provenance: which run a resumed run was forked from.
 
-Resumed runs get their own ``run_id`` and own ``run_meta.yaml`` — provenance
-is what makes them traceable back to the parent. A future reader can inspect
-``resume_provenance.yaml`` to find the parent run dir + the step it was
-resumed from.
-
-A run without this file is a fresh run.
+Resumed runs get their own `run_id` and own `run_meta.yaml`. Provenance is what makes
+them traceable back to the parent: the resume composition root sets
+`ExperimentConfig.resume_provenance` on the effective config it hands to `init_pd_run`,
+so the lineage is dumped into `run_meta.yaml` and surfaced in `wandb.config` (and thus
+the wandb UI). A run with `resume_provenance is None` is a fresh run.
 """
 
 from pathlib import Path
 
 from param_decomp.base_config import BaseConfig
 
-RESUME_PROVENANCE_FILENAME = "resume_provenance.yaml"
-
 
 class ResumeProvenance(BaseConfig):
-    """Sibling of ``run_meta.yaml`` recording where this resumed run came from."""
+    """Records where a resumed run came from. Lives on `ExperimentConfig`."""
 
     parent_run_dir: Path
     """Path to the parent run's directory."""
 
     parent_step: int
     """The step at which we resumed (i.e. the step number in the parent's
-    ``resume/step_<N>/`` snapshot we loaded from)."""
-
-
-def write_provenance(out_dir: Path, provenance: ResumeProvenance) -> None:
-    """Persist ``provenance`` to ``{out_dir}/resume_provenance.yaml``."""
-    provenance.to_file(out_dir / RESUME_PROVENANCE_FILENAME)
-
-
-def read_provenance(run_dir: Path) -> ResumeProvenance | None:
-    """Read provenance from ``run_dir``. Returns ``None`` if the run is fresh
-    (no ``resume_provenance.yaml`` file present)."""
-    path = run_dir / RESUME_PROVENANCE_FILENAME
-    if not path.is_file():
-        return None
-    return ResumeProvenance.from_file(path)
+    `training_<step>.pth` snapshot we loaded from)."""

--- a/param_decomp_lab/tests/test_three_pool_config_fork.py
+++ b/param_decomp_lab/tests/test_three_pool_config_fork.py
@@ -1,0 +1,161 @@
+"""Parse-time constraint tests for the Option-C 3-pool config fork.
+
+The whole point of `ThreePoolConstrainedPDConfig` + `ThreePoolLMExperimentConfig` is to
+move 3-pool misconfiguration failures from "minutes into a multi-node launch" to "YAML
+parse on the login node". These tests pin that: a valid config parses, and each class of
+invalid config (wrong fixed scalar, missing/extra loss, bad batch divisibility, rank-0
+convention) fails at `model_validate`.
+"""
+
+import copy
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from param_decomp_lab.experiments.lm.three_pool_pd import (
+    ThreePoolConstrainedPDConfig,
+    ThreePoolLosses,
+)
+from param_decomp_lab.experiments.lm.three_pool_run import ThreePoolLMExperimentConfig
+
+_VALID_YAML = (
+    Path(__file__).parents[1]
+    / "experiments/lm/_resumption_validation/gpt2_small_3pool_save_repro.yaml"
+)
+
+
+def _valid_dict() -> dict[str, Any]:
+    return yaml.safe_load(_VALID_YAML.read_text())
+
+
+def test_valid_config_parses() -> None:
+    cfg = ThreePoolLMExperimentConfig.model_validate(_valid_dict())
+    assert [m.type for m in cfg.pd.loss_metrics] == [
+        "FaithfulnessLoss",
+        "ImportanceMinimalityLoss",
+        "StochasticReconLayerwiseLoss",
+        "PersistentPGDReconLoss",
+    ]
+    # Fixed scalars take their frozen Literal defaults.
+    assert cfg.pd.sampling == "continuous"
+    assert cfg.pd.n_mask_samples == 1
+    assert cfg.pd.use_delta_component is True
+    assert cfg.pd.identity_decomposition_targets is None
+
+
+def test_pd_dump_roundtrips_through_constrained_config() -> None:
+    """The snapshot path dumps `pd` and re-validates as the constrained type on resume.
+
+    `loss_metrics` is excluded from the dump (derived from `losses`), so the round-trip
+    must reconstruct it.
+    """
+    cfg = ThreePoolLMExperimentConfig.model_validate(_valid_dict())
+    dumped = cfg.pd.model_dump()
+    assert "loss_metrics" not in dumped
+    assert "losses" in dumped
+    reloaded = ThreePoolConstrainedPDConfig.model_validate(dumped)
+    assert [m.type for m in reloaded.loss_metrics] == [m.type for m in cfg.pd.loss_metrics]
+
+
+@pytest.mark.parametrize("scalar,bad", [("n_mask_samples", 3), ("sampling", "binomial")])
+def test_wrong_fixed_scalar_rejected(scalar: str, bad: Any) -> None:
+    data = _valid_dict()
+    data["pd"][scalar] = bad
+    with pytest.raises(ValidationError):
+        ThreePoolLMExperimentConfig.model_validate(data)
+
+
+def test_use_delta_component_false_rejected() -> None:
+    data = _valid_dict()
+    data["pd"]["use_delta_component"] = False
+    with pytest.raises(ValidationError):
+        ThreePoolLMExperimentConfig.model_validate(data)
+
+
+def test_missing_loss_rejected() -> None:
+    data = _valid_dict()
+    del data["pd"]["losses"]["ppgd"]
+    with pytest.raises(ValidationError):
+        ThreePoolLMExperimentConfig.model_validate(data)
+
+
+def test_extra_forbidden_loss_rejected() -> None:
+    """An extra key on the losses struct is forbidden (extra='forbid')."""
+    data = _valid_dict()
+    data["pd"]["losses"]["unmasked"] = {"coeff": 1.0}
+    with pytest.raises(ValidationError):
+        ThreePoolLMExperimentConfig.model_validate(data)
+
+
+def test_authoring_loss_metrics_directly_rejected() -> None:
+    data = _valid_dict()
+    data["pd"]["loss_metrics"] = [{"type": "FaithfulnessLoss", "coeff": 1.0}]
+    with pytest.raises(ValidationError):
+        ThreePoolConstrainedPDConfig.model_validate(data["pd"])
+
+
+def test_missing_coeff_rejected() -> None:
+    losses = _valid_dict()["pd"]["losses"]
+    del losses["faith"]["coeff"]
+    with pytest.raises(ValidationError):
+        ThreePoolLosses.model_validate(losses)
+
+
+def test_ppgd_start_frac_nonzero_rejected() -> None:
+    data = _valid_dict()
+    data["pd"]["losses"]["ppgd"]["start_frac"] = 0.5
+    with pytest.raises(ValidationError):
+        ThreePoolLMExperimentConfig.model_validate(data)
+
+
+def test_batch_not_divisible_by_topology_rejected() -> None:
+    """Cross-field check: batch_size must be divisible by each pool arity. The topology
+    stays valid (uniform N_per_block=2); only batch_size is made indivisible by it."""
+    data = _valid_dict()
+    data["pd"]["batch_size"] = 3  # N_per_block=2 does not divide 3
+    with pytest.raises(ValidationError):
+        ThreePoolLMExperimentConfig.model_validate(data)
+
+
+def test_rank0_not_lw_leader_rejected() -> None:
+    """Cross-field check: rank 0 must be the LW pool's block-0 leader."""
+    data = _valid_dict()
+    groups = data["runtime"]["topology"]["layerwise_block_groups"]
+    # Swap rank 0 out of the first block's leader slot (move it to CI pool's place).
+    groups[0]["ranks"] = [9, 1]
+    with pytest.raises(ValidationError):
+        ThreePoolLMExperimentConfig.model_validate(data)
+
+
+def test_topology_under_runtime_not_three_pool_field() -> None:
+    """The topology lives on `runtime.topology`; the old top-level `three_pool` key is
+    no longer accepted (extra='forbid')."""
+    data = _valid_dict()
+    topology = copy.deepcopy(data["runtime"]["topology"])
+    data["three_pool"] = topology
+    with pytest.raises(ValidationError):
+        ThreePoolLMExperimentConfig.model_validate(data)
+
+
+def test_resume_provenance_field_defaults_none_and_roundtrips() -> None:
+    """Fresh config has `resume_provenance is None`; a populated one survives a dump +
+    reload (so it lands in run_meta.yaml / wandb.config)."""
+    from param_decomp_lab.resumption import ResumeProvenance
+
+    cfg = ThreePoolLMExperimentConfig.model_validate(_valid_dict())
+    assert cfg.resume_provenance is None
+
+    resumed = cfg.model_copy(
+        update={
+            "resume_provenance": ResumeProvenance(
+                parent_run_dir=Path("/runs/p-parent"), parent_step=5000
+            )
+        }
+    )
+    reloaded = ThreePoolLMExperimentConfig.model_validate(resumed.model_dump(mode="json"))
+    assert reloaded.resume_provenance is not None
+    assert reloaded.resume_provenance.parent_step == 5000
+    assert reloaded.resume_provenance.parent_run_dir == Path("/runs/p-parent")

--- a/param_decomp_lab/three_pool/CLAUDE.md
+++ b/param_decomp_lab/three_pool/CLAUDE.md
@@ -7,7 +7,7 @@ docstring in `optimize.py` for the data-handling contract.
 
 | File | What it covers |
 |---|---|
-| `optimize.py` | `ThreePoolTrainer` + `optimize_three_pool`; the training loop, `snapshot`/`from_snapshot`, config validation |
+| `optimize.py` | `ThreePoolTrainer` + `optimize_three_pool`; the training loop, `snapshot`/`from_snapshot`. Consumes `ThreePoolConstrainedPDConfig` (reads `pd.losses.*` directly). Config constraints are now type-level (see `experiments/lm/three_pool_pd.py`) + a load-time validator on `ThreePoolLMExperimentConfig`; only site-coverage validation remains here (`_build_runtime`, needs the loaded model) |
 | `layout.py` | `World` topology; `build_world` constructs every process group (threading `pg_timeout` into each); `BatchEdge` — symmetric per-edge batch-slice geometry (CI↔LW, CI↔PPGD) answering routing for both fan directions |
 | `checkpoint.py` | `gather_full_state_dict_to_rank0` — rebuilds the full model state on rank 0 |
 | `config.py` | `ThreePoolConfig` + topology validation |

--- a/param_decomp_lab/three_pool/config.py
+++ b/param_decomp_lab/three_pool/config.py
@@ -17,9 +17,9 @@ global shared transformer CI fns that span all sites).
 
 Topology integrity checks (rank disjointness, uniform N_per_block, CI-pool
 cross-divisibility with Layerwise/PPGD arities) run at validation time; checks
-that depend on ``pd.batch_size`` (divisibility) run in
-``_validate_pd_config_for_three_pool`` since they need the paired ``PDConfig``
-to evaluate.
+that depend on ``pd.batch_size`` (divisibility) + the rank-0 convention run on
+``ThreePoolLMExperimentConfig`` (in ``experiments.lm.three_pool_run``) since they
+need the paired ``ThreePoolConstrainedPDConfig`` to evaluate.
 """
 
 from typing import Self
@@ -139,7 +139,7 @@ class ThreePoolConfig(BaseConfig):
         # (CI↔LW, CI↔PPGD) must be a clean one-to-K fan-out in EITHER direction:
         # one arity divides the other, so every batch-slice overlap is a whole,
         # aligned sub-slice. (The batch-divisibility of each arity itself is
-        # enforced against pd.batch_size in _validate_pd_config_for_three_pool.)
+        # enforced against pd.batch_size on ThreePoolLMExperimentConfig.)
         n_ci = len(self.ci_ranks)
         n_ppgd = len(self.ppgd_ranks)
         assert n_per_block % n_ci == 0 or n_ci % n_per_block == 0, (

--- a/param_decomp_lab/three_pool/optimize.py
+++ b/param_decomp_lab/three_pool/optimize.py
@@ -62,12 +62,7 @@ from param_decomp.decomposition_targets import (
 )
 from param_decomp.distributed import seed_all_ranks, seed_per_rank
 from param_decomp.masks import AllLayersRouter
-from param_decomp.metrics.base import LossMetricConfig
-from param_decomp.metrics.importance_minimality import ImportanceMinimalityLossConfig
-from param_decomp.metrics.persistent_pgd_recon import (
-    PersistentPGDReconLossConfig,
-    validate_pgd_scope,
-)
+from param_decomp.metrics.persistent_pgd_recon import validate_pgd_scope
 from param_decomp.metrics.persistent_pgd_state import (
     PerBatchPerPositionScope,
     PersistentPGDState,
@@ -78,6 +73,7 @@ from param_decomp.schedule import get_scheduled_value
 from param_decomp.sdpa_strict import verify_flash_attention_available
 from param_decomp.torch_helpers import loop_dataloader
 from param_decomp.training_state import ThreePoolTrainingState
+from param_decomp_lab.experiments.lm.three_pool_pd import ThreePoolConstrainedPDConfig
 from param_decomp_lab.three_pool.checkpoint import gather_full_state_dict_to_rank0
 from param_decomp_lab.three_pool.config import ThreePoolConfig
 from param_decomp_lab.three_pool.context import (
@@ -121,37 +117,6 @@ def _resolve_pg_timeout() -> datetime.timedelta:
     return _DEFAULT_PG_TIMEOUT
 
 
-# Loss-metric type discriminators required for the 3-pool training path.
-REQUIRED_LOSS_METRIC_TYPES: frozenset[str] = frozenset(
-    {
-        "FaithfulnessLoss",
-        "ImportanceMinimalityLoss",
-        "StochasticReconLayerwiseLoss",
-        "PersistentPGDReconLoss",
-    }
-)
-
-FORBIDDEN_LOSS_METRIC_TYPES: frozenset[str] = frozenset(
-    {
-        "StochasticReconLoss",
-        "StochasticReconSubsetLoss",
-        "StochasticReconSubsetCEAndKL",
-        "PersistentPGDReconSubsetLoss",
-        "CIMaskedReconLoss",
-        "CIMaskedReconLayerwiseLoss",
-        "CIMaskedReconSubsetLoss",
-        "UnmaskedReconLoss",
-        "PGDReconLoss",
-        "PGDReconLayerwiseLoss",
-        "PGDReconSubsetLoss",
-        "CIMaskedAttnPatternsReconLoss",
-        "StochasticAttnPatternsReconLoss",
-        "StochasticHiddenActsReconLoss",
-        "CIHiddenActsReconLoss",
-    }
-)
-
-
 class ThreePoolTrainer:
     """Stateful 3-pool trainer.
 
@@ -170,7 +135,7 @@ class ThreePoolTrainer:
     :meth:`snapshot`, so all ranks must call it in sync.
     """
 
-    pd_config: PDConfig
+    pd_config: ThreePoolConstrainedPDConfig
     runtime_config: RuntimeConfig
     three_pool_config: ThreePoolConfig
     reconstruction_loss: ReconstructionLoss
@@ -187,7 +152,7 @@ class ThreePoolTrainer:
         target_model: nn.Module,
         run_batch: RunBatch,
         reconstruction_loss: ReconstructionLoss,
-        pd_config: PDConfig,
+        pd_config: ThreePoolConstrainedPDConfig,
         runtime_config: RuntimeConfig,
         three_pool_config: ThreePoolConfig,
     ) -> None:
@@ -212,10 +177,9 @@ class ThreePoolTrainer:
         if ci_attn is not None:
             d_model, n_heads = ci_attn
             verify_flash_attention_available(head_dim=d_model // n_heads)
-        _validate_pd_config_for_three_pool(pd_config, three_pool_config)
         # PPGD runs only on PPGD pool; the relevant per-rank batch is batch // n_ppgd.
         validate_pgd_scope(
-            pd_config.loss_metrics,
+            [pd_config.losses.ppgd],
             batch_size=pd_config.batch_size,
             world_size=len(three_pool_config.ppgd_ranks),
         )
@@ -570,7 +534,7 @@ class ThreePoolTrainer:
         pd_dict = snapshot.pd_config
         if cfg_overrides is not None:
             pd_dict = {**pd_dict, **cfg_overrides}
-        pd_config = PDConfig.model_validate(pd_dict)
+        pd_config = ThreePoolConstrainedPDConfig.model_validate(pd_dict)
         runtime_config = RuntimeConfig.model_validate(snapshot.runtime_config)
         three_pool_config = ThreePoolConfig.model_validate(snapshot.three_pool_config)
 
@@ -901,7 +865,7 @@ def optimize_three_pool(
     *,
     run_batch: RunBatch,
     reconstruction_loss: ReconstructionLoss,
-    pd_config: PDConfig,
+    pd_config: ThreePoolConstrainedPDConfig,
     runtime_config: RuntimeConfig,
     three_pool_config: ThreePoolConfig,
     cadence: Cadence,
@@ -985,81 +949,15 @@ def _rank_invariant_fingerprint_core(fp: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _validate_pd_config_for_three_pool(
-    pd_config: PDConfig,
-    three_pool_config: ThreePoolConfig,
-) -> None:
-    """Fail loudly on any PDConfig the 3-pool path can't honour."""
-    by_type: dict[str, LossMetricConfig] = {m.type: m for m in pd_config.loss_metrics}
-
-    missing = sorted(REQUIRED_LOSS_METRIC_TYPES - set(by_type))
-    assert not missing, (
-        f"3-pool requires these loss metrics: {sorted(REQUIRED_LOSS_METRIC_TYPES)}.\n"
-        f"Missing: {missing}. Got: {sorted(by_type)}."
-    )
-    illegal = sorted(FORBIDDEN_LOSS_METRIC_TYPES & set(by_type))
-    assert not illegal, (
-        f"3-pool does not implement these loss metrics (they would be silently ignored): "
-        f"{illegal}. Remove them or extend the 3-pool path."
-    )
-
-    for name in REQUIRED_LOSS_METRIC_TYPES:
-        assert by_type[name].coeff is not None, (
-            f"pd_config.loss_metrics[{name!r}].coeff is required for 3-pool training"
-        )
-
-    n_per_block = len(three_pool_config.layerwise_block_groups[0].ranks)
-    n_ci = len(three_pool_config.ci_ranks)
-    n_ppgd = len(three_pool_config.ppgd_ranks)
-    bs = pd_config.batch_size
-    assert bs % n_per_block == 0, (
-        f"pd_config.batch_size ({bs}) must be divisible by N_per_block ({n_per_block}) "
-        f"= len(layerwise_block_groups[0].ranks)"
-    )
-    assert bs % n_ci == 0, (
-        f"pd_config.batch_size ({bs}) must be divisible by N_ci ({n_ci}) = len(ci_ranks)"
-    )
-    assert bs % n_ppgd == 0, (
-        f"pd_config.batch_size ({bs}) must be divisible by N_ppgd ({n_ppgd}) = len(ppgd_ranks)"
-    )
-
-    assert pd_config.use_delta_component, (
-        "3-pool requires pd_config.use_delta_component=True (hardcoded in LW's "
-        "layerwise stoch recon + PPGD's PPGD warmup)."
-    )
-
-    assert pd_config.sampling == "continuous", (
-        "3-pool hardcodes `sampling='continuous'` in CI pool's CI computation; "
-        f"got pd_config.sampling={pd_config.sampling!r}."
-    )
-    assert pd_config.n_mask_samples == 1, (
-        "3-pool draws exactly one stochastic mask per site per step in LW; "
-        f"got pd_config.n_mask_samples={pd_config.n_mask_samples}."
-    )
-
-    assert pd_config.identity_decomposition_targets is None, (
-        "3-pool path does not call `insert_identity_operations_`; "
-        "`identity_decomposition_targets` would be silently ignored."
-    )
-
-    # Convention: rank 0 must be the Layerwise pool's block 0 leader.
-    assert three_pool_config.layerwise_block_groups[0].ranks[0] == 0, (
-        "Convention: rank 0 must be the LW pool's block 0 leader (so reductions "
-        "can ship CI/PPGD pool losses to rank 0). Reorder layerwise_block_groups "
-        "so the first group starts with rank 0."
-    )
-
-    ppgd_cfg = by_type["PersistentPGDReconLoss"]
-    assert isinstance(ppgd_cfg, PersistentPGDReconLossConfig)
-    assert ppgd_cfg.start_frac == 0.0, (
-        "3-pool path does not implement PersistentPGDReconLoss.start_frac > 0; "
-        "PPGD always runs from step 0."
-    )
+def _required[T](value: T | None) -> T:
+    """Narrow a value the `ThreePoolLosses` validator already guarantees non-None."""
+    assert value is not None
+    return value
 
 
 def _build_runtime(
     target_model: nn.Module,
-    pd_config: PDConfig,
+    pd_config: ThreePoolConstrainedPDConfig,
     runtime_config: RuntimeConfig,
     three_pool_config: ThreePoolConfig,
     run_batch: RunBatch,
@@ -1082,16 +980,9 @@ def _build_runtime(
                 f"Available: {sorted(c_per_site)[:5]}..."
             )
 
-    by_type: dict[str, LossMetricConfig] = {m.type: m for m in pd_config.loss_metrics}
-    ppgd_cfg = by_type["PersistentPGDReconLoss"]
-    imp_min_cfg = by_type["ImportanceMinimalityLoss"]
-    assert isinstance(ppgd_cfg, PersistentPGDReconLossConfig)
-    assert isinstance(imp_min_cfg, ImportanceMinimalityLossConfig)
-
-    def _coeff(name: str) -> float:
-        c = by_type[name].coeff
-        assert c is not None
-        return float(c)
+    losses = pd_config.losses
+    ppgd_cfg = losses.ppgd
+    imp_min_cfg = losses.imp
 
     block_groups = tuple(
         LayerwiseBlockGroup(ranks=tuple(bg.ranks), owned_sites=tuple(bg.owned_sites))
@@ -1109,10 +1000,10 @@ def _build_runtime(
         run_batch=run_batch,
         reconstruction_loss=reconstruction_loss,
         ppgd_cfg=ppgd_cfg,
-        coeff_faith=_coeff("FaithfulnessLoss"),
-        coeff_imp=_coeff("ImportanceMinimalityLoss"),
-        coeff_stoch=_coeff("StochasticReconLayerwiseLoss"),
-        coeff_ppgd=_coeff("PersistentPGDReconLoss"),
+        coeff_faith=float(_required(losses.faith.coeff)),
+        coeff_imp=float(_required(losses.imp.coeff)),
+        coeff_stoch=float(_required(losses.stoch.coeff)),
+        coeff_ppgd=float(_required(losses.ppgd.coeff)),
         imp_min_pnorm=imp_min_cfg.pnorm,
         imp_min_beta=imp_min_cfg.beta,
         imp_min_eps=imp_min_cfg.eps,


### PR DESCRIPTION
## What

Implements **Option C (radical)** from the 3-pool runtime design note: splits the 3-pool path into its own config types + composition root, baking the 3-pool's constraints into the types so misconfigurations fail at YAML parse on the login node instead of minutes into a multi-node launch.

**DRAFT — do not merge.** Base: `feature/multipool`. Does not touch the running run (job 34574 / p-df5b9fbd).

## Shape

- **`ThreePoolConstrainedPDConfig`** (`experiments/lm/three_pool_pd.py`) — subclass of core `PDConfig` (IS-A, substitutable). Fixed scalars become frozen `Literal` defaults (`sampling="continuous"`, `n_mask_samples=1`, `use_delta_component=True`, `identity_decomposition_targets=None`). The generic `loss_metrics` list is replaced by a typed **`ThreePoolLosses(faith, imp, stoch, ppgd)`** struct — "exactly these four, each with a coeff" is unrepresentable-if-wrong. A before-validator derives the inherited `loss_metrics` list from the struct and excludes it from serialization (round-trips cleanly through the snapshot dump).
- **`ThreePoolRuntimeConfig`** — subclass of core `RuntimeConfig` (the three scalars) + `topology: ThreePoolConfig`. Nothing enters core's `RuntimeConfig`.
- **`ThreePoolLMExperimentConfig`** — standalone sibling of `LMExperimentConfig` (which drops `three_pool` and is now purely single-pool). Cross-field checks coupling `pd` to `runtime.topology` (batch divisibility, rank-0 convention) run as a load-time `@model_validator`.
- **Dispatch by entry point** — new `pd-lm-3pool` console script + `three_pool_run.py` composition root (fresh / resume / `--dp` submit). `run.py` dropped all `three_pool` branches; shared pure builders (`build_target`, `build_lm_loader`, `make_run_batch`, `_build_eval_loop`, `_split_metrics_by_slow`, `_resolve_train_run_id`) imported from it. `init_pd_run` / `_build_eval_loop` relaxed to structural protocols.
- **`ThreePoolTrainer`** now reads `pd.losses.faith/.imp/.stoch/.ppgd` directly. Deleted `_validate_pd_config_for_three_pool` (~70 lines) + the `by_type` dict-build + the `isinstance` asserts; only the site-coverage check (needs the loaded model) remains, in `_build_runtime`.
- **`SavedThreePoolLMRun`** reload sibling.
- **Resume provenance** now lives on the config (`resume_provenance` field on both config families) → flows into `run_meta.yaml` + `wandb.config` via `init_pd_run`, so a resumed run's lineage is visible in the wandb UI. Dropped the write-only FS `resume_provenance.yaml` side-file (no consumers).
- Migrated the two 3-pool YAMLs to the new shape.

## Validation

- **Parse-rejection tests** (`tests/test_three_pool_config_fork.py`): wrong fixed scalar, missing/extra loss, missing coeff, ppgd start_frac>0, batch-not-divisible, rank-0-not-leader, authoring `loss_metrics` directly, old top-level `three_pool` key — all fail at `model_validate`; valid config parses; pd dump round-trips; provenance defaults None / round-trips.
- **Behavior-preserving smoke**: OLD `pd-lm` (origin/feature/multipool) vs NEW `pd-lm-3pool`, same seed, 8-GPU gpt2-small q/k repro, 25 steps → **BIT-IDENTICAL** loss curves (faith/imp/ppgd/stoch/total, all logged steps, max abs diff 0.0). NEW run reached saves at 10/20/25 (exercises the 3-pool checkpoint barrier).
- `make check` clean (0 errors, 0 warnings); 282 lab tests + the new suite pass.

## Note that didn't survive contact with the code

- **Old-checkpoint resume incompatibility**: `from_snapshot` now re-validates `pd_config` as `ThreePoolConstrainedPDConfig`, so resuming from a *pre-fork* checkpoint (old-format `pd_config` dump with `loss_metrics`, no `losses`) would fail. Acceptable per no-legacy + this being a post-launch follow-up; flagged for awareness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>