### PR TITLE
three_pool: integrate #540 (async consolidation) + #541 (config fork)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,8 @@ All declared in `param_decomp_lab/pyproject.toml`.
 |---|---|---|
 | `pd-tms` | `experiments/tms/run.py` | Run TMS experiment from a YAML |
 | `pd-resid-mlp` | `experiments/resid_mlp/run.py` | Run ResidMLP from a YAML |
-| `pd-lm` | `experiments/lm/run.py` | Run LM from a YAML |
+| `pd-lm` | `experiments/lm/run.py` | Run single-pool LM from a YAML |
+| `pd-lm-3pool` | `experiments/lm/three_pool_run.py` | Run 3-pool LM from a `ThreePoolLMExperimentConfig` YAML |
 | `pd-lm-layerwise` | `experiments/lm/layerwise.py` | Split an LM YAML into per-matrix configs, submit as a SLURM array |
 | `pd-pretrain` | `experiments/lm/pretrain/cli.py` | Pretrain target models |
 | `pd-harvest` | `harvest/scripts/run_slurm_cli.py` | Submit harvest SLURM job |

--- a/param_decomp/run_sink.py
+++ b/param_decomp/run_sink.py
@@ -17,7 +17,7 @@ the eval period.
 
 from typing import Any, Protocol, runtime_checkable
 
-from param_decomp.training_state import ThreePoolTrainingState, TrainingState
+from param_decomp.training_state import TrainingState
 
 
 @runtime_checkable
@@ -52,14 +52,17 @@ class OnePoolRunSink(Protocol):
 class ThreePoolRunSink(Protocol):
     """Side-effect sink for a 3-pool training run.
 
-    Identical to `OnePoolRunSink` apart from the checkpoint parameter's state
-    type. Two separate protocols rather than a union so each trainer's
-    ``run()`` signature can only accept a sink wired to its own pool's state.
+    Unlike `OnePoolRunSink`, the 3-pool sink does NOT persist a training state
+    from the train loop. The trainer writes self-contained per-rank partials to
+    a shared-FS scratch dir (cheap, no rank-0 read), then calls
+    `checkpoint_written` so the sink can fire the async consolidation+eval job
+    that reads those partials, assembles ``model_<step>.pth`` +
+    ``training_<step>.pth`` off the critical path, and runs the slow eval.
     """
 
     def log(self, metrics: dict[str, Any], step: int) -> None: ...
     def console(self, *lines: str) -> None: ...
-    def checkpoint(self, snapshot: ThreePoolTrainingState, *, final: bool) -> None: ...
+    def checkpoint_written(self, step: int, *, final: bool) -> None: ...
     def finish(self) -> None: ...
 
 

--- a/param_decomp_lab/experiments/CLAUDE.md
+++ b/param_decomp_lab/experiments/CLAUDE.md
@@ -12,15 +12,41 @@ the concrete reload class directly.
 ```
 experiments/
 ├── utils.py                 # ExperimentConfig[T,D] generic + EvalConfig + WandbConfig
-│                            # + init_pd_run + RUN_META_FILENAME
+│                            # + init_pd_run + RUN_META_FILENAME + resume_provenance field
 ├── tms/run.py
 ├── resid_mlp/run.py
 └── lm/
-    ├── run.py
+    ├── run.py               # single-pool LM (pd-lm)
+    ├── three_pool_run.py    # 3-pool LM (pd-lm-3pool): ThreePoolLMExperimentConfig
+    ├── three_pool_pd.py     # ThreePoolConstrainedPDConfig + ThreePoolLosses
     ├── layerwise.py         # split LM YAML into per-matrix configs + SLURM-array submit
     ├── data.py
     └── pretrain/            # see lm/pretrain/CLAUDE.md
 ```
+
+## 3-pool config fork (`pd-lm-3pool`)
+
+The 3-pool training path is a standalone sibling of `pd-lm`, not a flag on it. Dispatch
+is by entry point (the repo idiom — no discriminator). `ThreePoolLMExperimentConfig`
+(in `lm/three_pool_run.py`) is a standalone `BaseConfig` with `pd:
+ThreePoolConstrainedPDConfig`, `runtime: ThreePoolRuntimeConfig` (core `RuntimeConfig`
+scalars + `topology: ThreePoolConfig`), and the usual `cadence`/`target`/`data`/`eval`/
+`wandb`. `LMExperimentConfig` is purely single-pool (no `three_pool` field).
+
+`ThreePoolConstrainedPDConfig` (in `lm/three_pool_pd.py`) subclasses core `PDConfig` and
+bakes the 3-pool's invariants into the types — `sampling`/`n_mask_samples`/
+`use_delta_component`/`identity_decomposition_targets` are frozen `Literal` defaults, and
+the generic `loss_metrics` list is replaced by a typed `ThreePoolLosses(faith, imp,
+stoch, ppgd)` struct (it derives the inherited `loss_metrics` list from the struct via a
+before-validator and excludes it from serialization). `ThreePoolTrainer` reads
+`pd.losses.faith` / `.imp` / `.stoch` / `.ppgd` directly — no `by_type` dict, no
+`isinstance` asserts. Cross-field checks coupling `pd` to `runtime.topology` (batch
+divisibility, rank-0 convention) run as a `@model_validator` on
+`ThreePoolLMExperimentConfig`, so 3-pool misconfigs fail at YAML parse, not minutes into
+a multi-node launch. (Site coverage — owned sites ∈ decomposition_targets after pattern
+expansion — stays in `ThreePoolTrainer._build_runtime` since it needs the loaded model.)
+
+Reload: `SavedThreePoolLMRun` (in `three_pool_run.py`) mirrors `SavedLMRun`.
 
 ## YAML schema
 

--- a/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_async_consol.yaml
+++ b/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_async_consol.yaml
@@ -1,6 +1,5 @@
 pd:
   seed: 0
-  n_mask_samples: 1
   ci_config:
     mode: global
     fn_type: global_shared_transformer
@@ -13,15 +12,12 @@ pd:
         n_heads: 12
         max_len: 128
         rope_base: 10000.0
-  sampling: continuous
   sigmoid_type: leaky_hard
   decomposition_targets:
   - module_pattern: h.*.attn.q_proj
     C: 64
   - module_pattern: h.*.attn.k_proj
     C: 64
-  identity_decomposition_targets: null
-  use_delta_component: true
   batch_size: 2
   steps: 25
   components_optimizer:
@@ -40,36 +36,36 @@ pd:
   faithfulness_warmup_steps: 2
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_weight_decay: 0.0
-  loss_metrics:
-  - type: FaithfulnessLoss
-    coeff: 100000000.0
-  - type: StochasticReconLayerwiseLoss
-    coeff: 100.0
-  - type: ImportanceMinimalityLoss
-    coeff: 3.2e-05
-    pnorm: 2.0
-    beta: 0.5
-    p_anneal_start_frac: 0.0
-    p_anneal_final_p: 0.3
-    p_anneal_end_frac: 1.0
-    eps: 1.0e-12
-  - type: PersistentPGDReconLoss
-    coeff: 1.0
-    optimizer:
-      type: adam
-      beta1: 0.5
-      beta2: 0.99
-      eps: 1.0e-08
-      lr_schedule:
-        start_val: 0.01
-        warmup_pct: 0.025
-        final_val_frac: 1.0
-        fn_type: constant
-    scope:
-      type: per_batch_per_position
-    use_sigmoid_parameterization: false
-    n_warmup_steps: 2
-    n_samples: 1
+  losses:
+    faith:
+      coeff: 100000000.0
+    imp:
+      coeff: 3.2e-05
+      pnorm: 2.0
+      beta: 0.5
+      p_anneal_start_frac: 0.0
+      p_anneal_final_p: 0.3
+      p_anneal_end_frac: 1.0
+      eps: 1.0e-12
+    stoch:
+      coeff: 100.0
+    ppgd:
+      coeff: 1.0
+      optimizer:
+        type: adam
+        beta1: 0.5
+        beta2: 0.99
+        eps: 1.0e-08
+        lr_schedule:
+          start_val: 0.01
+          warmup_pct: 0.025
+          final_val_frac: 1.0
+          fn_type: constant
+      scope:
+        type: per_batch_per_position
+      use_sigmoid_parameterization: false
+      n_warmup_steps: 2
+      n_samples: 1
 cadence:
   train_log_every: 5
   save_every: 5
@@ -90,6 +86,49 @@ runtime:
   autocast_bf16: true
   device: cuda
   dp: null
+  topology:
+    use_fused_kl: true
+    ci_ranks:
+    - 6
+    ppgd_ranks:
+    - 7
+    layerwise_block_groups:
+    - ranks:
+      - 0
+      - 1
+      owned_sites:
+      - h.0.attn.q_proj
+      - h.0.attn.k_proj
+      - h.1.attn.q_proj
+      - h.1.attn.k_proj
+      - h.2.attn.q_proj
+      - h.2.attn.k_proj
+      - h.3.attn.q_proj
+      - h.3.attn.k_proj
+    - ranks:
+      - 2
+      - 3
+      owned_sites:
+      - h.4.attn.q_proj
+      - h.4.attn.k_proj
+      - h.5.attn.q_proj
+      - h.5.attn.k_proj
+      - h.6.attn.q_proj
+      - h.6.attn.k_proj
+      - h.7.attn.q_proj
+      - h.7.attn.k_proj
+    - ranks:
+      - 4
+      - 5
+      owned_sites:
+      - h.8.attn.q_proj
+      - h.8.attn.k_proj
+      - h.9.attn.q_proj
+      - h.9.attn.k_proj
+      - h.10.attn.q_proj
+      - h.10.attn.k_proj
+      - h.11.attn.q_proj
+      - h.11.attn.k_proj
 target:
   spec:
     kind: hf_weights_in_vendored
@@ -108,46 +147,3 @@ data:
   streaming: true
   buffer_size: 1000
   shuffle_each_epoch: true
-three_pool:
-  use_fused_kl: true
-  ci_ranks:
-  - 6
-  ppgd_ranks:
-  - 7
-  layerwise_block_groups:
-  - ranks:
-    - 0
-    - 1
-    owned_sites:
-    - h.0.attn.q_proj
-    - h.0.attn.k_proj
-    - h.1.attn.q_proj
-    - h.1.attn.k_proj
-    - h.2.attn.q_proj
-    - h.2.attn.k_proj
-    - h.3.attn.q_proj
-    - h.3.attn.k_proj
-  - ranks:
-    - 2
-    - 3
-    owned_sites:
-    - h.4.attn.q_proj
-    - h.4.attn.k_proj
-    - h.5.attn.q_proj
-    - h.5.attn.k_proj
-    - h.6.attn.q_proj
-    - h.6.attn.k_proj
-    - h.7.attn.q_proj
-    - h.7.attn.k_proj
-  - ranks:
-    - 4
-    - 5
-    owned_sites:
-    - h.8.attn.q_proj
-    - h.8.attn.k_proj
-    - h.9.attn.q_proj
-    - h.9.attn.k_proj
-    - h.10.attn.q_proj
-    - h.10.attn.k_proj
-    - h.11.attn.q_proj
-    - h.11.attn.k_proj

--- a/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_async_consol.yaml
+++ b/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_async_consol.yaml
@@ -1,0 +1,153 @@
+pd:
+  seed: 0
+  n_mask_samples: 1
+  ci_config:
+    mode: global
+    fn_type: global_shared_transformer
+    simple_transformer_ci_cfg:
+      d_model: 768
+      n_blocks: 2
+      mlp_hidden_dim:
+      - 512
+      attn_config:
+        n_heads: 12
+        max_len: 128
+        rope_base: 10000.0
+  sampling: continuous
+  sigmoid_type: leaky_hard
+  decomposition_targets:
+  - module_pattern: h.*.attn.q_proj
+    C: 64
+  - module_pattern: h.*.attn.k_proj
+    C: 64
+  identity_decomposition_targets: null
+  use_delta_component: true
+  batch_size: 2
+  steps: 25
+  components_optimizer:
+    lr_schedule:
+      start_val: 0.0003
+      warmup_pct: 0.03
+      final_val_frac: 0.1
+      fn_type: cosine
+    grad_clip_norm: 0.01
+  ci_fn_optimizer:
+    lr_schedule:
+      start_val: 0.0001
+      warmup_pct: 0.03
+      final_val_frac: 0.1
+      fn_type: cosine
+  faithfulness_warmup_steps: 2
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_weight_decay: 0.0
+  loss_metrics:
+  - type: FaithfulnessLoss
+    coeff: 100000000.0
+  - type: StochasticReconLayerwiseLoss
+    coeff: 100.0
+  - type: ImportanceMinimalityLoss
+    coeff: 3.2e-05
+    pnorm: 2.0
+    beta: 0.5
+    p_anneal_start_frac: 0.0
+    p_anneal_final_p: 0.3
+    p_anneal_end_frac: 1.0
+    eps: 1.0e-12
+  - type: PersistentPGDReconLoss
+    coeff: 1.0
+    optimizer:
+      type: adam
+      beta1: 0.5
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        start_val: 0.01
+        warmup_pct: 0.025
+        final_val_frac: 1.0
+        fn_type: constant
+    scope:
+      type: per_batch_per_position
+    use_sigmoid_parameterization: false
+    n_warmup_steps: 2
+    n_samples: 1
+cadence:
+  train_log_every: 5
+  save_every: 5
+eval:
+  n_steps: 1
+  batch_size: 2
+  every: 10
+  slow_every: 10
+  slow_on_first_step: true
+  metrics:
+  - type: CI_L0
+    groups:
+      total:
+      - '*'
+  - type: CEandKLLosses
+    rounding_threshold: 0.0
+runtime:
+  autocast_bf16: true
+  device: cuda
+  dp: null
+target:
+  spec:
+    kind: hf_weights_in_vendored
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.gpt2_simple.GPT2Simple
+    model_name: openai-community/gpt2
+  output_extract: 0
+  activation_checkpointing: false
+data:
+  tokenizer_name: openai-community/gpt2
+  max_seq_len: 128
+  dataset_name: apollo-research/Skylion007-openwebtext-tokenizer-gpt2
+  column_name: input_ids
+  train_split: train
+  eval_split: train
+  is_tokenized: true
+  streaming: true
+  buffer_size: 1000
+  shuffle_each_epoch: true
+three_pool:
+  use_fused_kl: true
+  ci_ranks:
+  - 6
+  ppgd_ranks:
+  - 7
+  layerwise_block_groups:
+  - ranks:
+    - 0
+    - 1
+    owned_sites:
+    - h.0.attn.q_proj
+    - h.0.attn.k_proj
+    - h.1.attn.q_proj
+    - h.1.attn.k_proj
+    - h.2.attn.q_proj
+    - h.2.attn.k_proj
+    - h.3.attn.q_proj
+    - h.3.attn.k_proj
+  - ranks:
+    - 2
+    - 3
+    owned_sites:
+    - h.4.attn.q_proj
+    - h.4.attn.k_proj
+    - h.5.attn.q_proj
+    - h.5.attn.k_proj
+    - h.6.attn.q_proj
+    - h.6.attn.k_proj
+    - h.7.attn.q_proj
+    - h.7.attn.k_proj
+  - ranks:
+    - 4
+    - 5
+    owned_sites:
+    - h.8.attn.q_proj
+    - h.8.attn.k_proj
+    - h.9.attn.q_proj
+    - h.9.attn.k_proj
+    - h.10.attn.q_proj
+    - h.10.attn.k_proj
+    - h.11.attn.q_proj
+    - h.11.attn.k_proj

--- a/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_live_4gpu.yaml
+++ b/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_live_4gpu.yaml
@@ -1,0 +1,145 @@
+pd:
+  seed: 0
+  n_mask_samples: 1
+  ci_config:
+    mode: global
+    fn_type: global_shared_transformer
+    simple_transformer_ci_cfg:
+      d_model: 768
+      n_blocks: 2
+      mlp_hidden_dim:
+      - 512
+      attn_config:
+        n_heads: 12
+        max_len: 128
+        rope_base: 10000.0
+  sampling: continuous
+  sigmoid_type: leaky_hard
+  decomposition_targets:
+  - module_pattern: h.*.attn.q_proj
+    C: 64
+  - module_pattern: h.*.attn.k_proj
+    C: 64
+  identity_decomposition_targets: null
+  use_delta_component: true
+  batch_size: 2
+  steps: 25
+  components_optimizer:
+    lr_schedule:
+      start_val: 0.0003
+      warmup_pct: 0.03
+      final_val_frac: 0.1
+      fn_type: cosine
+    grad_clip_norm: 0.01
+  ci_fn_optimizer:
+    lr_schedule:
+      start_val: 0.0001
+      warmup_pct: 0.03
+      final_val_frac: 0.1
+      fn_type: cosine
+  faithfulness_warmup_steps: 2
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_weight_decay: 0.0
+  loss_metrics:
+  - type: FaithfulnessLoss
+    coeff: 100000000.0
+  - type: StochasticReconLayerwiseLoss
+    coeff: 100.0
+  - type: ImportanceMinimalityLoss
+    coeff: 3.2e-05
+    pnorm: 2.0
+    beta: 0.5
+    p_anneal_start_frac: 0.0
+    p_anneal_final_p: 0.3
+    p_anneal_end_frac: 1.0
+    eps: 1.0e-12
+  - type: PersistentPGDReconLoss
+    coeff: 1.0
+    optimizer:
+      type: adam
+      beta1: 0.5
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        start_val: 0.01
+        warmup_pct: 0.025
+        final_val_frac: 1.0
+        fn_type: constant
+    scope:
+      type: per_batch_per_position
+    use_sigmoid_parameterization: false
+    n_warmup_steps: 2
+    n_samples: 1
+cadence:
+  train_log_every: 5
+  save_every: 5
+eval:
+  n_steps: 1
+  batch_size: 2
+  every: 10
+  slow_every: 10
+  slow_on_first_step: true
+  metrics:
+  - type: CI_L0
+    groups:
+      total:
+      - '*'
+  - type: CEandKLLosses
+    rounding_threshold: 0.0
+runtime:
+  autocast_bf16: true
+  device: cuda
+  dp: null
+target:
+  spec:
+    kind: hf_weights_in_vendored
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.gpt2_simple.GPT2Simple
+    model_name: openai-community/gpt2
+  output_extract: 0
+  activation_checkpointing: false
+data:
+  tokenizer_name: openai-community/gpt2
+  max_seq_len: 128
+  dataset_name: apollo-research/Skylion007-openwebtext-tokenizer-gpt2
+  column_name: input_ids
+  train_split: train
+  eval_split: train
+  is_tokenized: true
+  streaming: true
+  buffer_size: 1000
+  shuffle_each_epoch: true
+three_pool:
+  use_fused_kl: true
+  ci_ranks:
+  - 2
+  ppgd_ranks:
+  - 3
+  layerwise_block_groups:
+  - ranks:
+    - 0
+    - 1
+    owned_sites:
+    - h.0.attn.q_proj
+    - h.0.attn.k_proj
+    - h.1.attn.q_proj
+    - h.1.attn.k_proj
+    - h.2.attn.q_proj
+    - h.2.attn.k_proj
+    - h.3.attn.q_proj
+    - h.3.attn.k_proj
+    - h.4.attn.q_proj
+    - h.4.attn.k_proj
+    - h.5.attn.q_proj
+    - h.5.attn.k_proj
+    - h.6.attn.q_proj
+    - h.6.attn.k_proj
+    - h.7.attn.q_proj
+    - h.7.attn.k_proj
+    - h.8.attn.q_proj
+    - h.8.attn.k_proj
+    - h.9.attn.q_proj
+    - h.9.attn.k_proj
+    - h.10.attn.q_proj
+    - h.10.attn.k_proj
+    - h.11.attn.q_proj
+    - h.11.attn.k_proj

--- a/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_live_4gpu.yaml
+++ b/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_live_4gpu.yaml
@@ -1,6 +1,5 @@
 pd:
   seed: 0
-  n_mask_samples: 1
   ci_config:
     mode: global
     fn_type: global_shared_transformer
@@ -13,15 +12,12 @@ pd:
         n_heads: 12
         max_len: 128
         rope_base: 10000.0
-  sampling: continuous
   sigmoid_type: leaky_hard
   decomposition_targets:
   - module_pattern: h.*.attn.q_proj
     C: 64
   - module_pattern: h.*.attn.k_proj
     C: 64
-  identity_decomposition_targets: null
-  use_delta_component: true
   batch_size: 2
   steps: 25
   components_optimizer:
@@ -40,36 +36,36 @@ pd:
   faithfulness_warmup_steps: 2
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_weight_decay: 0.0
-  loss_metrics:
-  - type: FaithfulnessLoss
-    coeff: 100000000.0
-  - type: StochasticReconLayerwiseLoss
-    coeff: 100.0
-  - type: ImportanceMinimalityLoss
-    coeff: 3.2e-05
-    pnorm: 2.0
-    beta: 0.5
-    p_anneal_start_frac: 0.0
-    p_anneal_final_p: 0.3
-    p_anneal_end_frac: 1.0
-    eps: 1.0e-12
-  - type: PersistentPGDReconLoss
-    coeff: 1.0
-    optimizer:
-      type: adam
-      beta1: 0.5
-      beta2: 0.99
-      eps: 1.0e-08
-      lr_schedule:
-        start_val: 0.01
-        warmup_pct: 0.025
-        final_val_frac: 1.0
-        fn_type: constant
-    scope:
-      type: per_batch_per_position
-    use_sigmoid_parameterization: false
-    n_warmup_steps: 2
-    n_samples: 1
+  losses:
+    faith:
+      coeff: 100000000.0
+    imp:
+      coeff: 3.2e-05
+      pnorm: 2.0
+      beta: 0.5
+      p_anneal_start_frac: 0.0
+      p_anneal_final_p: 0.3
+      p_anneal_end_frac: 1.0
+      eps: 1.0e-12
+    stoch:
+      coeff: 100.0
+    ppgd:
+      coeff: 1.0
+      optimizer:
+        type: adam
+        beta1: 0.5
+        beta2: 0.99
+        eps: 1.0e-08
+        lr_schedule:
+          start_val: 0.01
+          warmup_pct: 0.025
+          final_val_frac: 1.0
+          fn_type: constant
+      scope:
+        type: per_batch_per_position
+      use_sigmoid_parameterization: false
+      n_warmup_steps: 2
+      n_samples: 1
 cadence:
   train_log_every: 5
   save_every: 5
@@ -90,6 +86,41 @@ runtime:
   autocast_bf16: true
   device: cuda
   dp: null
+  topology:
+    use_fused_kl: true
+    ci_ranks:
+    - 2
+    ppgd_ranks:
+    - 3
+    layerwise_block_groups:
+    - ranks:
+      - 0
+      - 1
+      owned_sites:
+      - h.0.attn.q_proj
+      - h.0.attn.k_proj
+      - h.1.attn.q_proj
+      - h.1.attn.k_proj
+      - h.2.attn.q_proj
+      - h.2.attn.k_proj
+      - h.3.attn.q_proj
+      - h.3.attn.k_proj
+      - h.4.attn.q_proj
+      - h.4.attn.k_proj
+      - h.5.attn.q_proj
+      - h.5.attn.k_proj
+      - h.6.attn.q_proj
+      - h.6.attn.k_proj
+      - h.7.attn.q_proj
+      - h.7.attn.k_proj
+      - h.8.attn.q_proj
+      - h.8.attn.k_proj
+      - h.9.attn.q_proj
+      - h.9.attn.k_proj
+      - h.10.attn.q_proj
+      - h.10.attn.k_proj
+      - h.11.attn.q_proj
+      - h.11.attn.k_proj
 target:
   spec:
     kind: hf_weights_in_vendored
@@ -108,38 +139,3 @@ data:
   streaming: true
   buffer_size: 1000
   shuffle_each_epoch: true
-three_pool:
-  use_fused_kl: true
-  ci_ranks:
-  - 2
-  ppgd_ranks:
-  - 3
-  layerwise_block_groups:
-  - ranks:
-    - 0
-    - 1
-    owned_sites:
-    - h.0.attn.q_proj
-    - h.0.attn.k_proj
-    - h.1.attn.q_proj
-    - h.1.attn.k_proj
-    - h.2.attn.q_proj
-    - h.2.attn.k_proj
-    - h.3.attn.q_proj
-    - h.3.attn.k_proj
-    - h.4.attn.q_proj
-    - h.4.attn.k_proj
-    - h.5.attn.q_proj
-    - h.5.attn.k_proj
-    - h.6.attn.q_proj
-    - h.6.attn.k_proj
-    - h.7.attn.q_proj
-    - h.7.attn.k_proj
-    - h.8.attn.q_proj
-    - h.8.attn.k_proj
-    - h.9.attn.q_proj
-    - h.9.attn.k_proj
-    - h.10.attn.q_proj
-    - h.10.attn.k_proj
-    - h.11.attn.q_proj
-    - h.11.attn.k_proj

--- a/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_live_4gpu_2save.yaml
+++ b/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_live_4gpu_2save.yaml
@@ -1,0 +1,145 @@
+pd:
+  seed: 0
+  n_mask_samples: 1
+  ci_config:
+    mode: global
+    fn_type: global_shared_transformer
+    simple_transformer_ci_cfg:
+      d_model: 768
+      n_blocks: 2
+      mlp_hidden_dim:
+      - 512
+      attn_config:
+        n_heads: 12
+        max_len: 128
+        rope_base: 10000.0
+  sampling: continuous
+  sigmoid_type: leaky_hard
+  decomposition_targets:
+  - module_pattern: h.*.attn.q_proj
+    C: 64
+  - module_pattern: h.*.attn.k_proj
+    C: 64
+  identity_decomposition_targets: null
+  use_delta_component: true
+  batch_size: 2
+  steps: 25
+  components_optimizer:
+    lr_schedule:
+      start_val: 0.0003
+      warmup_pct: 0.03
+      final_val_frac: 0.1
+      fn_type: cosine
+    grad_clip_norm: 0.01
+  ci_fn_optimizer:
+    lr_schedule:
+      start_val: 0.0001
+      warmup_pct: 0.03
+      final_val_frac: 0.1
+      fn_type: cosine
+  faithfulness_warmup_steps: 2
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_weight_decay: 0.0
+  loss_metrics:
+  - type: FaithfulnessLoss
+    coeff: 100000000.0
+  - type: StochasticReconLayerwiseLoss
+    coeff: 100.0
+  - type: ImportanceMinimalityLoss
+    coeff: 3.2e-05
+    pnorm: 2.0
+    beta: 0.5
+    p_anneal_start_frac: 0.0
+    p_anneal_final_p: 0.3
+    p_anneal_end_frac: 1.0
+    eps: 1.0e-12
+  - type: PersistentPGDReconLoss
+    coeff: 1.0
+    optimizer:
+      type: adam
+      beta1: 0.5
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        start_val: 0.01
+        warmup_pct: 0.025
+        final_val_frac: 1.0
+        fn_type: constant
+    scope:
+      type: per_batch_per_position
+    use_sigmoid_parameterization: false
+    n_warmup_steps: 2
+    n_samples: 1
+cadence:
+  train_log_every: 5
+  save_every: 20
+eval:
+  n_steps: 1
+  batch_size: 2
+  every: 10
+  slow_every: 10
+  slow_on_first_step: true
+  metrics:
+  - type: CI_L0
+    groups:
+      total:
+      - '*'
+  - type: CEandKLLosses
+    rounding_threshold: 0.0
+runtime:
+  autocast_bf16: true
+  device: cuda
+  dp: null
+target:
+  spec:
+    kind: hf_weights_in_vendored
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.gpt2_simple.GPT2Simple
+    model_name: openai-community/gpt2
+  output_extract: 0
+  activation_checkpointing: false
+data:
+  tokenizer_name: openai-community/gpt2
+  max_seq_len: 128
+  dataset_name: apollo-research/Skylion007-openwebtext-tokenizer-gpt2
+  column_name: input_ids
+  train_split: train
+  eval_split: train
+  is_tokenized: true
+  streaming: true
+  buffer_size: 1000
+  shuffle_each_epoch: true
+three_pool:
+  use_fused_kl: true
+  ci_ranks:
+  - 2
+  ppgd_ranks:
+  - 3
+  layerwise_block_groups:
+  - ranks:
+    - 0
+    - 1
+    owned_sites:
+    - h.0.attn.q_proj
+    - h.0.attn.k_proj
+    - h.1.attn.q_proj
+    - h.1.attn.k_proj
+    - h.2.attn.q_proj
+    - h.2.attn.k_proj
+    - h.3.attn.q_proj
+    - h.3.attn.k_proj
+    - h.4.attn.q_proj
+    - h.4.attn.k_proj
+    - h.5.attn.q_proj
+    - h.5.attn.k_proj
+    - h.6.attn.q_proj
+    - h.6.attn.k_proj
+    - h.7.attn.q_proj
+    - h.7.attn.k_proj
+    - h.8.attn.q_proj
+    - h.8.attn.k_proj
+    - h.9.attn.q_proj
+    - h.9.attn.k_proj
+    - h.10.attn.q_proj
+    - h.10.attn.k_proj
+    - h.11.attn.q_proj
+    - h.11.attn.k_proj

--- a/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_live_4gpu_2save.yaml
+++ b/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_live_4gpu_2save.yaml
@@ -1,6 +1,5 @@
 pd:
   seed: 0
-  n_mask_samples: 1
   ci_config:
     mode: global
     fn_type: global_shared_transformer
@@ -13,15 +12,12 @@ pd:
         n_heads: 12
         max_len: 128
         rope_base: 10000.0
-  sampling: continuous
   sigmoid_type: leaky_hard
   decomposition_targets:
   - module_pattern: h.*.attn.q_proj
     C: 64
   - module_pattern: h.*.attn.k_proj
     C: 64
-  identity_decomposition_targets: null
-  use_delta_component: true
   batch_size: 2
   steps: 25
   components_optimizer:
@@ -40,36 +36,36 @@ pd:
   faithfulness_warmup_steps: 2
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_weight_decay: 0.0
-  loss_metrics:
-  - type: FaithfulnessLoss
-    coeff: 100000000.0
-  - type: StochasticReconLayerwiseLoss
-    coeff: 100.0
-  - type: ImportanceMinimalityLoss
-    coeff: 3.2e-05
-    pnorm: 2.0
-    beta: 0.5
-    p_anneal_start_frac: 0.0
-    p_anneal_final_p: 0.3
-    p_anneal_end_frac: 1.0
-    eps: 1.0e-12
-  - type: PersistentPGDReconLoss
-    coeff: 1.0
-    optimizer:
-      type: adam
-      beta1: 0.5
-      beta2: 0.99
-      eps: 1.0e-08
-      lr_schedule:
-        start_val: 0.01
-        warmup_pct: 0.025
-        final_val_frac: 1.0
-        fn_type: constant
-    scope:
-      type: per_batch_per_position
-    use_sigmoid_parameterization: false
-    n_warmup_steps: 2
-    n_samples: 1
+  losses:
+    faith:
+      coeff: 100000000.0
+    imp:
+      coeff: 3.2e-05
+      pnorm: 2.0
+      beta: 0.5
+      p_anneal_start_frac: 0.0
+      p_anneal_final_p: 0.3
+      p_anneal_end_frac: 1.0
+      eps: 1.0e-12
+    stoch:
+      coeff: 100.0
+    ppgd:
+      coeff: 1.0
+      optimizer:
+        type: adam
+        beta1: 0.5
+        beta2: 0.99
+        eps: 1.0e-08
+        lr_schedule:
+          start_val: 0.01
+          warmup_pct: 0.025
+          final_val_frac: 1.0
+          fn_type: constant
+      scope:
+        type: per_batch_per_position
+      use_sigmoid_parameterization: false
+      n_warmup_steps: 2
+      n_samples: 1
 cadence:
   train_log_every: 5
   save_every: 20
@@ -90,6 +86,41 @@ runtime:
   autocast_bf16: true
   device: cuda
   dp: null
+  topology:
+    use_fused_kl: true
+    ci_ranks:
+    - 2
+    ppgd_ranks:
+    - 3
+    layerwise_block_groups:
+    - ranks:
+      - 0
+      - 1
+      owned_sites:
+      - h.0.attn.q_proj
+      - h.0.attn.k_proj
+      - h.1.attn.q_proj
+      - h.1.attn.k_proj
+      - h.2.attn.q_proj
+      - h.2.attn.k_proj
+      - h.3.attn.q_proj
+      - h.3.attn.k_proj
+      - h.4.attn.q_proj
+      - h.4.attn.k_proj
+      - h.5.attn.q_proj
+      - h.5.attn.k_proj
+      - h.6.attn.q_proj
+      - h.6.attn.k_proj
+      - h.7.attn.q_proj
+      - h.7.attn.k_proj
+      - h.8.attn.q_proj
+      - h.8.attn.k_proj
+      - h.9.attn.q_proj
+      - h.9.attn.k_proj
+      - h.10.attn.q_proj
+      - h.10.attn.k_proj
+      - h.11.attn.q_proj
+      - h.11.attn.k_proj
 target:
   spec:
     kind: hf_weights_in_vendored
