### PR TITLE
fix: hard-exit distributed runs to avoid teardown SIGABRT

### DIFF
--- a/param_decomp_lab/distributed.py
+++ b/param_decomp_lab/distributed.py
@@ -6,6 +6,7 @@ collectives.
 """
 
 import os
+import sys
 from collections.abc import Callable
 from functools import wraps
 
@@ -88,14 +89,34 @@ def cleanup_distributed() -> None:
 
 
 def with_distributed_cleanup[**P, T](fn: Callable[P, T]) -> Callable[P, T]:
-    """Wrap `fn` so `cleanup_distributed` runs in a ``finally`` block on return/raise."""
+    """Run `fn`, then tear distributed down — hard-exiting on the success path.
+
+    On a distributed run that returns normally, every rank barriers (so rank 0's
+    end-of-run wandb flush lands before any peer exits) and then `os._exit`. The
+    hard exit is load-bearing: it skips CPython finalization, where a C-extension
+    daemon thread releasing the GIL after the interpreter starts finalizing aborts
+    the process with `PyGILState_Release` (SIGABRT). That abort fails the SLURM job,
+    and torchrun's peer teardown can kill rank 0 mid-flush so the final step never
+    syncs — even though training succeeded.
+
+    On error, or when not distributed, just `cleanup_distributed` and propagate: no
+    barrier, since a dead peer would hang the collective.
+    """
 
     @wraps(fn)
     def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         try:
-            return fn(*args, **kwargs)
-        finally:
+            result = fn(*args, **kwargs)
+        except BaseException:
             cleanup_distributed()
+            raise
+        if not is_distributed():
+            cleanup_distributed()
+            return result
+        sync_across_processes()
+        sys.stdout.flush()
+        sys.stderr.flush()
+        os._exit(0)
 
     return wrapper
 


### PR DESCRIPTION
## Description

Distributed LM runs (e.g. job `43139`, run `p-9081c804`) were marked **FAILED** by SLURM despite training, final eval, checkpointing, and figure-saving all succeeding. The failure is a crash during Python interpreter shutdown:

```
Fatal Python error: PyGILState_Release: thread state ... must be current when releasing
Python runtime state: finalizing
terminate called without an active exception
```

After `trainer.run` returns, ranks are unsynchronized through shutdown (the trainer skips its per-step barrier on the final step). During CPython finalization a C-extension daemon thread releases the GIL after the interpreter has started finalizing, aborting the process with `PyGILState_Release` (SIGABRT, exit -6) on a non-main rank. torchrun then tears down peers, which can kill rank 0 mid-`wandb.finish()` — so the final logged step never syncs to W&B even though it's present locally in `metrics.jsonl`.

This was recurring: the same signature appears in 11+ run logs.

## Motivation and Context

Two user-visible symptoms, one root cause:
- Healthy runs show up as **FAILED** (breaks job-status bookkeeping / dependency chains).
- The **final step is missing from W&B** when rank 0 gets killed mid-flush.

## Fix

`with_distributed_cleanup` now, on the **distributed success path**:
1. `sync_across_processes()` — barrier so rank 0's end-of-run `wandb.finish()` lands before any peer exits;
2. flush stdio and `os._exit(0)` — bypassing CPython finalization entirely, which is where the GIL race aborts.

The error path and non-distributed runs keep best-effort `cleanup_distributed()` with **no barrier** (a dead peer would hang the collective). Because the success path never enters finalization, the crash is eliminated by construction.

## How Has This Been Tested?

Reproduced and verified with small fast 8-GPU gpt2-small runs (the failing production config was `world_size=8` single-node):

- **Without fix** — job `55277`: `FAILED`, `PyGILState_Release` + SIGABRT on a non-main rank, after "Finished training loop".
- **With fix** — job `55278`, identical config: `COMPLETED`, exit `0:0`, zero crash signatures, `wandb: Synced 5 W&B file(s), 18 media file(s)`.

Passes `ruff` + `basedpyright` (pre-commit).

## Does this PR introduce a breaking change?

No. Behaviour changes only at end-of-run for distributed (torchrun) jobs: they now exit 0 cleanly instead of aborting during finalization. Non-distributed runs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)