### PR TITLE
chore: set wandb project to param-decomp-llama for llama-3.1-8b

### DIFF
--- a/param_decomp_lab/experiments/lm/llama-3.1-8b.yaml
+++ b/param_decomp_lab/experiments/lm/llama-3.1-8b.yaml
@@ -131,4 +131,4 @@ runtime:
   device: cuda
   dp: null
 wandb:
-  project: param-decomp
+  project: param-decomp-llama


### PR DESCRIPTION
Point the `llama-3.1-8b` experiment's wandb logging at the new `param-decomp-llama` project, keeping its runs separate from the main `param-decomp` project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)