### PR TITLE
Add lore-pd MCP server to the project

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,3 +1,16 @@
 {
-  "mcpServers": {}
+  "mcpServers": {
+    "lore-pd": {
+      "command": "uvx",
+      "args": [
+        "--from",
+        "lore[mcp] @ git+https://github.com/goodfire-ai/lore.git",
+        "lore-mcp"
+      ],
+      "env": {
+        "LORE_REMOTE": "https://github.com/goodfire-ai/pd-lore.git",
+        "LORE_AUTHOR": "${LORE_AUTHOR:-agent:claude@pd}"
+      }
+    }
+  }
 }


### PR DESCRIPTION
Registers the **lore** knowledge base (pd-lore) for Claude Code sessions opened in this repo.

```json
"lore-pd": {
  "command": "uvx",
  "args": ["--from", "lore[mcp] @ git+https://github.com/goodfire-ai/lore.git", "lore-mcp"],
  "env": {
    "LORE_REMOTE": "https://github.com/goodfire-ai/pd-lore.git",
    "LORE_AUTHOR": "${LORE_AUTHOR:-agent:claude@pd}"
  }
}
```

## Why here (not the plugin marketplace)
lore is **project-scoped / multi-instance** — one MCP server per KB, distinct `LORE_REMOTE`/`LORE_AUTHOR`. Committing to this project's `.mcp.json` is the right shape: every clone of param-decomp (laptop, login node, compute, worktrees) gets `lore-pd` automatically, scoped to *this* project, without foisting it on unrelated projects.

## How it stays current
`uvx` re-resolves `goodfire-ai/lore@main` each time the server spawns (each session start), so a session restart picks up the latest tool — no cache-busting.

## Teammate notes
- Requires **`uv` on PATH** and **read access to `goodfire-ai/lore` + `goodfire-ai/pd-lore`**.
- First session shows an MCP trust prompt — approve `lore-pd`.
- Optional `export LORE_AUTHOR=human:<you>` for attribution (else defaults to `agent:claude@pd`).
- Verify: `/mcp` → `lore-pd` with 10 `kb_*` tools.
- After merge: pull main, restart sessions, and remove any per-user `lore`/`lore-pd` entry from `~/.claude.json` so it doesn't double up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)