@@ -108,38 +139,3 @@ data:
   streaming: true
   buffer_size: 1000
   shuffle_each_epoch: true
-three_pool:
-  use_fused_kl: true
-  ci_ranks:
-  - 2
-  ppgd_ranks:
-  - 3
-  layerwise_block_groups:
-  - ranks:
-    - 0
-    - 1
-    owned_sites:
-    - h.0.attn.q_proj
-    - h.0.attn.k_proj
-    - h.1.attn.q_proj
-    - h.1.attn.k_proj
-    - h.2.attn.q_proj
-    - h.2.attn.k_proj
-    - h.3.attn.q_proj
-    - h.3.attn.k_proj
-    - h.4.attn.q_proj
-    - h.4.attn.k_proj
-    - h.5.attn.q_proj
-    - h.5.attn.k_proj
-    - h.6.attn.q_proj
-    - h.6.attn.k_proj
-    - h.7.attn.q_proj
-    - h.7.attn.k_proj
-    - h.8.attn.q_proj
-    - h.8.attn.k_proj
-    - h.9.attn.q_proj
-    - h.9.attn.k_proj
-    - h.10.attn.q_proj
-    - h.10.attn.k_proj
-    - h.11.attn.q_proj
-    - h.11.attn.k_proj

--- a/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_live_e2e.yaml
+++ b/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_live_e2e.yaml
@@ -1,0 +1,149 @@
+pd:
+  seed: 0
+  n_mask_samples: 1
+  ci_config:
+    mode: global
+    fn_type: global_shared_transformer
+    simple_transformer_ci_cfg:
+      d_model: 768
+      n_blocks: 2
+      mlp_hidden_dim:
+      - 512
+      attn_config:
+        n_heads: 12
+        max_len: 128
+        rope_base: 10000.0
+  sampling: continuous
+  sigmoid_type: leaky_hard
+  decomposition_targets:
+  - module_pattern: h.*.attn.q_proj
+    C: 64
+  - module_pattern: h.*.attn.k_proj
+    C: 64
+  identity_decomposition_targets: null
+  use_delta_component: true
+  batch_size: 2
+  steps: 25
+  components_optimizer:
+    lr_schedule:
+      start_val: 0.0003
+      warmup_pct: 0.03
+      final_val_frac: 0.1
+      fn_type: cosine
+    grad_clip_norm: 0.01
+  ci_fn_optimizer:
+    lr_schedule:
+      start_val: 0.0001
+      warmup_pct: 0.03
+      final_val_frac: 0.1
+      fn_type: cosine
+  faithfulness_warmup_steps: 2
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_weight_decay: 0.0
+  loss_metrics:
+  - type: FaithfulnessLoss
+    coeff: 100000000.0
+  - type: StochasticReconLayerwiseLoss
+    coeff: 100.0
+  - type: ImportanceMinimalityLoss
+    coeff: 3.2e-05
+    pnorm: 2.0
+    beta: 0.5
+    p_anneal_start_frac: 0.0
+    p_anneal_final_p: 0.3
+    p_anneal_end_frac: 1.0
+    eps: 1.0e-12
+  - type: PersistentPGDReconLoss
+    coeff: 1.0
+    optimizer:
+      type: adam
+      beta1: 0.5
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        start_val: 0.01
+        warmup_pct: 0.025
+        final_val_frac: 1.0
+        fn_type: constant
+    scope:
+      type: per_batch_per_position
+    use_sigmoid_parameterization: false
+    n_warmup_steps: 2
+    n_samples: 1
+cadence:
+  train_log_every: 5
+  save_every: 5
+eval:
+  n_steps: 1
+  batch_size: 2
+  every: 10
+  slow_every: 10
+  slow_on_first_step: true
+  metrics:
+  - type: CI_L0
+    groups:
+      total:
+      - '*'
+  - type: CEandKLLosses
+    rounding_threshold: 0.0
+runtime:
+  autocast_bf16: true
+  device: cuda
+  dp: null
+target:
+  spec:
+    kind: hf_weights_in_vendored
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.gpt2_simple.GPT2Simple
+    model_name: openai-community/gpt2
+  output_extract: 0
+  activation_checkpointing: false
+data:
+  tokenizer_name: openai-community/gpt2
+  max_seq_len: 128
+  dataset_name: apollo-research/Skylion007-openwebtext-tokenizer-gpt2
+  column_name: input_ids
+  train_split: train
+  eval_split: train
+  is_tokenized: true
+  streaming: true
+  buffer_size: 1000
+  shuffle_each_epoch: true
+three_pool:
+  use_fused_kl: true
+  ci_ranks:
+  - 4
+  ppgd_ranks:
+  - 5
+  layerwise_block_groups:
+  - ranks:
+    - 0
+    - 1
+    owned_sites:
+    - h.0.attn.q_proj
+    - h.0.attn.k_proj
+    - h.1.attn.q_proj
+    - h.1.attn.k_proj
+    - h.2.attn.q_proj
+    - h.2.attn.k_proj
+    - h.3.attn.q_proj
+    - h.3.attn.k_proj
+    - h.4.attn.q_proj
+    - h.4.attn.k_proj
+    - h.5.attn.q_proj
+    - h.5.attn.k_proj
+  - ranks:
+    - 2
+    - 3
+    owned_sites:
+    - h.6.attn.q_proj
+    - h.6.attn.k_proj
+    - h.7.attn.q_proj
+    - h.7.attn.k_proj
+    - h.8.attn.q_proj
+    - h.8.attn.k_proj
+    - h.9.attn.q_proj
+    - h.9.attn.k_proj
+    - h.10.attn.q_proj
+    - h.10.attn.k_proj
+    - h.11.attn.q_proj
+    - h.11.attn.k_proj

--- a/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_live_e2e.yaml
+++ b/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_live_e2e.yaml
@@ -1,6 +1,5 @@
 pd:
   seed: 0
-  n_mask_samples: 1
   ci_config:
     mode: global
     fn_type: global_shared_transformer
@@ -13,15 +12,12 @@ pd:
         n_heads: 12
         max_len: 128
         rope_base: 10000.0
-  sampling: continuous
   sigmoid_type: leaky_hard
   decomposition_targets:
   - module_pattern: h.*.attn.q_proj
     C: 64
   - module_pattern: h.*.attn.k_proj
     C: 64
-  identity_decomposition_targets: null
-  use_delta_component: true
   batch_size: 2
   steps: 25
   components_optimizer:
@@ -40,36 +36,36 @@ pd:
   faithfulness_warmup_steps: 2
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_weight_decay: 0.0
-  loss_metrics:
-  - type: FaithfulnessLoss
-    coeff: 100000000.0
-  - type: StochasticReconLayerwiseLoss
-    coeff: 100.0
-  - type: ImportanceMinimalityLoss
-    coeff: 3.2e-05
-    pnorm: 2.0
-    beta: 0.5
-    p_anneal_start_frac: 0.0
-    p_anneal_final_p: 0.3
-    p_anneal_end_frac: 1.0
-    eps: 1.0e-12
-  - type: PersistentPGDReconLoss
-    coeff: 1.0
-    optimizer:
-      type: adam
-      beta1: 0.5
-      beta2: 0.99
-      eps: 1.0e-08
-      lr_schedule:
-        start_val: 0.01
-        warmup_pct: 0.025
-        final_val_frac: 1.0
-        fn_type: constant
-    scope:
-      type: per_batch_per_position
-    use_sigmoid_parameterization: false
-    n_warmup_steps: 2
-    n_samples: 1
+  losses:
+    faith:
+      coeff: 100000000.0
+    imp:
+      coeff: 3.2e-05
+      pnorm: 2.0
+      beta: 0.5
+      p_anneal_start_frac: 0.0
+      p_anneal_final_p: 0.3
+      p_anneal_end_frac: 1.0
+      eps: 1.0e-12
+    stoch:
+      coeff: 100.0
+    ppgd:
+      coeff: 1.0
+      optimizer:
+        type: adam
+        beta1: 0.5
+        beta2: 0.99
+        eps: 1.0e-08
+        lr_schedule:
+          start_val: 0.01
+          warmup_pct: 0.025
+          final_val_frac: 1.0
+          fn_type: constant
+      scope:
+        type: per_batch_per_position
+      use_sigmoid_parameterization: false
+      n_warmup_steps: 2
+      n_samples: 1
 cadence:
   train_log_every: 5
   save_every: 5
@@ -90,6 +86,45 @@ runtime:
   autocast_bf16: true
   device: cuda
   dp: null
+  topology:
+    use_fused_kl: true
+    ci_ranks:
+    - 4
+    ppgd_ranks:
+    - 5
+    layerwise_block_groups:
+    - ranks:
+      - 0
+      - 1
+      owned_sites:
+      - h.0.attn.q_proj
+      - h.0.attn.k_proj
+      - h.1.attn.q_proj
+      - h.1.attn.k_proj
+      - h.2.attn.q_proj
+      - h.2.attn.k_proj
+      - h.3.attn.q_proj
+      - h.3.attn.k_proj
+      - h.4.attn.q_proj
+      - h.4.attn.k_proj
+      - h.5.attn.q_proj
+      - h.5.attn.k_proj
+    - ranks:
+      - 2
+      - 3
+      owned_sites:
+      - h.6.attn.q_proj
+      - h.6.attn.k_proj
+      - h.7.attn.q_proj
+      - h.7.attn.k_proj
+      - h.8.attn.q_proj
+      - h.8.attn.k_proj
+      - h.9.attn.q_proj
+      - h.9.attn.k_proj
+      - h.10.attn.q_proj
+      - h.10.attn.k_proj
+      - h.11.attn.q_proj
+      - h.11.attn.k_proj
 target:
   spec:
     kind: hf_weights_in_vendored
@@ -108,42 +143,3 @@ data:
   streaming: true
   buffer_size: 1000
   shuffle_each_epoch: true
-three_pool:
-  use_fused_kl: true
-  ci_ranks:
-  - 4
-  ppgd_ranks:
-  - 5
-  layerwise_block_groups:
-  - ranks:
-    - 0
-    - 1
-    owned_sites:
-    - h.0.attn.q_proj
-    - h.0.attn.k_proj
-    - h.1.attn.q_proj
-    - h.1.attn.k_proj
-    - h.2.attn.q_proj
-    - h.2.attn.k_proj
-    - h.3.attn.q_proj
-    - h.3.attn.k_proj
-    - h.4.attn.q_proj
-    - h.4.attn.k_proj
-    - h.5.attn.q_proj
-    - h.5.attn.k_proj
-  - ranks:
-    - 2
-    - 3
-    owned_sites:
-    - h.6.attn.q_proj
-    - h.6.attn.k_proj
-    - h.7.attn.q_proj
-    - h.7.attn.k_proj
-    - h.8.attn.q_proj
-    - h.8.attn.k_proj
-    - h.9.attn.q_proj
-    - h.9.attn.k_proj
-    - h.10.attn.q_proj
-    - h.10.attn.k_proj
-    - h.11.attn.q_proj
-    - h.11.attn.k_proj

--- a/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_save_repro.yaml
+++ b/param_decomp_lab/experiments/lm/_resumption_validation/gpt2_small_3pool_save_repro.yaml
@@ -1,6 +1,5 @@
 pd:
   seed: 0
-  n_mask_samples: 1
   ci_config:
     mode: global
     fn_type: global_shared_transformer
@@ -13,15 +12,12 @@ pd:
         n_heads: 12
         max_len: 128
         rope_base: 10000.0
-  sampling: continuous
   sigmoid_type: leaky_hard
   decomposition_targets:
   - module_pattern: h.*.attn.q_proj
     C: 64
   - module_pattern: h.*.attn.k_proj
     C: 64
-  identity_decomposition_targets: null
-  use_delta_component: true
   batch_size: 2
   steps: 25
   components_optimizer:
@@ -40,36 +36,36 @@ pd:
   faithfulness_warmup_steps: 2
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_weight_decay: 0.0
-  loss_metrics:
-  - type: FaithfulnessLoss
-    coeff: 100000000.0
-  - type: StochasticReconLayerwiseLoss
-    coeff: 100.0
-  - type: ImportanceMinimalityLoss
-    coeff: 3.2e-05
-    pnorm: 2.0
-    beta: 0.5
-    p_anneal_start_frac: 0.0
-    p_anneal_final_p: 0.3
-    p_anneal_end_frac: 1.0
-    eps: 1.0e-12
-  - type: PersistentPGDReconLoss
-    coeff: 1.0
-    optimizer:
-      type: adam
-      beta1: 0.5
-      beta2: 0.99
-      eps: 1.0e-08
-      lr_schedule:
-        start_val: 0.01
-        warmup_pct: 0.025
-        final_val_frac: 1.0
-        fn_type: constant
-    scope:
-      type: per_batch_per_position
-    use_sigmoid_parameterization: false
-    n_warmup_steps: 2
-    n_samples: 1
+  losses:
+    faith:
+      coeff: 100000000.0
+    imp:
+      coeff: 3.2e-05
+      pnorm: 2.0
+      beta: 0.5
+      p_anneal_start_frac: 0.0
+      p_anneal_final_p: 0.3
+      p_anneal_end_frac: 1.0
+      eps: 1.0e-12
+    stoch:
+      coeff: 100.0
+    ppgd:
+      coeff: 1.0
+      optimizer:
+        type: adam
+        beta1: 0.5
+        beta2: 0.99
+        eps: 1.0e-08
+        lr_schedule:
+          start_val: 0.01
+          warmup_pct: 0.025
+          final_val_frac: 1.0
+          fn_type: constant
+      scope:
+        type: per_batch_per_position
+      use_sigmoid_parameterization: false
+      n_warmup_steps: 2
+      n_samples: 1
 cadence:
   train_log_every: 5
   save_every: 10
@@ -90,6 +86,49 @@ runtime:
   autocast_bf16: true
   device: cuda
   dp: null
+  topology:
+    use_fused_kl: true
+    ci_ranks:
+    - 6
+    ppgd_ranks:
+    - 7
+    layerwise_block_groups:
+    - ranks:
+      - 0
+      - 1
+      owned_sites:
+      - h.0.attn.q_proj
+      - h.0.attn.k_proj
+      - h.1.attn.q_proj
+      - h.1.attn.k_proj
+      - h.2.attn.q_proj
+      - h.2.attn.k_proj
+      - h.3.attn.q_proj
+      - h.3.attn.k_proj
+    - ranks:
+      - 2
+      - 3
+      owned_sites:
+      - h.4.attn.q_proj
+      - h.4.attn.k_proj
+      - h.5.attn.q_proj
+      - h.5.attn.k_proj
+      - h.6.attn.q_proj
+      - h.6.attn.k_proj
+      - h.7.attn.q_proj
+      - h.7.attn.k_proj
+    - ranks:
+      - 4
+      - 5
+      owned_sites:
+      - h.8.attn.q_proj
+      - h.8.attn.k_proj
+      - h.9.attn.q_proj
+      - h.9.attn.k_proj
+      - h.10.attn.q_proj
+      - h.10.attn.k_proj
+      - h.11.attn.q_proj
+      - h.11.attn.k_proj
 target:
   spec:
     kind: hf_weights_in_vendored
@@ -108,46 +147,3 @@ data:
   streaming: true
   buffer_size: 1000
   shuffle_each_epoch: true
-three_pool:
-  use_fused_kl: true
-  ci_ranks:
-  - 6
-  ppgd_ranks:
-  - 7
-  layerwise_block_groups:
-  - ranks:
-    - 0
-    - 1
-    owned_sites:
-    - h.0.attn.q_proj
-    - h.0.attn.k_proj
-    - h.1.attn.q_proj
-    - h.1.attn.k_proj
-    - h.2.attn.q_proj
-    - h.2.attn.k_proj
-    - h.3.attn.q_proj
-    - h.3.attn.k_proj
-  - ranks:
-    - 2
-    - 3
-    owned_sites:
-    - h.4.attn.q_proj
-    - h.4.attn.k_proj
-    - h.5.attn.q_proj
-    - h.5.attn.k_proj
-    - h.6.attn.q_proj
-    - h.6.attn.k_proj
-    - h.7.attn.q_proj
-    - h.7.attn.k_proj
-  - ranks:
-    - 4
-    - 5
-    owned_sites:
-    - h.8.attn.q_proj
-    - h.8.attn.k_proj
-    - h.9.attn.q_proj
-    - h.9.attn.k_proj
-    - h.10.attn.q_proj
-    - h.10.attn.k_proj
-    - h.11.attn.q_proj
-    - h.11.attn.k_proj

--- a/param_decomp_lab/experiments/lm/_resumption_validation/resume_consol_test.yaml
+++ b/param_decomp_lab/experiments/lm/_resumption_validation/resume_consol_test.yaml
@@ -1,0 +1,2 @@
+from_run: /mnt/data/artifacts/mechanisms/param-decomp/decompositions/p-consoltest01
+step: 15

--- a/param_decomp_lab/experiments/lm/_resumption_validation/resume_consol_test.yaml
+++ b/param_decomp_lab/experiments/lm/_resumption_validation/resume_consol_test.yaml
@@ -1,2 +1,0 @@
-from_run: /mnt/data/artifacts/mechanisms/param-decomp/decompositions/p-consoltest01
-step: 15

--- a/param_decomp_lab/experiments/lm/_resumption_validation/resume_live_e2e.yaml
+++ b/param_decomp_lab/experiments/lm/_resumption_validation/resume_live_e2e.yaml
@@ -1,0 +1,2 @@
+from_run: /mnt/data/artifacts/mechanisms/param-decomp/decompositions/p-livee2e05
+step: 20

--- a/param_decomp_lab/experiments/lm/_resumption_validation/resume_live_e2e.yaml
+++ b/param_decomp_lab/experiments/lm/_resumption_validation/resume_live_e2e.yaml
@@ -1,2 +1,0 @@
-from_run: /mnt/data/artifacts/mechanisms/param-decomp/decompositions/p-livee2e05
-step: 20

--- a/param_decomp_lab/experiments/lm/_xl_production/gpt2_xl_qk_200k.yaml
+++ b/param_decomp_lab/experiments/lm/_xl_production/gpt2_xl_qk_200k.yaml
@@ -1,0 +1,383 @@
+pd:
+  seed: 0
+  ci_config:
+    mode: global
+    fn_type: global_shared_transformer
+    simple_transformer_ci_cfg:
+      d_model: 4096
+      n_blocks: 8
+      mlp_hidden_dim:
+      - 16384
+      attn_config:
+        n_heads: 32
+        max_len: 1024
+        rope_base: 10000.0
+  sigmoid_type: leaky_hard
+  decomposition_targets:
+  - module_pattern: h.*.attn.q_proj
+    C: 1024
+  - module_pattern: h.*.attn.k_proj
+    C: 1024
+  batch_size: 48
+  steps: 200000
+  components_optimizer:
+    lr_schedule:
+      start_val: 0.00086603
+      warmup_pct: 0.03
+      final_val_frac: 0.1
+      fn_type: cosine
+    grad_clip_norm: 0.01
+  ci_fn_optimizer:
+    lr_schedule:
+      start_val: 0.00017321
+      warmup_pct: 0.03
+      final_val_frac: 0.1
+      fn_type: cosine
+  faithfulness_warmup_steps: 400
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_weight_decay: 0.0
+  losses:
+    faith:
+      coeff: 100000000.0
+    imp:
+      coeff: 3.2e-05
+      pnorm: 2.0
+      beta: 0.5
+      p_anneal_start_frac: 0.0
+      p_anneal_final_p: 0.3
+      p_anneal_end_frac: 1.0
+      eps: 1.0e-12
+    stoch:
+      coeff: 100.0
+    ppgd:
+      coeff: 1.0
+      optimizer:
+        type: adam
+        beta1: 0.5
+        beta2: 0.99
+        eps: 1.0e-08
+        lr_schedule:
+          start_val: 0.01
+          warmup_pct: 0.05
+          final_val_frac: 1.0
+          fn_type: constant
+      scope:
+        type: per_batch_per_position
+      use_sigmoid_parameterization: false
+      n_warmup_steps: 2
+      n_samples: 1
+cadence:
+  train_log_every: 100
+  save_every: 5000
+eval:
+  n_steps: 1
+  batch_size: 48
+  every: 1000
+  slow_every: 10000
+  slow_on_first_step: true
+  metrics:
+  - type: CIHistograms
+    n_batches_accum: 1
+  - type: ComponentActivationDensity
+  - type: CI_L0
+    groups:
+      total:
+      - '*'
+      q_proj:
+      - h.*.attn.q_proj
+      k_proj:
+      - h.*.attn.k_proj
+      layer_0:
+      - h.0.*
+      layer_23:
+      - h.23.*
+      layer_47:
+      - h.47.*
+  - type: CEandKLLosses
+    rounding_threshold: 0.0
+  - type: CIMeanPerComponent
+  - type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - type: PGDReconLoss
+    init: random
+    step_size: 0.1
+    n_steps: 20
+    mask_scope: shared_across_batch
+runtime:
+  autocast_bf16: true
+  device: cuda
+  dp: null
+  topology:
+    use_fused_kl: true
+    ci_ranks:
+    - 96
+    - 97
+    - 98
+    - 99
+    - 100
+    - 101
+    - 102
+    - 103
+    - 104
+    - 105
+    - 106
+    - 107
+    - 108
+    - 109
+    - 110
+    - 111
+    - 112
+    - 113
+    - 114
+    - 115
+    - 116
+    - 117
+    - 118
+    - 119
+    ppgd_ranks:
+    - 120
+    - 121
+    - 122
+    - 123
+    - 124
+    - 125
+    - 126
+    - 127
+    - 128
+    - 129
+    - 130
+    - 131
+    - 132
+    - 133
+    - 134
+    - 135
+    - 136
+    - 137
+    - 138
+    - 139
+    - 140
+    - 141
+    - 142
+    - 143
+    layerwise_block_groups:
+    - ranks:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+      - 8
+      - 9
+      - 10
+      - 11
+      - 12
+      - 13
+      - 14
+      - 15
+      - 16
+      - 17
+      - 18
+      - 19
+      - 20
+      - 21
+      - 22
+      - 23
+      owned_sites:
+      - h.0.attn.q_proj
+      - h.0.attn.k_proj
+      - h.1.attn.q_proj
+      - h.1.attn.k_proj
+      - h.2.attn.q_proj
+      - h.2.attn.k_proj
+      - h.3.attn.q_proj
+      - h.3.attn.k_proj
+      - h.4.attn.q_proj
+      - h.4.attn.k_proj
+      - h.5.attn.q_proj
+      - h.5.attn.k_proj
+      - h.6.attn.q_proj
+      - h.6.attn.k_proj
+      - h.7.attn.q_proj
+      - h.7.attn.k_proj
+      - h.8.attn.q_proj
+      - h.8.attn.k_proj
+      - h.9.attn.q_proj
+      - h.9.attn.k_proj
+      - h.10.attn.q_proj
+      - h.10.attn.k_proj
+      - h.11.attn.q_proj
+      - h.11.attn.k_proj
+    - ranks:
+      - 24
+      - 25
+      - 26
+      - 27
+      - 28
+      - 29
+      - 30
+      - 31
+      - 32
+      - 33
+      - 34
+      - 35
+      - 36
+      - 37
+      - 38
+      - 39
+      - 40
+      - 41
+      - 42
+      - 43
+      - 44
+      - 45
+      - 46
+      - 47
+      owned_sites:
+      - h.12.attn.q_proj
+      - h.12.attn.k_proj
+      - h.13.attn.q_proj
+      - h.13.attn.k_proj
+      - h.14.attn.q_proj
+      - h.14.attn.k_proj
+      - h.15.attn.q_proj
+      - h.15.attn.k_proj
+      - h.16.attn.q_proj
+      - h.16.attn.k_proj
+      - h.17.attn.q_proj
+      - h.17.attn.k_proj
+      - h.18.attn.q_proj
+      - h.18.attn.k_proj
+      - h.19.attn.q_proj
+      - h.19.attn.k_proj
+      - h.20.attn.q_proj
+      - h.20.attn.k_proj
+      - h.21.attn.q_proj
+      - h.21.attn.k_proj
+      - h.22.attn.q_proj
+      - h.22.attn.k_proj
+      - h.23.attn.q_proj
+      - h.23.attn.k_proj
+    - ranks:
+      - 48
+      - 49
+      - 50
+      - 51
+      - 52
+      - 53
+      - 54
+      - 55
+      - 56
+      - 57
+      - 58
+      - 59
+      - 60
+      - 61
+      - 62
+      - 63
+      - 64
+      - 65
+      - 66
+      - 67
+      - 68
+      - 69
+      - 70
+      - 71
+      owned_sites:
+      - h.24.attn.q_proj
+      - h.24.attn.k_proj
+      - h.25.attn.q_proj
+      - h.25.attn.k_proj
+      - h.26.attn.q_proj
+      - h.26.attn.k_proj
+      - h.27.attn.q_proj
+      - h.27.attn.k_proj
+      - h.28.attn.q_proj
+      - h.28.attn.k_proj
+      - h.29.attn.q_proj
+      - h.29.attn.k_proj
+      - h.30.attn.q_proj
+      - h.30.attn.k_proj
+      - h.31.attn.q_proj
+      - h.31.attn.k_proj
+      - h.32.attn.q_proj
+      - h.32.attn.k_proj
+      - h.33.attn.q_proj
+      - h.33.attn.k_proj
+      - h.34.attn.q_proj
+      - h.34.attn.k_proj
+      - h.35.attn.q_proj
+      - h.35.attn.k_proj
+    - ranks:
+      - 72
+      - 73
+      - 74
+      - 75
+      - 76
+      - 77
+      - 78
+      - 79
+      - 80
+      - 81
+      - 82
+      - 83
+      - 84
+      - 85
+      - 86
+      - 87
+      - 88
+      - 89
+      - 90
+      - 91
+      - 92
+      - 93
+      - 94
+      - 95
+      owned_sites:
+      - h.36.attn.q_proj
+      - h.36.attn.k_proj
+      - h.37.attn.q_proj
+      - h.37.attn.k_proj
+      - h.38.attn.q_proj
+      - h.38.attn.k_proj
+      - h.39.attn.q_proj
+      - h.39.attn.k_proj
+      - h.40.attn.q_proj
+      - h.40.attn.k_proj
+      - h.41.attn.q_proj
+      - h.41.attn.k_proj
+      - h.42.attn.q_proj
+      - h.42.attn.k_proj
+      - h.43.attn.q_proj
+      - h.43.attn.k_proj
+      - h.44.attn.q_proj
+      - h.44.attn.k_proj
+      - h.45.attn.q_proj
+      - h.45.attn.k_proj
+      - h.46.attn.q_proj
+      - h.46.attn.k_proj
+      - h.47.attn.q_proj
+      - h.47.attn.k_proj
+wandb:
+  project: param-decomp
+  entity: goodfire
+target:
+  spec:
+    kind: hf_weights_in_vendored
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.gpt2_simple.GPT2Simple
+    model_name: openai-community/gpt2-xl
+  output_extract: 0
+  activation_checkpointing: false
+data:
+  tokenizer_name: openai-community/gpt2
+  max_seq_len: 1024
+  dataset_name: apollo-research/Skylion007-openwebtext-tokenizer-gpt2
+  column_name: input_ids
+  train_split: train
+  eval_split: train
+  is_tokenized: true
+  streaming: true
+  buffer_size: 1000
+  shuffle_each_epoch: true

--- a/param_decomp_lab/experiments/lm/_xl_production/gpt2_xl_qk_b48_sqrtlr.yaml
+++ b/param_decomp_lab/experiments/lm/_xl_production/gpt2_xl_qk_b48_sqrtlr.yaml
@@ -1,6 +1,5 @@
 pd:
   seed: 0
-  n_mask_samples: 1
   ci_config:
     mode: global
     fn_type: global_shared_transformer
@@ -13,15 +12,12 @@ pd:
         n_heads: 32
         max_len: 1024
         rope_base: 10000.0
-  sampling: continuous
   sigmoid_type: leaky_hard
   decomposition_targets:
   - module_pattern: h.*.attn.q_proj
     C: 1024
   - module_pattern: h.*.attn.k_proj
     C: 1024
-  identity_decomposition_targets: null
-  use_delta_component: true
   batch_size: 48
   steps: 50000
   components_optimizer:
@@ -40,36 +36,36 @@ pd:
   faithfulness_warmup_steps: 400
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_weight_decay: 0.0
-  loss_metrics:
-  - type: FaithfulnessLoss
-    coeff: 100000000.0
-  - type: StochasticReconLayerwiseLoss
-    coeff: 100.0
-  - type: ImportanceMinimalityLoss
-    coeff: 3.2e-05
-    pnorm: 2.0
-    beta: 0.5
-    p_anneal_start_frac: 0.0
-    p_anneal_final_p: 0.3
-    p_anneal_end_frac: 1.0
-    eps: 1.0e-12
-  - type: PersistentPGDReconLoss
-    coeff: 1.0
-    optimizer:
-      type: adam
-      beta1: 0.5
-      beta2: 0.99
-      eps: 1.0e-08
-      lr_schedule:
-        start_val: 0.01
-        warmup_pct: 0.025
-        final_val_frac: 1.0
-        fn_type: constant
-    scope:
-      type: per_batch_per_position
-    use_sigmoid_parameterization: false
-    n_warmup_steps: 2
-    n_samples: 1
+  losses:
+    faith:
+      coeff: 100000000.0
+    imp:
+      coeff: 3.2e-05
+      pnorm: 2.0
+      beta: 0.5
+      p_anneal_start_frac: 0.0
+      p_anneal_final_p: 0.3
+      p_anneal_end_frac: 1.0
+      eps: 1.0e-12
+    stoch:
+      coeff: 100.0
+    ppgd:
+      coeff: 1.0
+      optimizer:
+        type: adam
+        beta1: 0.5
+        beta2: 0.99
+        eps: 1.0e-08
+        lr_schedule:
+          start_val: 0.01
+          warmup_pct: 0.025
+          final_val_frac: 1.0
+          fn_type: constant
+      scope:
+        type: per_batch_per_position
+      use_sigmoid_parameterization: false
+      n_warmup_steps: 2
+      n_samples: 1
 cadence:
   train_log_every: 100
   save_every: 5000
@@ -111,6 +107,259 @@ runtime:
   autocast_bf16: true
   device: cuda
   dp: null
