### PR TITLE
refactor(3-pool): SUM-grad convention (supersedes #545; fixes 2nd stoch→V/U instance)

### DIFF
--- a/param_decomp_lab/tests/test_three_pool_grad_check_distributed.py
+++ b/param_decomp_lab/tests/test_three_pool_grad_check_distributed.py
@@ -1,0 +1,572 @@
+"""Comprehensive distributed grad check for the 3-pool SUM-grad convention.
+
+Validates the central claim of ``three_pool/SUM_GRAD_CONVENTION.md``: at a
+NON-square topology with ALL loss terms enabled (faith + stoch + imp-min + ppgd
+recon), the fully-reduced gradient on the REPLICATED params — the CI-fn weights
+and the V/U weights — equals the single-process full-batch gradient for the
+identical total loss.
+
+Method. Build a tiny ``GPT2Simple``, a non-square ``World``
+(``n_ci=4 != n_per_block=2``, 2 blocks, ``n_ppgd=2`` — exercises the CI-fine
+routing regime, in-block DP replication, and cross-block summation), run ONE
+3-pool step per pool up to (not including) ``optimizer.step`` (the optimizer is
+neutralized so the assembled ``.grad`` survives), and compare:
+
+  * the CI pool's fully-reduced CI-fn grad, and
+  * each LW block's fully-reduced V/U grad
+
+to a single-process reference that replays the identical loss on the full batch
+with the SAME pinned RNG (stochastic mask noise ``u``, delta_mask, PPGD source
+init + trajectory). The PPGD trajectory is matched by gathering the distributed
+per-rank initial sources into the reference before warmup (PerBatchPerPosition
+sources are per-position independent, so the gathered full-batch trajectory is
+bit-identical to the per-rank-sliced one).
+
+Run directly:
+   torchrun --standalone --nproc_per_node=8 --master_port=29531 \
+     param_decomp_lab/tests/test_three_pool_grad_check_distributed.py
+or via pytest (spawns torchrun in a subprocess).
+"""
+
+# pyright: reportArgumentType=false, reportOptionalMemberAccess=false
+# pyright: reportAttributeAccessIssue=false, reportUnusedParameter=false
+# pyright: reportUnusedVariable=false
+
+import os
+import subprocess
+from datetime import timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+import torch
+import torch.distributed as dist
+from torch import Tensor
+
+from param_decomp.ci_fns import (
+    AttnConfig,
+    GlobalCiConfig,
+    GlobalSharedTransformerCiConfig,
+)
+from param_decomp.decomposition_targets import DecompositionTarget
+from param_decomp.masks import AllLayersRouter, make_mask_infos
+from param_decomp.metrics.importance_minimality import (
+    finalize_imp_min,
+    per_component_lp_sums,
+)
+from param_decomp.metrics.persistent_pgd_recon import PersistentPGDReconLossConfig
+from param_decomp.metrics.persistent_pgd_state import (
+    AdamPGDConfig,
+    PerBatchPerPositionScope,
+    PersistentPGDState,
+)
+from param_decomp.schedule import ScheduleConfig
+from param_decomp_lab.batch_and_loss_fns import recon_loss_mse
+from param_decomp_lab.distributed import cleanup_distributed, init_distributed
+from param_decomp_lab.experiments.lm.pretrain.models.gpt2_simple import (
+    GPT2Simple,
+    GPT2SimpleConfig,
+)
+from param_decomp_lab.experiments.lm.vendored.component_model import LMComponentModel
+from param_decomp_lab.three_pool.context import CIContext, LWContext, PPGDContext
+from param_decomp_lab.three_pool.layout import LayerwiseBlockGroup, build_world
+from param_decomp_lab.three_pool.loss_strategy import LayerwiseLossStrategy
+from param_decomp_lab.three_pool.runtime import _ThreePoolRuntime
+from param_decomp_lab.three_pool.step_ci import step_ci
+from param_decomp_lab.three_pool.step_layerwise import step_layerwise
+from param_decomp_lab.three_pool.step_ppgd import step_ppgd
+
+# ── Topology: non-square, multi-block, in-block DP, n_ppgd > 1 ────────────────
+_CI_RANKS = [0, 1, 2, 3]  # n_ci = 4
+_BLOCK0_RANKS = [4, 5]  # n_per_block = 2
+_BLOCK1_RANKS = [6, 7]
+_PPGD_RANKS = [8, 9]  # n_ppgd = 2
+_WORLD_SIZE = 10
+_BATCH_GLOBAL = 4
+_SEQ_LEN = 3
+_VOCAB = 16
+_D_MODEL = 8
+_N_HEAD = 2
+_C = 2  # per-site component count
+
+_SITES_BLOCK0 = ["h.0.attn.q_proj"]
+_SITES_BLOCK1 = ["h.1.attn.q_proj"]
+_ALL_SITES = _SITES_BLOCK0 + _SITES_BLOCK1
+
+_COEFF_FAITH = 3.0
+_COEFF_IMP = 0.7
+_COEFF_STOCH = 5.0
+_COEFF_PPGD = 2.0
+_IMP_PNORM = 2.0
+_IMP_BETA = 0.5
+_IMP_EPS = 1e-12
+_PPGD_WARMUP = 2
+
+_MODEL_SEED = 1234
+_BATCH_SEED = 99
+_STOCH_RNG_SEED = 7  # pins u + delta_mask for stoch (per-site, per-call)
+_PPGD_INIT_SEED = 55
+
+
+def _build_target() -> GPT2Simple:
+    cfg = GPT2SimpleConfig(
+        model_type="GPT2Simple",
+        block_size=_SEQ_LEN,
+        vocab_size=_VOCAB,
+        n_layer=2,
+        n_head=_N_HEAD,
+        n_embd=_D_MODEL,
+        flash_attention=False,
+    )
+    torch.manual_seed(_MODEL_SEED)
+    model = GPT2Simple(cfg)
+    model.requires_grad_(False)
+    return model
+
+
+def _decomp_targets() -> list[DecompositionTarget]:
+    return [DecompositionTarget(module_path=s, C=_C) for s in _ALL_SITES]
+
+
+def _ci_config() -> GlobalCiConfig:
+    # global_shared_transformer reads pre_weight_acts (independent of V/U), so CI
+    # values don't depend on the component weights — matching production and
+    # keeping the CI-fn grad cleanly separable from the V/U grad.
+    return GlobalCiConfig(
+        fn_type="global_shared_transformer",
+        simple_transformer_ci_cfg=GlobalSharedTransformerCiConfig(
+            d_model=_D_MODEL,
+            n_blocks=1,
+            mlp_hidden_dim=[8],
+            attn_config=AttnConfig(n_heads=_N_HEAD, max_len=_SEQ_LEN, rope_base=10000.0),
+        ),
+    )
+
+
+def _ppgd_cfg() -> PersistentPGDReconLossConfig:
+    return PersistentPGDReconLossConfig(
+        coeff=_COEFF_PPGD,
+        optimizer=AdamPGDConfig(
+            beta1=0.5,
+            beta2=0.99,
+            eps=1e-8,
+            lr_schedule=ScheduleConfig(start_val=0.01, fn_type="constant"),
+        ),
+        scope=PerBatchPerPositionScope(),
+        use_sigmoid_parameterization=False,
+        n_warmup_steps=_PPGD_WARMUP,
+        n_samples=1,
+    )
+
+
+def _build_runtime(numel_global: int) -> _ThreePoolRuntime:
+    block_groups = (
+        LayerwiseBlockGroup(ranks=tuple(_BLOCK0_RANKS), owned_sites=tuple(_SITES_BLOCK0)),
+        LayerwiseBlockGroup(ranks=tuple(_BLOCK1_RANKS), owned_sites=tuple(_SITES_BLOCK1)),
+    )
+    return _ThreePoolRuntime(
+        ci_ranks=tuple(_CI_RANKS),
+        layerwise_block_groups=block_groups,
+        ppgd_ranks=tuple(_PPGD_RANKS),
+        batch_global=_BATCH_GLOBAL,
+        c_per_site={s: _C for s in _ALL_SITES},
+        ci_config=_ci_config(),
+        sigmoid_type="leaky_hard",
+        run_batch=lambda model, batch: model(batch),  # unused on CPU recon path
+        reconstruction_loss=recon_loss_mse,
+        ppgd_cfg=_ppgd_cfg(),
+        coeff_faith=_COEFF_FAITH,
+        coeff_imp=_COEFF_IMP,
+        coeff_stoch=_COEFF_STOCH,
+        coeff_ppgd=_COEFF_PPGD,
+        imp_min_pnorm=_IMP_PNORM,
+        imp_min_beta=_IMP_BETA,
+        imp_min_eps=_IMP_EPS,
+        imp_min_p_anneal_start_frac=0.0,
+        imp_min_p_anneal_final_p=None,
+        imp_min_p_anneal_end_frac=1.0,
+        lr_components=0.0,
+        lr_ci_fn=0.0,
+        grad_clip_norm_components=None,
+        grad_clip_norm_ci_fn=None,
+        numel_global=numel_global,
+        bf16_autocast=False,
+        use_fused_kl=False,
+    )
+
+
+def _build_component_model(rank: int) -> LMComponentModel:
+    target = _build_target()
+    # Seed identically on every rank so V/U + CI fn init match (DDP partners).
+    torch.manual_seed(_MODEL_SEED + 1)
+    cm = LMComponentModel.build(
+        target_model=target,
+        decomposition_targets=_decomp_targets(),
+        ci_config=_ci_config(),
+        sigmoid_type="leaky_hard",
+    )
+    return cm
+
+
+def _global_batch() -> Tensor:
+    torch.manual_seed(_BATCH_SEED)
+    return torch.randint(0, _VOCAB, (_BATCH_GLOBAL, _SEQ_LEN))
+
+
+def _pin_stoch_rng() -> None:
+    """Pin the RNG the stoch path consumes (u + delta_mask in _layerwise_one_site)."""
+    torch.manual_seed(_STOCH_RNG_SEED)
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Distributed side
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _neutralize_optimizer(opt: torch.optim.Optimizer) -> None:
+    """Replace ``step`` with a no-op so the assembled .grad survives for capture."""
+    opt.step = lambda *a, **k: None  # type: ignore[method-assign]
+
+
+def _make_ppgd_state(world: Any, runtime: _ThreePoolRuntime, strategy: Any) -> PersistentPGDState:
+    return PersistentPGDState(
+        module_to_c=runtime.c_per_site,
+        batch_dims=(world.batch_local_ppgd, _SEQ_LEN),
+        device=torch.device("cpu"),
+        use_delta_component=True,
+        optimizer_cfg=runtime.ppgd_cfg.optimizer,
+        scope=runtime.ppgd_cfg.scope,
+        use_sigmoid_parameterization=runtime.ppgd_cfg.use_sigmoid_parameterization,
+        n_warmup_steps=runtime.ppgd_cfg.n_warmup_steps,
+        n_samples=runtime.ppgd_cfg.n_samples,
+        router=AllLayersRouter(),
+        reconstruction_loss=strategy.recon_loss,
+    )
+
+
+def _gather_initial_ppgd_sources(
+    ppgd_state: PersistentPGDState | None, ctx: Any, world: Any
+) -> dict[str, Tensor] | None:
+    """All-gather each PPGD rank's pre-warmup sources so rank 0 can replay the
+    exact PPGD trajectory in the reference.
+
+    Uses ``all_gather_object`` on the WORLD default group (collective on every
+    rank). Non-PPGD ranks contribute ``None``. Returns the reassembled
+    full-batch sources on rank 0, ``None`` elsewhere.
+    """
+    payload: dict[str, Any] | None = None
+    if isinstance(ctx, PPGDContext):
+        assert ppgd_state is not None
+        sl = ctx.role.batch_slice(world.batch_local_ppgd)
+        start = sl.start if sl.start is not None else 0
+        payload = {
+            "start": start,
+            "sources": {s: ppgd_state.sources[s].detach().clone() for s in ppgd_state.sources},
+        }
+    gathered: list[Any] = [None] * _WORLD_SIZE
+    dist.all_gather_object(gathered, payload)
+    if dist.get_rank() != 0:
+        return None
+    source_c = _C + 1  # use_delta_component
+    full = {s: torch.zeros(_BATCH_GLOBAL, _SEQ_LEN, source_c) for s in _ALL_SITES}
+    for item in gathered:
+        if item is None:
+            continue
+        start = item["start"]
+        for s, t in item["sources"].items():
+            full[s][start : start + t.shape[0]] = t
+    return full
+
+
+def _run_distributed_step() -> tuple[dict[str, Tensor], dict[str, Tensor] | None]:
+    """Run one 3-pool step on this rank.
+
+    Returns ``(captured_grads, ref_ppgd_sources_or_None)`` where captured_grads
+    is {param_key: fully_reduced_grad} for the params this rank leads, and the
+    second element is the reassembled full-batch PPGD initial sources (rank 0
+    only)."""
+    from param_decomp_lab.three_pool.context import build_pool_context
+
+    world = build_world(
+        ci_ranks=list(_CI_RANKS),
+        layerwise_block_groups=[
+            LayerwiseBlockGroup(ranks=tuple(_BLOCK0_RANKS), owned_sites=tuple(_SITES_BLOCK0)),
+            LayerwiseBlockGroup(ranks=tuple(_BLOCK1_RANKS), owned_sites=tuple(_SITES_BLOCK1)),
+        ],
+        ppgd_ranks=list(_PPGD_RANKS),
+        batch_global=_BATCH_GLOBAL,
+        pg_timeout=timedelta(seconds=120),
+        device=None,
+    )
+    rank = dist.get_rank()
+    ctx = build_pool_context(world, rank)
+    cm = _build_component_model(rank)
+    numel_global = sum(cm.target_weight(s).numel() for s in _ALL_SITES)
+
+    # NOTE: the trainer drops pool-irrelevant params for memory; we keep all of
+    # them so the layerwise ('mlp') CI fn — which reads component activations —
+    # works on the CI pool too. Dropping is a memory opt, irrelevant to grads.
+    runtime = _build_runtime(numel_global)
+    strategy = LayerwiseLossStrategy.unfused(recon_loss_mse)
+    batch = _global_batch()
+
+    # PPGD state must exist BEFORE the source-gather collective (all ranks).
+    ppgd_state: PersistentPGDState | None = None
+    if isinstance(ctx, PPGDContext):
+        torch.manual_seed(_PPGD_INIT_SEED + rank)
+        ppgd_state = _make_ppgd_state(world, runtime, strategy)
+    ref_sources = _gather_initial_ppgd_sources(ppgd_state, ctx, world)
+
+    captured: dict[str, Tensor] = {}
+    match ctx:
+        case CIContext():
+            ci_fn_params = list(cm.ci_fn.parameters())  # type: ignore[union-attr]
+            opt = torch.optim.AdamW(ci_fn_params, lr=0.0)
+            _neutralize_optimizer(opt)
+            _pin_stoch_rng()
+            step_ci(
+                ctx,
+                cm,
+                opt,
+                ci_fn_params,
+                batch_T=batch,
+                batch_T_plus_1=None,
+                h_cache_T=None,
+                cfg=runtime,
+                current_frac_of_training=0.0,
+                should_log=False,
+            )
+            if ctx.role.is_pool_leader:
+                for n, p in cm.ci_fn.named_parameters():  # type: ignore[union-attr]
+                    assert p.grad is not None, f"ci_fn.{n} grad is None"
+                    captured[f"ci_fn.{n}"] = p.grad.detach().clone()
+        case LWContext():
+            comp_params = [p for s in ctx.role.owned_sites for p in cm.components[s].parameters()]
+            opt = torch.optim.AdamW(comp_params, lr=0.0)
+            _neutralize_optimizer(opt)
+            _pin_stoch_rng()
+            step_layerwise(ctx, cm, opt, comp_params, batch, runtime, strategy, should_log=False)
+            if ctx.role.is_block_leader:
+                for s in ctx.role.owned_sites:
+                    for n, p in cm.components[s].named_parameters():
+                        assert p.grad is not None, f"components.{s}.{n} grad is None"
+                        captured[f"components.{s}.{n}"] = p.grad.detach().clone()
+        case PPGDContext():
+            assert ppgd_state is not None
+            step_ppgd(
+                ctx, cm, ppgd_state, batch, runtime, strategy, step=0, n_steps=1, should_log=False
+            )
+    return captured, ref_sources
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Single-process reference (full batch, identical loss, pinned RNG)
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _reference_grads(initial_ppgd_sources: dict[str, Tensor]) -> dict[str, Tensor]:
+    """Full-batch single-process gradient for the identical total loss.
+
+    Mirrors the per-term seeding the step functions apply, but on the global
+    batch in one process: faith, stoch, imp-min, ppgd recon. Returns
+    {param_key: grad} for ci_fn.* and components.<site>.*.
+    """
+    cm = _build_component_model(0)  # full model (CI fn + components)
+    numel_global = sum(cm.target_weight(s).numel() for s in _ALL_SITES)
+    runtime = _build_runtime(numel_global)
+    strategy = LayerwiseLossStrategy.unfused(recon_loss_mse)
+    batch = _global_batch()
+
+    ci_fn_params = list(cm.ci_fn.parameters())  # type: ignore[union-attr]
+    comp_params = [p for s in _ALL_SITES for p in cm.components[s].parameters()]
+    for p in [*ci_fn_params, *comp_params]:
+        p.grad = None
+
+    n_sites_total = len(_ALL_SITES)
+
+    # --- CI fn forward (full batch) ---
+    _, cache = cm.forward_with_pre_weight_acts(batch)
+    cache = {k: v.to(torch.float32) for k, v in cache.items()}
+    ci = cm.calc_causal_importances(
+        pre_weight_acts=cache, sampling="continuous", detach_inputs=False
+    )
+
+    # --- faith (full batch == single-pool) ---
+    weight_deltas = cm.calc_weight_deltas()
+    sum_sq = torch.zeros(())
+    for d in weight_deltas.values():
+        sum_sq = sum_sq + (d**2).sum()
+    faith_loss = sum_sq / numel_global
+    (_COEFF_FAITH * faith_loss).backward(retain_graph=True)
+
+    # --- imp-min (full batch == single-pool exact) ---
+    per_component_sums, n_examples = per_component_lp_sums(
+        ci_upper_leaky=ci.upper_leaky, pnorm=_IMP_PNORM, eps=_IMP_EPS
+    )
+    imp_loss = finalize_imp_min(
+        per_component_sums=per_component_sums, n_examples=n_examples, beta=_IMP_BETA
+    )
+    (_COEFF_IMP * imp_loss).backward(retain_graph=True)
+
+    # --- stoch (per-site, pinned RNG matching _layerwise_one_site order) ---
+    target_full = cm(batch).detach()
+    _pin_stoch_rng()
+    for s in _ALL_SITES:
+        ci_s = ci.lower_leaky[s]
+        u = torch.rand_like(ci_s)
+        mask = ci_s + (1 - ci_s) * u
+        delta = cm.target_weight(s) - cm.components[s].weight
+        delta_mask = torch.rand(ci_s.shape[:-1], dtype=ci_s.dtype)
+        mask_infos = make_mask_infos(
+            {s: mask},
+            weight_deltas_and_masks={s: (delta, delta_mask)},
+            routing_masks="all",
+        )
+        pred = cm(batch, mask_infos=mask_infos)
+        # The single-process recon's n_positions IS the global count (full batch),
+        # matching the distributed code's ``n_positions_local * n_per_block``.
+        loss_s, n_positions_global = strategy.recon_loss(pred=pred, target=target_full)
+        denom = n_positions_global * n_sites_total
+        (_COEFF_STOCH * loss_s / denom).backward(retain_graph=True)
+
+    # --- ppgd recon (full batch, replayed sources) ---
+    ppgd_state = PersistentPGDState(
+        module_to_c=runtime.c_per_site,
+        batch_dims=(_BATCH_GLOBAL, _SEQ_LEN),
+        device=torch.device("cpu"),
+        use_delta_component=True,
+        optimizer_cfg=runtime.ppgd_cfg.optimizer,
+        scope=runtime.ppgd_cfg.scope,
+        use_sigmoid_parameterization=runtime.ppgd_cfg.use_sigmoid_parameterization,
+        n_warmup_steps=runtime.ppgd_cfg.n_warmup_steps,
+        n_samples=runtime.ppgd_cfg.n_samples,
+        router=AllLayersRouter(),
+        reconstruction_loss=strategy.recon_loss,
+    )
+    with torch.no_grad():
+        for s in ppgd_state.sources:
+            ppgd_state.sources[s].copy_(initial_ppgd_sources[s])
+    ppgd_state.update_lr(step=0, total_steps=1)
+    ci_scratch = {
+        s: ci.lower_leaky[s].detach().to(torch.float32).clone().requires_grad_(True)
+        for s in _ALL_SITES
+    }
+    ppgd_state.warmup(
+        model=cm,
+        batch=batch,
+        target_out=target_full,
+        ci=ci_scratch,
+        weight_deltas=cm.calc_weight_deltas(),
+    )
+    ppgd_sum_loss, n_ppgd_examples = ppgd_state.compute_recon_sum_and_n(
+        model=cm,
+        batch=batch,
+        target_out=target_full,
+        ci=ci_scratch,
+        weight_deltas=cm.calc_weight_deltas(),
+    )
+    # canonical PPGD loss: coeff * recon_sum / n_examples_global, on V/U AND ci_scratch.
+    ppgd_scaled = _COEFF_PPGD * ppgd_sum_loss / n_ppgd_examples
+    # V/U grads accumulate directly; ci_scratch grads must propagate through the
+    # CI fn graph (the distributed run ships g_CI back and seeds lower_leaky).
+    ci_scratch_grads = torch.autograd.grad(
+        ppgd_scaled, list(ci_scratch.values()), retain_graph=True
+    )
+    ppgd_scaled.backward()  # populates V/U .grad for ppgd term
+    torch.autograd.backward(
+        tensors=[ci.lower_leaky[s] for s in _ALL_SITES],
+        grad_tensors=list(ci_scratch_grads),
+    )
+
+    out: dict[str, Tensor] = {}
+    for n, p in cm.ci_fn.named_parameters():  # type: ignore[union-attr]
+        assert p.grad is not None
+        out[f"ci_fn.{n}"] = p.grad.detach().clone()
+    for s in _ALL_SITES:
+        for n, p in cm.components[s].named_parameters():
+            assert p.grad is not None
+            out[f"components.{s}.{n}"] = p.grad.detach().clone()
+    return out
+
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Driver
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _run_test() -> None:
+    init_distributed()
+    try:
+        rank = dist.get_rank()
+        assert dist.get_world_size() == _WORLD_SIZE
+
+        captured, ref_sources = _run_distributed_step()
+
+        gathered: list[Any] = [None] * _WORLD_SIZE
+        dist.all_gather_object(gathered, captured)
+
+        if rank == 0:
+            dist_grads: dict[str, Tensor] = {}
+            for d in gathered:
+                assert d is not None
+                dist_grads.update(d)
+            assert ref_sources is not None
+            _report_and_assert(dist_grads, ref_sources)
+    finally:
+        cleanup_distributed()
+
+
+def _report_and_assert(dist_grads: dict[str, Tensor], ref_sources: dict[str, Tensor]) -> None:
+    ref_grads = _reference_grads(ref_sources)
+    keys = sorted(dist_grads.keys())
+    assert set(keys) == set(ref_grads.keys()), (
+        f"param-key mismatch:\n dist={sorted(dist_grads)}\n ref ={sorted(ref_grads)}"
+    )
+    print("\n=== 3-pool SUM-grad convention: distributed vs single-process reference ===")
+    print("topology: n_ci=4, n_per_block=2 (2 blocks), n_ppgd=2 (NON-square)")
+    worst = 0.0
+    for k in keys:
+        dg, rg = dist_grads[k], ref_grads[k]
+        assert dg.shape == rg.shape, f"{k}: shape {tuple(dg.shape)} vs {tuple(rg.shape)}"
+        denom = rg.abs().max().clamp_min(1e-12)
+        rel = (dg - rg).abs().max().item() / denom.item()
+        # mean ratio over nonzero ref entries (a scalar "are they the same scale?")
+        mask = rg.abs() > 1e-8
+        ratio = (dg[mask] / rg[mask]).mean().item() if mask.any() else float("nan")
+        worst = max(worst, rel)
+        print(f"  {k:34s} max|Δ|/max|ref|={rel:.2e}  mean(dist/ref)={ratio:.6f}")
+    print(f"worst relative error across all params: {worst:.2e}")
+    for k in keys:
+        torch.testing.assert_close(
+            dist_grads[k],
+            ref_grads[k],
+            rtol=2e-4,
+            atol=2e-5,
+            msg=lambda m, k=k: f"grad mismatch on {k}:\n{m}",
+        )
+    print("PASS: all reduced grads match the single-process reference at non-square topology.")
+
+
+if __name__ == "__main__":
+    _run_test()
+
+
+@pytest.mark.slow
+class TestThreePoolGradCheckDistributed:
+    def test_grad_check(self) -> None:
+        cmd = [
+            "torchrun",
+            "--standalone",
+            f"--nproc_per_node={_WORLD_SIZE}",
+            "--master_port",
+            "29531",
+            str(Path(__file__).resolve()),
+        ]
+        env = os.environ.copy()
+        env["CUDA_VISIBLE_DEVICES"] = ""
+        result = subprocess.run(cmd, env=env, capture_output=True, text=True, timeout=300)
+        if result.returncode != 0:
+            print(f"STDOUT:\n{result.stdout}")
+            print(f"STDERR:\n{result.stderr}")
+            raise RuntimeError(f"grad check failed (code {result.returncode})")
+        print(result.stdout)

--- a/param_decomp_lab/tests/test_three_pool_grad_scaling.py
+++ b/param_decomp_lab/tests/test_three_pool_grad_scaling.py
@@ -1,13 +1,14 @@
-"""Regression test for PPGD -> CI gradient scaling under a multi-rank CI pool.
+"""Regression test for PPGD gradient scaling under the SUM-grad convention.
 
-The CI pool ends each step with an AVG all-reduce over its ``n_ci`` ranks
-(``all_reduce_ci_fn_grads``). PPGD's CI grad is injected per-position on a single
-CI rank, so that AVG divides it by ``n_ci``; ``_scale_grads`` must pre-multiply
-the CI grad by ``n_ci`` to compensate (the LW stoch path does the same via its
-``/ n_ci`` denom). V/U never hits that AVG, so it keeps the plain scale.
+Under the SUM-grad convention (``three_pool/SUM_GRAD_CONVENTION.md``) every
+data-parallel gradient reduction is SUM, so a producer's grad is a partial sum
+normalized only by the honest global count — it carries NO pool-size transport
+factor. For PPGD this means V/U and CI now share ONE scale
+``coeff_ppgd / n_examples_global``: the old ``* n_ci`` on the CI grad (which
+compensated for the CI-pool AVG-reduce, PR #545) is gone, because the CI-pool
+reduce is now a SUM.
 
-At ``n_ci=1`` the factor is a no-op — which is why the bug was invisible to the
-8-GPU (``n_ci=1``) configs and only bit production (``n_ci`` = 16 / 24).
+Sources stay per-rank-local (``1 / n_examples_local``).
 """
 
 from types import SimpleNamespace
@@ -35,7 +36,7 @@ def _ones() -> dict[str, torch.Tensor]:
     return {"site": torch.ones(2, 2)}
 
 
-def test_ppgd_ci_grad_carries_extra_n_ci_factor() -> None:
+def test_ppgd_vu_and_ci_share_one_scale() -> None:
     n_ci, n_ppgd, n_examples_local, coeff = 4, 2, 8, 3.0
     raw = RawGrads(v=_ones(), u=_ones(), ci=_ones(), sources=_ones())
 
@@ -43,10 +44,26 @@ def test_ppgd_ci_grad_carries_extra_n_ci_factor() -> None:
         raw, n_examples_local, _fake_ctx(n_ci=n_ci, n_ppgd=n_ppgd), _fake_cfg(coeff_ppgd=coeff)
     )
 
-    vu_scale = coeff / (n_examples_local * n_ppgd)
-    torch.testing.assert_close(raw.v["site"], torch.full((2, 2), vu_scale))
-    torch.testing.assert_close(raw.u["site"], torch.full((2, 2), vu_scale))
-    # CI must carry the extra * n_ci to survive the CI-pool AVG all-reduce.
-    torch.testing.assert_close(raw.ci["site"], torch.full((2, 2), vu_scale * n_ci))
+    # V/U and CI are both partial sums under the SUM convention: one scale.
+    shared_scale = coeff / (n_examples_local * n_ppgd)
+    torch.testing.assert_close(raw.v["site"], torch.full((2, 2), shared_scale))
+    torch.testing.assert_close(raw.u["site"], torch.full((2, 2), shared_scale))
+    torch.testing.assert_close(raw.ci["site"], torch.full((2, 2), shared_scale))
     # Sources: 1 / n_examples_local only — no coeff, no 1/n_ppgd, no n_ci.
     torch.testing.assert_close(raw.sources["site"], torch.full((2, 2), 1.0 / n_examples_local))
+
+
+def test_ppgd_ci_scale_is_independent_of_n_ci() -> None:
+    """The defining property of the SUM convention: the CI grad scale does not
+    depend on ``n_ci`` (the old patch multiplied it by ``n_ci``)."""
+    n_ppgd, n_examples_local, coeff = 2, 8, 3.0
+    scales: list[float] = []
+    for n_ci in (1, 4, 16):
+        raw = RawGrads(v=_ones(), u=_ones(), ci=_ones(), sources=_ones())
+        _scale_grads(
+            raw, n_examples_local, _fake_ctx(n_ci=n_ci, n_ppgd=n_ppgd), _fake_cfg(coeff_ppgd=coeff)
+        )
+        scales.append(raw.ci["site"][0, 0].item())
+    assert scales[0] == scales[1] == scales[2], (
+        f"CI scale must be independent of n_ci under SUM convention; got {scales}"
+    )

--- a/param_decomp_lab/three_pool/CLAUDE.md
+++ b/param_decomp_lab/three_pool/CLAUDE.md
@@ -18,6 +18,22 @@ docstring in `optimize.py` for the data-handling contract.
 | `portals.py` | Cross-pool exchanges as typed objects — one class per DAG edge (pack layout + routing + dtype + PG in one place) |
 | `step_{ci,layerwise,ppgd}.py` | per-pool step functions |
 | `eval_step.py` | 3-pool eval pass (PPGD pool runs metrics; others barrier through) |
+| `SUM_GRAD_CONVENTION.md` | the gradient-assembly scaling convention (proposal) |
+
+## Gradient-assembly scaling: the SUM convention
+
+See `SUM_GRAD_CONVENTION.md` for the full derivation. Summary: every
+data-parallel gradient reduction is **SUM** (`all_reduce_ci_fn_grads`,
+`all_reduce_grads_in_block`, and PPGD's V/U reduce). Each producer emits a
+*partial sum* normalized only by the honest GLOBAL count — NO `n_ci` /
+`n_per_block` transport factor. `SUM(partials) = total`, so no producer needs a
+pool's size. The REPLICATED contributions are handled structurally rather than by
+a replica-count divide: faith + broadcast-PPGD V/U **contribute once** (emitted
+on the block leader only), and imp-min uses the **detached-global-residual** trick
+(`S = local + (all_reduce_sum(local.detach()) - local.detach())`) so its backward
+is a local partial. The grad-clip `n_replicas` is unchanged — it counts distinct
+params for the global norm, independent of the grad-reduce op. Validated by
+`tests/test_three_pool_grad_check_distributed.py` (non-square, all loss terms).
 
 ## Checkpoint save: partials on the loop, consolidation off it
 

--- a/param_decomp_lab/three_pool/SUM_GRAD_CONVENTION.md
+++ b/param_decomp_lab/three_pool/SUM_GRAD_CONVENTION.md
@@ -1,0 +1,132 @@
+# SUM-grad convention (proposal)
+
+A structural redesign of the 3-pool gradient-assembly scaling, replacing the
+per-instance "pre-scale to survive a downstream reduction" patches (4 recurring
+bugs, latest = PR #545's PPGD `×n_ci`) with a single convention.
+
+## The bug class
+
+The CI-fn weights and the V/U weights are each REPLICATED across ranks. Their
+gradients are assembled from multiple producers (stoch, faith, imp-min, ppgd)
+and reduced across ranks. Every recurring bug had the same shape: a producer
+pre-scaled its gradient by a *pool-size factor* (`n_ci`, `n_per_block`) so its
+contribution would survive a downstream AVG-reduce it couldn't locally see. That
+factor leaks pool-size knowledge into the gradient VALUES, and a single
+differentiated scalar that feeds two destinations with different reductions
+(stoch → CI leaves ÷n_ci AND V/U ÷n_per_block) is guaranteed wrong on a
+non-square topology.
+
+## The convention
+
+**Every gradient crossing a cross-rank reduction is a partial SUM, normalized
+only by the honest GLOBAL count (global examples/positions × sites), carrying NO
+pool-size transport factor. All data-parallel gradient reductions are SUM.**
+
+Partial sums compose: `SUM(partials) = total`. So no producer needs to know any
+pool's size; the only normalization is the honest global count, which is locally
+derivable (`P_global = n_positions_local × n_per_block`, `n_examples_global =
+n_examples_local × n_ppgd`). The conversion factor that turns a local count into
+a global count is NOT a transport factor — it is part of computing the honest
+denominator, and it disappears entirely on a square topology only by coincidence.
+
+### Consequences
+
+1. **The grad all-reduce is SUM.** After an *all*-reduce every rank holds the
+   identical value either way; under SUM that value is the TOTAL, which equals
+   the single-pool gradient *because each producer already divided by the global
+   count*. The optimizer steps on it directly.
+2. **`cross_pool_clip_grad_norm(n_replicas)` is UNCHANGED.** Subtle: this divide
+   is about counting DISTINCT parameters for the global norm, not about the grad
+   reduce. After the in-pool *all*-reduce (SUM or AVG), every replica holds the
+   IDENTICAL grad; the pool-wide sq-SUM therefore counts each block's params
+   `n_per_block` times either way, so the `n_replicas` dedup stays. (The grad
+   VALUE differs — SUM gives the single-pool total, AVG gave total/n_per_block —
+   but the replica COUNT being summed is the same.)
+3. **stoch's one scale feeds both destinations.** CI leaves (→ CI pool, SUM) and
+   V/U (→ LW block, SUM) both want the same partial-sum scale
+   `coeff_stoch / (P_global × n_sites_total)`. The double-duty bug is structurally
+   impossible now: there is only one correct scale and it serves both.
+4. **PPGD's `×n_ci` DIES.** V/U and CI both want `coeff_ppgd / n_examples_global`;
+   the CI path no longer needs the extra `×n_ci` to survive an AVG. The two
+   collapse to one scale — the shape the V/U path (which never had a bug) always
+   had.
+
+## The wrinkle: replicated contributions
+
+The convention is clean for genuine DP partials (disjoint batch slices). It does
+NOT, by itself, handle REPLICATED contributions — gradients that are IDENTICAL on
+every rank in the reduction group because they were computed from replicated
+inputs rather than a disjoint data slice:
+
+- **faith V/U** (`_faithfulness_loss`): computed from the replicated V/U weights →
+  identical on every block rank → under SUM, `n_per_block×` too big.
+- **broadcast PPGD V/U**: sum-reduced within PPGD then broadcast to all block
+  ranks → identical on every block rank → same `n_per_block×` problem.
+- **imp-min CI**: the autograd-aware `dist_fn.all_reduce(SUM)` backward
+  SUM-reduces the *replicated* upstream gradient across the CI pool, leaving each
+  rank with `n_ci×` its true partial. Under the old AVG this was exactly the
+  factor that made it correct; under SUM it is `n_ci×` too big.
+
+Three ways to handle each:
+
+  (a) **Divide the replicated contribution by the replica count before the SUM.**
+      Rejected: this REINTRODUCES the pool-size factor into a producer — exactly
+      what the convention abolishes. It only relocates the factor.
+  (b) **Contribute once.** Compute the replicated contribution on a single rank
+      (the block leader) so there is no replica to undo. Chosen for faith and
+      broadcast PPGD V/U.
+  (c) **Detached-global-residual.** Make the forward value global but the backward
+      flow only through the local contribution:
+      `S = local + (all_reduce_sum(local.detach()) - local.detach())`.
+      Forward `S = global_sum`; backward `∂S/∂local = 1`, no cross-rank term, so
+      each rank gets its TRUE partial which SUM-composes. Chosen for imp-min
+      (its loss genuinely needs the global sum inside the `log2`, so option (b)
+      doesn't apply — it isn't a replica, it's a global reduction).
+
+### faith / broadcast PPGD → contribute once (option b)
+
+- **faith**: run the faith backward on the **block leader only**. The leader's
+  `.grad` then carries the full single-pool faith grad once; non-leaders
+  contribute zero faith. After the block SUM every rank holds it exactly once.
+  Faith is already divided by `numel_global`, so the leader's value is already
+  the single-pool grad — no further scaling.
+- **broadcast PPGD V/U**: skip the in-block broadcast; the block **leader** adds
+  the received PPGD grad to its `.grad`, non-leaders add nothing. After the block
+  SUM every rank holds it once.
+
+These two changes mean the block all-reduce SUM now combines ONLY:
+`leader_faith + leader_ppgd + Σ_ranks stoch_partial_r` = the single-pool total.
+
+### imp-min → detached-global-residual (option c)
+
+`_importance_minimality_loss` replaces the autograd-aware `dist_fn.all_reduce`
+with the detached-global-residual on `per_component_sums`. Forward identical
+(global sum inside `finalize_imp_min`'s `log2` and mean), backward flows only
+through this rank's local CI values → a true partial → SUM-composes under the CI
+pool's SUM all-reduce. The `×n_ci` knowledge leaves the imp path entirely.
+
+## The honest verdict
+
+Does the SUM convention ELIMINATE pool-size knowledge from producers?
+
+- **From the data-parallel producers: YES.** stoch, ppgd V/U, ppgd CI all lose
+  every `n_ci` / `n_per_block` *transport* factor. The #545 `×n_ci` is deleted.
+  stoch's two destinations collapse to one scale. The remaining `n_per_block` in
+  stoch's denom is not a transport factor — it is the `local→global` position
+  count conversion, which any honest global normalization needs.
+- **From the replicated contributions: NO — but it RELOCATES the count to a
+  structurally honest place.** faith and broadcast-PPGD no longer *scale* by
+  `n_per_block`; instead they *contribute once* (a topology fact: "this grad is
+  replicated, emit it on one rank"). imp-min no longer *relies on AVG to cancel*
+  `n_ci`; instead it *states* "my backward is a local partial" via the residual
+  trick. The replica count does not appear as a numeric factor in any producer's
+  gradient value — it appears as a *placement* decision (which rank emits) or a
+  *graph* decision (detach the cross-rank term).
+
+Net: the convention is **not a free win** — replicated contributions still need
+the system to know they are replicated. But it converts an error-prone numeric
+coupling ("multiply by the size of a pool you can't see, to survive a reduce that
+happens elsewhere") into a local, inspectable structural statement ("this is a
+partial; emit it once" / "this is replicated; detach the global term"). That is a
+genuine simplification for the DP majority and a clearer, harder-to-get-wrong
+encoding for the replicated minority — not a lateral move.

--- a/param_decomp_lab/three_pool/portals.py
+++ b/param_decomp_lab/three_pool/portals.py
@@ -439,44 +439,39 @@ class GradVuFromPPGD:
     def recv(
         self, role: LWRole, v_templates: dict[str, Tensor], u_templates: dict[str, Tensor]
     ) -> tuple[dict[str, Tensor], dict[str, Tensor]]:
-        """Block leader recvs g_VU for owned sites from PPGD leader, then
-        in-block broadcasts so all replicas see the same grad."""
+        """Block leader recvs g_VU for owned sites from PPGD leader; non-leaders
+        get nothing.
+
+        Contribute-once (see ``SUM_GRAD_CONVENTION.md``): PPGD's grad is identical
+        across block replicas, so under the block SUM-reduce it must land on
+        exactly ONE rank. We add it to the leader's ``.grad`` only and skip the
+        old in-block broadcast — the SUM then distributes it to every replica
+        exactly once. Non-leaders return empty dicts and add nothing.
+        """
+        if not role.is_block_leader:
+            return {}, {}
+
+        my_sites = role.owned_sites
+        packed_numel = sum(v_templates[s].numel() + u_templates[s].numel() for s in my_sites)
+        sample = v_templates[my_sites[0]]
+        packed = torch.empty(packed_numel, dtype=WIRE_DTYPE, device=sample.device)
+        ppgd_leader = self.world.ppgd_ranks[0]
+        with time_nccl_op("GradVuFromPPGD.recv:recv"):
+            dist.recv(packed, src=ppgd_leader, group=self.world.cross_pool_p2p_group)
         v_grads: dict[str, Tensor] = {}
         u_grads: dict[str, Tensor] = {}
-
-        if role.is_block_leader:
-            my_sites = role.owned_sites
-            packed_numel = sum(v_templates[s].numel() + u_templates[s].numel() for s in my_sites)
-            sample = v_templates[my_sites[0]]
-            packed = torch.empty(packed_numel, dtype=WIRE_DTYPE, device=sample.device)
-            ppgd_leader = self.world.ppgd_ranks[0]
-            with time_nccl_op("GradVuFromPPGD.recv:recv"):
-                dist.recv(packed, src=ppgd_leader, group=self.world.cross_pool_p2p_group)
-            offset = 0
-            for s in my_sites:
-                v_n = v_templates[s].numel()
-                u_n = u_templates[s].numel()
-                v_grads[s] = (
-                    packed[offset : offset + v_n].view_as(v_templates[s]).to(v_templates[s].dtype)
-                )
-                offset += v_n
-                u_grads[s] = (
-                    packed[offset : offset + u_n].view_as(u_templates[s]).to(u_templates[s].dtype)
-                )
-                offset += u_n
-        else:
-            for s in role.owned_sites:
-                v_grads[s] = torch.empty_like(v_templates[s])
-                u_grads[s] = torch.empty_like(u_templates[s])
-
-        block_group = self.world.block_group_groups[role.block_idx]
-        block_leader_rank = self.world.layerwise_block_groups[role.block_idx].leader
-        with time_nccl_op("GradVuFromPPGD.recv:in_block_bcast"):
-            for s in role.owned_sites:
-                v_grads[s] = v_grads[s].contiguous()
-                u_grads[s] = u_grads[s].contiguous()
-                dist.broadcast(v_grads[s], src=block_leader_rank, group=block_group)
-                dist.broadcast(u_grads[s], src=block_leader_rank, group=block_group)
+        offset = 0
+        for s in my_sites:
+            v_n = v_templates[s].numel()
+            u_n = u_templates[s].numel()
+            v_grads[s] = (
+                packed[offset : offset + v_n].view_as(v_templates[s]).to(v_templates[s].dtype)
+            )
+            offset += v_n
+            u_grads[s] = (
+                packed[offset : offset + u_n].view_as(u_templates[s]).to(u_templates[s].dtype)
+            )
+            offset += u_n
         return v_grads, u_grads
 
 
@@ -616,12 +611,18 @@ def _bucketed_all_reduce(
 
 
 def all_reduce_ci_fn_grads(world: World, params: Iterable[nn.Parameter]) -> None:
-    """CI in-pool AVG-reduce on CI fn grads (standard DDP). No-op for 1-rank pool."""
+    """CI in-pool SUM-reduce on CI fn grads. No-op for 1-rank pool.
+
+    SUM, not AVG (see ``SUM_GRAD_CONVENTION.md``): each producer's CI grad is a
+    partial sum already normalized by the honest global count, so the cross-rank
+    SUM reassembles the single-pool total directly. No producer pre-scales by
+    ``n_ci`` to survive this reduce.
+    """
     if dist.get_world_size(world.ci_pool_group) <= 1:
         return
     _bucketed_all_reduce(
         (p.grad for p in params if p.grad is not None),
-        dist.ReduceOp.AVG,
+        dist.ReduceOp.SUM,
         world.ci_pool_group,
         "all_reduce_ci_fn_grads",
     )
@@ -635,8 +636,16 @@ def sum_reduce_ppgd_grads(world: World, grads: Iterable[Tensor]) -> None:
 
 
 def all_reduce_grads_in_block(world: World, role: LWRole, params: Iterable[nn.Parameter]) -> None:
-    """LW in-block DDP AVG-reduce over V/U + faithfulness grads (async buckets,
-    wait + copy back). No-op when the block group is 1-rank or there are no grads."""
+    """LW in-block SUM-reduce over V/U grads (async buckets, wait + copy back).
+    No-op when the block group is 1-rank or there are no grads.
+
+    SUM, not AVG (see ``SUM_GRAD_CONVENTION.md``): the per-rank stoch grad is a
+    partial sum over a disjoint position slice, normalized by the honest global
+    count, so the cross-rank SUM reassembles the single-pool total. The
+    REPLICATED contributions (faith, broadcast PPGD grad) are emitted on the
+    block leader ONLY — contribute-once — so they survive the SUM exactly once
+    without any ``n_per_block`` pre-scaling.
+    """
     block_group = world.block_group_groups[role.block_idx]
     if dist.get_world_size(block_group) <= 1:
         return
@@ -652,7 +661,7 @@ def all_reduce_grads_in_block(world: World, role: LWRole, params: Iterable[nn.Pa
     with time_nccl_op("all_reduce_grads_in_block"):
         for bucket in buckets.values():
             flat = _flatten_dense_tensors(bucket)
-            w = dist.all_reduce(flat, op=dist.ReduceOp.AVG, group=block_group, async_op=True)
+            w = dist.all_reduce(flat, op=dist.ReduceOp.SUM, group=block_group, async_op=True)
             assert w is not None
             states.append((bucket, flat, w))
     for bucket, flat, w in states:

--- a/param_decomp_lab/three_pool/step_ci.py
+++ b/param_decomp_lab/three_pool/step_ci.py
@@ -50,7 +50,6 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
-import torch.distributed.nn.functional as dist_fn
 import torch.nn as nn
 from torch import Tensor
 
@@ -354,9 +353,10 @@ def _fused_backward_through_ci_fn(
     """Phase ci/8. Backward through the CI fn graph.
 
     Two gradient seeds enter the graph:
-      * ``coeff_imp * loss_imp`` — flows via ``ci.upper_leaky``. Its backward
-        traverses the autograd-aware ``dist_fn.all_reduce`` (96 NCCL
-        broadcasts back to every CI rank) before reaching the CI fn output.
+      * ``coeff_imp * loss_imp`` — flows via ``ci.upper_leaky``. Under the
+        SUM-grad convention the imp-min loss uses the detached-global-residual
+        trick, so its backward flows ONLY through this rank's local CI values (a
+        partial sum) — no cross-rank NCCL in the backward.
       * ``g_CI_total[s]`` per site — injected directly on ``ci.lower_leaky[s]``.
         96 separate gradient seeds rejoining at the shared CI fn output.
 
@@ -402,17 +402,28 @@ def _importance_minimality_loss(
     ci_pool_group: dist.ProcessGroup,
     n_ci_pool: int,
 ) -> Tensor:
-    """Exact (across CI pool) importance-minimality loss.
+    """Exact (across CI pool) importance-minimality loss, SUM-convention variant.
 
-    Each CI rank computes ``per_component_sums`` on its slice; we SUM-reduce
-    them across the CI pool with the autograd-aware all_reduce. ``n_examples``
-    is uniform across CI ranks (same batch_local_ci) so we multiply rather
-    than reduce.
+    Each CI rank computes ``per_component_sums`` on its disjoint batch slice; we
+    materialize the GLOBAL sums (needed inside ``finalize_imp_min``'s ``log2`` and
+    mean) via the detached-global-residual trick:
 
-    Autograd note: ``torch.distributed.nn.functional.all_reduce`` is the
-    autograd-aware variant — forward sums, backward broadcasts the upstream
-    gradient unchanged to every rank's input (correct for SUM since
-    ``∂global/∂local_i = 1`` for all i).
+      ``global = local + (all_reduce_sum(local.detach()) - local.detach())``
+
+    Forward value is the global sum; backward ``∂global/∂local = 1`` and the
+    cross-rank term is detached, so the gradient flows ONLY through THIS rank's
+    local CI values — a true partial sum. The CI-pool SUM all-reduce on the CI-fn
+    grads (``all_reduce_ci_fn_grads``) then reassembles the single-pool total.
+
+    This replaces the old autograd-aware ``dist_fn.all_reduce``, whose backward
+    SUM-reduced the REPLICATED upstream gradient across the pool, leaving each
+    rank with ``n_ci ×`` its partial — correct only because the (old) CI-pool AVG
+    divided it back out. Under the SUM convention that ``n_ci`` would no longer
+    cancel; the residual trick removes the pool-size dependence at the source (see
+    ``SUM_GRAD_CONVENTION.md``).
+
+    ``n_examples`` is uniform across CI ranks (same batch_local_ci), so multiply
+    rather than reduce.
     """
     annealed_p = annealed_pnorm(
         current_frac_of_training=current_frac_of_training,
@@ -424,20 +435,26 @@ def _importance_minimality_loss(
     per_component_sums, n_examples = per_component_lp_sums(
         ci_upper_leaky=ci_upper, pnorm=annealed_p, eps=cfg.imp_min_eps
     )
-    # per_component_lp_sums returns a per-rank Partial[SUM] over batch positions;
-    # materialize the global sums over the CI pool (autograd-aware so grad flows
-    # back to each rank's local CI values) before finalize. n_examples is uniform
-    # across CI ranks, so multiply rather than reduce.
     if n_ci_pool > 1:
         per_component_sums = {
-            k: dist_fn.all_reduce(v, op=dist.ReduceOp.SUM, group=ci_pool_group)
-            for k, v in per_component_sums.items()
+            k: _global_sum_local_grad(v, ci_pool_group) for k, v in per_component_sums.items()
         }
         n_examples = n_examples * n_ci_pool
-    # per_component_sums + n_examples are already global (reduced over the CI pool
-    # above), so finalize's log term computes log2(1 + global_sum) exactly.
     return finalize_imp_min(
         per_component_sums=per_component_sums,
         n_examples=n_examples,
         beta=cfg.imp_min_beta,
     )
+
+
+def _global_sum_local_grad(local: Tensor, group: dist.ProcessGroup) -> Tensor:
+    """Global sum in the forward, local-only gradient in the backward.
+
+    ``local + (all_reduce_sum(local.detach()) - local.detach())`` — the residual
+    is detached, so forward equals the global sum while backward flows only
+    through this rank's ``local`` (``∂/∂local = 1``). The result is a true partial
+    sum that SUM-composes across the CI pool (see ``SUM_GRAD_CONVENTION.md``).
+    """
+    global_detached = local.detach().clone()
+    dist.all_reduce(global_detached, op=dist.ReduceOp.SUM, group=group)
+    return local + (global_detached - local.detach())

--- a/param_decomp_lab/three_pool/step_layerwise.py
+++ b/param_decomp_lab/three_pool/step_layerwise.py
@@ -110,7 +110,7 @@ def step_layerwise(
         param.grad = None
 
     with strategy.context():
-        faith = _faithfulness_phase(component_model, device, cfg)
+        faith = _faithfulness_phase(component_model, device, cfg, ctx)
 
         ci_leaves = _wait_ci_and_releaf(ci_recv_pending, ctx, seq_len, cfg)
         stoch = _layerwise_streaming_phase(
@@ -162,11 +162,22 @@ def _target_fwd(
 
 
 def _faithfulness_phase(
-    component_model: LMComponentModel, device: torch.device, cfg: _ThreePoolRuntime
+    component_model: LMComponentModel, device: torch.device, cfg: _ThreePoolRuntime, ctx: LWContext
 ) -> Faith:
-    """Phase lw/D1. Faithfulness loss + backward into V/U .grad."""
+    """Phase lw/D1. Faithfulness loss + backward into V/U .grad (block leader only).
+
+    Contribute-once (see ``SUM_GRAD_CONVENTION.md``): faith is computed from the
+    replicated V/U weights, so it is identical across a block's DP partners. Under
+    the block SUM-reduce it must land on exactly ONE rank — the block leader runs
+    the backward; non-leaders skip it (their faith grad would be a duplicate). The
+    block SUM then spreads the leader's faith grad to every replica exactly once.
+
+    The loss / sum_sq / numel are still computed on every rank (they feed the
+    logger's global ratio, not the gradient), so logging is unchanged.
+    """
     loss, sum_sq, numel = _faithfulness_loss(component_model, device, cfg.numel_global)
-    (cfg.coeff_faith * loss).backward()
+    if ctx.role.is_block_leader:
+        (cfg.coeff_faith * loss).backward()
     return Faith(loss=loss, sum_sq=sum_sq, numel=numel)
 
 
@@ -194,12 +205,11 @@ def _layerwise_streaming_phase(
 ) -> Stoch:
     """Phase lw/D3. Per-owned-site stochastic recon, streaming fwd+bwd.
 
-    The per-site backward seeds the stoch gradient onto the re-leafed CI values,
-    which ship back to the CI pool and seed the CI-fn backward (alongside
-    imp-min and PPGD). For that CI-fn gradient to carry the same stoch:imp:pgd
-    balance as single-pool at ANY topology, the stoch seed must be GLOBALLY
-    normalized — divided by the global position count — not by this LW rank's
-    local count ``n_positions = batch_local_lw * seq_len``.
+    The per-site backward seeds the stoch gradient onto BOTH the re-leafed CI
+    values (→ CI pool) and the V/U weights (→ LW block). Under the SUM-grad
+    convention (see ``SUM_GRAD_CONVENTION.md``) both reductions are SUM, so the
+    seed is a single partial sum normalized only by the honest GLOBAL count —
+    and the SAME scale serves both destinations (no per-destination split).
 
     Derivation (single-pool target). Single-pool layerwise stoch backprops
     ``coeff_stoch * sum_loss / n_examples`` with ``n_examples =
@@ -207,25 +217,20 @@ def _layerwise_streaming_phase(
     so each (site, position) contributes a seed of
     ``coeff_stoch / (n_sites_total * P_global)``.
 
-    In 3-pool, each LW rank covers ``P_local = P_global / n_per_block`` distinct
-    positions, and the CI pool then AVG-reduces the assembled CI-fn grads over
-    ``n_ci``. With a per-site denom ``D``, the CI-fn stoch grad summed over all
-    positions and de-duplicated by the AVG is
-    ``(1 / n_ci) * P_global * coeff_stoch / D``. Setting that equal to the
-    single-pool total ``coeff_stoch / n_sites_total`` gives
-    ``D = P_global * n_sites_total / n_ci``.
-
-    Writing ``P_global = n_positions * n_per_block`` yields the form below. The
-    only difference from the (buggy) local normalization
-    ``n_positions * n_sites_total`` is the factor ``n_per_block / n_ci``, which
-    is exactly 1 on a square topology (``n_per_block == n_ci``) — so this is a
-    bit-exact no-op there and only changes non-square runs.
+    In 3-pool each LW rank covers ``P_local = P_global / n_per_block`` distinct
+    positions over its owned sites. Its seed is the SAME per-(site, position)
+    value ``coeff_stoch / (n_sites_total * P_global)``; the CI-pool SUM and the
+    LW-block SUM then reassemble the full single-pool sum (each global position
+    contributes exactly once). The denom is therefore the honest global count
+    ``n_sites_total * P_global`` with ``P_global = n_positions * n_per_block`` —
+    the only pool factor that survives is the ``local → global`` position
+    conversion ``n_per_block``, which is part of computing the global count, not
+    a transport factor. The old ``/ n_ci`` (to survive the CI-pool AVG) is gone.
     """
     owned_sites = ctx.role.owned_sites
     n_sites_total = len(cfg.c_per_site)
     device = target_local.device
     n_per_block = ctx.world.n_per_block
-    n_ci = ctx.world.n_ci
     with bf16_autocast(cfg.bf16_autocast):
         # Accumulate the display value as a GPU tensor (not a Python float) so
         # the per-site ``.item()`` doesn't force a CPU↔GPU sync that serializes
@@ -239,7 +244,8 @@ def _layerwise_streaming_phase(
                 component_model, batch_local, target_local, ci_leaves.per_site, s, strategy
             )
             assert loss_s.dim() == 0, f"layerwise loss for site {s!r} must be scalar"
-            stoch_grad_denom = n_positions * n_sites_total * n_per_block / n_ci
+            n_positions_global = n_positions * n_per_block
+            stoch_grad_denom = n_positions_global * n_sites_total
             (cfg.coeff_stoch * loss_s / stoch_grad_denom).backward()
             stoch_total_t = stoch_total_t + (loss_s.detach() / n_positions)
     return Stoch(total=stoch_total_t, n_owned=len(owned_sites))
@@ -255,9 +261,16 @@ def _send_g_ci(portals: LWPortals, role: LWRole, ci_leaves: CiLeaves) -> None:
 
 
 def _recv_and_combine_g_vu(ctx: LWContext, component_model: LMComponentModel) -> None:
-    """Phases lw/D5 + lw/D6. Recv PPGD's V/U grads, add to existing .grad."""
+    """Phases lw/D5 + lw/D6. Recv PPGD's V/U grads (block leader only), add to
+    existing .grad.
+
+    Contribute-once: PPGD's grad is replicated across block ranks, so only the
+    block leader recvs and adds it. The block SUM-reduce (lw/E) then spreads it
+    to every replica exactly once (see ``SUM_GRAD_CONVENTION.md``).
+    """
     v_grads_pgd, u_grads_pgd = _recv_g_vu_from_ppgd(ctx, component_model)
-    _combine_vu_grads_in_place(component_model, ctx.role.owned_sites, v_grads_pgd, u_grads_pgd)
+    if ctx.role.is_block_leader:
+        _combine_vu_grads_in_place(component_model, ctx.role.owned_sites, v_grads_pgd, u_grads_pgd)
 
 
 def run_faithfulness_warmup_layerwise(
@@ -362,18 +375,23 @@ def _recv_g_vu_from_ppgd(
     ctx: LWContext,
     component_model: LMComponentModel,
 ) -> tuple[dict[str, Tensor], dict[str, Tensor]]:
-    """Phase lw/D5. Recv V/U grads from PPGD pool (leader recvs, in-block bcast)."""
+    """Phase lw/D5. Recv V/U grads from PPGD pool (block leader only).
+
+    Non-leaders get empty dicts — PPGD's grad is replicated, so only the leader
+    contributes it (see ``_recv_and_combine_g_vu``).
+    """
     owned_sites = ctx.role.owned_sites
     v_templates = {s: component_model.components[s].V for s in owned_sites}
     u_templates = {s: component_model.components[s].U for s in owned_sites}
     v_grads_pgd, u_grads_pgd = ctx.portals.g_vu_from_ppgd.recv(ctx.role, v_templates, u_templates)
-    for s in owned_sites:
-        assert v_grads_pgd[s].shape == component_model.components[s].V.shape, (
-            f"v_grads_pgd[{s!r}] shape mismatch from PPGD send"
-        )
-        assert u_grads_pgd[s].shape == component_model.components[s].U.shape, (
-            f"u_grads_pgd[{s!r}] shape mismatch from PPGD send"
-        )
+    if ctx.role.is_block_leader:
+        for s in owned_sites:
+            assert v_grads_pgd[s].shape == component_model.components[s].V.shape, (
+                f"v_grads_pgd[{s!r}] shape mismatch from PPGD send"
+            )
+            assert u_grads_pgd[s].shape == component_model.components[s].U.shape, (
+                f"u_grads_pgd[{s!r}] shape mismatch from PPGD send"
+            )
     return v_grads_pgd, u_grads_pgd
 
 

--- a/param_decomp_lab/three_pool/step_ppgd.py
+++ b/param_decomp_lab/three_pool/step_ppgd.py
@@ -27,8 +27,8 @@ Phases (numbered to match ``DESIGN.md`` ``ppgd/N``):
   D4. Recon loss with the refined sources (the (N+1)'th forward).
   D5. Backward: one ``torch.autograd.grad`` over the UNSCALED recon sum yields
       raw g_VU + g_CI + g_sources; each consumer's own normalization is applied
-      explicitly afterward (V/U: coeff_ppgd / n_examples_global; CI: that times
-      n_ci to survive the CI-pool AVG-reduce; sources: 1 / n_examples_local).
+      explicitly afterward (V/U and CI share coeff_ppgd / n_examples_global — both
+      are partial sums under the SUM-grad convention; sources: 1 / n_examples_local).
   D5b. Send g_CI to CI pool (every rank, on its batch slice). Peer-to-peer
        point-to-point — no PPGD-internal reduce needed, so fires immediately
        after backward to unblock CI's recv-wait sooner.
@@ -226,33 +226,25 @@ def _scale_grads(
 ) -> None:
     """Phase ppgd/D5 (post). Apply each consumer's own normalization in place.
 
-    V/U and CI reproduce the serial gradient of the canonical PPGD loss
+    Under the SUM-grad convention (see ``SUM_GRAD_CONVENTION.md``) V/U and CI now
+    share ONE scale: both are partial sums of the canonical PPGD loss
       coeff_ppgd * recon_sum_loss / n_examples_global,
     where n_examples_global = n_examples_local * n_ppgd_ranks. Each rank holds
-    only its batch-slice's contribution, so the per-rank scale carries the
-    1/n_ppgd_ranks and the in-pool SUM-reduce reassembles the full-batch grad.
-
-    V/U and CI share that per-rank scale but diverge by their downstream
-    reduction: V/U is SUM-reduced in the PPGD pool, but the CI grad is later
-    AVG-reduced over n_ci ranks on the CI pool (``all_reduce_ci_fn_grads``), which
-    divides it by n_ci. CI therefore needs an extra * n_ci to survive that AVG —
-    mirroring the LW stoch path's `/ n_ci` denom.
+    only its batch-slice's contribution; the per-rank scale carries 1/n_ppgd, and
+    BOTH downstream reductions (V/U → PPGD-pool SUM, CI → CI-pool SUM) reassemble
+    the full-batch grad. The old ``* n_ci`` on the CI grad (PR #545, to survive the
+    CI-pool AVG) is GONE — the AVG it compensated for is now a SUM.
 
     Sources are per-rank-local adversary state optimized against THIS rank's own
-    recon mean (recon_sum_loss / n_examples_local) — no coeff, no 1/n_ppgd, no
-    n_ci. Identical to the warmup source grad.
-
-    Folding any one consumer's scaling into the differentiated scalar silently
-    mis-scales the others, which is why each is applied explicitly here.
+    recon mean (recon_sum_loss / n_examples_local) — no coeff, no 1/n_ppgd.
+    Identical to the warmup source grad.
     """
     n_ppgd_ranks = ctx.world.n_ppgd
-    n_ci = ctx.world.n_ci
-    vu_grad_scale = cfg.coeff_ppgd / (n_examples_local * n_ppgd_ranks)
-    ci_grad_scale = vu_grad_scale * n_ci
+    vu_and_ci_grad_scale = cfg.coeff_ppgd / (n_examples_local * n_ppgd_ranks)
     source_grad_scale = 1.0 / n_examples_local
-    _scale_grads_in_place(raw.v, vu_grad_scale)
-    _scale_grads_in_place(raw.u, vu_grad_scale)
-    _scale_grads_in_place(raw.ci, ci_grad_scale)
+    _scale_grads_in_place(raw.v, vu_and_ci_grad_scale)
+    _scale_grads_in_place(raw.u, vu_and_ci_grad_scale)
+    _scale_grads_in_place(raw.ci, vu_and_ci_grad_scale)
     _scale_grads_in_place(raw.sources, source_grad_scale)
 
 


### PR DESCRIPTION
## What

A structural fix for the recurring 3-pool gradient-scaling bug class: replace the per-instance "pre-scale to survive a downstream reduction" pattern with a single convention — **every gradient crossing a cross-rank reduction is a partial SUM, normalized only by the honest global count, carrying no pool-size transport factor; all data-parallel grad reductions are SUM**.

Full rationale + the honest trade-off analysis in `param_decomp_lab/three_pool/SUM_GRAD_CONVENTION.md`.

## Why

Four recurring bugs, all the same shape: a producer pre-scales its gradient by a pool-size factor (`n_ci`, `n_per_block`) to survive an AVG-reduce it can't locally see; the factor is invisible at `n_ci=1`/square and wrong otherwise. Two are **confirmed live by a real grad check**:
- **PPGD → CI** (the `×n_ci`, fixed manually in #545): `1/n_ci` too weak.
- **stoch → V/U** (a *second*, previously unfixed instance): one differentiated scalar feeds both the CI leaves (÷n_ci) and V/U (÷n_per_block); tuned for CI, so V/U lands `n_ci/n_per_block` off. Measured `0.500` at n_ci=2/n_per_block=4.

On the live run `p-97bab993` (n_ci=32, n_per_block=2) these are **16×** (V/U) and **32×** (CI) off — not subtle.

## How

- `all_reduce_ci_fn_grads` and `all_reduce_grads_in_block`: AVG → SUM.
- Producers normalize by the honest global count; **#545's `×n_ci` and stoch's `/n_ci` are deleted** (the factors evaporate for the data-parallel producers).
- Replicated contributions handled structurally, not numerically: faith + broadcast-PPGD V/U become **contribute-once** (block leader only); imp-min uses a **detached-global-residual** so its backward is a local partial sum.

## Relationship to #545

This **supersedes #545** by folding its fix into the convention (the manual `×n_ci` is removed because the AVG it compensated for is now a SUM). Based on `fix/ppgd-ci-grad-nci-scaling` so the diff here is *only* the structural change. @danbraunai-goodfire — keen for your read on whether to merge #545 then this, or collapse them.

## Validation

- New `test_three_pool_grad_check_distributed.py` (10-rank gloo, **non-square** n_ci=4/n_per_block=2/n_ppgd=2, all four loss terms, RNG/masks pinned): fully-reduced CI-fn **and** V/U grads vs single-process reference — **mean(dist/ref)=1.000000**, worst rel err 4e-7. Sensitivity-checked: AVG→CI gives 1/n_ci, faith-on-all-ranks gives n_per_block× (the check bites).
- `make check` clean; 42 three-pool/distributed tests pass.

## ⚠️ Draft — not merge-ready

The fix **changes effective gradient magnitudes** (it corrects them), so training dynamics / the stoch:imp:ppgd balance change and LRs may need retuning. Pending a behavioural smoke at a real (non-square) topology before this comes out of draft. Correctness is grad-check-proven; dynamics are not yet observed at scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