+  topology:
+    use_fused_kl: true
+    ci_ranks:
+    - 96
+    - 97
+    - 98
+    - 99
+    - 100
+    - 101
+    - 102
+    - 103
+    - 104
+    - 105
+    - 106
+    - 107
+    - 108
+    - 109
+    - 110
+    - 111
+    - 112
+    - 113
+    - 114
+    - 115
+    - 116
+    - 117
+    - 118
+    - 119
+    ppgd_ranks:
+    - 120
+    - 121
+    - 122
+    - 123
+    - 124
+    - 125
+    - 126
+    - 127
+    - 128
+    - 129
+    - 130
+    - 131
+    - 132
+    - 133
+    - 134
+    - 135
+    - 136
+    - 137
+    - 138
+    - 139
+    - 140
+    - 141
+    - 142
+    - 143
+    layerwise_block_groups:
+    - ranks:
+      - 0
+      - 1
+      - 2
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+      - 8
+      - 9
+      - 10
+      - 11
+      - 12
+      - 13
+      - 14
+      - 15
+      - 16
+      - 17
+      - 18
+      - 19
+      - 20
+      - 21
+      - 22
+      - 23
+      owned_sites:
+      - h.0.attn.q_proj
+      - h.0.attn.k_proj
+      - h.1.attn.q_proj
+      - h.1.attn.k_proj
+      - h.2.attn.q_proj
+      - h.2.attn.k_proj
+      - h.3.attn.q_proj
+      - h.3.attn.k_proj
+      - h.4.attn.q_proj
+      - h.4.attn.k_proj
+      - h.5.attn.q_proj
+      - h.5.attn.k_proj
+      - h.6.attn.q_proj
+      - h.6.attn.k_proj
+      - h.7.attn.q_proj
+      - h.7.attn.k_proj
+      - h.8.attn.q_proj
+      - h.8.attn.k_proj
+      - h.9.attn.q_proj
+      - h.9.attn.k_proj
+      - h.10.attn.q_proj
+      - h.10.attn.k_proj
+      - h.11.attn.q_proj
+      - h.11.attn.k_proj
+    - ranks:
+      - 24
+      - 25
+      - 26
+      - 27
+      - 28
+      - 29
+      - 30
+      - 31
+      - 32
+      - 33
+      - 34
+      - 35
+      - 36
+      - 37
+      - 38
+      - 39
+      - 40
+      - 41
+      - 42
+      - 43
+      - 44
+      - 45
+      - 46
+      - 47
+      owned_sites:
+      - h.12.attn.q_proj
+      - h.12.attn.k_proj
+      - h.13.attn.q_proj
+      - h.13.attn.k_proj
+      - h.14.attn.q_proj
+      - h.14.attn.k_proj
+      - h.15.attn.q_proj
+      - h.15.attn.k_proj
+      - h.16.attn.q_proj
+      - h.16.attn.k_proj
+      - h.17.attn.q_proj
+      - h.17.attn.k_proj
+      - h.18.attn.q_proj
+      - h.18.attn.k_proj
+      - h.19.attn.q_proj
+      - h.19.attn.k_proj
+      - h.20.attn.q_proj
+      - h.20.attn.k_proj
+      - h.21.attn.q_proj
+      - h.21.attn.k_proj
+      - h.22.attn.q_proj
+      - h.22.attn.k_proj
+      - h.23.attn.q_proj
+      - h.23.attn.k_proj
+    - ranks:
+      - 48
+      - 49
+      - 50
+      - 51
+      - 52
+      - 53
+      - 54
+      - 55
+      - 56
+      - 57
+      - 58
+      - 59
+      - 60
+      - 61
+      - 62
+      - 63
+      - 64
+      - 65
+      - 66
+      - 67
+      - 68
+      - 69
+      - 70
+      - 71
+      owned_sites:
+      - h.24.attn.q_proj
+      - h.24.attn.k_proj
+      - h.25.attn.q_proj
+      - h.25.attn.k_proj
+      - h.26.attn.q_proj
+      - h.26.attn.k_proj
+      - h.27.attn.q_proj
+      - h.27.attn.k_proj
+      - h.28.attn.q_proj
+      - h.28.attn.k_proj
+      - h.29.attn.q_proj
+      - h.29.attn.k_proj
+      - h.30.attn.q_proj
+      - h.30.attn.k_proj
+      - h.31.attn.q_proj
+      - h.31.attn.k_proj
+      - h.32.attn.q_proj
+      - h.32.attn.k_proj
+      - h.33.attn.q_proj
+      - h.33.attn.k_proj
+      - h.34.attn.q_proj
+      - h.34.attn.k_proj
+      - h.35.attn.q_proj
+      - h.35.attn.k_proj
+    - ranks:
+      - 72
+      - 73
+      - 74
+      - 75
+      - 76
+      - 77
+      - 78
+      - 79
+      - 80
+      - 81
+      - 82
+      - 83
+      - 84
+      - 85
+      - 86
+      - 87
+      - 88
+      - 89
+      - 90
+      - 91
+      - 92
+      - 93
+      - 94
+      - 95
+      owned_sites:
+      - h.36.attn.q_proj
+      - h.36.attn.k_proj
+      - h.37.attn.q_proj
+      - h.37.attn.k_proj
+      - h.38.attn.q_proj
+      - h.38.attn.k_proj
+      - h.39.attn.q_proj
+      - h.39.attn.k_proj
+      - h.40.attn.q_proj
+      - h.40.attn.k_proj
+      - h.41.attn.q_proj
+      - h.41.attn.k_proj
+      - h.42.attn.q_proj
+      - h.42.attn.k_proj
+      - h.43.attn.q_proj
+      - h.43.attn.k_proj
+      - h.44.attn.q_proj
+      - h.44.attn.k_proj
+      - h.45.attn.q_proj
+      - h.45.attn.k_proj
+      - h.46.attn.q_proj
+      - h.46.attn.k_proj
+      - h.47.attn.q_proj
+      - h.47.attn.k_proj
 wandb:
   project: param-decomp
   entity: goodfire
@@ -132,256 +381,3 @@ data:
   streaming: true
   buffer_size: 1000
   shuffle_each_epoch: true
-three_pool:
-  use_fused_kl: true
-  ci_ranks:
-  - 96
-  - 97
-  - 98
-  - 99
-  - 100
-  - 101
-  - 102
-  - 103
-  - 104
-  - 105
-  - 106
-  - 107
-  - 108
-  - 109
-  - 110
-  - 111
-  - 112
-  - 113
-  - 114
-  - 115
-  - 116
-  - 117
-  - 118
-  - 119
-  ppgd_ranks:
-  - 120
-  - 121
-  - 122
-  - 123
-  - 124
-  - 125
-  - 126
-  - 127
-  - 128
-  - 129
-  - 130
-  - 131
-  - 132
-  - 133
-  - 134
-  - 135
-  - 136
-  - 137
-  - 138
-  - 139
-  - 140
-  - 141
-  - 142
-  - 143
-  layerwise_block_groups:
-  - ranks:
-    - 0
-    - 1
-    - 2
-    - 3
-    - 4
-    - 5
-    - 6
-    - 7
-    - 8
-    - 9
-    - 10
-    - 11
-    - 12
-    - 13
-    - 14
-    - 15
-    - 16
-    - 17
-    - 18
-    - 19
-    - 20
-    - 21
-    - 22
-    - 23
-    owned_sites:
-    - h.0.attn.q_proj
-    - h.0.attn.k_proj
-    - h.1.attn.q_proj
-    - h.1.attn.k_proj
-    - h.2.attn.q_proj
-    - h.2.attn.k_proj
-    - h.3.attn.q_proj
-    - h.3.attn.k_proj
-    - h.4.attn.q_proj
-    - h.4.attn.k_proj
-    - h.5.attn.q_proj
-    - h.5.attn.k_proj
-    - h.6.attn.q_proj
-    - h.6.attn.k_proj
-    - h.7.attn.q_proj
-    - h.7.attn.k_proj
-    - h.8.attn.q_proj
-    - h.8.attn.k_proj
-    - h.9.attn.q_proj
-    - h.9.attn.k_proj
-    - h.10.attn.q_proj
-    - h.10.attn.k_proj
-    - h.11.attn.q_proj
-    - h.11.attn.k_proj
-  - ranks:
-    - 24
-    - 25
-    - 26
-    - 27
-    - 28
-    - 29
-    - 30
-    - 31
-    - 32
-    - 33
-    - 34
-    - 35
-    - 36
-    - 37
-    - 38
-    - 39
-    - 40
-    - 41
-    - 42
-    - 43
-    - 44
-    - 45
-    - 46
-    - 47
-    owned_sites:
-    - h.12.attn.q_proj
-    - h.12.attn.k_proj
-    - h.13.attn.q_proj
-    - h.13.attn.k_proj
-    - h.14.attn.q_proj
-    - h.14.attn.k_proj
-    - h.15.attn.q_proj
-    - h.15.attn.k_proj
-    - h.16.attn.q_proj
-    - h.16.attn.k_proj
-    - h.17.attn.q_proj
-    - h.17.attn.k_proj
-    - h.18.attn.q_proj
-    - h.18.attn.k_proj
-    - h.19.attn.q_proj
-    - h.19.attn.k_proj
-    - h.20.attn.q_proj
-    - h.20.attn.k_proj
-    - h.21.attn.q_proj
-    - h.21.attn.k_proj
-    - h.22.attn.q_proj
-    - h.22.attn.k_proj
-    - h.23.attn.q_proj
-    - h.23.attn.k_proj
-  - ranks:
-    - 48
-    - 49
-    - 50
-    - 51
-    - 52
-    - 53
-    - 54
-    - 55
-    - 56
-    - 57
-    - 58
-    - 59
-    - 60
-    - 61
-    - 62
-    - 63
-    - 64
-    - 65
-    - 66
-    - 67
-    - 68
-    - 69
-    - 70
-    - 71
-    owned_sites:
-    - h.24.attn.q_proj
-    - h.24.attn.k_proj
-    - h.25.attn.q_proj
-    - h.25.attn.k_proj
-    - h.26.attn.q_proj
-    - h.26.attn.k_proj
-    - h.27.attn.q_proj
-    - h.27.attn.k_proj
-    - h.28.attn.q_proj
-    - h.28.attn.k_proj
-    - h.29.attn.q_proj
-    - h.29.attn.k_proj
-    - h.30.attn.q_proj
-    - h.30.attn.k_proj
-    - h.31.attn.q_proj
-    - h.31.attn.k_proj
-    - h.32.attn.q_proj
-    - h.32.attn.k_proj
-    - h.33.attn.q_proj
-    - h.33.attn.k_proj
-    - h.34.attn.q_proj
-    - h.34.attn.k_proj
-    - h.35.attn.q_proj
-    - h.35.attn.k_proj
-  - ranks:
-    - 72
-    - 73
-    - 74
-    - 75
-    - 76
-    - 77
-    - 78
-    - 79
-    - 80
-    - 81
-    - 82
-    - 83
-    - 84
-    - 85
-    - 86
-    - 87
-    - 88
-    - 89
-    - 90
-    - 91
-    - 92
-    - 93
-    - 94
-    - 95
-    owned_sites:
-    - h.36.attn.q_proj
-    - h.36.attn.k_proj
-    - h.37.attn.q_proj
-    - h.37.attn.k_proj
-    - h.38.attn.q_proj
-    - h.38.attn.k_proj
-    - h.39.attn.q_proj
-    - h.39.attn.k_proj
-    - h.40.attn.q_proj
-    - h.40.attn.k_proj
-    - h.41.attn.q_proj
-    - h.41.attn.k_proj
-    - h.42.attn.q_proj
-    - h.42.attn.k_proj
-    - h.43.attn.q_proj
-    - h.43.attn.k_proj
-    - h.44.attn.q_proj
-    - h.44.attn.k_proj
-    - h.45.attn.q_proj
-    - h.45.attn.k_proj
-    - h.46.attn.q_proj
-    - h.46.attn.k_proj
-    - h.47.attn.q_proj
-    - h.47.attn.k_proj

--- a/param_decomp_lab/experiments/lm/async_eval.py
+++ b/param_decomp_lab/experiments/lm/async_eval.py
@@ -48,7 +48,7 @@ from param_decomp_lab.distributed import (
 )
 from param_decomp_lab.eval_metrics import EVAL_METRIC_CLASSES
 from param_decomp_lab.experiments.lm.run import (
-    SavedLMRun,
+    LMExperimentConfig,
     _resolve_train_run_id,
     build_lm_loader,
     build_target,
@@ -182,43 +182,46 @@ def main(
             to run. If omitted, falls back to the parent run's ``cfg.eval``.
         group / tags: optional wandb metadata for the resumed run.
     """
-    pd_run = SavedLMRun.from_path(run)
+    # Read the config from run_meta.yaml directly rather than `SavedLMRun.from_path`:
+    # for a 3-pool run no `model_<step>.pth` exists yet (this job assembles it
+    # below), and `from_path` eagerly resolves one, which would crash here.
+    train_run_id = _resolve_train_run_id(run)
+    out_dir = PARAM_DECOMP_OUT_DIR / "decompositions" / train_run_id
+    cfg = LMExperimentConfig.from_file(out_dir / RUN_META_FILENAME)
+
     if eval_config is not None:
         eval_cfg = EvalConfig.from_file(Path(eval_config))
     else:
-        assert pd_run.cfg.eval is not None, (
+        assert cfg.eval is not None, (
             f"async_eval requires either --eval-config or the parent config to "
             f"declare an `eval:` block ({run})"
         )
-        eval_cfg = pd_run.cfg.eval
-
-    train_run_id = _resolve_train_run_id(run)
+        eval_cfg = cfg.eval
 
     dist_state = init_distributed()
     if is_main_process():
         logger.info(f"Distributed state: {dist_state}")
-    set_seed(pd_run.cfg.pd.seed)
+    set_seed(cfg.pd.seed)
     device = get_device()
 
-    target_model = build_target(pd_run.cfg.target)
-    run_batch = make_run_batch(pd_run.cfg.target)
+    target_model = build_target(cfg.target)
+    run_batch = make_run_batch(cfg.target)
 
     # 3-pool runs write only per-rank partials on the train loop; this async job
     # consolidates them into model_<step>.pth + training_<step>.pth (off the
     # train-loop critical path) before evaluating. Rank 0 does the assembly; all
     # ranks barrier so the model file exists before any rank resolves it.
-    if pd_run.cfg.three_pool is not None:
+    if cfg.three_pool is not None:
         assert step is not None, "3-pool async consolidation requires an explicit --step"
         if is_main_process():
-            out_dir = PARAM_DECOMP_OUT_DIR / "decompositions" / train_run_id
             consolidate_step(
                 scratch_dir=out_dir / SNAPSHOT_SCRATCH_DIRNAME,
                 out_dir=out_dir,
                 step=step,
                 target_model=target_model,
                 run_batch=run_batch,
-                ci_config=pd_run.cfg.pd.ci_config,
-                sigmoid_type=pd_run.cfg.pd.sigmoid_type,
+                ci_config=cfg.pd.ci_config,
+                sigmoid_type=cfg.pd.sigmoid_type,
                 keep_last_n_training=DEFAULT_KEEP_LAST_N_TRAINING,
             )
         if dist.is_initialized():
@@ -237,7 +240,7 @@ def main(
         logger.info(f"async_eval: {run} @ step {resolved_step} (train run_id={train_run_id})")
 
     component_model = load_component_model(
-        pd_config=pd_run.cfg.pd,
+        pd_config=cfg.pd,
         checkpoint_path=checkpoint_path,
         target_model=target_model,
         run_batch=run_batch,
@@ -245,13 +248,13 @@ def main(
     component_model.to(device)
 
     eval_loader = build_lm_loader(
-        pd_run.cfg.target,
-        pd_run.cfg.data,
+        cfg.target,
+        cfg.data,
         split="eval",
         device=device,
         batch_size=eval_cfg.batch_size,
         dist_state=dist_state,
-        seed=pd_run.cfg.pd.seed,
+        seed=cfg.pd.seed,
     )
     eval_metrics = [EVAL_METRIC_CLASSES[m.type](m) for m in eval_cfg.metrics]
     for m in eval_metrics:
@@ -264,13 +267,13 @@ def main(
         n_steps=eval_cfg.n_steps,
         device=device,
         step=resolved_step,
-        pd_config=pd_run.cfg,
+        pd_config=cfg,
     )
 
     if is_main_process():
         _log_eval_to_wandb(
             results,
-            cfg=pd_run.cfg,
+            cfg=cfg,
             train_run_id=train_run_id,
             step=resolved_step,
             group=group,

--- a/param_decomp_lab/experiments/lm/async_eval.py
+++ b/param_decomp_lab/experiments/lm/async_eval.py
@@ -23,13 +23,13 @@ Usage:
 """
 
 import gc
-import os
 import time
 from pathlib import Path
 from typing import Any
 
 import fire
 import torch
+import torch.nn as nn
 import wandb
 from torch.utils.data import DataLoader
 
@@ -69,36 +69,41 @@ from param_decomp_lab.three_pool.consolidate import (
 
 
 def _consolidate_or_wait(
-    *, cfg: "LMExperimentConfig", out_dir: Path, step: int, poll_timeout_s: float = 1800.0
+    *,
+    cfg: "LMExperimentConfig",
+    out_dir: Path,
+    target_model: "nn.Module",
+    run_batch: Any,
+    step: int,
+    poll_timeout_s: float = 1800.0,
 ) -> None:
     """Assemble the step's checkpoint (rank 0) or wait for it (other ranks).
 
-    Runs BEFORE distributed/CUDA init so the assembly's ComponentModel buffer is
-    built on CPU. Rank is read from torchrun's `RANK` env (the process group is
-    not up yet). Rank 0 calls `consolidate_step` then the file exists; non-zero
-    ranks poll the shared FS for `training_<step>.pth`.
+    Rank 0 assembles on CPU and writes `training_<step>.pth` last; the other ranks
+    poll the shared FS for that file rather than waiting on an NCCL barrier, so the
+    multi-second CPU read+assemble never interleaves with a GPU collective.
+    Assembly is pinned to CPU via the default-device guard — building the full
+    ComponentModel buffer on the selected, shared GPU hangs.
     """
     training_path = out_dir / f"training_{step}.pth"
-    rank = int(os.environ.get("RANK", "0"))
-    if rank == 0:
-        target_model = build_target(cfg.target)
-        consolidate_step(
-            scratch_dir=out_dir / SNAPSHOT_SCRATCH_DIRNAME,
-            out_dir=out_dir,
-            step=step,
-            target_model=target_model,
-            run_batch=make_run_batch(cfg.target),
-            ci_config=cfg.pd.ci_config,
-            sigmoid_type=cfg.pd.sigmoid_type,
-            keep_last_n_training=DEFAULT_KEEP_LAST_N_TRAINING,
-        )
-        del target_model
+    if is_main_process():
+        with torch.device("cpu"):
+            consolidate_step(
+                scratch_dir=out_dir / SNAPSHOT_SCRATCH_DIRNAME,
+                out_dir=out_dir,
+                step=step,
+                target_model=target_model,
+                run_batch=run_batch,
+                ci_config=cfg.pd.ci_config,
+                sigmoid_type=cfg.pd.sigmoid_type,
+                keep_last_n_training=DEFAULT_KEEP_LAST_N_TRAINING,
+            )
         gc.collect()
         return
     deadline = time.perf_counter() + poll_timeout_s
     while not training_path.is_file():
         assert time.perf_counter() < deadline, (
-            f"rank {rank} timed out after {poll_timeout_s}s waiting for {training_path} "
+            f"timed out after {poll_timeout_s}s waiting for {training_path} "
             f"(rank-0 consolidation did not finish)"
         )
         time.sleep(2.0)
@@ -235,16 +240,6 @@ def main(
         )
         eval_cfg = cfg.eval
 
-    # Consolidate the 3-pool save BEFORE any CUDA / NCCL init. Assembly builds a
-    # full ComponentModel (incl. the transformer CI fn) as a CPU buffer; doing it
-    # after the GPU/process-group is up makes that construction land on a
-    # contended device and hang. So: rank 0 assembles on CPU here, the other
-    # ranks wait on the file's appearance (no collective — the PG isn't up yet),
-    # and only then does everyone init distributed for the eval pass.
-    if cfg.three_pool is not None:
-        assert step is not None, "3-pool async consolidation requires an explicit --step"
-        _consolidate_or_wait(cfg=cfg, out_dir=out_dir, step=step)
-
     dist_state = init_distributed()
     if is_main_process():
         logger.info(f"Distributed state: {dist_state}")
@@ -253,6 +248,19 @@ def main(
 
     target_model = build_target(cfg.target)
     run_batch = make_run_batch(cfg.target)
+
+    # Consolidate the 3-pool save. The train loop wrote only per-rank partials;
+    # this assembles model_<step>.pth + training_<step>.pth off the train-loop
+    # critical path. Rank 0 assembles on CPU; the other ranks WAIT on the file
+    # (not an NCCL barrier) so no GPU collective interleaves with the multi-second
+    # CPU read+assemble. Assembly is forced onto CPU — building the full
+    # ComponentModel buffer (incl. the transformer CI fn) on the selected, shared
+    # GPU hangs.
+    if cfg.three_pool is not None:
+        assert step is not None, "3-pool async consolidation requires an explicit --step"
+        _consolidate_or_wait(
+            cfg=cfg, out_dir=out_dir, target_model=target_model, run_batch=run_batch, step=step
+        )
 
     # Consolidation may be the only job to do — when there are no slow metrics
     # the 3-pool save still needs assembling, but there is no eval pass to run.

--- a/param_decomp_lab/experiments/lm/async_eval.py
+++ b/param_decomp_lab/experiments/lm/async_eval.py
@@ -75,35 +75,50 @@ def _consolidate_or_wait(
     target_model: "nn.Module",
     run_batch: Any,
     step: int,
-    poll_timeout_s: float = 1800.0,
+    wait_timeout_s: float = 1800.0,
 ) -> None:
     """Assemble the step's checkpoint (rank 0) or wait for it (other ranks).
 
     Rank 0 assembles on CPU and writes `training_<step>.pth` last; the other ranks
-    poll the shared FS for that file rather than waiting on an NCCL barrier, so the
-    multi-second CPU read+assemble never interleaves with a GPU collective.
-    Assembly is pinned to CPU via the default-device guard — building the full
-    ComponentModel buffer on the selected, shared GPU hangs.
+    wait on the shared FS rather than an NCCL barrier (the multi-second CPU
+    read+assemble shouldn't interleave with a GPU collective). Assembly is pinned
+    to CPU — building the full ComponentModel buffer on the selected, shared GPU
+    hangs.
+
+    Fail-fast on BOTH sides — never wedge holding GPUs:
+      * rank 0 writes a `.consolidate_failed_<step>` sentinel and re-raises if
+        consolidation throws, so the failure is visible and the GPUs release;
+      * the other ranks poll for the success file OR the sentinel, and time out;
+        any of the three exits the wait (the last two by raising).
     """
     training_path = out_dir / f"training_{step}.pth"
+    fail_sentinel = out_dir / f".consolidate_failed_{step}"
+    fail_sentinel.unlink(missing_ok=True)
     if is_main_process():
-        with torch.device("cpu"):
-            consolidate_step(
-                scratch_dir=out_dir / SNAPSHOT_SCRATCH_DIRNAME,
-                out_dir=out_dir,
-                step=step,
-                target_model=target_model,
-                run_batch=run_batch,
-                ci_config=cfg.pd.ci_config,
-                sigmoid_type=cfg.pd.sigmoid_type,
-                keep_last_n_training=DEFAULT_KEEP_LAST_N_TRAINING,
-            )
+        try:
+            with torch.device("cpu"):
+                consolidate_step(
+                    scratch_dir=out_dir / SNAPSHOT_SCRATCH_DIRNAME,
+                    out_dir=out_dir,
+                    step=step,
+                    target_model=target_model,
+                    run_batch=run_batch,
+                    ci_config=cfg.pd.ci_config,
+                    sigmoid_type=cfg.pd.sigmoid_type,
+                    keep_last_n_training=DEFAULT_KEEP_LAST_N_TRAINING,
+                )
+        except BaseException:
+            fail_sentinel.touch()
+            raise
         gc.collect()
         return
-    deadline = time.perf_counter() + poll_timeout_s
+    deadline = time.perf_counter() + wait_timeout_s
     while not training_path.is_file():
+        assert not fail_sentinel.is_file(), (
+            f"rank-0 consolidation failed (sentinel {fail_sentinel.name}); aborting wait"
+        )
         assert time.perf_counter() < deadline, (
-            f"timed out after {poll_timeout_s}s waiting for {training_path} "
+            f"timed out after {wait_timeout_s}s waiting for {training_path} "
             f"(rank-0 consolidation did not finish)"
         )
         time.sleep(2.0)

--- a/param_decomp_lab/experiments/lm/async_eval.py
+++ b/param_decomp_lab/experiments/lm/async_eval.py
@@ -23,12 +23,13 @@ Usage:
 """
 
 import gc
+import os
+import time
 from pathlib import Path
 from typing import Any
 
 import fire
 import torch
-import torch.distributed as dist
 import wandb
 from torch.utils.data import DataLoader
 
@@ -65,6 +66,42 @@ from param_decomp_lab.three_pool.consolidate import (
     SNAPSHOT_SCRATCH_DIRNAME,
     consolidate_step,
 )
+
+
+def _consolidate_or_wait(
+    *, cfg: "LMExperimentConfig", out_dir: Path, step: int, poll_timeout_s: float = 1800.0
+) -> None:
+    """Assemble the step's checkpoint (rank 0) or wait for it (other ranks).
+
+    Runs BEFORE distributed/CUDA init so the assembly's ComponentModel buffer is
+    built on CPU. Rank is read from torchrun's `RANK` env (the process group is
+    not up yet). Rank 0 calls `consolidate_step` then the file exists; non-zero
+    ranks poll the shared FS for `training_<step>.pth`.
+    """
+    training_path = out_dir / f"training_{step}.pth"
+    rank = int(os.environ.get("RANK", "0"))
+    if rank == 0:
+        target_model = build_target(cfg.target)
+        consolidate_step(
+            scratch_dir=out_dir / SNAPSHOT_SCRATCH_DIRNAME,
+            out_dir=out_dir,
+            step=step,
+            target_model=target_model,
+            run_batch=make_run_batch(cfg.target),
+            ci_config=cfg.pd.ci_config,
+            sigmoid_type=cfg.pd.sigmoid_type,
+            keep_last_n_training=DEFAULT_KEEP_LAST_N_TRAINING,
+        )
+        del target_model
+        gc.collect()
+        return
+    deadline = time.perf_counter() + poll_timeout_s
+    while not training_path.is_file():
+        assert time.perf_counter() < deadline, (
+            f"rank {rank} timed out after {poll_timeout_s}s waiting for {training_path} "
+            f"(rank-0 consolidation did not finish)"
+        )
+        time.sleep(2.0)
 
 
 def _resolve_eval_checkpoint_path(run_path: str | Path, step: int | None) -> Path:
@@ -198,6 +235,16 @@ def main(
         )
         eval_cfg = cfg.eval
 
+    # Consolidate the 3-pool save BEFORE any CUDA / NCCL init. Assembly builds a
+    # full ComponentModel (incl. the transformer CI fn) as a CPU buffer; doing it
+    # after the GPU/process-group is up makes that construction land on a
+    # contended device and hang. So: rank 0 assembles on CPU here, the other
+    # ranks wait on the file's appearance (no collective — the PG isn't up yet),
+    # and only then does everyone init distributed for the eval pass.
+    if cfg.three_pool is not None:
+        assert step is not None, "3-pool async consolidation requires an explicit --step"
+        _consolidate_or_wait(cfg=cfg, out_dir=out_dir, step=step)
+
     dist_state = init_distributed()
     if is_main_process():
         logger.info(f"Distributed state: {dist_state}")
@@ -206,26 +253,6 @@ def main(
 
     target_model = build_target(cfg.target)
     run_batch = make_run_batch(cfg.target)
-
-    # 3-pool runs write only per-rank partials on the train loop; this async job
-    # consolidates them into model_<step>.pth + training_<step>.pth (off the
-    # train-loop critical path) before evaluating. Rank 0 does the assembly; all
-    # ranks barrier so the model file exists before any rank resolves it.
-    if cfg.three_pool is not None:
-        assert step is not None, "3-pool async consolidation requires an explicit --step"
-        if is_main_process():
-            consolidate_step(
-                scratch_dir=out_dir / SNAPSHOT_SCRATCH_DIRNAME,
-                out_dir=out_dir,
-                step=step,
-                target_model=target_model,
-                run_batch=run_batch,
-                ci_config=cfg.pd.ci_config,
-                sigmoid_type=cfg.pd.sigmoid_type,
-                keep_last_n_training=DEFAULT_KEEP_LAST_N_TRAINING,
-            )
-        if dist.is_initialized():
-            dist.barrier()
 
     # Consolidation may be the only job to do — when there are no slow metrics
     # the 3-pool save still needs assembling, but there is no eval pass to run.

--- a/param_decomp_lab/experiments/lm/async_eval.py
+++ b/param_decomp_lab/experiments/lm/async_eval.py
@@ -1,8 +1,12 @@
-"""Run eval metrics against a saved LM PD checkpoint; log into the parent's wandb run.
+"""Consolidate a 3-pool save + run eval metrics; log into the parent's wandb run.
 
 This is an internal sbatch target, not a user-facing CLI. Invoked by
-:func:`param_decomp_lab.experiments.lm.run.submit_slurm_async_slow_eval` after a
-training save, to compute slow metrics off the critical path of training.
+:func:`param_decomp_lab.experiments.lm.run.submit_slurm_async_consolidate_and_eval`
+after a training save, off the critical path of training. For 3-pool runs it
+first assembles ``model_<step>.pth`` + ``training_<step>.pth`` from the train
+loop's per-rank partials (rank 0;
+:func:`param_decomp_lab.three_pool.consolidate.consolidate_step`), then runs the
+parent's slow metrics against the assembled checkpoint.
 
 The training side hands us:
   * ``--run <run_path>`` — the parent training run (SavedLMRun-compatible)
@@ -24,6 +28,7 @@ from typing import Any
 
 import fire
 import torch
+import torch.distributed as dist
 import wandb
 from torch.utils.data import DataLoader
 
@@ -51,9 +56,15 @@ from param_decomp_lab.experiments.lm.run import (
 )
 from param_decomp_lab.experiments.utils import RUN_META_FILENAME, EvalConfig
 from param_decomp_lab.infra.run_files import resolve_run_files
+from param_decomp_lab.infra.settings import PARAM_DECOMP_OUT_DIR
 from param_decomp_lab.infra.wandb import get_wandb_entity, try_wandb
 from param_decomp_lab.run_sink import _wandb_value
 from param_decomp_lab.seed import set_seed
+from param_decomp_lab.three_pool.consolidate import (
+    DEFAULT_KEEP_LAST_N_TRAINING,
+    SNAPSHOT_SCRATCH_DIRNAME,
+    consolidate_step,
+)
 
 
 def _resolve_eval_checkpoint_path(run_path: str | Path, step: int | None) -> Path:
@@ -181,23 +192,55 @@ def main(
         )
         eval_cfg = pd_run.cfg.eval
 
-    checkpoint_path = _resolve_eval_checkpoint_path(run, step)
-    resolved_step = _step_from_checkpoint_name(checkpoint_path.name)
     train_run_id = _resolve_train_run_id(run)
 
     dist_state = init_distributed()
     if is_main_process():
         logger.info(f"Distributed state: {dist_state}")
-        logger.info(f"async_eval: {run} @ step {resolved_step} (train run_id={train_run_id})")
     set_seed(pd_run.cfg.pd.seed)
     device = get_device()
 
     target_model = build_target(pd_run.cfg.target)
+    run_batch = make_run_batch(pd_run.cfg.target)
+
+    # 3-pool runs write only per-rank partials on the train loop; this async job
+    # consolidates them into model_<step>.pth + training_<step>.pth (off the
+    # train-loop critical path) before evaluating. Rank 0 does the assembly; all
+    # ranks barrier so the model file exists before any rank resolves it.
+    if pd_run.cfg.three_pool is not None:
+        assert step is not None, "3-pool async consolidation requires an explicit --step"
+        if is_main_process():
+            out_dir = PARAM_DECOMP_OUT_DIR / "decompositions" / train_run_id
+            consolidate_step(
+                scratch_dir=out_dir / SNAPSHOT_SCRATCH_DIRNAME,
+                out_dir=out_dir,
+                step=step,
+                target_model=target_model,
+                run_batch=run_batch,
+                ci_config=pd_run.cfg.pd.ci_config,
+                sigmoid_type=pd_run.cfg.pd.sigmoid_type,
+                keep_last_n_training=DEFAULT_KEEP_LAST_N_TRAINING,
+            )
+        if dist.is_initialized():
+            dist.barrier()
+
+    # Consolidation may be the only job to do — when there are no slow metrics
+    # the 3-pool save still needs assembling, but there is no eval pass to run.
+    if not eval_cfg.metrics:
+        if is_main_process():
+            logger.info("async_eval: no metrics; consolidation-only, skipping eval pass")
+        return
+
+    checkpoint_path = _resolve_eval_checkpoint_path(run, step)
+    resolved_step = _step_from_checkpoint_name(checkpoint_path.name)
+    if is_main_process():
+        logger.info(f"async_eval: {run} @ step {resolved_step} (train run_id={train_run_id})")
+
     component_model = load_component_model(
         pd_config=pd_run.cfg.pd,
         checkpoint_path=checkpoint_path,
         target_model=target_model,
-        run_batch=make_run_batch(pd_run.cfg.target),
+        run_batch=run_batch,
     )
     component_model.to(device)
 

--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -875,6 +875,13 @@ def submit_slurm_async_consolidate_and_eval(
         logger.info(f"PD_3POOL_SKIP_ASYNC_ONSAVE set; skipping async job for step {step}")
         return
 
+    # The consolidate+eval job's GPU count. Defaults to `dp`; overridable so a
+    # small-topology smoke can keep train + child within one node's 8 GPUs (and,
+    # in production, so a cheap eval doesn't have to match the train width).
+    dp_override = os.environ.get("PD_ASYNC_EVAL_DP", "").strip()
+    if dp_override:
+        dp = int(dp_override)
+
     slow_metrics = (
         _split_metrics_by_slow(parent_cfg.eval.metrics)[0] if parent_cfg.eval is not None else []
     )

--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -12,10 +12,11 @@ multi-node for N > 8 — N must then be a multiple of 8). For local DDP, invoke
 directly via
 `torchrun --standalone --nproc_per_node=N -m param_decomp_lab.experiments.lm.run config.yaml`.
 
-Async slow-eval of saved checkpoints lives in
+Async consolidation + slow-eval of 3-pool saves lives in
 ``param_decomp_lab.experiments.lm.async_eval``; the helper
-:func:`submit_slurm_async_slow_eval` below filters the parent's slow metrics into
-a temp YAML and submits an sbatch job that invokes that module.
+:func:`submit_slurm_async_consolidate_and_eval` below submits an sbatch job that
+assembles the canonical checkpoint from the train loop's per-rank partials and
+then runs the parent's slow metrics against it.
 """
 
 import atexit
@@ -86,6 +87,7 @@ from param_decomp_lab.resumption import (
 from param_decomp_lab.run_sink import OnePoolSink, ThreePoolSink
 from param_decomp_lab.seed import set_seed
 from param_decomp_lab.three_pool import ThreePoolConfig, ThreePoolTrainer
+from param_decomp_lab.three_pool.consolidate import SNAPSHOT_SCRATCH_DIRNAME
 
 
 def _resolve_class(fqn: str) -> type:
@@ -510,14 +512,16 @@ def _fresh_main(
     if cfg.three_pool is not None:
         run_id = _agree_on_run_id_three_pool(run_id, dist_state)
         out_dir = PARAM_DECOMP_OUT_DIR / "decompositions" / run_id
-        scratch_dir = out_dir / ".snapshot_scratch"
+        scratch_dir = out_dir / SNAPSHOT_SCRATCH_DIRNAME
         three_sink = init_pd_run(
             cfg,
             sink_class=ThreePoolSink,
             group=group,
             tags=tags,
             run_id=run_id,
-            on_save=lambda step: submit_slurm_async_slow_eval(out_dir, step=step, parent_cfg=cfg),
+            on_save=lambda step: submit_slurm_async_consolidate_and_eval(
+                out_dir, step=step, parent_cfg=cfg
+            ),
         )
         # Multi-pool eval mirrors the train data-handling contract: full eval
         # batch on every rank, sliced internally by each pool. So we pass
@@ -611,14 +615,14 @@ def _resume_main(
     if effective_cfg.three_pool is not None:
         run_id = _agree_on_run_id_three_pool(run_id, dist_state)
         out_dir = PARAM_DECOMP_OUT_DIR / "decompositions" / run_id
-        scratch_dir = out_dir / ".snapshot_scratch"
+        scratch_dir = out_dir / SNAPSHOT_SCRATCH_DIRNAME
         three_sink = init_pd_run(
             effective_cfg,
             sink_class=ThreePoolSink,
             group=group,
             tags=tags,
             run_id=run_id,
-            on_save=lambda step: submit_slurm_async_slow_eval(
+            on_save=lambda step: submit_slurm_async_consolidate_and_eval(
                 out_dir, step=step, parent_cfg=effective_cfg
             ),
         )
@@ -719,9 +723,9 @@ def _build_eval_loop(
     """Build the `EvalLoop` from `cfg.eval`, or `None` when eval is disabled.
 
     Slow metrics (class-attr ``slow=True``) are filtered out — in-train eval is
-    fast-only. Slow metrics are picked up later by the async eval-only job (which
-    receives the slow subset via a temp ``EvalConfig`` YAML, see
-    :func:`_submit_slurm_async_slow_eval`).
+    fast-only. Slow metrics are picked up later by the async job (which receives
+    the slow subset via a temp ``EvalConfig`` YAML, see
+    :func:`submit_slurm_async_consolidate_and_eval`).
     """
     if cfg.eval is None:
         return None
@@ -834,7 +838,7 @@ def _wandb_url_for_config(config_path: str | Path, run_id: str) -> str | None:
     return f"https://wandb.ai/{entity}/{cfg.wandb.project}/runs/{run_id}"
 
 
-def submit_slurm_async_slow_eval(
+def submit_slurm_async_consolidate_and_eval(
     run_path: str | Path,
     *,
     step: int,
@@ -842,32 +846,45 @@ def submit_slurm_async_slow_eval(
     dp: int = 8,
     time: str = "2:00:00",
     partition: str | None = DEFAULT_PARTITION_NAME,
-    job_name: str = "pd-lm-eval-slow",
+    job_name: str = "pd-lm-consol-eval",
     group: str | None = None,
     tags: str | None = None,
     no_snapshot: bool = False,
 ) -> None:
-    """Filter the parent's slow eval metrics into a temp YAML, submit a SLURM job.
+    """Submit the async job that consolidates a 3-pool save and runs slow eval.
 
-    Called from training right after a save: emits an async SLURM job that runs
-    *only* the slow metrics against ``model_<step>.pth`` via
-    ``python -m param_decomp_lab.experiments.lm.async_eval``, logging into the
-    parent's wandb run at the same step. No-op when the parent has no eval block
-    or no slow metrics.
+    Called from 3-pool training right after a save. The train loop has written
+    per-rank partials to the scratch dir; this job (off the critical path)
+    assembles ``model_<step>.pth`` + ``training_<step>.pth`` from them, prunes old
+    ``training_*.pth``, then runs the parent's *slow* eval metrics against the
+    assembled ``model_<step>.pth`` (logging into the parent's wandb run at the
+    same step). The job is ALWAYS submitted for 3-pool — consolidation is
+    mandatory even when there are no slow metrics; in that case the eval pass is a
+    no-op (see ``async_eval``).
     """
     from param_decomp_lab.experiments.utils import EvalConfig
 
-    if parent_cfg.eval is None:
-        return
-    slow_metrics, _fast = _split_metrics_by_slow(parent_cfg.eval.metrics)
-    if not slow_metrics:
+    assert parent_cfg.three_pool is not None, (
+        "async consolidate+eval is only for 3-pool runs (consolidation has nothing to do otherwise)"
+    )
+
+    # Test hook (never set in production): skip the child-job submission so a
+    # smoke can drive consolidation/eval out-of-band and stay within a GPU
+    # budget. The train loop still writes its partials regardless.
+    if os.environ.get("PD_3POOL_SKIP_ASYNC_ONSAVE", "").strip() in ("1", "true"):
+        logger.info(f"PD_3POOL_SKIP_ASYNC_ONSAVE set; skipping async job for step {step}")
         return
 
+    slow_metrics = (
+        _split_metrics_by_slow(parent_cfg.eval.metrics)[0] if parent_cfg.eval is not None else []
+    )
+    eval_batch_size = parent_cfg.eval.batch_size if parent_cfg.eval is not None else dp
+    eval_n_steps = parent_cfg.eval.n_steps if parent_cfg.eval is not None else 1
     slow_eval_cfg = EvalConfig(
-        batch_size=parent_cfg.eval.batch_size,
-        n_steps=parent_cfg.eval.n_steps,
-        every=parent_cfg.eval.every,
-        slow_every=parent_cfg.eval.every,  # any value; not consumed by async_eval
+        batch_size=eval_batch_size,
+        n_steps=eval_n_steps,
+        every=1,  # any value; not consumed by async_eval
+        slow_every=1,  # any value; not consumed by async_eval
         slow_on_first_step=True,
         metrics=slow_metrics,
     )

--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -1,5 +1,11 @@
 """LM PD experiment: YAML -> `Trainer` glue + `SavedLMRun` reload + resumption.
 
+Single-pool only — the 3-pool path is its own composition root
+(`experiments.lm.three_pool_run`, entry point `pd-lm-3pool`). This module keeps the
+pure, pool-agnostic builders (`build_target`, `build_lm_loader`, `make_run_batch`,
+`_build_eval_loop`, `_split_metrics_by_slow`, `_resolve_train_run_id`) that both paths
+import.
+
 Both the fresh-run path (`main`) and the reload path (`SavedLMRun`) share the
 module-level `build_target` / `build_lm_loader` / `make_run_batch`. The resume
 path (`main --resume <yaml>`) reads a parent run's `run_meta.yaml` plus
@@ -11,28 +17,16 @@ Run via `pd-lm path/to/config.yaml` (fresh) or `pd-lm --resume path/to/resume.ya
 multi-node for N > 8 — N must then be a multiple of 8). For local DDP, invoke
 directly via
 `torchrun --standalone --nproc_per_node=N -m param_decomp_lab.experiments.lm.run config.yaml`.
-
-Async slow-eval of saved checkpoints lives in
-``param_decomp_lab.experiments.lm.async_eval``; the helper
-:func:`submit_slurm_async_slow_eval` below filters the parent's slow metrics into
-a temp YAML and submits an sbatch job that invokes that module.
 """
 
-import atexit
-import datetime
 import importlib
-import json
 import os
 import shlex
-import sys
-import traceback
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Annotated, Any, Literal
+from typing import Annotated, Any, Literal, Protocol
 
 import fire
-import torch
-import torch.distributed as dist
 import torch.nn as nn
 from pydantic import Discriminator
 from torch.utils.data import DataLoader
@@ -40,10 +34,11 @@ from torch.utils.data import DataLoader
 from param_decomp.base_config import BaseConfig
 from param_decomp.batch_and_loss_fns import RunBatch
 from param_decomp.component_model import ComponentModel
+from param_decomp.configs import PDConfig
 from param_decomp.distributed import DistributedState, is_main_process
 from param_decomp.log import logger
 from param_decomp.optimize import EvalLoop, Trainer
-from param_decomp.training_state import ThreePoolTrainingState, TrainingState
+from param_decomp.training_state import TrainingState
 from param_decomp_lab.batch_and_loss_fns import make_run_batch as _make_run_batch
 from param_decomp_lab.batch_and_loss_fns import recon_loss_kl
 from param_decomp_lab.component_model_io import load_component_model
@@ -62,6 +57,7 @@ from param_decomp_lab.experiments.lm.data import (
 )
 from param_decomp_lab.experiments.utils import (
     RUN_META_FILENAME,
+    EvalConfig,
     ExperimentConfig,
     init_pd_run,
 )
@@ -69,11 +65,7 @@ from param_decomp_lab.infra.ddp_launch import build_ddp_launch
 from param_decomp_lab.infra.git import create_git_snapshot
 from param_decomp_lab.infra.paths import ModelPath
 from param_decomp_lab.infra.run_files import generate_run_id, resolve_run_files
-from param_decomp_lab.infra.settings import (
-    DEFAULT_PARTITION_NAME,
-    PARAM_DECOMP_OUT_DIR,
-    REPO_ROOT,
-)
+from param_decomp_lab.infra.settings import DEFAULT_PARTITION_NAME, REPO_ROOT
 from param_decomp_lab.infra.slurm import SlurmConfig, generate_script, submit_slurm_job
 from param_decomp_lab.infra.wandb import get_wandb_entity, parse_wandb_run_path
 from param_decomp_lab.resumption import (
@@ -81,11 +73,9 @@ from param_decomp_lab.resumption import (
     ResumeProvenance,
     read_training_snapshot,
     resolve_step,
-    write_provenance,
 )
-from param_decomp_lab.run_sink import OnePoolSink, ThreePoolSink
+from param_decomp_lab.run_sink import OnePoolSink
 from param_decomp_lab.seed import set_seed
-from param_decomp_lab.three_pool import ThreePoolConfig, ThreePoolTrainer
 
 
 def _resolve_class(fqn: str) -> type:
@@ -152,10 +142,7 @@ class LMTargetConfig(BaseConfig):
 
 
 class LMExperimentConfig(ExperimentConfig[LMTargetConfig, LMDataConfig]):
-    three_pool: ThreePoolConfig | None = None
-    """When set, training runs under the 3-pool strategy
-    (:class:`param_decomp_lab.three_pool.ThreePoolTrainer`) instead of single-process
-    :class:`param_decomp.optimize.Trainer`."""
+    pass
 
 
 def build_target(target_cfg: LMTargetConfig) -> nn.Module:
@@ -268,8 +255,9 @@ def main(
     Args:
         config_path: YAML for a fresh run. Required when not resuming.
         resume: Path to a `ResumeConfig` YAML pointing at a prior run. When set,
-            the parent's `run_meta.yaml` is the source of cfg truth; a new
-            `run_id` + sibling `resume_provenance.yaml` are written.
+            the parent's `run_meta.yaml` is the source of cfg truth; a new `run_id` is
+            allocated and `resume_provenance` (parent dir + step) is stamped onto the
+            effective config so it lands in `run_meta.yaml` + `wandb.config`.
         group / tags: wandb-only (no-ops without `wandb:`).
         dp / partition / time / job_name / no_snapshot / run_id: SLURM submission
             knobs. Passing `--dp N` outside torchrun submits a SLURM job: single-node
@@ -303,168 +291,6 @@ def main(
         _fresh_main(Path(config_path), group=group, tags=tags, run_id=run_id)
 
 
-def _agree_on_run_id_three_pool(run_id: str | None, dist_state: DistributedState | None) -> str:
-    """Broadcast (or generate-then-broadcast) a single run id across all ranks.
-
-    3-pool snapshot uses a file-based gather under
-    ``PARAM_DECOMP_OUT_DIR/decompositions/<run_id>/.snapshot_scratch/``; every
-    rank must compute the same path.
-    """
-    if is_main_process() and run_id is None:
-        run_id = generate_run_id("param_decomp")
-    if dist_state is not None:
-        objs: list[str | None] = [run_id]
-        dist.broadcast_object_list(objs, src=0)
-        run_id = objs[0]
-    assert run_id is not None
-    return run_id
-
-
-def _install_first_fail_marker(rank: int) -> None:
-    """On uncaught exception, write a structured marker to shared FS so a
-    debugger can identify which rank died and what hit it without grepping
-    through GB of NCCL log noise across N ranks. Always-on; cost is one
-    excepthook registration.
-
-    Writes ``$HOME/pd_first_fail/$SLURM_JOB_ID/rank<R>.json`` containing
-    ``{rank, exception_type, exception_message, traceback, timestamp_utc,
-    pid}``. Chains to the previous excepthook so behavior is otherwise
-    unchanged.
-
-    Open follow-up (#11 in the task list): once any rank writes its marker,
-    the rest of the world will block in their next collective for up to
-    30 min before monitoredBarrier times out. A future change should
-    ``dist.destroy_process_group()`` + ``os._exit(1)`` here so siblings
-    fast-fail in seconds via ``TORCH_NCCL_ASYNC_ERROR_HANDLING``. Skipped
-    for now because doing that wrong can hang siblings *worse*.
-    """
-    job_id = os.environ.get("SLURM_JOB_ID", "local")
-    out_dir = Path.home() / "pd_first_fail" / job_id
-    out_dir.mkdir(parents=True, exist_ok=True)
-    out_path = out_dir / f"rank{rank}.json"
-
-    prev_excepthook = sys.excepthook
-
-    def _excepthook(exctype: type[BaseException], value: BaseException, tb: Any) -> None:
-        try:
-            payload = {
-                "rank": rank,
-                "exception_type": exctype.__name__,
-                "exception_message": str(value),
-                "traceback": "".join(traceback.format_exception(exctype, value, tb)),
-                "timestamp_utc": datetime.datetime.now(datetime.UTC).isoformat(),
-                "pid": os.getpid(),
-            }
-            out_path.write_text(json.dumps(payload, indent=2))
-            print(f"[first-fail] rank={rank} wrote {out_path}", file=sys.stderr, flush=True)
-        except Exception as e:
-            print(f"[first-fail] failed to write marker: {e}", file=sys.stderr, flush=True)
-        prev_excepthook(exctype, value, tb)
-
-    sys.excepthook = _excepthook
-
-
-def _maybe_enable_memory_profile(rank: int) -> None:
-    """Opt-in CUDA memory-history recorder for offline ``memory_viz`` analysis.
-
-    Activated by env vars:
-      * ``PD_MEMORY_PROFILE_RANKS=0,32,96`` — comma-separated ranks to profile.
-      * ``PD_MEMORY_PROFILE_OUT=/abs/path/to/dir`` — dump directory.
-
-    Dumps to ``<dir>/mem_rank<R>.pickle`` on normal exit and on uncaught
-    exception. Load the pickle at https://pytorch.org/memory_viz.
-    """
-    prof_ranks_env = os.environ.get("PD_MEMORY_PROFILE_RANKS")
-    if not prof_ranks_env:
-        return
-    if rank not in {int(r) for r in prof_ranks_env.split(",") if r.strip()}:
-        return
-    out_dir = Path(os.environ["PD_MEMORY_PROFILE_OUT"])
-    out_dir.mkdir(parents=True, exist_ok=True)
-    out_path = out_dir / f"mem_rank{rank}.pickle"
-    logger.info(f"[mem-profile] recording rank={rank} → {out_path}")
-    torch.cuda.memory._record_memory_history(max_entries=200_000)
-
-    def _dump() -> None:
-        torch.cuda.memory._dump_snapshot(str(out_path))
-        logger.info(f"[mem-profile] dumped rank={rank} → {out_path}")
-
-    atexit.register(_dump)
-    prev_excepthook = sys.excepthook
-
-    def _excepthook(exctype: type[BaseException], value: BaseException, tb: Any) -> None:
-        _dump()
-        prev_excepthook(exctype, value, tb)
-
-    sys.excepthook = _excepthook
-
-
-def _maybe_build_torch_profiler(trainer: ThreePoolTrainer) -> torch.profiler.profile | None:
-    """Opt-in ``torch.profiler.profile`` for the listed ranks.
-
-    Activated by env vars:
-      * ``PD_TORCH_PROFILE_RANKS=0,96,100`` — ranks to profile. Typically one
-        per pool (LW block-0 leader, CI leader, PPGD leader).
-      * ``PD_TORCH_PROFILE_OUT=/abs/path/to/dir`` — trace dump directory.
-      * ``PD_TORCH_PROFILE_SKIP_FIRST`` (default 20) and
-        ``PD_TORCH_PROFILE_ACTIVE`` (default 3) — schedule knobs.
-      * ``PD_TORCH_PROFILE_MEMORY=0`` — disable profile_memory (CUPTI memory
-        instrumentation is the heaviest subsystem; toggle if you suspect
-        it's confounding measurements).
-      * ``PD_TORCH_PROFILE_STACK=1`` — Python source location per op
-        (~25% step-time hit, much larger traces, but huge readability win).
-      * ``PD_TORCH_PROFILE_MODULES=1`` — nn.Module hierarchy labels (cheap;
-        useful for per-site decomposition labels).
-      * ``PD_TORCH_PROFILE_SHAPES=1`` — per-op input tensor shapes.
-
-    Returns the profile context (caller passes it to ``trainer.run(profiler=
-    ...)`` which enters it) or ``None`` if this rank isn't profiled.
-
-    Verified at production scale (104 ranks, gpt2-xl, 3 profiled ranks one
-    per pool) on 2026-05-28 after commit 497e1542 removed a cosmetic pre-step
-    barrier that was the previously-suspected CUPTI deadlock.
-    """
-    prof_ranks_env = os.environ.get("PD_TORCH_PROFILE_RANKS", "").strip()
-    if not prof_ranks_env:
-        return None
-    prof_ranks = {int(r) for r in prof_ranks_env.split(",") if r.strip()}
-    my_rank = trainer.ctx.role.rank
-    if my_rank not in prof_ranks:
-        return None
-    out_dir = Path(os.environ["PD_TORCH_PROFILE_OUT"])
-    out_dir.mkdir(parents=True, exist_ok=True)
-    skip_first = int(os.environ.get("PD_TORCH_PROFILE_SKIP_FIRST", "20"))
-    active = int(os.environ.get("PD_TORCH_PROFILE_ACTIVE", "3"))
-    profile_memory = os.environ.get("PD_TORCH_PROFILE_MEMORY", "1") != "0"
-    with_stack = os.environ.get("PD_TORCH_PROFILE_STACK", "0") == "1"
-    with_modules = os.environ.get("PD_TORCH_PROFILE_MODULES", "0") == "1"
-    record_shapes = os.environ.get("PD_TORCH_PROFILE_SHAPES", "0") == "1"
-
-    pool = trainer.ctx.kind
-    trace_path = out_dir / f"trace_{pool}_rank{my_rank}.json"
-    logger.info(
-        f"[torch-profile] rank={my_rank} pool={pool} → {trace_path} "
-        f"(skip_first={skip_first}, active={active}, profile_memory={profile_memory}, "
-        f"with_stack={with_stack}, with_modules={with_modules}, record_shapes={record_shapes})"
-    )
-
-    def on_trace_ready(prof: torch.profiler.profile) -> None:
-        prof.export_chrome_trace(str(trace_path))
-        logger.info(f"[torch-profile] rank={my_rank} wrote {trace_path}")
-
-    return torch.profiler.profile(
-        activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA],
-        schedule=torch.profiler.schedule(
-            skip_first=skip_first, wait=0, warmup=1, active=active, repeat=1
-        ),
-        on_trace_ready=on_trace_ready,
-        record_shapes=record_shapes,
-        profile_memory=profile_memory,
-        with_stack=with_stack,
-        with_modules=with_modules,
-    )
-
-
 def _fresh_main(
     config_path: Path,
     *,
@@ -472,14 +298,12 @@ def _fresh_main(
     tags: str | None,
     run_id: str | None,
 ) -> None:
-    """Fresh-run path: parse YAML, dispatch on pool config, train from step 0."""
+    """Fresh-run path: parse YAML, build everything, train from step 0."""
     cfg = LMExperimentConfig.from_file(config_path)
 
     dist_state = init_distributed()
     if is_main_process():
         logger.info(f"Distributed state: {dist_state}")
-    _install_first_fail_marker(dist_state.rank if dist_state is not None else 0)
-    _maybe_enable_memory_profile(dist_state.rank if dist_state is not None else 0)
     set_seed(cfg.pd.seed)
     device = get_device()
     cfg = cfg.model_copy(
@@ -494,57 +318,17 @@ def _fresh_main(
     )
 
     target_model = build_target(cfg.target)
-    is_three_pool = cfg.three_pool is not None
     train_loader = build_lm_loader(
         cfg.target,
         cfg.data,
         split="train",
         device=device,
         batch_size=cfg.pd.batch_size,
-        # 3-pool requires the full global batch on every rank — each pool
-        # slices it locally. Single-pool uses standard DistributedSampler.
-        dist_state=None if is_three_pool else dist_state,
+        dist_state=dist_state,
         seed=cfg.pd.seed,
     )
 
-    if cfg.three_pool is not None:
-        run_id = _agree_on_run_id_three_pool(run_id, dist_state)
-        out_dir = PARAM_DECOMP_OUT_DIR / "decompositions" / run_id
-        scratch_dir = out_dir / ".snapshot_scratch"
-        three_sink = init_pd_run(
-            cfg,
-            sink_class=ThreePoolSink,
-            group=group,
-            tags=tags,
-            run_id=run_id,
-            on_save=lambda step: submit_slurm_async_slow_eval(out_dir, step=step, parent_cfg=cfg),
-        )
-        # Multi-pool eval mirrors the train data-handling contract: full eval
-        # batch on every rank, sliced internally by each pool. So we pass
-        # dist_state=None.
-        three_eval_loop = _build_eval_loop(cfg, device, dist_state=None)
-        try:
-            three_trainer = ThreePoolTrainer(
-                target_model=target_model,
-                run_batch=make_run_batch(cfg.target),
-                reconstruction_loss=recon_loss_kl,
-                pd_config=cfg.pd,
-                runtime_config=cfg.runtime,
-                three_pool_config=cfg.three_pool,
-            )
-            three_trainer.run(
-                train_loader,
-                three_sink,
-                cfg.cadence,
-                scratch_dir=scratch_dir,
-                eval_loop=three_eval_loop,
-                profiler=_maybe_build_torch_profiler(three_trainer),
-            )
-        finally:
-            three_sink.finish()
-        return
-
-    one_sink = init_pd_run(cfg, sink_class=OnePoolSink, group=group, tags=tags, run_id=run_id)
+    sink = init_pd_run(cfg, sink_class=OnePoolSink, group=group, tags=tags, run_id=run_id)
     eval_loop = _build_eval_loop(cfg, device, dist_state)
     try:
         trainer = Trainer(
@@ -554,9 +338,9 @@ def _fresh_main(
             pd_config=cfg.pd,
             runtime_config=cfg.runtime,
         )
-        trainer.run(train_loader, one_sink, cfg.cadence, eval_loop)
+        trainer.run(train_loader, sink, cfg.cadence, eval_loop)
     finally:
-        one_sink.finish()
+        sink.finish()
 
 
 def _resume_main(
@@ -575,11 +359,10 @@ def _resume_main(
     if is_main_process():
         logger.info(f"Distributed state: {dist_state}")
         logger.info(f"Resuming from {resume_cfg.from_run} @ step {resume_cfg.step}")
-    _install_first_fail_marker(dist_state.rank if dist_state is not None else 0)
-    _maybe_enable_memory_profile(dist_state.rank if dist_state is not None else 0)
     set_seed(parent_cfg.pd.seed)
     device = get_device()
 
+    resolved_step = resolve_step(resume_cfg.from_run, resume_cfg.step)
     effective_cfg = parent_cfg.model_copy(
         update={
             "runtime": parent_cfg.runtime.model_copy(
@@ -588,90 +371,42 @@ def _resume_main(
                     "dp": dist_state.world_size if dist_state is not None else None,
                 }
             ),
+            "resume_provenance": ResumeProvenance(
+                parent_run_dir=resume_cfg.from_run, parent_step=resolved_step
+            ),
         }
     )
 
-    resolved_step = resolve_step(resume_cfg.from_run, resume_cfg.step)
     snapshot = read_training_snapshot(resume_cfg.from_run, resolved_step)
+    assert isinstance(snapshot, TrainingState), (
+        f"1-pool resume needs TrainingState; got {type(snapshot).__name__}"
+    )
     snapshot.runtime_config["device"] = device
 
     target_model = build_target(effective_cfg.target)
-    is_three_pool = effective_cfg.three_pool is not None
     train_loader = build_lm_loader(
         effective_cfg.target,
         effective_cfg.data,
         split="train",
         device=device,
         batch_size=effective_cfg.pd.batch_size,
-        dist_state=None if is_three_pool else dist_state,
+        dist_state=dist_state,
         seed=effective_cfg.pd.seed,
     )
     run_batch = make_run_batch(effective_cfg.target)
 
-    if effective_cfg.three_pool is not None:
-        run_id = _agree_on_run_id_three_pool(run_id, dist_state)
-        out_dir = PARAM_DECOMP_OUT_DIR / "decompositions" / run_id
-        scratch_dir = out_dir / ".snapshot_scratch"
-        three_sink = init_pd_run(
-            effective_cfg,
-            sink_class=ThreePoolSink,
-            group=group,
-            tags=tags,
-            run_id=run_id,
-            on_save=lambda step: submit_slurm_async_slow_eval(
-                out_dir, step=step, parent_cfg=effective_cfg
-            ),
-        )
-        if three_sink.out_dir is not None:
-            write_provenance(
-                three_sink.out_dir,
-                ResumeProvenance(parent_run_dir=resume_cfg.from_run, parent_step=resolved_step),
-            )
-        three_eval_loop = _build_eval_loop(effective_cfg, device, dist_state=None)
-        try:
-            assert isinstance(snapshot, ThreePoolTrainingState), (
-                f"3-pool resume needs ThreePoolTrainingState; got {type(snapshot).__name__}"
-            )
-            three_trainer = ThreePoolTrainer.from_snapshot(
-                snapshot,
-                target_model=target_model,
-                run_batch=run_batch,
-                reconstruction_loss=recon_loss_kl,
-            )
-            three_trainer.run(
-                train_loader,
-                three_sink,
-                effective_cfg.cadence,
-                scratch_dir=scratch_dir,
-                eval_loop=three_eval_loop,
-                profiler=_maybe_build_torch_profiler(three_trainer),
-            )
-        finally:
-            three_sink.finish()
-        return
-
-    one_sink = init_pd_run(
-        effective_cfg, sink_class=OnePoolSink, group=group, tags=tags, run_id=run_id
-    )
-    if one_sink.out_dir is not None:
-        write_provenance(
-            one_sink.out_dir,
-            ResumeProvenance(parent_run_dir=resume_cfg.from_run, parent_step=resolved_step),
-        )
+    sink = init_pd_run(effective_cfg, sink_class=OnePoolSink, group=group, tags=tags, run_id=run_id)
     eval_loop = _build_eval_loop(effective_cfg, device, dist_state)
     try:
-        assert isinstance(snapshot, TrainingState), (
-            f"1-pool resume needs TrainingState; got {type(snapshot).__name__}"
-        )
         trainer = Trainer.from_snapshot(
             snapshot,
             target_model=target_model,
             run_batch=run_batch,
             reconstruction_loss=recon_loss_kl,
         )
-        trainer.run(train_loader, one_sink, effective_cfg.cadence, eval_loop)
+        trainer.run(train_loader, sink, effective_cfg.cadence, eval_loop)
     finally:
-        one_sink.finish()
+        sink.finish()
 
 
 def _split_metrics_by_slow(
@@ -695,8 +430,11 @@ def _split_metrics_by_slow(
     return slow_metrics, fast_metrics
 
 
-def _resolve_train_run_id(run_path: str | Path) -> str:
+def _resolve_train_run_id(run_path: str | Path) -> str:  # pyright: ignore[reportUnusedFunction]
     """Extract the parent run id from a `SavedLMRun.from_path`-compatible reference.
+
+    Shared helper imported by `experiments.lm.async_eval` and
+    `experiments.lm.three_pool_run` (basedpyright can't see the cross-module uses).
 
     Accepts wandb URL / `entity/project/runId` / bare `p-xxxxxxxx` / local directory
     whose final name is the run id (i.e. `PARAM_DECOMP_OUT_DIR/decompositions/<run_id>/`).
@@ -711,8 +449,25 @@ def _resolve_train_run_id(run_path: str | Path) -> str:
     return (p if p.is_dir() else p.parent).name
 
 
+class _EvalLoopInputs(Protocol):
+    """The slice of an experiment config `_build_eval_loop` reads.
+
+    Lets the single-pool `LMExperimentConfig` and the 3-pool
+    `ThreePoolLMExperimentConfig` share one eval-loop builder without a common base.
+    """
+
+    @property
+    def eval(self) -> EvalConfig | None: ...
+    @property
+    def target(self) -> LMTargetConfig: ...
+    @property
+    def data(self) -> LMDataConfig: ...
+    @property
+    def pd(self) -> PDConfig: ...
+
+
 def _build_eval_loop(
-    cfg: LMExperimentConfig,
+    cfg: _EvalLoopInputs,
     device: str,
     dist_state: DistributedState | None,
 ) -> EvalLoop | None:
@@ -721,7 +476,7 @@ def _build_eval_loop(
     Slow metrics (class-attr ``slow=True``) are filtered out — in-train eval is
     fast-only. Slow metrics are picked up later by the async eval-only job (which
     receives the slow subset via a temp ``EvalConfig`` YAML, see
-    :func:`_submit_slurm_async_slow_eval`).
+    ``submit_slurm_async_slow_eval`` in ``experiments.lm.three_pool_run``).
     """
     if cfg.eval is None:
         return None
@@ -832,96 +587,6 @@ def _wandb_url_for_config(config_path: str | Path, run_id: str) -> str | None:
         return None
     entity = cfg.wandb.entity or get_wandb_entity()
     return f"https://wandb.ai/{entity}/{cfg.wandb.project}/runs/{run_id}"
-
-
-def submit_slurm_async_slow_eval(
-    run_path: str | Path,
-    *,
-    step: int,
-    parent_cfg: "LMExperimentConfig",
-    dp: int = 8,
-    time: str = "2:00:00",
-    partition: str | None = DEFAULT_PARTITION_NAME,
-    job_name: str = "pd-lm-eval-slow",
-    group: str | None = None,
-    tags: str | None = None,
-    no_snapshot: bool = False,
-) -> None:
-    """Filter the parent's slow eval metrics into a temp YAML, submit a SLURM job.
-
-    Called from training right after a save: emits an async SLURM job that runs
-    *only* the slow metrics against ``model_<step>.pth`` via
-    ``python -m param_decomp_lab.experiments.lm.async_eval``, logging into the
-    parent's wandb run at the same step. No-op when the parent has no eval block
-    or no slow metrics.
-    """
-    from param_decomp_lab.experiments.utils import EvalConfig
-
-    if parent_cfg.eval is None:
-        return
-    slow_metrics, _fast = _split_metrics_by_slow(parent_cfg.eval.metrics)
-    if not slow_metrics:
-        return
-
-    slow_eval_cfg = EvalConfig(
-        batch_size=parent_cfg.eval.batch_size,
-        n_steps=parent_cfg.eval.n_steps,
-        every=parent_cfg.eval.every,
-        slow_every=parent_cfg.eval.every,  # any value; not consumed by async_eval
-        slow_on_first_step=True,
-        metrics=slow_metrics,
-    )
-    train_run_id = _resolve_train_run_id(run_path)
-    scratch = PARAM_DECOMP_OUT_DIR / "decompositions" / train_run_id / ".async_eval_configs"
-    scratch.mkdir(parents=True, exist_ok=True)
-    cfg_path = scratch / f"slow_eval_step_{step}.yaml"
-    slow_eval_cfg.to_file(cfg_path)
-
-    # Reuse the training run's snapshot ref. The training was launched from
-    # $HOME/param-decomp and the snapshot already exists there. Creating a new
-    # snapshot here would operate on whatever git repo this process happens to
-    # be in — when called from inside a training job, that's the node-local
-    # /tmp/.../workspace-* clone, which other nodes can't see. Plus, async eval
-    # should run the same code as the training that produced the checkpoint.
-    eval_run_id = generate_run_id("param_decomp")
-    snapshot_ref: str | None = f"refs/runs/snapshot/{train_run_id}" if not no_snapshot else None
-
-    base_command = shlex.join(
-        [
-            "-m",
-            "param_decomp_lab.experiments.lm.async_eval",
-            "--run",
-            str(run_path),
-            "--step",
-            str(step),
-            "--eval-config",
-            str(cfg_path),
-            *(["--group", group] if group is not None else []),
-            *(["--tags", tags] if tags is not None else []),
-        ]
-    )
-    launch = build_ddp_launch(
-        base_command,
-        dp=dp,
-        job_name=job_name,
-        snapshot_ref=snapshot_ref,
-        port_seed=eval_run_id,
-    )
-    slurm_config = SlurmConfig(
-        job_name=job_name,
-        partition=partition,
-        n_gpus=launch.gpus_per_node,
-        n_nodes=launch.n_nodes,
-        time=time,
-        snapshot_ref=snapshot_ref,
-        comment=f"async-slow-eval:{train_run_id}@{step}",
-    )
-    script = generate_script(slurm_config, launch.command, env=launch.env)
-    result = submit_slurm_job(script, "lm")
-    logger.info(
-        f"Async slow-eval submitted: parent={train_run_id} step={step} "
-        f"job_id={result.job_id} log={result.log_pattern}"
-    )
 
 
 def cli() -> None:

--- a/param_decomp_lab/experiments/lm/three_pool_pd.py
+++ b/param_decomp_lab/experiments/lm/three_pool_pd.py
@@ -1,0 +1,117 @@
+"""3-pool-constrained `PDConfig` subclass + the typed `ThreePoolLosses` struct.
+
+The 3-pool training path implements exactly one algorithm: continuous sampling, a
+single stochastic mask, a delta component, no identity ops, and exactly the four
+loss terms (faithfulness, importance-minimality, layerwise stoch recon, persistent
+PGD recon). On the generic `PDConfig` those facts were enforced by ~60 lines of
+runtime asserts inside `ThreePoolTrainer.__init__`
+(`_validate_pd_config_for_three_pool`), firing only after a multi-node launch
+reached construction.
+
+`ThreePoolConstrainedPDConfig` lifts those into the type: the fixed scalars become
+frozen `Literal` defaults, and `loss_metrics` (a generic ordered list) is replaced
+by the `ThreePoolLosses(faith, imp, stoch, ppgd)` struct so "exactly these four,
+each with a coeff" is unrepresentable-if-wrong. A `model_validator` derives the
+inherited `loss_metrics` list from the struct so everything that still consumes a
+`list[AnyLossMetricConfig]` (`ComponentModel` wiring, `validate_pgd_scope`,
+snapshot serialization, eval) keeps working unchanged.
+
+The residual cross-field checks (batch divisibility, rank-0 convention, site
+coverage) that couple `pd` to the topology live on `ThreePoolLMExperimentConfig`
+(see `three_pool_run.py`), since only there are both `pd` and `runtime.topology`
+visible at load time.
+"""
+
+from typing import Any, Literal, Self
+
+from pydantic import Field, model_validator
+
+from param_decomp.base_config import BaseConfig
+from param_decomp.configs import AnyLossMetricConfig, PDConfig
+from param_decomp.metrics.faithfulness import FaithfulnessLossConfig
+from param_decomp.metrics.importance_minimality import ImportanceMinimalityLossConfig
+from param_decomp.metrics.persistent_pgd_recon import PersistentPGDReconLossConfig
+from param_decomp.metrics.stochastic_recon_layerwise import StochasticReconLayerwiseLossConfig
+
+
+class ThreePoolLosses(BaseConfig):
+    """The exactly-these-four loss set the 3-pool path implements.
+
+    Replaces `PDConfig.loss_metrics`'s generic `list[AnyLossMetricConfig]` so a
+    missing / extra / wrong-typed loss is a parse error, not a runtime assert. Each
+    field carries the metric's own params (`imp.pnorm`/`beta`, `ppgd.optimizer`/
+    `scope`/`n_warmup_steps`, …) plus its `coeff`. The trainer reads
+    `pd.losses.faith` / `.imp` / `.stoch` / `.ppgd` directly — no `by_type` dict, no
+    `isinstance` narrowing.
+    """
+
+    faith: FaithfulnessLossConfig
+    imp: ImportanceMinimalityLossConfig
+    stoch: StochasticReconLayerwiseLossConfig
+    ppgd: PersistentPGDReconLossConfig
+
+    @model_validator(mode="after")
+    def validate_coeffs_present(self) -> Self:
+        for name, cfg in (
+            ("faith", self.faith),
+            ("imp", self.imp),
+            ("stoch", self.stoch),
+            ("ppgd", self.ppgd),
+        ):
+            assert cfg.coeff is not None, f"losses.{name}.coeff is required for 3-pool training"
+        assert self.ppgd.start_frac == 0.0, (
+            "3-pool path does not implement PersistentPGDReconLoss.start_frac > 0; "
+            "PPGD always runs from step 0."
+        )
+        return self
+
+
+class ThreePoolConstrainedPDConfig(PDConfig):
+    """`PDConfig` narrowed to what the 3-pool path can honour.
+
+    Substitutable for `PDConfig` everywhere (`ThreePoolTrainer`, `load_component_model`
+    consume inherited fields), but the fixed scalars are frozen `Literal` defaults and
+    the loss set is the typed `ThreePoolLosses` struct. The inherited `loss_metrics`
+    list is derived from `losses` so list-consuming code keeps working.
+    """
+
+    # These narrow inherited `PDConfig` fields to the single value the 3-pool path
+    # honours. basedpyright flags the narrowing as an incompatible variable override
+    # (pydantic class attrs read as mutable/invariant); the narrowing is the point.
+    sampling: Literal["continuous"] = "continuous"  # pyright: ignore[reportIncompatibleVariableOverride]
+    n_mask_samples: Literal[1] = 1  # pyright: ignore[reportIncompatibleVariableOverride]
+    use_delta_component: Literal[True] = True  # pyright: ignore[reportIncompatibleVariableOverride]
+    identity_decomposition_targets: None = None  # pyright: ignore[reportIncompatibleVariableOverride]
+
+    losses: ThreePoolLosses
+
+    # Derived from `losses` (see `derive_loss_metrics`); excluded from serialization
+    # so a round-trip through `model_dump()` re-derives it rather than re-supplying it.
+    loss_metrics: list[AnyLossMetricConfig] = Field(default_factory=list, exclude=True)
+
+    @model_validator(mode="before")
+    @classmethod
+    def derive_loss_metrics(cls, data: Any) -> Any:
+        # `loss_metrics` is the inherited generic list consumed by ComponentModel
+        # wiring, validate_pgd_scope, snapshot serialization, and eval. It's not
+        # authored on this config (the struct is) — derive it from `losses` in the
+        # canonical order before field validation, so the parent's
+        # `validate_loss_metrics_have_coeff` (which runs on the populated list) and
+        # downstream list consumers both see the four metrics. Authoring
+        # `loss_metrics` directly is rejected — the struct is the single source.
+        if not isinstance(data, dict):
+            return data
+        assert "loss_metrics" not in data, (
+            "ThreePoolConstrainedPDConfig derives `loss_metrics` from `losses`; "
+            "do not author `loss_metrics` directly."
+        )
+        assert "losses" in data, "ThreePoolConstrainedPDConfig requires a `losses` block"
+        losses = ThreePoolLosses.model_validate(data["losses"])
+        data = dict(data)
+        data["loss_metrics"] = [
+            losses.faith.model_dump(),
+            losses.imp.model_dump(),
+            losses.stoch.model_dump(),
+            losses.ppgd.model_dump(),
+        ]
+        return data

--- a/param_decomp_lab/experiments/lm/three_pool_run.py
+++ b/param_decomp_lab/experiments/lm/three_pool_run.py
@@ -1,0 +1,699 @@
+"""3-pool LM PD experiment: YAML -> `ThreePoolTrainer` glue + reload + resumption.
+
+The 3-pool sibling of `experiments.lm.run`. Its config — `ThreePoolLMExperimentConfig`
+— bakes the 3-pool's constraints into the types (`ThreePoolConstrainedPDConfig`'s fixed
+scalars + typed `ThreePoolLosses` struct; `ThreePoolRuntimeConfig`'s authored
+`topology`), so misconfigurations fail at YAML parse on the login node rather than
+minutes into a multi-node launch.
+
+Dispatch is by entry point, not a discriminator: `pd-lm-3pool` selects this composition
+root (single-pool `pd-lm` -> `experiments.lm.run`), matching the repo's per-experiment
+idiom. The pure, pool-agnostic builders (`build_target`, `build_lm_loader`,
+`make_run_batch`, `_build_eval_loop`, `_split_metrics_by_slow`, `_resolve_train_run_id`)
+are imported from `experiments.lm.run` — only the 3-pool-specific scaffolding (full-batch
+loader, run-id agreement, `ThreePoolSink`, scratch dir, profiler / mem-profile /
+first-fail debug hooks, async slow-eval) lives here.
+
+Run via `pd-lm-3pool path/to/config.yaml` (fresh) or
+`pd-lm-3pool --resume path/to/resume.yaml` (resume). Pass `--dp N` to submit a DDP SLURM
+job (single-node for N <= 8, multi-node for N > 8 — N must then be a multiple of 8). For
+local DDP, invoke directly via
+`torchrun --standalone --nproc_per_node=N -m param_decomp_lab.experiments.lm.three_pool_run config.yaml`.
+"""
+
+import atexit
+import datetime
+import json
+import os
+import shlex
+import sys
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Self
+
+import fire
+import torch
+import torch.distributed as dist
+import torch.profiler
+from pydantic import model_validator
+
+from param_decomp.base_config import BaseConfig
+from param_decomp.component_model import ComponentModel
+from param_decomp.configs import Cadence, RuntimeConfig
+from param_decomp.distributed import DistributedState, is_main_process
+from param_decomp.log import logger
+from param_decomp.training_state import ThreePoolTrainingState
+from param_decomp_lab.batch_and_loss_fns import recon_loss_kl
+from param_decomp_lab.component_model_io import load_component_model
+from param_decomp_lab.distributed import (
+    get_device,
+    init_distributed,
+    with_distributed_cleanup,
+)
+from param_decomp_lab.experiments.lm.data import LMDataConfig
+from param_decomp_lab.experiments.lm.run import (
+    LMTargetConfig,
+    _build_eval_loop,
+    _resolve_train_run_id,
+    _split_metrics_by_slow,
+    build_lm_loader,
+    build_target,
+    make_run_batch,
+)
+from param_decomp_lab.experiments.lm.three_pool_pd import ThreePoolConstrainedPDConfig
+from param_decomp_lab.experiments.utils import (
+    RUN_META_FILENAME,
+    EvalConfig,
+    WandbConfig,
+    init_pd_run,
+)
+from param_decomp_lab.infra.ddp_launch import build_ddp_launch
+from param_decomp_lab.infra.git import create_git_snapshot
+from param_decomp_lab.infra.paths import ModelPath
+from param_decomp_lab.infra.run_files import generate_run_id, resolve_run_files
+from param_decomp_lab.infra.settings import (
+    DEFAULT_PARTITION_NAME,
+    PARAM_DECOMP_OUT_DIR,
+    REPO_ROOT,
+)
+from param_decomp_lab.infra.slurm import SlurmConfig, generate_script, submit_slurm_job
+from param_decomp_lab.infra.wandb import get_wandb_entity
+from param_decomp_lab.resumption import (
+    ResumeConfig,
+    ResumeProvenance,
+    read_training_snapshot,
+    resolve_step,
+)
+from param_decomp_lab.run_sink import ThreePoolSink
+from param_decomp_lab.seed import set_seed
+from param_decomp_lab.three_pool import ThreePoolConfig, ThreePoolTrainer
+
+
+class ThreePoolRuntimeConfig(RuntimeConfig):
+    """Core's substrate scalars (`autocast_bf16` / `device` / `dp`) + the authored
+    rank->pool `topology`.
+
+    Subclasses `RuntimeConfig` so it's substitutable wherever a `RuntimeConfig` is
+    expected (`ThreePoolTrainer.__init__`, snapshot serialization) and reuses the three
+    scalars rather than duplicating them. `dp` is the launch-derived world readout
+    (overwritten from the torchrun world at launch); `topology` is the authored rank
+    assignment that pairs with `ThreePoolConstrainedPDConfig`. Core's `RuntimeConfig`
+    itself stays pool-blind — the topology is added only here, in lab.
+    """
+
+    topology: ThreePoolConfig
+
+
+class ThreePoolLMExperimentConfig(BaseConfig):
+    """Full YAML schema for a 3-pool LM PD run. Standalone sibling of
+    `LMExperimentConfig` (not a variant of it).
+
+    The cross-field checks that couple `pd` to `runtime.topology` (batch divisibility,
+    rank-0 convention, site coverage) run here at load time — the only place both are
+    visible — so they fail at parse rather than inside `ThreePoolTrainer.__init__`.
+    """
+
+    pd: ThreePoolConstrainedPDConfig
+    runtime: ThreePoolRuntimeConfig
+    cadence: Cadence
+    target: LMTargetConfig
+    data: LMDataConfig
+    eval: EvalConfig | None = None
+    wandb: WandbConfig | None = None
+    resume_provenance: ResumeProvenance | None = None
+    """Set on resumed runs (parent run dir + step); `None` for fresh runs. Lives on the
+    config so it flows into `run_meta.yaml` and `wandb.config` via `init_pd_run`, making a
+    resumed run's lineage visible in the wandb UI."""
+
+    @model_validator(mode="after")
+    def validate_pd_against_topology(self) -> Self:
+        topology = self.runtime.topology
+        n_per_block = len(topology.layerwise_block_groups[0].ranks)
+        n_ci = len(topology.ci_ranks)
+        n_ppgd = len(topology.ppgd_ranks)
+        bs = self.pd.batch_size
+        assert bs % n_per_block == 0, (
+            f"pd.batch_size ({bs}) must be divisible by N_per_block ({n_per_block}) "
+            f"= len(topology.layerwise_block_groups[0].ranks)"
+        )
+        assert bs % n_ci == 0, (
+            f"pd.batch_size ({bs}) must be divisible by N_ci ({n_ci}) = len(topology.ci_ranks)"
+        )
+        assert bs % n_ppgd == 0, (
+            f"pd.batch_size ({bs}) must be divisible by N_ppgd ({n_ppgd}) "
+            f"= len(topology.ppgd_ranks)"
+        )
+        assert topology.layerwise_block_groups[0].ranks[0] == 0, (
+            "Convention: rank 0 must be the LW pool's block 0 leader (so reductions can "
+            "ship CI/PPGD pool losses to rank 0). Reorder layerwise_block_groups so the "
+            "first group starts with rank 0."
+        )
+        # Site coverage (every LW-owned site is in decomposition_targets after pattern
+        # expansion) needs the loaded target model and stays in `_build_runtime`.
+        return self
+
+
+@dataclass(frozen=True)
+class SavedThreePoolLMRun:
+    """Handle to a completed 3-pool LM PD run on disk or in W&B.
+
+    Sibling of `SavedLMRun` for the 3-pool config type. `load_model` consumes only
+    inherited `PDConfig` fields, so inference / inspection of a 3-pool decomposition
+    works identically to a single-pool one.
+    """
+
+    cfg: ThreePoolLMExperimentConfig
+    checkpoint_path: Path
+
+    @classmethod
+    def from_path(cls, path: ModelPath) -> "SavedThreePoolLMRun":
+        files = resolve_run_files(
+            path, config_filename=RUN_META_FILENAME, checkpoint_prefix="model"
+        )
+        return cls(
+            cfg=ThreePoolLMExperimentConfig.from_file(files.config_path),
+            checkpoint_path=files.checkpoint_path,
+        )
+
+    def load_model(self) -> ComponentModel:
+        return load_component_model(
+            pd_config=self.cfg.pd,
+            checkpoint_path=self.checkpoint_path,
+            target_model=build_target(self.cfg.target),
+            run_batch=make_run_batch(self.cfg.target),
+        )
+
+
+def _agree_on_run_id(run_id: str | None, dist_state: DistributedState | None) -> str:
+    """Broadcast (or generate-then-broadcast) a single run id across all ranks.
+
+    3-pool snapshot uses a file-based gather under
+    `PARAM_DECOMP_OUT_DIR/decompositions/<run_id>/.snapshot_scratch/`; every rank must
+    compute the same path.
+    """
+    if is_main_process() and run_id is None:
+        run_id = generate_run_id("param_decomp")
+    if dist_state is not None:
+        objs: list[str | None] = [run_id]
+        dist.broadcast_object_list(objs, src=0)
+        run_id = objs[0]
+    assert run_id is not None
+    return run_id
+
+
+def _install_first_fail_marker(rank: int) -> None:
+    """On uncaught exception, write a structured marker to shared FS so a debugger can
+    identify which rank died and what hit it without grepping GB of NCCL log noise.
+
+    Writes `$HOME/pd_first_fail/$SLURM_JOB_ID/rank<R>.json`. Chains to the previous
+    excepthook so behavior is otherwise unchanged.
+    """
+    job_id = os.environ.get("SLURM_JOB_ID", "local")
+    out_dir = Path.home() / "pd_first_fail" / job_id
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"rank{rank}.json"
+
+    prev_excepthook = sys.excepthook
+
+    def _excepthook(exctype: type[BaseException], value: BaseException, tb: Any) -> None:
+        try:
+            payload = {
+                "rank": rank,
+                "exception_type": exctype.__name__,
+                "exception_message": str(value),
+                "traceback": "".join(traceback.format_exception(exctype, value, tb)),
+                "timestamp_utc": datetime.datetime.now(datetime.UTC).isoformat(),
+                "pid": os.getpid(),
+            }
+            out_path.write_text(json.dumps(payload, indent=2))
+            print(f"[first-fail] rank={rank} wrote {out_path}", file=sys.stderr, flush=True)
+        except Exception as e:
+            print(f"[first-fail] failed to write marker: {e}", file=sys.stderr, flush=True)
+        prev_excepthook(exctype, value, tb)
+
+    sys.excepthook = _excepthook
+
+
+def _maybe_enable_memory_profile(rank: int) -> None:
+    """Opt-in CUDA memory-history recorder for offline `memory_viz` analysis.
+
+    Env: `PD_MEMORY_PROFILE_RANKS=0,32,96` (ranks) + `PD_MEMORY_PROFILE_OUT=/abs/dir`.
+    Dumps `<dir>/mem_rank<R>.pickle` on normal exit and on uncaught exception. Load at
+    https://pytorch.org/memory_viz.
+    """
+    prof_ranks_env = os.environ.get("PD_MEMORY_PROFILE_RANKS")
+    if not prof_ranks_env:
+        return
+    if rank not in {int(r) for r in prof_ranks_env.split(",") if r.strip()}:
+        return
+    out_dir = Path(os.environ["PD_MEMORY_PROFILE_OUT"])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / f"mem_rank{rank}.pickle"
+    logger.info(f"[mem-profile] recording rank={rank} -> {out_path}")
+    torch.cuda.memory._record_memory_history(max_entries=200_000)
+
+    def _dump() -> None:
+        torch.cuda.memory._dump_snapshot(str(out_path))
+        logger.info(f"[mem-profile] dumped rank={rank} -> {out_path}")
+
+    atexit.register(_dump)
+    prev_excepthook = sys.excepthook
+
+    def _excepthook(exctype: type[BaseException], value: BaseException, tb: Any) -> None:
+        _dump()
+        prev_excepthook(exctype, value, tb)
+
+    sys.excepthook = _excepthook
+
+
+def _maybe_build_torch_profiler(trainer: ThreePoolTrainer) -> "torch.profiler.profile | None":
+    """Opt-in `torch.profiler.profile` for the listed ranks (typically one per pool).
+
+    Env: `PD_TORCH_PROFILE_RANKS=0,96,100` + `PD_TORCH_PROFILE_OUT=/abs/dir`, plus
+    schedule / instrumentation knobs (`PD_TORCH_PROFILE_SKIP_FIRST` default 20,
+    `_ACTIVE` default 3, `_MEMORY` default on, `_STACK` / `_MODULES` / `_SHAPES` off).
+    Returns the profile context (caller passes it to `trainer.run(profiler=...)`) or
+    `None` if this rank isn't profiled. Verified at 104 ranks (gpt2-xl) 2026-05-28.
+    """
+    prof_ranks_env = os.environ.get("PD_TORCH_PROFILE_RANKS", "").strip()
+    if not prof_ranks_env:
+        return None
+    prof_ranks = {int(r) for r in prof_ranks_env.split(",") if r.strip()}
+    my_rank = trainer.ctx.role.rank
+    if my_rank not in prof_ranks:
+        return None
+    out_dir = Path(os.environ["PD_TORCH_PROFILE_OUT"])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    skip_first = int(os.environ.get("PD_TORCH_PROFILE_SKIP_FIRST", "20"))
+    active = int(os.environ.get("PD_TORCH_PROFILE_ACTIVE", "3"))
+    profile_memory = os.environ.get("PD_TORCH_PROFILE_MEMORY", "1") != "0"
+    with_stack = os.environ.get("PD_TORCH_PROFILE_STACK", "0") == "1"
+    with_modules = os.environ.get("PD_TORCH_PROFILE_MODULES", "0") == "1"
+    record_shapes = os.environ.get("PD_TORCH_PROFILE_SHAPES", "0") == "1"
+
+    pool = trainer.ctx.kind
+    trace_path = out_dir / f"trace_{pool}_rank{my_rank}.json"
+    logger.info(
+        f"[torch-profile] rank={my_rank} pool={pool} -> {trace_path} "
+        f"(skip_first={skip_first}, active={active}, profile_memory={profile_memory}, "
+        f"with_stack={with_stack}, with_modules={with_modules}, record_shapes={record_shapes})"
+    )
+
+    def on_trace_ready(prof: "torch.profiler.profile") -> None:
+        prof.export_chrome_trace(str(trace_path))
+        logger.info(f"[torch-profile] rank={my_rank} wrote {trace_path}")
+
+    return torch.profiler.profile(
+        activities=[torch.profiler.ProfilerActivity.CPU, torch.profiler.ProfilerActivity.CUDA],
+        schedule=torch.profiler.schedule(
+            skip_first=skip_first, wait=0, warmup=1, active=active, repeat=1
+        ),
+        on_trace_ready=on_trace_ready,
+        record_shapes=record_shapes,
+        profile_memory=profile_memory,
+        with_stack=with_stack,
+        with_modules=with_modules,
+    )
+
+
+@with_distributed_cleanup
+def main(
+    config_path: str | Path | None = None,
+    *,
+    resume: str | Path | None = None,
+    group: str | None = None,
+    tags: str | None = None,
+    dp: int | None = None,
+    partition: str | None = DEFAULT_PARTITION_NAME,
+    time: str = "72:00:00",
+    job_name: str = "pd-lm-3pool",
+    no_snapshot: bool = False,
+    run_id: str | None = None,
+) -> None:
+    """Run a 3-pool LM PD experiment end-to-end.
+
+    Args:
+        config_path: YAML for a fresh run. Required when not resuming.
+        resume: Path to a `ResumeConfig` YAML pointing at a prior 3-pool run.
+        group / tags: wandb-only (no-ops without `wandb:`).
+        dp / partition / time / job_name / no_snapshot / run_id: SLURM submission knobs.
+            Passing `--dp N` outside torchrun submits a SLURM job: single-node for
+            N <= 8, multi-node for N > 8 (N must be a multiple of 8).
+    """
+    if dp is not None and os.environ.get("WORLD_SIZE") is None:
+        assert (config_path is not None) != (resume is not None), (
+            "--dp SLURM submission requires exactly one of config_path or --resume"
+        )
+        _submit_slurm(
+            config_path,
+            resume=resume,
+            dp=dp,
+            group=group,
+            tags=tags,
+            partition=partition,
+            time=time,
+            job_name=job_name,
+            no_snapshot=no_snapshot,
+            run_id=run_id,
+        )
+        return
+
+    if resume is not None:
+        assert config_path is None, "pass either config_path or --resume, not both"
+        _resume_main(Path(resume), group=group, tags=tags, run_id=run_id)
+    else:
+        assert config_path is not None, "must provide either config_path or --resume"
+        _fresh_main(Path(config_path), group=group, tags=tags, run_id=run_id)
+
+
+def _fresh_main(
+    config_path: Path,
+    *,
+    group: str | None,
+    tags: str | None,
+    run_id: str | None,
+) -> None:
+    """Fresh-run path: parse YAML, build everything, train from step 0."""
+    cfg = ThreePoolLMExperimentConfig.from_file(config_path)
+
+    dist_state = init_distributed()
+    if is_main_process():
+        logger.info(f"Distributed state: {dist_state}")
+    rank = dist_state.rank if dist_state is not None else 0
+    _install_first_fail_marker(rank)
+    _maybe_enable_memory_profile(rank)
+    set_seed(cfg.pd.seed)
+    device = get_device()
+    cfg = cfg.model_copy(
+        update={
+            "runtime": cfg.runtime.model_copy(
+                update={
+                    "device": device,
+                    "dp": dist_state.world_size if dist_state is not None else None,
+                }
+            )
+        }
+    )
+
+    target_model = build_target(cfg.target)
+    # 3-pool requires the full global batch on every rank — each pool slices it
+    # locally. So the loader is built with dist_state=None (no DistributedSampler).
+    train_loader = build_lm_loader(
+        cfg.target,
+        cfg.data,
+        split="train",
+        device=device,
+        batch_size=cfg.pd.batch_size,
+        dist_state=None,
+        seed=cfg.pd.seed,
+    )
+
+    run_id = _agree_on_run_id(run_id, dist_state)
+    out_dir = PARAM_DECOMP_OUT_DIR / "decompositions" / run_id
+    scratch_dir = out_dir / ".snapshot_scratch"
+    sink = init_pd_run(
+        cfg,
+        sink_class=ThreePoolSink,
+        group=group,
+        tags=tags,
+        run_id=run_id,
+        on_save=lambda step: submit_slurm_async_slow_eval(out_dir, step=step, parent_cfg=cfg),
+    )
+    eval_loop = _build_eval_loop(cfg, device, dist_state=None)
+    try:
+        trainer = ThreePoolTrainer(
+            target_model=target_model,
+            run_batch=make_run_batch(cfg.target),
+            reconstruction_loss=recon_loss_kl,
+            pd_config=cfg.pd,
+            runtime_config=cfg.runtime,
+            three_pool_config=cfg.runtime.topology,
+        )
+        trainer.run(
+            train_loader,
+            sink,
+            cfg.cadence,
+            scratch_dir=scratch_dir,
+            eval_loop=eval_loop,
+            profiler=_maybe_build_torch_profiler(trainer),
+        )
+    finally:
+        sink.finish()
+
+
+def _resume_main(
+    resume_cfg_path: Path,
+    *,
+    group: str | None,
+    tags: str | None,
+    run_id: str | None,
+) -> None:
+    """Resume-run path: read parent `run_meta.yaml` + `training_<step>.pth`, rebuild via
+    `ThreePoolTrainer.from_snapshot`, continue training."""
+    resume_cfg = ResumeConfig.from_file(resume_cfg_path)
+    parent_cfg = ThreePoolLMExperimentConfig.from_file(resume_cfg.from_run / RUN_META_FILENAME)
+
+    dist_state = init_distributed()
+    if is_main_process():
+        logger.info(f"Distributed state: {dist_state}")
+        logger.info(f"Resuming from {resume_cfg.from_run} @ step {resume_cfg.step}")
+    rank = dist_state.rank if dist_state is not None else 0
+    _install_first_fail_marker(rank)
+    _maybe_enable_memory_profile(rank)
+    set_seed(parent_cfg.pd.seed)
+    device = get_device()
+
+    resolved_step = resolve_step(resume_cfg.from_run, resume_cfg.step)
+    effective_cfg = parent_cfg.model_copy(
+        update={
+            "runtime": parent_cfg.runtime.model_copy(
+                update={
+                    "device": device,
+                    "dp": dist_state.world_size if dist_state is not None else None,
+                }
+            ),
+            "resume_provenance": ResumeProvenance(
+                parent_run_dir=resume_cfg.from_run, parent_step=resolved_step
+            ),
+        }
+    )
+
+    snapshot = read_training_snapshot(resume_cfg.from_run, resolved_step)
+    assert isinstance(snapshot, ThreePoolTrainingState), (
+        f"3-pool resume needs ThreePoolTrainingState; got {type(snapshot).__name__}"
+    )
+    snapshot.runtime_config["device"] = device
+
+    target_model = build_target(effective_cfg.target)
+    train_loader = build_lm_loader(
+        effective_cfg.target,
+        effective_cfg.data,
+        split="train",
+        device=device,
+        batch_size=effective_cfg.pd.batch_size,
+        dist_state=None,
+        seed=effective_cfg.pd.seed,
+    )
+
+    run_id = _agree_on_run_id(run_id, dist_state)
+    out_dir = PARAM_DECOMP_OUT_DIR / "decompositions" / run_id
+    scratch_dir = out_dir / ".snapshot_scratch"
+    sink = init_pd_run(
+        effective_cfg,
+        sink_class=ThreePoolSink,
+        group=group,
+        tags=tags,
+        run_id=run_id,
+        on_save=lambda step: submit_slurm_async_slow_eval(
+            out_dir, step=step, parent_cfg=effective_cfg
+        ),
+    )
+    eval_loop = _build_eval_loop(effective_cfg, device, dist_state=None)
+    try:
+        trainer = ThreePoolTrainer.from_snapshot(
+            snapshot,
+            target_model=target_model,
+            run_batch=make_run_batch(effective_cfg.target),
+            reconstruction_loss=recon_loss_kl,
+        )
+        trainer.run(
+            train_loader,
+            sink,
+            effective_cfg.cadence,
+            scratch_dir=scratch_dir,
+            eval_loop=eval_loop,
+            profiler=_maybe_build_torch_profiler(trainer),
+        )
+    finally:
+        sink.finish()
+
+
+def _submit_slurm(
+    config_path: str | Path | None,
+    *,
+    resume: str | Path | None,
+    dp: int,
+    group: str | None,
+    tags: str | None,
+    partition: str | None,
+    time: str,
+    job_name: str,
+    no_snapshot: bool,
+    run_id: str | None,
+) -> None:
+    run_id = run_id or generate_run_id("param_decomp")
+    snapshot_ref: str | None = None
+    commit_hash = "no-snapshot"
+    if not no_snapshot:
+        snapshot_ref, commit_hash = create_git_snapshot(snapshot_id=run_id)
+        logger.info(f"Created git snapshot: {snapshot_ref} ({commit_hash[:8]})")
+
+    yaml_target = resume if resume is not None else config_path
+    assert yaml_target is not None
+    path = Path(yaml_target)
+    if path.is_absolute() and path.is_relative_to(REPO_ROOT):
+        yaml_arg = path.relative_to(REPO_ROOT).as_posix()
+    else:
+        yaml_arg = str(yaml_target)
+
+    module = "param_decomp_lab.experiments.lm.three_pool_run"
+    if resume is not None:
+        base_parts = ["-m", module, "--resume", yaml_arg, "--run_id", run_id]
+    else:
+        base_parts = ["-m", module, yaml_arg, "--run_id", run_id]
+    if group is not None:
+        base_parts += ["--group", group]
+    if tags is not None:
+        base_parts += ["--tags", tags]
+    base_command = shlex.join(base_parts)
+
+    launch = build_ddp_launch(
+        base_command,
+        dp=dp,
+        job_name=job_name,
+        snapshot_ref=snapshot_ref,
+        port_seed=run_id,
+    )
+    slurm_config = SlurmConfig(
+        job_name=job_name,
+        partition=partition,
+        n_gpus=launch.gpus_per_node,
+        n_nodes=launch.n_nodes,
+        time=time,
+        snapshot_ref=snapshot_ref,
+        comment=run_id,
+    )
+    script = generate_script(slurm_config, launch.command, env=launch.env)
+    result = submit_slurm_job(script, "lm")
+
+    wandb_url = _wandb_url_for_config(config_path, run_id) if config_path is not None else None
+
+    logger.section("3-pool LM PD job submitted!")
+    summary: dict[str, str | None] = {
+        "Run ID": run_id,
+        "Job ID": result.job_id,
+        "Log file": result.log_pattern,
+        "Script": str(result.script_path),
+        "Snapshot": f"{snapshot_ref} ({commit_hash[:8]})" if snapshot_ref else "(none)",
+    }
+    if wandb_url is not None:
+        summary["WandB run URL"] = wandb_url
+    logger.values(summary)
+
+
+def _wandb_url_for_config(config_path: str | Path, run_id: str) -> str | None:
+    cfg = ThreePoolLMExperimentConfig.from_file(config_path)
+    if cfg.wandb is None:
+        return None
+    entity = cfg.wandb.entity or get_wandb_entity()
+    return f"https://wandb.ai/{entity}/{cfg.wandb.project}/runs/{run_id}"
+
+
+def submit_slurm_async_slow_eval(
+    run_path: str | Path,
+    *,
+    step: int,
+    parent_cfg: ThreePoolLMExperimentConfig,
+    dp: int = 8,
+    time: str = "2:00:00",
+    partition: str | None = DEFAULT_PARTITION_NAME,
+    job_name: str = "pd-lm-eval-slow",
+    group: str | None = None,
+    tags: str | None = None,
+    no_snapshot: bool = False,
+) -> None:
+    """Filter the parent's slow eval metrics into a temp YAML, submit a SLURM job.
+
+    Called from training right after a save: emits an async SLURM job that runs only the
+    slow metrics against `model_<step>.pth` via
+    `python -m param_decomp_lab.experiments.lm.async_eval`, logging into the parent's
+    wandb run at the same step. No-op when the parent has no eval block or no slow metrics.
+    """
+    if parent_cfg.eval is None:
+        return
+    slow_metrics, _fast = _split_metrics_by_slow(parent_cfg.eval.metrics)
+    if not slow_metrics:
+        return
+
+    slow_eval_cfg = EvalConfig(
+        batch_size=parent_cfg.eval.batch_size,
+        n_steps=parent_cfg.eval.n_steps,
+        every=parent_cfg.eval.every,
+        slow_every=parent_cfg.eval.every,  # any value; not consumed by async_eval
+        slow_on_first_step=True,
+        metrics=slow_metrics,
+    )
+    train_run_id = _resolve_train_run_id(run_path)
+    scratch = PARAM_DECOMP_OUT_DIR / "decompositions" / train_run_id / ".async_eval_configs"
+    scratch.mkdir(parents=True, exist_ok=True)
+    cfg_path = scratch / f"slow_eval_step_{step}.yaml"
+    slow_eval_cfg.to_file(cfg_path)
+
+    eval_run_id = generate_run_id("param_decomp")
+    snapshot_ref: str | None = f"refs/runs/snapshot/{train_run_id}" if not no_snapshot else None
+
+    base_command = shlex.join(
+        [
+            "-m",
+            "param_decomp_lab.experiments.lm.async_eval",
+            "--run",
+            str(run_path),
+            "--step",
+            str(step),
+            "--eval-config",
+            str(cfg_path),
+            *(["--group", group] if group is not None else []),
+            *(["--tags", tags] if tags is not None else []),
+        ]
+    )
+    launch = build_ddp_launch(
+        base_command,
+        dp=dp,
+        job_name=job_name,
+        snapshot_ref=snapshot_ref,
+        port_seed=eval_run_id,
+    )
+    slurm_config = SlurmConfig(
+        job_name=job_name,
+        partition=partition,
+        n_gpus=launch.gpus_per_node,
+        n_nodes=launch.n_nodes,
+        time=time,
+        snapshot_ref=snapshot_ref,
+        comment=f"async-slow-eval:{train_run_id}@{step}",
+    )
+    script = generate_script(slurm_config, launch.command, env=launch.env)
+    result = submit_slurm_job(script, "lm")
+    logger.info(
+        f"Async slow-eval submitted: parent={train_run_id} step={step} "
+        f"job_id={result.job_id} log={result.log_pattern}"
+    )
+
+
+def cli() -> None:
+    fire.Fire(main)
+
+
+if __name__ == "__main__":
+    cli()

--- a/param_decomp_lab/experiments/utils.py
+++ b/param_decomp_lab/experiments/utils.py
@@ -5,17 +5,20 @@ types.
 """
 
 from collections.abc import Callable
+from pathlib import Path
+from typing import Protocol
 
 import wandb
 from pydantic import Field, PositiveInt
 
-from param_decomp.base_config import BaseConfig
+from param_decomp.base_config import BaseConfig, runtime_cast
 from param_decomp.configs import Cadence, PDConfig, RuntimeConfig
 from param_decomp.distributed import is_main_process
 from param_decomp_lab.eval_metrics import AnyEvalMetricConfig
 from param_decomp_lab.infra.run_files import generate_run_id
 from param_decomp_lab.infra.settings import PARAM_DECOMP_OUT_DIR
 from param_decomp_lab.infra.wandb import try_wandb
+from param_decomp_lab.resumption.provenance import ResumeProvenance
 from param_decomp_lab.run_sink import OnePoolSink, ThreePoolSink
 
 RUN_META_FILENAME = "run_meta.yaml"
@@ -58,10 +61,29 @@ class ExperimentConfig[T: BaseConfig, D: BaseConfig](BaseConfig):
     data: D
     eval: EvalConfig | None = None
     wandb: WandbConfig | None = None
+    resume_provenance: ResumeProvenance | None = None
+    """Set on resumed runs (parent run dir + step); `None` for fresh runs. Lives on the
+    config so it flows into `run_meta.yaml` and `wandb.config` via `init_pd_run`, making a
+    resumed run's lineage visible in the wandb UI."""
 
 
-def init_pd_run[T: BaseConfig, D: BaseConfig, S: OnePoolSink | ThreePoolSink](
-    cfg: ExperimentConfig[T, D],
+class _PdRunInputs(Protocol):
+    """The slice of an experiment config `init_pd_run` reads.
+
+    Lets the single-pool `ExperimentConfig` and the standalone 3-pool
+    `ThreePoolLMExperimentConfig` share one sink builder without a common base — it
+    only touches `cadence`, `wandb`, and `to_file`, never `pd` / `runtime`.
+    """
+
+    @property
+    def cadence(self) -> Cadence: ...
+    @property
+    def wandb(self) -> "WandbConfig | None": ...
+    def to_file(self, path: Path | str) -> None: ...
+
+
+def init_pd_run[S: OnePoolSink | ThreePoolSink](
+    cfg: _PdRunInputs,
     *,
     sink_class: type[S],
     group: str | None,
@@ -95,7 +117,7 @@ def init_pd_run[T: BaseConfig, D: BaseConfig, S: OnePoolSink | ThreePoolSink](
         project=cfg.wandb.project,
         entity=cfg.wandb.entity,
         run_id=run_id,
-        config=cfg,
+        config=runtime_cast(BaseConfig, cfg),
         group=group,
         tags=parsed_tags,
         keep_last_n_checkpoints=keep_last_n,

--- a/param_decomp_lab/pyproject.toml
+++ b/param_decomp_lab/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 pd-tms = "param_decomp_lab.experiments.tms.run:cli"
 pd-resid-mlp = "param_decomp_lab.experiments.resid_mlp.run:cli"
 pd-lm = "param_decomp_lab.experiments.lm.run:cli"
+pd-lm-3pool = "param_decomp_lab.experiments.lm.three_pool_run:cli"
 pd-lm-layerwise = "param_decomp_lab.experiments.lm.layerwise:cli"
 pd-pretrain = "param_decomp_lab.experiments.lm.pretrain.cli:cli"
 # Post-processing pipeline CLIs (SLURM-driven; lab subtrees).

--- a/param_decomp_lab/resumption/__init__.py
+++ b/param_decomp_lab/resumption/__init__.py
@@ -15,19 +15,11 @@ from param_decomp_lab.resumption.config import (
     read_training_snapshot,
     resolve_step,
 )
-from param_decomp_lab.resumption.provenance import (
-    RESUME_PROVENANCE_FILENAME,
-    ResumeProvenance,
-    read_provenance,
-    write_provenance,
-)
+from param_decomp_lab.resumption.provenance import ResumeProvenance
 
 __all__ = [
-    "RESUME_PROVENANCE_FILENAME",
     "ResumeConfig",
     "ResumeProvenance",
-    "read_provenance",
     "read_training_snapshot",
     "resolve_step",
-    "write_provenance",
 ]

--- a/param_decomp_lab/resumption/provenance.py
+++ b/param_decomp_lab/resumption/provenance.py
@@ -1,41 +1,23 @@
-"""Resume provenance: a small YAML sibling of ``run_meta.yaml`` recording
-which run a resumed run was forked from.
+"""Resume provenance: which run a resumed run was forked from.
 
-Resumed runs get their own ``run_id`` and own ``run_meta.yaml`` — provenance
-is what makes them traceable back to the parent. A future reader can inspect
-``resume_provenance.yaml`` to find the parent run dir + the step it was
-resumed from.
-
-A run without this file is a fresh run.
+Resumed runs get their own `run_id` and own `run_meta.yaml`. Provenance is what makes
+them traceable back to the parent: the resume composition root sets
+`ExperimentConfig.resume_provenance` on the effective config it hands to `init_pd_run`,
+so the lineage is dumped into `run_meta.yaml` and surfaced in `wandb.config` (and thus
+the wandb UI). A run with `resume_provenance is None` is a fresh run.
 """
 
 from pathlib import Path
 
 from param_decomp.base_config import BaseConfig
 
-RESUME_PROVENANCE_FILENAME = "resume_provenance.yaml"
-
 
 class ResumeProvenance(BaseConfig):
-    """Sibling of ``run_meta.yaml`` recording where this resumed run came from."""
+    """Records where a resumed run came from. Lives on `ExperimentConfig`."""
 
     parent_run_dir: Path
     """Path to the parent run's directory."""
 
     parent_step: int
     """The step at which we resumed (i.e. the step number in the parent's
-    ``resume/step_<N>/`` snapshot we loaded from)."""
-
-
-def write_provenance(out_dir: Path, provenance: ResumeProvenance) -> None:
-    """Persist ``provenance`` to ``{out_dir}/resume_provenance.yaml``."""
-    provenance.to_file(out_dir / RESUME_PROVENANCE_FILENAME)
-
-
-def read_provenance(run_dir: Path) -> ResumeProvenance | None:
-    """Read provenance from ``run_dir``. Returns ``None`` if the run is fresh
-    (no ``resume_provenance.yaml`` file present)."""
-    path = run_dir / RESUME_PROVENANCE_FILENAME
-    if not path.is_file():
-        return None
-    return ResumeProvenance.from_file(path)
+    `training_<step>.pth` snapshot we loaded from)."""

--- a/param_decomp_lab/run_sink.py
+++ b/param_decomp_lab/run_sink.py
@@ -1,10 +1,11 @@
 """Concrete `RunSink` classes used by the in-repo experiments and lab tooling.
 
 Two pool-specific sinks (`OnePoolSink`, `ThreePoolSink`) share a private base
-(`_LabSinkBase`) for the local-files / wandb / console / log plumbing. The
-subclasses differ only in `checkpoint`'s typed parameter — 1-pool takes
-`TrainingState`, 3-pool takes `ThreePoolTrainingState`. Each delegates to a
-shared `_persist` for the actual save.
+(`_LabSinkBase`) for the local-files / wandb / console / log plumbing. They
+differ in how a checkpoint is persisted: `OnePoolSink.checkpoint` writes the
+`TrainingState` synchronously via `_persist`; `ThreePoolSink.checkpoint_written`
+persists nothing (the trainer already wrote per-rank partials) and only fires
+the async consolidation+eval job via the `on_save` hook.
 
 Three constructors on each:
 
@@ -29,7 +30,7 @@ from tqdm import tqdm
 from param_decomp.base_config import BaseConfig
 from param_decomp.distributed import is_main_process
 from param_decomp.log import logger
-from param_decomp.training_state import ThreePoolTrainingState, TrainingState
+from param_decomp.training_state import TrainingState
 from param_decomp_lab.infra.run_files import save_file
 from param_decomp_lab.infra.wandb import init_wandb, try_wandb
 
@@ -163,7 +164,7 @@ class _LabSinkBase:
         if self._wandb_active and wandb.run is not None:
             wandb.finish()
 
-    def _persist(self, snapshot: TrainingState | ThreePoolTrainingState, *, final: bool) -> None:
+    def _persist(self, snapshot: TrainingState, *, final: bool) -> None:
         """Save the snapshot as `model_<step>.pth` + `training_<step>.pth`.
 
         `model_<step>.pth` is just the component-model state dict — the artifact
@@ -202,10 +203,20 @@ class OnePoolSink(_LabSinkBase):
 
 @dataclass(frozen=True)
 class ThreePoolSink(_LabSinkBase):
-    """Lab sink for 3-pool runs (satisfies `ThreePoolRunSink`)."""
+    """Lab sink for 3-pool runs (satisfies `ThreePoolRunSink`).
 
-    def checkpoint(self, snapshot: ThreePoolTrainingState, *, final: bool) -> None:
-        self._persist(snapshot, final=final)
+    Persists nothing itself: the trainer has already written self-contained
+    per-rank partials to the scratch dir. This only fires the rank-0 `on_save`
+    hook, which submits the async job that consolidates those partials into
+    ``model_<step>.pth`` + ``training_<step>.pth`` and runs the slow eval.
+    """
+
+    def checkpoint_written(self, step: int, *, final: bool) -> None:
+        del final  # the async consolidation path is identical for the final save
+        if self.out_dir is None:
+            return
+        if self.on_save is not None:
+            self.on_save(step)
 
 
 def _wandb_value(v: Any) -> Any:

--- a/param_decomp_lab/tests/test_three_pool_config_fork.py
+++ b/param_decomp_lab/tests/test_three_pool_config_fork.py
@@ -1,0 +1,161 @@
+"""Parse-time constraint tests for the Option-C 3-pool config fork.
+
+The whole point of `ThreePoolConstrainedPDConfig` + `ThreePoolLMExperimentConfig` is to
+move 3-pool misconfiguration failures from "minutes into a multi-node launch" to "YAML
+parse on the login node". These tests pin that: a valid config parses, and each class of
+invalid config (wrong fixed scalar, missing/extra loss, bad batch divisibility, rank-0
+convention) fails at `model_validate`.
+"""
+
+import copy
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from pydantic import ValidationError
+
+from param_decomp_lab.experiments.lm.three_pool_pd import (
+    ThreePoolConstrainedPDConfig,
+    ThreePoolLosses,
+)
+from param_decomp_lab.experiments.lm.three_pool_run import ThreePoolLMExperimentConfig
+
+_VALID_YAML = (
+    Path(__file__).parents[1]
+    / "experiments/lm/_resumption_validation/gpt2_small_3pool_save_repro.yaml"
+)
+
+
+def _valid_dict() -> dict[str, Any]:
+    return yaml.safe_load(_VALID_YAML.read_text())
+
+
+def test_valid_config_parses() -> None:
+    cfg = ThreePoolLMExperimentConfig.model_validate(_valid_dict())
+    assert [m.type for m in cfg.pd.loss_metrics] == [
+        "FaithfulnessLoss",
+        "ImportanceMinimalityLoss",
+        "StochasticReconLayerwiseLoss",
+        "PersistentPGDReconLoss",
+    ]
+    # Fixed scalars take their frozen Literal defaults.
+    assert cfg.pd.sampling == "continuous"
+    assert cfg.pd.n_mask_samples == 1
+    assert cfg.pd.use_delta_component is True
+    assert cfg.pd.identity_decomposition_targets is None
+
+
+def test_pd_dump_roundtrips_through_constrained_config() -> None:
+    """The snapshot path dumps `pd` and re-validates as the constrained type on resume.
+
+    `loss_metrics` is excluded from the dump (derived from `losses`), so the round-trip
+    must reconstruct it.
+    """
+    cfg = ThreePoolLMExperimentConfig.model_validate(_valid_dict())
+    dumped = cfg.pd.model_dump()
+    assert "loss_metrics" not in dumped
+    assert "losses" in dumped
+    reloaded = ThreePoolConstrainedPDConfig.model_validate(dumped)
+    assert [m.type for m in reloaded.loss_metrics] == [m.type for m in cfg.pd.loss_metrics]
+
+
+@pytest.mark.parametrize("scalar,bad", [("n_mask_samples", 3), ("sampling", "binomial")])
+def test_wrong_fixed_scalar_rejected(scalar: str, bad: Any) -> None:
+    data = _valid_dict()
+    data["pd"][scalar] = bad
+    with pytest.raises(ValidationError):
+        ThreePoolLMExperimentConfig.model_validate(data)
+
+
+def test_use_delta_component_false_rejected() -> None:
+    data = _valid_dict()
+    data["pd"]["use_delta_component"] = False
+    with pytest.raises(ValidationError):
+        ThreePoolLMExperimentConfig.model_validate(data)
+
+
+def test_missing_loss_rejected() -> None:
+    data = _valid_dict()
+    del data["pd"]["losses"]["ppgd"]
+    with pytest.raises(ValidationError):
+        ThreePoolLMExperimentConfig.model_validate(data)
+
+
+def test_extra_forbidden_loss_rejected() -> None:
+    """An extra key on the losses struct is forbidden (extra='forbid')."""
+    data = _valid_dict()
+    data["pd"]["losses"]["unmasked"] = {"coeff": 1.0}
+    with pytest.raises(ValidationError):
+        ThreePoolLMExperimentConfig.model_validate(data)
+
+
+def test_authoring_loss_metrics_directly_rejected() -> None:
+    data = _valid_dict()
+    data["pd"]["loss_metrics"] = [{"type": "FaithfulnessLoss", "coeff": 1.0}]
+    with pytest.raises(ValidationError):
+        ThreePoolConstrainedPDConfig.model_validate(data["pd"])
+
+
+def test_missing_coeff_rejected() -> None:
+    losses = _valid_dict()["pd"]["losses"]
+    del losses["faith"]["coeff"]
+    with pytest.raises(ValidationError):
+        ThreePoolLosses.model_validate(losses)
+
+
+def test_ppgd_start_frac_nonzero_rejected() -> None:
+    data = _valid_dict()
+    data["pd"]["losses"]["ppgd"]["start_frac"] = 0.5
+    with pytest.raises(ValidationError):
+        ThreePoolLMExperimentConfig.model_validate(data)
+
+
+def test_batch_not_divisible_by_topology_rejected() -> None:
+    """Cross-field check: batch_size must be divisible by each pool arity. The topology
+    stays valid (uniform N_per_block=2); only batch_size is made indivisible by it."""
+    data = _valid_dict()
+    data["pd"]["batch_size"] = 3  # N_per_block=2 does not divide 3
+    with pytest.raises(ValidationError):
+        ThreePoolLMExperimentConfig.model_validate(data)
+
+
+def test_rank0_not_lw_leader_rejected() -> None:
+    """Cross-field check: rank 0 must be the LW pool's block-0 leader."""
+    data = _valid_dict()
+    groups = data["runtime"]["topology"]["layerwise_block_groups"]
+    # Swap rank 0 out of the first block's leader slot (move it to CI pool's place).
+    groups[0]["ranks"] = [9, 1]
+    with pytest.raises(ValidationError):
+        ThreePoolLMExperimentConfig.model_validate(data)
+
+
+def test_topology_under_runtime_not_three_pool_field() -> None:
+    """The topology lives on `runtime.topology`; the old top-level `three_pool` key is
+    no longer accepted (extra='forbid')."""
+    data = _valid_dict()
+    topology = copy.deepcopy(data["runtime"]["topology"])
+    data["three_pool"] = topology
+    with pytest.raises(ValidationError):
+        ThreePoolLMExperimentConfig.model_validate(data)
+
+
+def test_resume_provenance_field_defaults_none_and_roundtrips() -> None:
+    """Fresh config has `resume_provenance is None`; a populated one survives a dump +
+    reload (so it lands in run_meta.yaml / wandb.config)."""
+    from param_decomp_lab.resumption import ResumeProvenance
+
+    cfg = ThreePoolLMExperimentConfig.model_validate(_valid_dict())
+    assert cfg.resume_provenance is None
+
+    resumed = cfg.model_copy(
+        update={
+            "resume_provenance": ResumeProvenance(
+                parent_run_dir=Path("/runs/p-parent"), parent_step=5000
+            )
+        }
+    )
+    reloaded = ThreePoolLMExperimentConfig.model_validate(resumed.model_dump(mode="json"))
+    assert reloaded.resume_provenance is not None
+    assert reloaded.resume_provenance.parent_step == 5000
+    assert reloaded.resume_provenance.parent_run_dir == Path("/runs/p-parent")

--- a/param_decomp_lab/tests/test_three_pool_pg_timeout.py
+++ b/param_decomp_lab/tests/test_three_pool_pg_timeout.py
@@ -1,17 +1,27 @@
 """Regression tests for the 3-pool checkpoint-save NCCL-watchdog-timeout fix.
 
-Two independent failure surfaces are covered:
+Three failure surfaces are covered:
 
   * ``_resolve_pg_timeout`` reads the ``PD_3POOL_PG_TIMEOUT_S`` override (the
-    knob the save-watchdog repro uses to force the bug at small scale) and
-    otherwise returns the generous default.
+    knob the watchdog-safe-at-low-timeout test uses to force a tight bound) and
+    otherwise returns the default.
 
   * ``build_world`` threads its ``pg_timeout`` into *every* ``dist.new_group``
     call. This is the actual production fix: ``new_group`` does NOT inherit the
     timeout passed to ``init_process_group`` — with ``timeout=None`` it falls
     back to the 10-min NCCL default. The 3-pool runs all real collectives on
-    these subgroups, so a slow checkpoint save trips that 10-min watchdog
-    unless the timeout is set explicitly here.
+    these subgroups, so a slow collective trips that watchdog unless the timeout
+    is set explicitly here.
+
+  * The async-consolidation invariant: the union of every rank's
+    self-contained partial must exactly cover the full model's V/U + CI-fn
+    state-dict keys, so ``assemble_model_state_dict_from_partials`` can rebuild
+    the checkpoint off the train loop with no live ranks.
+
+The default PG timeout came down from 30 min to 10 min once consolidation moved
+off the train loop: the longest on-loop collective gap is now the fast-eval
+pass + a partial-write barrier (minutes), not the old ~10-min rank-0 read of
+~100 GB of partials.
 """
 
 import datetime
@@ -19,6 +29,10 @@ import datetime
 import pytest
 import torch.distributed as dist
 
+from param_decomp_lab.three_pool.checkpoint import (
+    ci_fn_state_keys,
+    owned_model_state_keys,
+)
 from param_decomp_lab.three_pool.layout import LayerwiseBlockGroup, build_world
 from param_decomp_lab.three_pool.optimize import (
     _DEFAULT_PG_TIMEOUT,
@@ -30,7 +44,7 @@ from param_decomp_lab.three_pool.optimize import (
 def test_resolve_pg_timeout_default(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("PD_3POOL_PG_TIMEOUT_S", raising=False)
     assert _resolve_pg_timeout() == _DEFAULT_PG_TIMEOUT
-    assert datetime.timedelta(minutes=30) == _DEFAULT_PG_TIMEOUT
+    assert datetime.timedelta(minutes=10) == _DEFAULT_PG_TIMEOUT
 
 
 def test_resolve_pg_timeout_env_override(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -112,3 +126,36 @@ def test_fingerprint_core_catches_topology_mismatch() -> None:
     }
     changed_ppgd = {**base, "ppgd_ranks": [5]}
     assert _rank_invariant_fingerprint_core(base) != _rank_invariant_fingerprint_core(changed_ppgd)
+
+
+def test_leader_partials_exactly_cover_model_state() -> None:
+    """The per-leader partial slices (LW owned-site V/U + CI fn) must partition
+    the full model's fillable keys with no gaps or overlaps — the invariant the
+    async consolidation asserts before assembling the checkpoint."""
+    sites = ("h.0.attn.q_proj", "h.1.attn.q_proj", "h.2.mlp.c_fc")
+    model_keys = {
+        "_components.h-0-attn-q_proj.V",
+        "_components.h-0-attn-q_proj.U",
+        "_components.h-1-attn-q_proj.V",
+        "_components.h-1-attn-q_proj.U",
+        "_components.h-2-mlp-c_fc.V",
+        "_components.h-2-mlp-c_fc.U",
+        "ci_fn._global_ci_fn.embed.weight",
+        "ci_fn._global_ci_fn.proj.weight",
+        # target-model keys (not owned by any leader; come from the fresh buffer)
+        "target_model.transformer.wte.weight",
+        "target_model.transformer.h.0.attn.c_attn.weight",
+    }
+    target_keys = {k for k in model_keys if k.startswith("target_model.")}
+    fillable = model_keys - target_keys
+
+    # Two LW blocks: block 0 owns sites 0+1, block 1 owns site 2. CI leader owns ci_fn.
+    block0 = owned_model_state_keys(model_keys, owned_sites=(sites[0], sites[1]))
+    block1 = owned_model_state_keys(model_keys, owned_sites=(sites[2],))
+    ci = ci_fn_state_keys(model_keys)
+
+    assert block0.isdisjoint(block1)
+    assert block0.isdisjoint(ci)
+    assert block1.isdisjoint(ci)
+    assert block0 | block1 | ci == fillable
+    assert target_keys.isdisjoint(block0 | block1 | ci)

--- a/param_decomp_lab/three_pool/CLAUDE.md
+++ b/param_decomp_lab/three_pool/CLAUDE.md
@@ -7,7 +7,7 @@ docstring in `optimize.py` for the data-handling contract.
 
 | File | What it covers |
 |---|---|
-| `optimize.py` | `ThreePoolTrainer` + `optimize_three_pool`; the training loop, `snapshot`/`from_snapshot`, config validation |
+| `optimize.py` | `ThreePoolTrainer` + `optimize_three_pool`; the training loop, `snapshot`/`from_snapshot`. Consumes `ThreePoolConstrainedPDConfig` (reads `pd.losses.*` directly). Config constraints are now type-level (see `experiments/lm/three_pool_pd.py`) + a load-time validator on `ThreePoolLMExperimentConfig`; only site-coverage validation remains here (`_build_runtime`, needs the loaded model) |
 | `layout.py` | `World` topology; `build_world` constructs every process group (threading `pg_timeout` into each); `BatchEdge` — symmetric per-edge batch-slice geometry (CI↔LW, CI↔PPGD) answering routing for both fan directions |
 | `checkpoint.py` | `gather_full_state_dict_to_rank0` — rebuilds the full model state on rank 0 |
 | `config.py` | `ThreePoolConfig` + topology validation |

--- a/param_decomp_lab/three_pool/CLAUDE.md
+++ b/param_decomp_lab/three_pool/CLAUDE.md
@@ -10,7 +10,8 @@ docstring in `optimize.py` for the data-handling contract.
 | `optimize.py` | `ThreePoolTrainer` + `optimize_three_pool`; the training loop, `snapshot`/`from_snapshot`, config validation |
 | `layout.py` | `World` topology; `build_world` constructs every process group (threading `pg_timeout` into each); `BatchEdge` — symmetric per-edge batch-slice geometry (CI↔LW, CI↔PPGD) answering routing for both fan directions |
 | `checkpoint.py` | offline state_dict assembly from on-disk partials (`assemble_model_state_dict_from_partials`) + the leader key-partition helpers (`owned_model_state_keys` / `ci_fn_state_keys`) |
-| `consolidate.py` | `consolidate_step` — async, off-train-loop assembly of `model_<step>.pth` + `training_<step>.pth` from a step's scratch partials; prunes old `training_*.pth`; deletes the scratch dir |
+| `consolidate.py` | `consolidate_step` — async, off-train-loop assembly of `model_<step>.pth` + `training_<step>.pth` from a step's scratch partials; prunes old `training_*.pth`; deletes the scratch dir. `unconsolidated_steps` lists recoverable steps |
+| `consolidate_cli.py` | `python -m …consolidate_cli <run> [--step N]` — manual CPU-only recovery for a failed/preempted async consolidation (separate module to avoid an import cycle with `experiments.lm.run`) |
 | `config.py` | `ThreePoolConfig` + topology validation |
 | `role.py` | `PoolRole = CIRole \| LWRole \| PPGDRole` — this rank's pool role; per-pool fields are union variants, not optional attrs |
 | `context.py` | `PoolContext = CIContext \| LWContext \| PPGDContext` — `world` + `role` + this pool's portals; the trainer matches on it to dispatch step fns |
@@ -37,15 +38,47 @@ rank-0 assembly here.
 of a step's partials → assembles the full `ComponentModel` state_dict +
 `ThreePoolTrainingState` → writes `model_<S>.pth` + `training_<S>.pth` → prunes
 old `training_*.pth` to the last `DEFAULT_KEEP_LAST_N_TRAINING` (=3; **all
-`model_*.pth` are kept**) → deletes `step_<S>/`. It runs as the first phase of
-the existing async slow-eval job (`experiments/lm/async_eval.py`, rank 0 only,
-then a barrier) so the assembled `model_<S>.pth` exists before the eval loads it.
-Idempotent: a no-op if `training_<S>.pth` already exists or the scratch dir is
-gone.
+`model_*.pth` are kept**) → deletes `step_<S>/`. It runs inside the async
+slow-eval job (`experiments/lm/async_eval.py`), as a CPU-only phase BEFORE the
+eval pass, so the assembled `model_<S>.pth` exists before the eval loads it.
+Idempotent: a no-op if `training_<S>.pth` already exists (and it cleans any
+leftover scratch in that case); the scratch dir is deleted only on success.
 
 This is the fix for how run 34446 (p-a5b667e9) died: the old synchronous rank-0
 read held the other ranks at a barrier past the NCCL watchdog. There is no
 on-loop read to outrun the watchdog now.
+
+### Consolidation reliability (the async job's contract)
+
+`async_eval.main` runs consolidation via `_consolidate_or_wait`, which is
+engineered to **never hang** (a hung job holds GPUs forever — the one
+unacceptable failure mode for an off-loop job):
+
+  * **CPU-only, post-init.** Assembly builds a full `ComponentModel` buffer; it
+    must run on CPU (under `torch.device("cpu")`) — building it on the job's
+    selected, shared GPU hangs. It runs AFTER `init_distributed` (so
+    `build_target`'s `ensure_cached_and_call` has its distributed state) but the
+    buffer never touches the GPU. `assemble_model_state_dict_from_partials`
+    freezes the target (`eval()` + `requires_grad_(False)`) before constructing
+    the buffer — `build_target` only `.eval()`s it, and `ComponentModel` asserts
+    a frozen target (an unfrozen target was the original "hang": rank 0 hit the
+    assertion and died while the other rank waited).
+  * **Rank 0 assembles; others file-wait, fail-fast.** Non-rank-0 ranks poll the
+    shared FS for `training_<S>.pth` (written last) rather than an NCCL barrier
+    (so the multi-second CPU read never interleaves with a GPU collective). On
+    any consolidation error rank 0 writes a `.consolidate_failed_<S>` sentinel
+    and re-raises; the waiters bail out (raising) on the sentinel OR a bounded
+    timeout. A failed child **errors and releases its GPUs**, it does not wedge.
+  * **Partials persist on failure → re-runnable.** `consolidate_step` deletes
+    `step_<S>/` only after a successful write, so a failed/preempted
+    consolidation leaves the partials intact. Recover with the CLI:
+
+        python -m param_decomp_lab.three_pool.consolidate_cli <run_id|out_dir> [--step N]
+
+    With no `--step` it consolidates every `unconsolidated_steps(out_dir)` (a step
+    with partials but no `training_<step>.pth`). The prune is concurrency-safe
+    (`unlink(missing_ok=True)`) since multiple per-step children may prune the
+    same old file at once.
 
 ## Process-group timeout
 

--- a/param_decomp_lab/three_pool/CLAUDE.md
+++ b/param_decomp_lab/three_pool/CLAUDE.md
@@ -9,7 +9,8 @@ docstring in `optimize.py` for the data-handling contract.
 |---|---|
 | `optimize.py` | `ThreePoolTrainer` + `optimize_three_pool`; the training loop, `snapshot`/`from_snapshot`, config validation |
 | `layout.py` | `World` topology; `build_world` constructs every process group (threading `pg_timeout` into each); `BatchEdge` — symmetric per-edge batch-slice geometry (CI↔LW, CI↔PPGD) answering routing for both fan directions |
-| `checkpoint.py` | `gather_full_state_dict_to_rank0` — rebuilds the full model state on rank 0 |
+| `checkpoint.py` | offline state_dict assembly from on-disk partials (`assemble_model_state_dict_from_partials`) + the leader key-partition helpers (`owned_model_state_keys` / `ci_fn_state_keys`) |
+| `consolidate.py` | `consolidate_step` — async, off-train-loop assembly of `model_<step>.pth` + `training_<step>.pth` from a step's scratch partials; prunes old `training_*.pth`; deletes the scratch dir |
 | `config.py` | `ThreePoolConfig` + topology validation |
 | `role.py` | `PoolRole = CIRole \| LWRole \| PPGDRole` — this rank's pool role; per-pool fields are union variants, not optional attrs |
 | `context.py` | `PoolContext = CIContext \| LWContext \| PPGDContext` — `world` + `role` + this pool's portals; the trainer matches on it to dispatch step fns |
@@ -17,53 +18,76 @@ docstring in `optimize.py` for the data-handling contract.
 | `step_{ci,layerwise,ppgd}.py` | per-pool step functions |
 | `eval_step.py` | 3-pool eval pass (PPGD pool runs metrics; others barrier through) |
 
-## Checkpoint-save invariant (do not break)
+## Checkpoint save: partials on the loop, consolidation off it
 
-`snapshot()` is collective. The ordering is: all ranks gather the model to
-rank 0, all ranks write their per-rank partial to the shared-FS scratch dir,
-barrier, then **rank 0 alone** serially reads every partial (~100 GB at XL) to
-assemble the canonical `ThreePoolTrainingState`. The other ranks have nothing
-to do during that read.
+The save path is split so the train loop never blocks on a multi-GB read.
 
-There is a **mandatory rejoining `dist.barrier(group=cross_pool_p2p_group)`
-after rank 0 finishes reading.** Without it, the non-rank-0 ranks race ahead
-into the next training step while rank 0 is still reading; the next step's
-collectives (PPGD V/U all-reduce, cross-pool sends) block on rank 0 and trip
-the NCCL collective-timeout watchdog, aborting the whole job. This is exactly
-how run 34446 (p-a5b667e9) died at its first checkpoint. The barrier makes all
-ranks resume in lock-step.
+`snapshot()` (on the train loop, all ranks collective): each rank writes a
+**self-contained partial** to `scratch_dir/step_<S>/rank_<r>.pth` — its owned
+model params (LW block leaders → owned-sites V/U; CI pool leader → CI fn),
+its optimizer state (name-keyed), and (PPGD) its sources. Rank 0 also writes
+`meta.pth` (configs + fingerprint + `c_per_site` / `all_sites`). There is **one
+pre-write barrier** (so rank 0's `mkdir` + `meta` write land before others write
+into the dir) and **one post-write rejoin barrier** (so all ranks leave
+`snapshot()` together). Both barriers are cheap — no rank does a 100 GB read on
+the loop anymore — so neither can overrun the watchdog. NO model NCCL gather, NO
+rank-0 assembly here.
 
-## Process-group timeout (do not lower)
+`consolidate_step()` (`consolidate.py`, async SLURM job, off the loop): reads all
+of a step's partials → assembles the full `ComponentModel` state_dict +
+`ThreePoolTrainingState` → writes `model_<S>.pth` + `training_<S>.pth` → prunes
+old `training_*.pth` to the last `DEFAULT_KEEP_LAST_N_TRAINING` (=3; **all
+`model_*.pth` are kept**) → deletes `step_<S>/`. It runs as the first phase of
+the existing async slow-eval job (`experiments/lm/async_eval.py`, rank 0 only,
+then a barrier) so the assembled `model_<S>.pth` exists before the eval loads it.
+Idempotent: a no-op if `training_<S>.pth` already exists or the scratch dir is
+gone.
+
+This is the fix for how run 34446 (p-a5b667e9) died: the old synchronous rank-0
+read held the other ranks at a barrier past the NCCL watchdog. There is no
+on-loop read to outrun the watchdog now.
+
+## Process-group timeout
 
 `build_world` takes a `pg_timeout` and threads it into every `dist.new_group`
 call. **This is load-bearing:** `new_group` does NOT inherit the timeout passed
 to `init_process_group` — with `timeout=None` it silently uses the 10-min NCCL
 library default. The 3-pool runs all of its real collectives on these subgroups
 (never the default group), so the timeout must be set explicitly or a slow
-checkpoint save / eval pass trips the 10-min watchdog.
+collective trips the watchdog.
 
-The default is 30 min (`_DEFAULT_PG_TIMEOUT` in `optimize.py`). The invariant is
-simply: **the PG timeout must exceed the worst-case rank-0 checkpoint read
-time.** Override (seconds) via `PD_3POOL_PG_TIMEOUT_S` — used by the
-save-watchdog repro (`scripts/repro_3pool_save_watchdog.sbatch`) to force the
-bug at small scale.
+The default is **10 min** (`_DEFAULT_PG_TIMEOUT` in `optimize.py`), brought down
+from 30 min once consolidation moved off the loop. The invariant is now: **the
+PG timeout must exceed the worst-case on-loop collective gap**, which is the
+in-train (fast) eval pass plus a checkpoint partial-write barrier — minutes, not
+the old ~10-min rank-0 read. Override (seconds) via `PD_3POOL_PG_TIMEOUT_S` —
+used by the watchdog-safe-at-low-timeout test to force a tight bound.
 
 ## Resume (`from_snapshot`)
 
 3-pool runs persist a `ThreePoolTrainingState` (not the single-pool
-`TrainingState`); `read_training_snapshot` returns either and the caller
-narrows. `from_snapshot` validates the saved topology against the current one,
-but the comparison runs on EVERY rank, so it compares only the
-**rank-invariant** core (`world_size` / `ci_ranks` / `ppgd_ranks` /
-block count) via `_rank_invariant_fingerprint_core` — never a rank-local view.
-That helper also tolerates the pre-fix rank-local fingerprint format baked into
-existing production checkpoints (p-a5b667e9). The per-block ranks→sites mapping
-is re-derived from the snapshot's `three_pool_config`.
+`TrainingState`), written by the **async consolidation job**, not the train loop.
+`resolve_step` / `read_training_snapshot` pick the latest consolidated
+`training_<step>.pth`. If a run dies after a save but before that step's
+consolidation finishes, resume from the previous consolidated step — at most one
+save-interval of lost progress (the scratch partials for the unconsolidated step
+are left on disk; they can be consolidated manually via `consolidate_step` if
+that interval matters).
+
+`from_snapshot` validates the saved topology against the current one, but the
+comparison runs on EVERY rank, so it compares only the **rank-invariant** core
+(`world_size` / `ci_ranks` / `ppgd_ranks` / block count) via
+`_rank_invariant_fingerprint_core` — never a rank-local view. That helper also
+tolerates the pre-fix rank-local fingerprint format baked into existing
+production checkpoints (p-a5b667e9). The per-block ranks→sites mapping is
+re-derived from the snapshot's `three_pool_config`.
 
 Repro/fault-injection env knobs (never set in production):
-`PD_3POOL_PG_TIMEOUT_S`, `PD_3POOL_SNAPSHOT_RANK0_SLEEP_S` (inject a sleep into
-rank-0's read), `PD_3POOL_DISABLE_REJOIN_BARRIER` (reproduces the pre-fix race).
-Regression tests: `param_decomp_lab/tests/test_three_pool_pg_timeout.py`.
+`PD_3POOL_PG_TIMEOUT_S`, `PD_3POOL_SNAPSHOT_RANK0_SLEEP_S` (sleeps rank 0 inside
+`snapshot()` AFTER the partial write — proves the sleep no longer stalls the
+loop now that the read is async), `PD_3POOL_DISABLE_REJOIN_BARRIER` (drops the
+post-write rejoin barrier). Regression tests:
+`param_decomp_lab/tests/test_three_pool_pg_timeout.py`.
 
 ## Cross-pool batch divisibility (bidirectional)
 

--- a/param_decomp_lab/three_pool/checkpoint.py
+++ b/param_decomp_lab/three_pool/checkpoint.py
@@ -68,6 +68,11 @@ def assemble_model_state_dict_from_partials(
     The union of every partial's keys must exactly cover the full-decomposition
     model's V/U + CI-fn keys (target-model params come from the fresh buffer).
     """
+    # ComponentModel asserts the target has no trainable params; build_target only
+    # `.eval()`s it, so freeze here (the training / load_component_model paths
+    # freeze at their own construction sites).
+    target_model.eval()
+    target_model.requires_grad_(False)
     full_targets = [DecompositionTarget(module_path=s, C=c_per_site[s]) for s in all_sites]
     full_cm = ComponentModel(
         target_model=target_model,

--- a/param_decomp_lab/three_pool/checkpoint.py
+++ b/param_decomp_lab/three_pool/checkpoint.py
@@ -1,27 +1,22 @@
-"""Distributed checkpoint assembly for 3-pool training.
+"""Offline checkpoint assembly for 3-pool training.
 
-Rank 0 only holds its own block's V/U (and a random-init CI fn). To produce a
-checkpoint that matches the schema ``load_component_model_from_checkpoint``
-expects (one flat ``state_dict`` with every site's V/U + the trained CI fn),
-this module gathers state onto rank 0 from:
+The train loop never assembles a checkpoint. Instead each rank writes a
+self-contained partial to a shared-FS scratch dir (see
+``ThreePoolTrainer.snapshot``): its owned model params (LW leaders → owned-sites
+V/U; CI leader → CI fn), its optimizer state, and (PPGD) its sources. A separate
+async SLURM job then reads every partial for a step and assembles the canonical
+artifacts off the training critical path.
 
-  * Every LW block leader → its owned sites' V/U.
-  * The CI pool leader → all CI fn params.
-
-Rank 0 assembles the gathered tensors into a temporary "full" ``ComponentModel``
-(with all sites in its decomposition targets) and returns that model's
-``state_dict()``. The temp model shares ``target_model`` with rank 0's existing
-component model — ``ComponentModel.__init__`` doesn't mutate ``target_model``,
-so this is safe.
-
-Non-leader ranks no-op. All ranks must enter ``gather_full_state_dict_to_rank0``
-in sync so the P2P sends/recvs match up.
+This module owns that offline assembly. It builds a full-decomposition
+``ComponentModel`` on CPU as an assembly buffer, copies in every site's V/U + the
+CI fn from the partials, and returns its ``state_dict()`` — the same flat schema
+``load_component_model_from_checkpoint`` expects. No live ranks, no NCCL: the
+assembly is pure file I/O + tensor copies.
 """
 
-# pyright: reportArgumentType=false
+from typing import Any
 
 import torch
-import torch.distributed as dist
 import torch.nn as nn
 from torch import Tensor
 
@@ -30,111 +25,81 @@ from param_decomp.ci_fns import CiConfig
 from param_decomp.ci_sigmoids import SigmoidType
 from param_decomp.component_model import ComponentModel
 from param_decomp.decomposition_targets import DecompositionTarget
-from param_decomp_lab.three_pool.context import CIContext, LWContext, PoolContext
 
 
-def gather_full_state_dict_to_rank0(
-    ctx: PoolContext,
-    component_model: ComponentModel,
-    target_model: nn.Module,
-    run_batch: RunBatch,
-    ci_config: CiConfig,
-    sigmoid_type: SigmoidType,
-    c_per_site: dict[str, int],
-    device: torch.device,
-) -> dict[str, Tensor] | None:
-    """Collect V/U + CI fn onto rank 0 and return the assembled state_dict.
+def site_to_component_prefix(site: str) -> str:
+    """State-dict key prefix for a site's V/U params.
 
-    Returns the state_dict on rank 0; ``None`` everywhere else. All ranks must
-    call this function in sync (the gather uses ordered P2P sends/recvs).
+    ``ComponentModel`` registers components under an ``nn.ModuleDict`` keyed by
+    the site with dots replaced by dashes (so dots don't nest module levels), so
+    ``h.0.attn.q_proj`` → ``_components.h-0-attn-q_proj``.
     """
-    world = ctx.world
-    match ctx:
-        case LWContext() if ctx.role.rank == 0:
-            return _rank0_assemble(
-                ctx=ctx,
-                local_component_model=component_model,
-                target_model=target_model,
-                run_batch=run_batch,
-                ci_config=ci_config,
-                sigmoid_type=sigmoid_type,
-                c_per_site=c_per_site,
-                device=device,
-            )
-        case LWContext() if ctx.role.is_block_leader:
-            for s in ctx.role.owned_sites:
-                comp = component_model.components[s]
-                dist.send(comp.V.data.contiguous(), dst=0, group=world.cross_pool_p2p_group)
-                dist.send(comp.U.data.contiguous(), dst=0, group=world.cross_pool_p2p_group)
-            return None
-        case CIContext() if ctx.role.is_pool_leader:
-            assert component_model.ci_fn is not None, "CI pool must keep its CI fn"
-            for _, p in component_model.ci_fn.named_parameters():
-                dist.send(p.data.contiguous(), dst=0, group=world.cross_pool_p2p_group)
-            return None
-        case _:
-            # Non-leader LW ranks, non-leader CI ranks, all PPGD ranks: no-op.
-            return None
+    return f"_components.{site.replace('.', '-')}"
 
 
-def _rank0_assemble(
-    ctx: LWContext,
-    local_component_model: ComponentModel,
+def owned_model_state_keys(
+    model_state_dict_keys: set[str], *, owned_sites: tuple[str, ...]
+) -> set[str]:
+    """The V/U state-dict keys for ``owned_sites`` (LW block leaders' partial)."""
+    prefixes = tuple(f"{site_to_component_prefix(s)}." for s in owned_sites)
+    return {k for k in model_state_dict_keys if k.startswith(prefixes)}
+
+
+def ci_fn_state_keys(model_state_dict_keys: set[str]) -> set[str]:
+    """The CI-fn state-dict keys (the CI pool leader's partial)."""
+    return {k for k in model_state_dict_keys if k.startswith("ci_fn.")}
+
+
+def assemble_model_state_dict_from_partials(
+    *,
+    partials: list[dict[str, Any]],
     target_model: nn.Module,
     run_batch: RunBatch,
     ci_config: CiConfig,
     sigmoid_type: SigmoidType,
     c_per_site: dict[str, int],
-    device: torch.device,
+    all_sites: tuple[str, ...],
 ) -> dict[str, Tensor]:
-    """Build a full ComponentModel as an assembly buffer; populate from local
-    rank's V/U + recvs; return its state_dict."""
-    world = ctx.world
-    full_targets = [DecompositionTarget(module_path=s, C=c_per_site[s]) for s in world.all_sites]
-    # Share target_model with the existing local component_model — ComponentModel
-    # __init__ doesn't mutate target_model, so two ComponentModels can coexist
-    # over the same target.
+    """Assemble the full ComponentModel state_dict from per-rank scratch partials.
+
+    Each partial's ``model_params`` holds the CPU tensors that rank owns (a slice
+    of its own ``component_model.state_dict()``): LW block leaders contribute their
+    owned sites' ``_components.<site>.*``, the CI pool leader contributes ``ci_fn.*``.
+    The union of every partial's keys must exactly cover the full-decomposition
+    model's V/U + CI-fn keys (target-model params come from the fresh buffer).
+    """
+    full_targets = [DecompositionTarget(module_path=s, C=c_per_site[s]) for s in all_sites]
     full_cm = ComponentModel(
         target_model=target_model,
         run_batch=run_batch,
         decomposition_targets=full_targets,
         ci_config=ci_config,
         sigmoid_type=sigmoid_type,
-    ).to(device)
+    )
 
-    # Copy rank 0's own trained V/U into the assembly buffer.
+    # `ComponentModel` registers `target_model` as a submodule, so its frozen
+    # weights appear in the state_dict under the `target_model.` prefix. They come
+    # from the freshly-built buffer (which shares the real target_model), so the
+    # partials only need to cover the V/U + CI-fn keys — everything NOT under
+    # `target_model.`.
+    expected_keys = set(full_cm.state_dict().keys())
+    fillable_keys = {k for k in expected_keys if not k.startswith("target_model.")}
+
+    collected: dict[str, Tensor] = {}
+    for partial in partials:
+        for k, v in partial["model_params"].items():
+            assert k not in collected, f"duplicate model param {k!r} across partials"
+            collected[k] = v
+
+    assert set(collected.keys()) == fillable_keys, (
+        "partials do not cover the full model state_dict:\n"
+        f"  missing: {sorted(fillable_keys - set(collected))}\n"
+        f"  extra:   {sorted(set(collected) - fillable_keys)}"
+    )
+
+    full_state = full_cm.state_dict()
     with torch.no_grad():
-        for s in ctx.role.owned_sites:
-            full_cm.components[s].V.data.copy_(local_component_model.components[s].V.data)
-            full_cm.components[s].U.data.copy_(local_component_model.components[s].U.data)
+        for k, v in collected.items():
+            full_state[k].copy_(v)
 
-    # Recv V/U from every other LW block leader. Order on both sides must match
-    # the iteration order of `bg.owned_sites` for each non-rank-0 block leader.
-    for bg in world.layerwise_block_groups:
-        if bg.leader == 0:
-            continue
-        for s in bg.owned_sites:
-            V_template = full_cm.components[s].V.data
-            U_template = full_cm.components[s].U.data
-            V_buf = torch.empty_like(V_template)
-            U_buf = torch.empty_like(U_template)
-            dist.recv(V_buf, src=bg.leader, group=world.cross_pool_p2p_group)
-            dist.recv(U_buf, src=bg.leader, group=world.cross_pool_p2p_group)
-            with torch.no_grad():
-                V_template.copy_(V_buf)
-                U_template.copy_(U_buf)
-
-    # Recv CI fn params from CI pool leader. Same `named_parameters()` iteration
-    # order on both sides since the CI fn is constructed from the same config.
-    ci_leader = world.ci_ranks[0]
-    assert full_cm.ci_fn is not None, "checkpoint reconstruction needs a CI fn"
-    for _, p in full_cm.ci_fn.named_parameters():
-        buf = torch.empty_like(p.data)
-        dist.recv(buf, src=ci_leader, group=world.cross_pool_p2p_group)
-        with torch.no_grad():
-            p.data.copy_(buf)
-
-    state_dict = {k: v.cpu() for k, v in full_cm.state_dict().items()}
-    del full_cm
-    torch.cuda.empty_cache()
-    return state_dict
+    return {k: v.cpu() for k, v in full_state.items()}

--- a/param_decomp_lab/three_pool/config.py
+++ b/param_decomp_lab/three_pool/config.py
@@ -17,9 +17,9 @@ global shared transformer CI fns that span all sites).
 
 Topology integrity checks (rank disjointness, uniform N_per_block, CI-pool
 cross-divisibility with Layerwise/PPGD arities) run at validation time; checks
-that depend on ``pd.batch_size`` (divisibility) run in
-``_validate_pd_config_for_three_pool`` since they need the paired ``PDConfig``
-to evaluate.
+that depend on ``pd.batch_size`` (divisibility) + the rank-0 convention run on
+``ThreePoolLMExperimentConfig`` (in ``experiments.lm.three_pool_run``) since they
+need the paired ``ThreePoolConstrainedPDConfig`` to evaluate.
 """
 
 from typing import Self
@@ -139,7 +139,7 @@ class ThreePoolConfig(BaseConfig):
         # (CI↔LW, CI↔PPGD) must be a clean one-to-K fan-out in EITHER direction:
         # one arity divides the other, so every batch-slice overlap is a whole,
         # aligned sub-slice. (The batch-divisibility of each arity itself is
-        # enforced against pd.batch_size in _validate_pd_config_for_three_pool.)
+        # enforced against pd.batch_size on ThreePoolLMExperimentConfig.)
         n_ci = len(self.ci_ranks)
         n_ppgd = len(self.ppgd_ranks)
         assert n_per_block % n_ci == 0 or n_ci % n_per_block == 0, (

--- a/param_decomp_lab/three_pool/consolidate.py
+++ b/param_decomp_lab/three_pool/consolidate.py
@@ -166,3 +166,22 @@ def _prune_old_training(out_dir: Path, *, keep_last_n: int) -> None:
         if path.is_file():
             path.unlink()
             logger.info(f"consolidate: pruned old {path.name}")
+
+
+def unconsolidated_steps(out_dir: Path) -> list[int]:
+    """Steps that have scratch partials on disk but no `training_<step>.pth` yet.
+
+    These are saves the async job never finished consolidating (it crashed, was
+    preempted, or never ran). They're safe + cheap to consolidate by re-running.
+    """
+    scratch = out_dir / SNAPSHOT_SCRATCH_DIRNAME
+    if not scratch.is_dir():
+        return []
+    out: list[int] = []
+    for d in scratch.glob("step_*"):
+        if not d.is_dir():
+            continue
+        step = int(d.name.removeprefix("step_"))
+        if not (out_dir / f"training_{step}.pth").is_file():
+            out.append(step)
+    return sorted(out)

--- a/param_decomp_lab/three_pool/consolidate.py
+++ b/param_decomp_lab/three_pool/consolidate.py
@@ -1,0 +1,168 @@
+"""Offline consolidation of a 3-pool checkpoint from its scratch partials.
+
+The 3-pool train loop writes per-rank partials to ``scratch_dir/step_<S>/`` (see
+``ThreePoolTrainer.snapshot``) and then continues — it never assembles the
+canonical checkpoint. This module does that assembly off the critical path,
+driven by the async SLURM job that already runs the slow eval. It reads every
+partial for a step, builds the full ``ComponentModel`` state_dict + the canonical
+``ThreePoolTrainingState``, writes ``model_<S>.pth`` + ``training_<S>.pth``,
+prunes old ``training_*.pth`` (keeping all ``model_*.pth``), and removes the
+step's scratch dir.
+
+Idempotent: if ``training_<S>.pth`` already exists, consolidation is a no-op (the
+async job may be retried). If the scratch dir is already gone (consolidation ran
+before, or the run died), it's also a no-op — the consolidated artifacts are the
+source of truth.
+"""
+
+import os
+import shutil
+import time
+from pathlib import Path
+from typing import Any
+
+import torch
+import torch.nn as nn
+
+from param_decomp.batch_and_loss_fns import RunBatch
+from param_decomp.ci_fns import CiConfig
+from param_decomp.ci_sigmoids import SigmoidType
+from param_decomp.log import logger
+from param_decomp.training_state import ThreePoolTrainingState
+from param_decomp_lab.infra.run_files import save_file
+from param_decomp_lab.three_pool.checkpoint import assemble_model_state_dict_from_partials
+
+SNAPSHOT_SCRATCH_DIRNAME = ".snapshot_scratch"
+"""Subdir under the run's out_dir that holds the per-step partials. The trainer
+writes here; consolidation reads + cleans here."""
+
+CONSOLIDATE_META_FILENAME = "meta.pth"
+
+DEFAULT_KEEP_LAST_N_TRAINING = 3
+"""How many ``training_<step>.pth`` files to keep after consolidation. All
+``model_<step>.pth`` files are always kept (they're the downstream artifact)."""
+
+
+def step_scratch_dir(scratch_dir: Path, step: int) -> Path:
+    return scratch_dir / f"step_{step}"
+
+
+def consolidate_step(
+    *,
+    scratch_dir: Path,
+    out_dir: Path,
+    step: int,
+    target_model: nn.Module,
+    run_batch: RunBatch,
+    ci_config: CiConfig,
+    sigmoid_type: SigmoidType,
+    keep_last_n_training: int,
+) -> None:
+    """Assemble + persist the step-S checkpoint from its scratch partials.
+
+    No-op (returns early) when ``training_<S>.pth`` already exists or the scratch
+    dir for the step is missing — both mean the work is already done (or was done
+    by a prior, possibly-retried, invocation).
+    """
+    training_path = out_dir / f"training_{step}.pth"
+    if training_path.is_file():
+        logger.info(f"consolidate: {training_path.name} already exists; skipping")
+        return
+
+    step_dir = step_scratch_dir(scratch_dir, step)
+    if not step_dir.is_dir():
+        logger.warning(
+            f"consolidate: scratch dir {step_dir} missing and no {training_path.name}; "
+            f"nothing to consolidate for step {step}"
+        )
+        return
+
+    # PD_3POOL_SNAPSHOT_RANK0_SLEEP_S models the old slow rank-0 read. It now
+    # lives here, off the train loop, so injecting it proves the train loop's PG
+    # timeout is unaffected by a slow consolidation (the watchdog-safe test).
+    sleep_s = os.environ.get("PD_3POOL_SNAPSHOT_RANK0_SLEEP_S", "").strip()
+    if sleep_s:
+        logger.info(f"consolidate: sleep {sleep_s}s (fault injection, off train loop)")
+        time.sleep(float(sleep_s))
+
+    meta = torch.load(step_dir / CONSOLIDATE_META_FILENAME, map_location="cpu", weights_only=False)
+    world_size: int = meta["world_size"]
+    all_sites: tuple[str, ...] = tuple(meta["all_sites"])
+    c_per_site: dict[str, int] = meta["c_per_site"]
+
+    partials: list[dict[str, Any]] = []
+    for r in range(world_size):
+        partials.append(
+            torch.load(step_dir / f"rank_{r}.pth", map_location="cpu", weights_only=False)
+        )
+    logger.info(f"consolidate: read {world_size} partials for step {step}")
+
+    model_state = assemble_model_state_dict_from_partials(
+        partials=partials,
+        target_model=target_model,
+        run_batch=run_batch,
+        ci_config=ci_config,
+        sigmoid_type=sigmoid_type,
+        c_per_site=c_per_site,
+        all_sites=all_sites,
+    )
+
+    components_optimizer: dict[str, dict[str, Any]] = {}
+    ci_fn_optimizer: dict[str, dict[str, Any]] = {}
+    ppgd_by_rank: dict[int, dict[str, Any]] = {}
+    for r, partial in enumerate(partials):
+        pool: str = partial["pool"]
+        match pool:
+            case "layerwise":
+                components_optimizer.update(partial["optimizer_by_name"])
+            case "ci":
+                ci_fn_optimizer.update(partial["optimizer_by_name"])
+            case "ppgd":
+                if "ppgd" in partial:
+                    ppgd_by_rank[r] = partial["ppgd"]
+            case _:
+                raise AssertionError(f"unknown pool {pool!r} in rank-{r} partial")
+
+    state = ThreePoolTrainingState(
+        step=step,
+        pd_config=meta["pd_config"],
+        runtime_config=meta["runtime_config"],
+        three_pool_config=meta["three_pool_config"],
+        layout_fingerprint=meta["layout_fingerprint"],
+        component_model=model_state,
+        components_optimizer=components_optimizer,
+        ci_fn_optimizer=ci_fn_optimizer,
+        ppgd_state_by_rank=ppgd_by_rank,
+    )
+
+    model_path = out_dir / f"model_{step}.pth"
+    save_file(model_state, model_path)
+    save_file(state, training_path)
+    logger.info(f"consolidate: wrote {model_path.name} + {training_path.name}")
+
+    _prune_old_training(out_dir, keep_last_n=keep_last_n_training)
+
+    shutil.rmtree(step_dir, ignore_errors=True)
+    logger.info(f"consolidate: removed scratch {step_dir}")
+
+
+def _prune_old_training(out_dir: Path, *, keep_last_n: int) -> None:
+    """Delete all but the last ``keep_last_n`` ``training_<step>.pth`` files.
+
+    ``model_<step>.pth`` files are never pruned — they're the downstream artifact
+    and are cheap relative to the full training state.
+    """
+    steps: list[int] = []
+    for p in out_dir.glob("training_*.pth"):
+        try:
+            steps.append(int(p.stem.removeprefix("training_")))
+        except ValueError:
+            continue
+    steps.sort()
+    if len(steps) <= keep_last_n:
+        return
+    for step in steps[: len(steps) - keep_last_n]:
+        path = out_dir / f"training_{step}.pth"
+        if path.is_file():
+            path.unlink()
+            logger.info(f"consolidate: pruned old {path.name}")

--- a/param_decomp_lab/three_pool/consolidate.py
+++ b/param_decomp_lab/three_pool/consolidate.py
@@ -65,11 +65,15 @@ def consolidate_step(
     by a prior, possibly-retried, invocation).
     """
     training_path = out_dir / f"training_{step}.pth"
+    step_dir = step_scratch_dir(scratch_dir, step)
     if training_path.is_file():
+        # Already consolidated. Clean up any scratch left behind by a prior run
+        # that wrote the checkpoint but died before removing it (e.g. crashed in
+        # prune), so this step stops looking unconsolidated.
         logger.info(f"consolidate: {training_path.name} already exists; skipping")
+        shutil.rmtree(step_dir, ignore_errors=True)
         return
 
-    step_dir = step_scratch_dir(scratch_dir, step)
     if not step_dir.is_dir():
         logger.warning(
             f"consolidate: scratch dir {step_dir} missing and no {training_path.name}; "
@@ -163,9 +167,11 @@ def _prune_old_training(out_dir: Path, *, keep_last_n: int) -> None:
         return
     for step in steps[: len(steps) - keep_last_n]:
         path = out_dir / f"training_{step}.pth"
-        if path.is_file():
-            path.unlink()
-            logger.info(f"consolidate: pruned old {path.name}")
+        # missing_ok: a concurrently-running consolidation job for another step
+        # may have already pruned this same old file. That's benign — the target
+        # state (this file gone) is reached either way.
+        path.unlink(missing_ok=True)
+        logger.info(f"consolidate: pruned old {path.name}")
 
 
 def unconsolidated_steps(out_dir: Path) -> list[int]:

--- a/param_decomp_lab/three_pool/consolidate_cli.py
+++ b/param_decomp_lab/three_pool/consolidate_cli.py
@@ -1,0 +1,65 @@
+"""Manual CPU-only consolidation of a 3-pool run's scratch partials.
+
+Recovery tool for a failed/preempted async consolidation. The train loop always
+leaves a step's partials on disk until that step consolidates successfully, so a
+failed consolidation is fixed by re-running this:
+
+    python -m param_decomp_lab.three_pool.consolidate_cli p-xxxxxxxx
+    python -m param_decomp_lab.three_pool.consolidate_cli p-xxxxxxxx --step 5000
+
+With no ``--step`` it consolidates every step that has partials but no
+``training_<step>.pth`` yet (see `unconsolidated_steps`).
+
+Separate module from `consolidate` so the `experiments.lm.run` import here
+doesn't form an import cycle (`run` imports `consolidate`).
+"""
+
+from pathlib import Path
+
+import fire
+
+from param_decomp.log import logger
+from param_decomp_lab.experiments.lm.run import (
+    LMExperimentConfig,
+    build_target,
+    make_run_batch,
+)
+from param_decomp_lab.experiments.utils import RUN_META_FILENAME
+from param_decomp_lab.infra.settings import PARAM_DECOMP_OUT_DIR
+from param_decomp_lab.three_pool.consolidate import (
+    DEFAULT_KEEP_LAST_N_TRAINING,
+    SNAPSHOT_SCRATCH_DIRNAME,
+    consolidate_step,
+    unconsolidated_steps,
+)
+
+
+def cli(
+    run: str,
+    *,
+    step: int | None = None,
+    keep_last_n_training: int = DEFAULT_KEEP_LAST_N_TRAINING,
+) -> None:
+    out_dir = Path(run) if Path(run).is_dir() else PARAM_DECOMP_OUT_DIR / "decompositions" / run
+    cfg = LMExperimentConfig.from_file(out_dir / RUN_META_FILENAME)
+    target_model = build_target(cfg.target)
+    run_batch = make_run_batch(cfg.target)
+
+    steps = [step] if step is not None else unconsolidated_steps(out_dir)
+    assert steps, f"nothing to consolidate under {out_dir} (no unconsolidated scratch steps)"
+    logger.info(f"consolidate CLI: steps {steps} under {out_dir}")
+    for s in steps:
+        consolidate_step(
+            scratch_dir=out_dir / SNAPSHOT_SCRATCH_DIRNAME,
+            out_dir=out_dir,
+            step=s,
+            target_model=target_model,
+            run_batch=run_batch,
+            ci_config=cfg.pd.ci_config,
+            sigmoid_type=cfg.pd.sigmoid_type,
+            keep_last_n_training=keep_last_n_training,
+        )
+
+
+if __name__ == "__main__":
+    fire.Fire(cli)

--- a/param_decomp_lab/three_pool/optimize.py
+++ b/param_decomp_lab/three_pool/optimize.py
@@ -494,7 +494,12 @@ class ThreePoolTrainer:
         if cfg_overrides is not None:
             pd_dict = {**pd_dict, **cfg_overrides}
         pd_config = ThreePoolConstrainedPDConfig.model_validate(pd_dict)
-        runtime_config = RuntimeConfig.model_validate(snapshot.runtime_config)
+        # The saved runtime_config is a `ThreePoolRuntimeConfig` dump (base scalars +
+        # `topology`). The trainer takes the base `RuntimeConfig` scalars here and the
+        # topology via `three_pool_config` (the source of truth, identical to the dumped
+        # `topology`), so drop the duplicate `topology` key before validating as base.
+        runtime_dict = {k: v for k, v in snapshot.runtime_config.items() if k != "topology"}
+        runtime_config = RuntimeConfig.model_validate(runtime_dict)
         three_pool_config = ThreePoolConfig.model_validate(snapshot.three_pool_config)
 
         trainer = cls(

--- a/param_decomp_lab/three_pool/optimize.py
+++ b/param_decomp_lab/three_pool/optimize.py
@@ -62,12 +62,7 @@ from param_decomp.decomposition_targets import (
 )
 from param_decomp.distributed import seed_all_ranks, seed_per_rank
 from param_decomp.masks import AllLayersRouter
-from param_decomp.metrics.base import LossMetricConfig
-from param_decomp.metrics.importance_minimality import ImportanceMinimalityLossConfig
-from param_decomp.metrics.persistent_pgd_recon import (
-    PersistentPGDReconLossConfig,
-    validate_pgd_scope,
-)
+from param_decomp.metrics.persistent_pgd_recon import validate_pgd_scope
 from param_decomp.metrics.persistent_pgd_state import (
     PerBatchPerPositionScope,
     PersistentPGDState,
@@ -78,6 +73,7 @@ from param_decomp.schedule import get_scheduled_value
 from param_decomp.sdpa_strict import verify_flash_attention_available
 from param_decomp.torch_helpers import loop_dataloader
 from param_decomp.training_state import ThreePoolTrainingState
+from param_decomp_lab.experiments.lm.three_pool_pd import ThreePoolConstrainedPDConfig
 from param_decomp_lab.three_pool.checkpoint import gather_full_state_dict_to_rank0
 from param_decomp_lab.three_pool.config import ThreePoolConfig
 from param_decomp_lab.three_pool.context import (
@@ -121,37 +117,6 @@ def _resolve_pg_timeout() -> datetime.timedelta:
     return _DEFAULT_PG_TIMEOUT
 
 
-# Loss-metric type discriminators required for the 3-pool training path.
-REQUIRED_LOSS_METRIC_TYPES: frozenset[str] = frozenset(
-    {
-        "FaithfulnessLoss",
-        "ImportanceMinimalityLoss",
-        "StochasticReconLayerwiseLoss",
-        "PersistentPGDReconLoss",
-    }
-)
-
-FORBIDDEN_LOSS_METRIC_TYPES: frozenset[str] = frozenset(
-    {
-        "StochasticReconLoss",
-        "StochasticReconSubsetLoss",
-        "StochasticReconSubsetCEAndKL",
-        "PersistentPGDReconSubsetLoss",
-        "CIMaskedReconLoss",
-        "CIMaskedReconLayerwiseLoss",
-        "CIMaskedReconSubsetLoss",
-        "UnmaskedReconLoss",
-        "PGDReconLoss",
-        "PGDReconLayerwiseLoss",
-        "PGDReconSubsetLoss",
-        "CIMaskedAttnPatternsReconLoss",
-        "StochasticAttnPatternsReconLoss",
-        "StochasticHiddenActsReconLoss",
-        "CIHiddenActsReconLoss",
-    }
-)
-
-
 class ThreePoolTrainer:
     """Stateful 3-pool trainer.
 
@@ -170,7 +135,7 @@ class ThreePoolTrainer:
     :meth:`snapshot`, so all ranks must call it in sync.
     """
 
-    pd_config: PDConfig
+    pd_config: ThreePoolConstrainedPDConfig
     runtime_config: RuntimeConfig
     three_pool_config: ThreePoolConfig
     reconstruction_loss: ReconstructionLoss
@@ -187,7 +152,7 @@ class ThreePoolTrainer:
         target_model: nn.Module,
         run_batch: RunBatch,
         reconstruction_loss: ReconstructionLoss,
-        pd_config: PDConfig,
+        pd_config: ThreePoolConstrainedPDConfig,
         runtime_config: RuntimeConfig,
         three_pool_config: ThreePoolConfig,
     ) -> None:
@@ -212,10 +177,9 @@ class ThreePoolTrainer:
         if ci_attn is not None:
             d_model, n_heads = ci_attn
             verify_flash_attention_available(head_dim=d_model // n_heads)
-        _validate_pd_config_for_three_pool(pd_config, three_pool_config)
         # PPGD runs only on PPGD pool; the relevant per-rank batch is batch // n_ppgd.
         validate_pgd_scope(
-            pd_config.loss_metrics,
+            [pd_config.losses.ppgd],
             batch_size=pd_config.batch_size,
             world_size=len(three_pool_config.ppgd_ranks),
         )
@@ -570,7 +534,7 @@ class ThreePoolTrainer:
         pd_dict = snapshot.pd_config
         if cfg_overrides is not None:
             pd_dict = {**pd_dict, **cfg_overrides}
-        pd_config = PDConfig.model_validate(pd_dict)
+        pd_config = ThreePoolConstrainedPDConfig.model_validate(pd_dict)
         runtime_config = RuntimeConfig.model_validate(snapshot.runtime_config)
         three_pool_config = ThreePoolConfig.model_validate(snapshot.three_pool_config)
 
@@ -901,7 +865,7 @@ def optimize_three_pool(
     *,
     run_batch: RunBatch,
     reconstruction_loss: ReconstructionLoss,
-    pd_config: PDConfig,
+    pd_config: ThreePoolConstrainedPDConfig,
     runtime_config: RuntimeConfig,
     three_pool_config: ThreePoolConfig,
     cadence: Cadence,
@@ -985,81 +949,15 @@ def _rank_invariant_fingerprint_core(fp: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _validate_pd_config_for_three_pool(
-    pd_config: PDConfig,
-    three_pool_config: ThreePoolConfig,
-) -> None:
-    """Fail loudly on any PDConfig the 3-pool path can't honour."""
-    by_type: dict[str, LossMetricConfig] = {m.type: m for m in pd_config.loss_metrics}
-
-    missing = sorted(REQUIRED_LOSS_METRIC_TYPES - set(by_type))
-    assert not missing, (
-        f"3-pool requires these loss metrics: {sorted(REQUIRED_LOSS_METRIC_TYPES)}.\n"
-        f"Missing: {missing}. Got: {sorted(by_type)}."
-    )
-    illegal = sorted(FORBIDDEN_LOSS_METRIC_TYPES & set(by_type))
-    assert not illegal, (
-        f"3-pool does not implement these loss metrics (they would be silently ignored): "
-        f"{illegal}. Remove them or extend the 3-pool path."
-    )
-
-    for name in REQUIRED_LOSS_METRIC_TYPES:
-        assert by_type[name].coeff is not None, (
-            f"pd_config.loss_metrics[{name!r}].coeff is required for 3-pool training"
-        )
-
-    n_per_block = len(three_pool_config.layerwise_block_groups[0].ranks)
-    n_ci = len(three_pool_config.ci_ranks)
-    n_ppgd = len(three_pool_config.ppgd_ranks)
-    bs = pd_config.batch_size
-    assert bs % n_per_block == 0, (
-        f"pd_config.batch_size ({bs}) must be divisible by N_per_block ({n_per_block}) "
-        f"= len(layerwise_block_groups[0].ranks)"
-    )
-    assert bs % n_ci == 0, (
-        f"pd_config.batch_size ({bs}) must be divisible by N_ci ({n_ci}) = len(ci_ranks)"
-    )
-    assert bs % n_ppgd == 0, (
-        f"pd_config.batch_size ({bs}) must be divisible by N_ppgd ({n_ppgd}) = len(ppgd_ranks)"
-    )
-
-    assert pd_config.use_delta_component, (
-        "3-pool requires pd_config.use_delta_component=True (hardcoded in LW's "
-        "layerwise stoch recon + PPGD's PPGD warmup)."
-    )
-
-    assert pd_config.sampling == "continuous", (
-        "3-pool hardcodes `sampling='continuous'` in CI pool's CI computation; "
-        f"got pd_config.sampling={pd_config.sampling!r}."
-    )
-    assert pd_config.n_mask_samples == 1, (
-        "3-pool draws exactly one stochastic mask per site per step in LW; "
-        f"got pd_config.n_mask_samples={pd_config.n_mask_samples}."
-    )
-
-    assert pd_config.identity_decomposition_targets is None, (
-        "3-pool path does not call `insert_identity_operations_`; "
-        "`identity_decomposition_targets` would be silently ignored."
-    )
-
-    # Convention: rank 0 must be the Layerwise pool's block 0 leader.
-    assert three_pool_config.layerwise_block_groups[0].ranks[0] == 0, (
-        "Convention: rank 0 must be the LW pool's block 0 leader (so reductions "
-        "can ship CI/PPGD pool losses to rank 0). Reorder layerwise_block_groups "
-        "so the first group starts with rank 0."
-    )
-
-    ppgd_cfg = by_type["PersistentPGDReconLoss"]
-    assert isinstance(ppgd_cfg, PersistentPGDReconLossConfig)
-    assert ppgd_cfg.start_frac == 0.0, (
-        "3-pool path does not implement PersistentPGDReconLoss.start_frac > 0; "
-        "PPGD always runs from step 0."
-    )
+def _required[T](value: T | None) -> T:
+    """Narrow a value the `ThreePoolLosses` validator already guarantees non-None."""
+    assert value is not None
+    return value
 
 
 def _build_runtime(
     target_model: nn.Module,
-    pd_config: PDConfig,
+    pd_config: ThreePoolConstrainedPDConfig,
     runtime_config: RuntimeConfig,
     three_pool_config: ThreePoolConfig,
     run_batch: RunBatch,
@@ -1082,16 +980,9 @@ def _build_runtime(
                 f"Available: {sorted(c_per_site)[:5]}..."
             )
 
-    by_type: dict[str, LossMetricConfig] = {m.type: m for m in pd_config.loss_metrics}
-    ppgd_cfg = by_type["PersistentPGDReconLoss"]
-    imp_min_cfg = by_type["ImportanceMinimalityLoss"]
-    assert isinstance(ppgd_cfg, PersistentPGDReconLossConfig)
-    assert isinstance(imp_min_cfg, ImportanceMinimalityLossConfig)
-
-    def _coeff(name: str) -> float:
-        c = by_type[name].coeff
-        assert c is not None
-        return float(c)
+    losses = pd_config.losses
+    ppgd_cfg = losses.ppgd
+    imp_min_cfg = losses.imp
 
     block_groups = tuple(
         LayerwiseBlockGroup(ranks=tuple(bg.ranks), owned_sites=tuple(bg.owned_sites))
@@ -1109,10 +1000,10 @@ def _build_runtime(
         run_batch=run_batch,
         reconstruction_loss=reconstruction_loss,
         ppgd_cfg=ppgd_cfg,
-        coeff_faith=_coeff("FaithfulnessLoss"),
-        coeff_imp=_coeff("ImportanceMinimalityLoss"),
-        coeff_stoch=_coeff("StochasticReconLayerwiseLoss"),
-        coeff_ppgd=_coeff("PersistentPGDReconLoss"),
+        coeff_faith=float(_required(losses.faith.coeff)),
+        coeff_imp=float(_required(losses.imp.coeff)),
+        coeff_stoch=float(_required(losses.stoch.coeff)),
+        coeff_ppgd=float(_required(losses.ppgd.coeff)),
         imp_min_pnorm=imp_min_cfg.pnorm,
         imp_min_beta=imp_min_cfg.beta,
         imp_min_eps=imp_min_cfg.eps,

--- a/param_decomp_lab/three_pool/optimize.py
+++ b/param_decomp_lab/three_pool/optimize.py
@@ -39,7 +39,6 @@ sliced-from-global pattern.
 import datetime
 import itertools
 import os
-import shutil
 import time
 from contextlib import nullcontext
 from pathlib import Path
@@ -78,8 +77,15 @@ from param_decomp.schedule import get_scheduled_value
 from param_decomp.sdpa_strict import verify_flash_attention_available
 from param_decomp.torch_helpers import loop_dataloader
 from param_decomp.training_state import ThreePoolTrainingState
-from param_decomp_lab.three_pool.checkpoint import gather_full_state_dict_to_rank0
+from param_decomp_lab.three_pool.checkpoint import (
+    ci_fn_state_keys,
+    owned_model_state_keys,
+)
 from param_decomp_lab.three_pool.config import ThreePoolConfig
+from param_decomp_lab.three_pool.consolidate import (
+    CONSOLIDATE_META_FILENAME,
+    step_scratch_dir,
+)
 from param_decomp_lab.three_pool.context import (
     CIContext,
     LWContext,
@@ -105,13 +111,13 @@ from param_decomp_lab.three_pool.step_layerwise import (
 )
 from param_decomp_lab.three_pool.step_ppgd import step_ppgd
 
-# Collective timeout for every 3-pool subgroup. Generous (vs the 10-min NCCL
-# default) because a checkpoint save at XL serially reads ~100 GB of partials
-# on rank 0 while the other 143 ranks wait at the post-save barrier — that read
-# can take many minutes, and any rank reaching the next step's collective before
-# rank 0 rejoins must not trip the watchdog. Env-overridable (seconds) so the
-# save-watchdog repro can force the timeout at small scale.
-_DEFAULT_PG_TIMEOUT = datetime.timedelta(minutes=30)
+# Collective timeout for every 3-pool subgroup. Now that consolidation is async
+# (off the train loop), the longest gap between collectives on the loop is the
+# in-train (fast) eval pass plus a checkpoint partial-write barrier — minutes,
+# not the old ~10-min rank-0 read of ~100 GB. 10 min covers that worst case with
+# generous margin while still being far below "hang forever". Env-overridable
+# (seconds) so the watchdog-safe-at-low-timeout test can force a tight bound.
+_DEFAULT_PG_TIMEOUT = datetime.timedelta(minutes=10)
 
 
 def _resolve_pg_timeout() -> datetime.timedelta:
@@ -161,13 +167,15 @@ class ThreePoolTrainer:
     the first batch of :meth:`run` because its source tensor shapes depend on
     the data's sequence dims.
 
-    Resume support is rank-local: :meth:`snapshot` produces a self-contained
-    :class:`~param_decomp.trainer_snapshot.TrainerSnapshot` whose ``resume``
-    half carries this rank's slice, and :meth:`from_snapshot` reconstructs
-    one from it. The lab's resume loader composes per-rank shards across
-    ranks. The snapshot's ``consumable`` half is the gathered full state
-    (rank 0 only; ``None`` elsewhere) — the gather happens inside
-    :meth:`snapshot`, so all ranks must call it in sync.
+    Checkpointing is split across two phases. :meth:`snapshot` runs on the train
+    loop: each rank writes a self-contained partial (its owned model params +
+    optimizer state + PPGD sources) to the shared-FS scratch dir, with a single
+    barrier — no rank-0 read, no model assembly. The async consolidation job
+    (:mod:`param_decomp_lab.three_pool.consolidate`) later reads every partial,
+    assembles the canonical :class:`~param_decomp.training_state.ThreePoolTrainingState`
+    + ``model_<step>.pth``, and runs the slow eval. :meth:`from_snapshot`
+    reconstructs a trainer from a consolidated ``ThreePoolTrainingState`` (each
+    rank loads its own slice).
     """
 
     pd_config: PDConfig
@@ -399,156 +407,107 @@ class ThreePoolTrainer:
             case PPGDContext():
                 return []
 
-    def snapshot(self, scratch_dir: Path) -> ThreePoolTrainingState | None:
-        """Canonical point-in-time view of the 3-pool trainer.
+    def snapshot(self, scratch_dir: Path) -> None:
+        """Write this rank's self-contained checkpoint partial; then return.
 
-        On rank 0 (the only rank a sink consumes from), assembles a
-        topology-free :class:`ThreePoolTrainingState`:
+        Each rank writes everything needed to reconstruct the checkpoint for
+        its own slice to ``scratch_dir / f"step_{S}" / f"rank_{rank}.pth"``:
 
-        * ``component_model``: the full gathered model state (every site's V/U
-          plus the CI fn) from :func:`gather_full_state_dict_to_rank0`.
-        * ``components_optimizer`` / ``ci_fn_optimizer``: per-parameter
-          optimizer state keyed by param name, merged across all ranks.
-          ``components_optimizer`` comes from the layerwise pool (each LW
-          rank contributes its owned sites); ``ci_fn_optimizer`` comes from
-          the CI pool (all CI ranks have the same state via in-pool
-          all-reduce, so any suffices).
-        * ``ppgd_state_by_rank``: PPGD adversarial sources, keyed by PPGD
-          rank id. Genuinely rank-coupled for ``PerBatchPerPositionScope``
-          sources (sized by the rank-local batch slice).
+        * ``model_params``: a slice of this rank's ``component_model.state_dict()`` —
+          LW block leaders contribute their owned sites' ``_components.<site>.*``,
+          the CI pool leader contributes ``ci_fn.*``, everyone else contributes
+          nothing (their V/U / CI fn are replicas of a leader's).
+        * ``optimizer_by_name``: this rank's optimizer state, name-keyed.
+        * ``ppgd``: PPGD adversarial sources (PPGD ranks only).
 
-        Returns ``None`` on non-rank-0 — the lab sink is silent on those
-        ranks anyway, and the trainer never needs their canonical state.
-
-        Args:
-            scratch_dir: Shared-filesystem directory all ranks can write
-                to / read from. Used as the rendezvous for the per-rank
-                contributions (optimizer state, PPGD sources). Each
-                snapshot at step ``S`` writes / reads under
-                ``scratch_dir / f"step_{S}"`` and cleans it up on rank 0.
+        Rank 0 also writes ``meta.pth`` (configs + layout fingerprint + the
+        ``c_per_site`` / ``all_sites`` needed to rebuild the full model). A
+        single barrier ensures every partial is on the shared FS before the
+        train loop continues — there is NO rank-0 read and NO model assembly
+        here. The async consolidation job
+        (:func:`param_decomp_lab.three_pool.consolidate.consolidate_step`)
+        reads these partials off the critical path.
         """
-        trace("snapshot: enter gather_full_state_dict_to_rank0")
-        gathered_model = gather_full_state_dict_to_rank0(
-            ctx=self.ctx,
-            component_model=self.component_model,
-            target_model=self._target_model,
-            run_batch=self._run_batch,
-            ci_config=self.pd_config.ci_config,
-            sigmoid_type=self.pd_config.sigmoid_type,
-            c_per_site=self.runtime.c_per_site,
-            device=self._device,
-        )
-        trace("snapshot: gather_full_state_dict_to_rank0 done")
+        partial = self._build_my_partial()
 
-        my_named_params = self._named_params_for_my_optimizer()
-        my_optimizer_by_name: dict[str, dict[str, Any]] = (
-            optimizer_state_by_name(self.optimizer, my_named_params)
-            if self.optimizer is not None
-            else {}
-        )
-        my_contribution: dict[str, Any] = {
-            "pool": self.ctx.kind,
-            "optimizer_by_name": my_optimizer_by_name,
-        }
-        if self.ppgd_state is not None:
-            my_contribution["ppgd"] = self.ppgd_state.state_dict()
-        elif self._pending_ppgd_resume_state is not None:
-            my_contribution["ppgd"] = self._pending_ppgd_resume_state
-
-        # File-based gather rather than dist.gather_object: at XL the aggregate
-        # pickle payload (LW optimizer state + PPGD sources) is ~8 GB and
-        # gather_object scales poorly. Each rank writes its contribution to a
-        # shared-FS path, a barrier ensures all writes are visible, then rank 0
-        # reads them all.
         p2p_group = self.ctx.world.cross_pool_p2p_group
-        world_size = self.ctx.world.world_size
-        step_dir = scratch_dir / f"step_{self.step}"
+        step_dir = step_scratch_dir(scratch_dir, self.step)
         if self.ctx.role.rank == 0:
             step_dir.mkdir(parents=True, exist_ok=True)
+            torch.save(self._build_meta(), step_dir / CONSOLIDATE_META_FILENAME)
 
+        # The mkdir + meta write race: rank 0 must finish them before any other
+        # rank writes its partial into step_dir.
         trace("snapshot: enter barrier (pre-write)")
         dist.barrier(group=p2p_group)
         trace("snapshot: barrier (pre-write) done")
 
         partial_path = step_dir / f"rank_{self.ctx.role.rank}.pth"
         trace(f"snapshot: writing partial {partial_path.name}")
-        torch.save(my_contribution, partial_path)
+        torch.save(partial, partial_path)
         trace("snapshot: partial write done")
 
-        trace("snapshot: enter barrier (post-write)")
-        dist.barrier(group=p2p_group)
-        trace("snapshot: barrier (post-write) done")
-
-        # Only rank 0 assembles the canonical state — it serially reads every
-        # rank's partial (~100 GB at XL). Non-rank-0 ranks have nothing left to
-        # do here, but they MUST NOT advance to the next training step until
-        # rank 0 finishes: the next step's collectives (PPGD V/U all-reduce,
-        # cross-pool sends) would block on rank 0 still reading, and at XL that
-        # read overruns the collective watchdog and aborts the job. The
-        # rejoining barrier below makes all ranks resume training in lock-step.
-        gathered_state: ThreePoolTrainingState | None = None
-        if self.ctx.role.rank == 0:
-            gathered_state = self._assemble_rank0_state(
-                step_dir=step_dir,
-                world_size=world_size,
-                gathered_model=gathered_model,
-            )
-
-        # PD_3POOL_DISABLE_REJOIN_BARRIER reproduces the pre-fix bug (non-rank-0
-        # ranks racing ahead while rank 0 reads). For the save-watchdog repro
-        # only — never set in production.
+        # One rejoining barrier so all ranks leave snapshot together. This is
+        # cheap now (just the partial write, no 100 GB read), so it cannot
+        # overrun the collective watchdog. PD_3POOL_DISABLE_REJOIN_BARRIER skips
+        # it for the legacy race repro. The old PD_3POOL_SNAPSHOT_RANK0_SLEEP_S
+        # fault injection now lives in the async consolidate job (off the loop),
+        # since that is where the slow read moved — the train loop has nothing
+        # slow left to sleep through.
         if os.environ.get("PD_3POOL_DISABLE_REJOIN_BARRIER", "").strip() in ("1", "true"):
             trace("snapshot: REJOIN BARRIER DISABLED (repro mode)")
-            return gathered_state
-        trace("snapshot: enter barrier (rejoin after rank-0 read)")
+            return
+        trace("snapshot: enter barrier (post-write rejoin)")
         dist.barrier(group=p2p_group)
-        trace("snapshot: barrier (rejoin after rank-0 read) done")
-        return gathered_state
+        trace("snapshot: barrier (post-write rejoin) done")
 
-    def _assemble_rank0_state(
-        self,
-        *,
-        step_dir: Path,
-        world_size: int,
-        gathered_model: dict[str, Any] | None,
-    ) -> ThreePoolTrainingState:
-        rank0_read_sleep_s = os.environ.get("PD_3POOL_SNAPSHOT_RANK0_SLEEP_S", "").strip()
-        if rank0_read_sleep_s:
-            trace(f"snapshot: rank-0 read sleep {rank0_read_sleep_s}s (fault injection)")
-            time.sleep(float(rank0_read_sleep_s))
-
-        gathered: list[dict[str, Any]] = []
-        for r in range(world_size):
-            gathered.append(torch.load(step_dir / f"rank_{r}.pth", weights_only=False))
-        trace("snapshot: rank-0 read all partials")
-        shutil.rmtree(step_dir, ignore_errors=True)
-        components_by_name: dict[str, dict[str, Any]] = {}
-        ci_fn_by_name: dict[str, dict[str, Any]] = {}
-        ppgd_by_rank: dict[int, dict[str, Any]] = {}
-        for r, c in enumerate(gathered):
-            pool: str = c["pool"]
-            match pool:
-                case "layerwise":
-                    components_by_name.update(c["optimizer_by_name"])
-                case "ci":
-                    ci_fn_by_name.update(c["optimizer_by_name"])
-                case "ppgd":
-                    if "ppgd" in c:
-                        ppgd_by_rank[r] = c["ppgd"]
-                case _:
-                    raise AssertionError(f"unknown pool {pool!r} in rank-{r} contribution")
-        assert gathered_model is not None  # rank 0 always has the gathered model
-        return ThreePoolTrainingState(
-            step=self.step,
-            pd_config=self.pd_config.model_dump(),
-            runtime_config=self.runtime_config.model_dump(),
-            three_pool_config=self.three_pool_config.model_dump(),
-            layout_fingerprint=_layout_fingerprint(self.ctx),
-            component_model=gathered_model,
-            components_optimizer=components_by_name,
-            ci_fn_optimizer=ci_fn_by_name,
-            ppgd_state_by_rank=ppgd_by_rank,
+    def _build_my_partial(self) -> dict[str, Any]:
+        my_named_params = self._named_params_for_my_optimizer()
+        my_optimizer_by_name: dict[str, dict[str, Any]] = (
+            optimizer_state_by_name(self.optimizer, my_named_params)
+            if self.optimizer is not None
+            else {}
         )
+        partial: dict[str, Any] = {
+            "pool": self.ctx.kind,
+            "model_params": self._owned_model_params(),
+            "optimizer_by_name": my_optimizer_by_name,
+        }
+        if self.ppgd_state is not None:
+            partial["ppgd"] = self.ppgd_state.state_dict()
+        elif self._pending_ppgd_resume_state is not None:
+            partial["ppgd"] = self._pending_ppgd_resume_state
+        return partial
+
+    def _owned_model_params(self) -> dict[str, Tensor]:
+        """The slice of this rank's model state_dict it's responsible for saving.
+
+        Only leaders contribute: LW block leaders own their sites' V/U, the CI
+        pool leader owns the CI fn. Every other rank holds a replica, so it
+        contributes nothing — the union across leaders covers the full model.
+        """
+        sd = self.component_model.state_dict()
+        keys = set(sd.keys())
+        match self.ctx:
+            case LWContext() if self.ctx.role.is_block_leader:
+                owned = owned_model_state_keys(keys, owned_sites=self.ctx.role.owned_sites)
+            case CIContext() if self.ctx.role.is_pool_leader:
+                owned = ci_fn_state_keys(keys)
+            case _:
+                owned = set()
+        return {k: sd[k].cpu() for k in owned}
+
+    def _build_meta(self) -> dict[str, Any]:
+        return {
+            "step": self.step,
+            "world_size": self.ctx.world.world_size,
+            "all_sites": list(self.ctx.world.all_sites),
+            "c_per_site": dict(self.runtime.c_per_site),
+            "pd_config": self.pd_config.model_dump(),
+            "runtime_config": self.runtime_config.model_dump(),
+            "three_pool_config": self.three_pool_config.model_dump(),
+            "layout_fingerprint": _layout_fingerprint(self.ctx),
+        }
 
     @classmethod
     def from_snapshot(
@@ -875,9 +834,8 @@ class ThreePoolTrainer:
                     )
 
                 if cadence.should_save(step):
-                    snap = self.snapshot(scratch_dir)
-                    if snap is not None:
-                        sink.checkpoint(snap, final=False)
+                    self.snapshot(scratch_dir)
+                    sink.checkpoint_written(step, final=False)
 
                 batch_T = (
                     batch_T_plus_1
@@ -890,9 +848,8 @@ class ThreePoolTrainer:
                     profiler.step()
 
             self.step = n_steps
-            snap = self.snapshot(scratch_dir)
-            if snap is not None:
-                sink.checkpoint(snap, final=True)
+            self.snapshot(scratch_dir)
+            sink.checkpoint_written(self.step, final=True)
 
 
 def optimize_three_pool(


### PR DESCRIPTION
## What

Integrates the two validated 3-pool draft PRs into one branch so the ~5-day 200k
production run launches on the final clean code. **DRAFT — do not merge.** Base:
`feature/multipool`. Does NOT touch the running run (job 34574 / p-df5b9fbd).

- **#540** (`refactor/3pool-async-consolidation`): checkpoint consolidation moved OFF the
  train loop into the async child job.
- **#541** (`feature/three-pool-config-fork`): standalone `ThreePoolLMExperimentConfig` +
  `pd-lm-3pool` composition root; `run.py` is single-pool-only.

## Reconciliation (the overlap)

#541 moved the 3-pool composition root out of `run.py` into `three_pool_run.py`; #540
had changed things in `run.py`'s (now-deleted) 3-pool path. Resolutions:

- **`three_pool_run.py`** (the new 3-pool root) now carries #540's async consolidation:
  `on_save` fires `submit_slurm_async_consolidate_and_eval` (replacing the old
  `submit_slurm_async_slow_eval`), scratch dirs use `SNAPSHOT_SCRATCH_DIRNAME`, and the
  function gained #540's `PD_3POOL_SKIP_ASYNC_ONSAVE` / `PD_ASYNC_EVAL_DP` hooks +
  always-submit semantics. (`three_pool_run.py:418-424`, `507-513`, `616-710`)
- **`run_sink.py`**: `ThreePoolSink.checkpoint_written` (#540) fires the on_save hook; the
  3-pool trainer calls it instead of the old `checkpoint(snapshot)`.
- **`optimize.py`** (clean merge of both): `snapshot()` writes per-rank partials (#540)
  under the `ThreePoolConstrainedPDConfig` type + `pd.losses.*` coeff reads (#541); the
  run-loop save calls `sink.checkpoint_written` (#540); `from_snapshot` validates the
  constrained config (#541) + the new file-based checkpoint key helpers (#540). Import
  conflict resolved to keep #540's `owned_model_state_keys`/`ci_fn_state_keys` (the old
  `gather_full_state_dict_to_rank0` is deleted) + #541's `ThreePoolConstrainedPDConfig`.
- **`async_eval.py` + `consolidate_cli.py`**: now read the run as
  `ThreePoolLMExperimentConfig` (not the now-single-pool `LMExperimentConfig`) via
  `run_meta.yaml`, and always consolidate (the 3-pool entry point guarantees 3-pool).
- **#540's 4 validation YAMLs** migrated to the new `ThreePoolLMExperimentConfig` shape
  (the only 3-pool entry is now `pd-lm-3pool`).

### Integration bug found + fixed

`from_snapshot` validated the consolidated `training_<step>.pth`'s `runtime_config` as
base `RuntimeConfig`, but #541's `ThreePoolRuntimeConfig` dump carries an extra
`topology` key → pydantic `extra_forbidden` on resume. This was latent until #540's
consolidated checkpoints were actually read by #541's resume path. Fix: drop the
duplicate `topology` key (already carried by `three_pool_config`) before validating the
base scalars. (`optimize.py:496-501`)

## Re-validation (all via `pd-lm-3pool`, ≤8 GPU, opportunistic)

1. **train → async child → consolidate → COMPLETE** ✅ — 4-GPU train (job 34783) wrote
   per-rank partials at every save; on_save submitted async children (34784–34788) which
   read 4 partials → wrote `model_<S>.pth` + `training_<S>.pth` → pruned `training_*.pth`
   to last 3 (all 5 `model_*.pth` kept) → deleted scratch.
2. **resume from a live-child-produced checkpoint** ✅ — resumed from child-produced
   `training_15.pth` (job 34793), continued 16→25, no topology mismatch (validated the
   `from_snapshot` fix).
3. **fail-fast + rerun** ✅ — corrupted a partial → async child (34792) rank-0 wrote
   `.consolidate_failed_20`, re-raised; waiters bailed on the sentinel; child exited
   non-zero (GPUs released, no hang); partials persisted; `consolidate_cli` then
   recovered both unconsolidated steps (CPU-only).
4. **bit-identical training** ✅ — OLD `pd-lm` 3-pool (job 34794) vs NEW `pd-lm-3pool`
   (34795), same seed/config, **max abs loss diff 0.0 across 42 (step,key) values** —
   the integration did not perturb the training math.

`make check` clean (0 errors/warnings). Core (179) + lab (283) + 3-pool/config-fork (38)
tests pass.

## Production config

`param_decomp_lab/experiments/lm/_xl_production/gpt2_xl_qk_200k.yaml` migrated to the new
shape: recreated from the b48 3-pool config with `steps: 200000` and PPGD optimizer
`warmup_pct: 0.05` (else identical). Parses + round-trips; `pd-lm-3pool` accepts it.

**Leave as a ready-to-merge integrated branch. The human merges + launches.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
