### PR TITLE
feat: prune old checkpoints from wandb alongside local disk

### DIFF
--- a/param_decomp_lab/run_sink.py
+++ b/param_decomp_lab/run_sink.py
@@ -152,7 +152,8 @@ class RunSink:
 
         No-op when `out_dir is None` (silent sink / non-main rank); wandb upload
         only when wandb is active. Prunes older (model, training) pairs after the
-        write when ``keep_last_n_checkpoints`` is set.
+        write when ``keep_last_n_checkpoints`` is set — locally, and also from the
+        wandb run when wandb is active.
         """
         if self.out_dir is None:
             return
@@ -165,7 +166,11 @@ class RunSink:
             try_wandb(wandb.save, str(model_path), base_path=str(self.out_dir), policy="now")
             try_wandb(wandb.save, str(training_path), base_path=str(self.out_dir), policy="now")
         if self.keep_last_n_checkpoints is not None:
-            _prune_old_checkpoints(self.out_dir, keep_last_n=self.keep_last_n_checkpoints)
+            _prune_old_checkpoints(
+                self.out_dir,
+                keep_last_n=self.keep_last_n_checkpoints,
+                prune_wandb=self._wandb_active,
+            )
 
     def finish(self) -> None:
         """End-of-run cleanup."""
@@ -180,30 +185,55 @@ def _wandb_value(v: Any) -> Any:
     return v
 
 
-def _prune_old_checkpoints(out_dir: Path, *, keep_last_n: int) -> None:
-    """Delete (``model_<step>.pth``, ``training_<step>.pth``) pairs except for the
-    top ``keep_last_n`` by step number.
+def _checkpoint_steps_to_prune(out_dir: Path, *, keep_last_n: int) -> list[int]:
+    """Steps (oldest first) whose (model, training) files exceed `keep_last_n`.
 
-    A "pair" is the two files written together by :meth:`RunSink.checkpoint`; we
-    glob each independently and prune by step rather than assuming both must
-    exist, since a future caller might write only one of them.
+    A "pair" is the two files written together by `RunSink.checkpoint`; we glob
+    each prefix independently and prune by step rather than assuming both exist,
+    since a future caller might write only one of them.
     """
 
-    def steps(prefix: str) -> list[int]:
-        out: list[int] = []
+    def steps(prefix: str) -> set[int]:
+        out: set[int] = set()
         for p in out_dir.glob(f"{prefix}_*.pth"):
             try:
-                out.append(int(p.stem.removeprefix(f"{prefix}_")))
+                out.add(int(p.stem.removeprefix(f"{prefix}_")))
             except ValueError:
                 continue
         return out
 
-    all_steps = sorted(set(steps("model")) | set(steps("training")))
-    if len(all_steps) <= keep_last_n:
-        return
-    to_delete = all_steps[: len(all_steps) - keep_last_n]
-    for step in to_delete:
-        for prefix in ("model", "training"):
-            path = out_dir / f"{prefix}_{step}.pth"
-            if path.is_file():
-                path.unlink()
+    all_steps = sorted(steps("model") | steps("training"))
+    return all_steps[: max(0, len(all_steps) - keep_last_n)]
+
+
+def _delete_wandb_files(names: list[str]) -> None:
+    """Best-effort deletion of the named run files from the active wandb run.
+
+    Broad catch by design: pruning is cleanup, not correctness, and the public
+    API raises errors wandb's `normalize_exceptions` does not coerce to
+    `CommError` (unwrapped `run.files()` pagination, non-`CommError` `Error`
+    subclasses), so a narrow catch would crash training on a flaky delete.
+    `BaseException` (Ctrl-C, `SystemExit`) still propagates.
+    """
+    assert wandb.run is not None
+    assert names, "empty names would match all run files via run.files()"
+    try:
+        run = wandb.Api().run(f"{wandb.run.entity}/{wandb.run.project}/{wandb.run.id}")
+        for file in run.files(names=names):  # server filters to existing matches
+            file.delete()
+    except Exception as e:
+        logger.warning(f"wandb checkpoint pruning failed (non-fatal): {e}")
+
+
+def _prune_old_checkpoints(out_dir: Path, *, keep_last_n: int, prune_wandb: bool) -> None:
+    """Delete (`model_<step>.pth`, `training_<step>.pth`) pairs beyond the most
+    recent `keep_last_n` — locally, and from the active wandb run when `prune_wandb`.
+    """
+    to_prune = _checkpoint_steps_to_prune(out_dir, keep_last_n=keep_last_n)
+    names = [f"{prefix}_{step}.pth" for step in to_prune for prefix in ("model", "training")]
+    for name in names:
+        path = out_dir / name
+        if path.is_file():
+            path.unlink()
+    if prune_wandb and names:
+        _delete_wandb_files(names)

--- a/param_decomp_lab/tests/test_resumption.py
+++ b/param_decomp_lab/tests/test_resumption.py
@@ -29,7 +29,7 @@ from param_decomp_lab.resumption import (
     read_training_snapshot,
     resolve_step,
 )
-from param_decomp_lab.run_sink import RunSink
+from param_decomp_lab.run_sink import RunSink, _checkpoint_steps_to_prune
 
 
 class TinyLinear(nn.Module):
@@ -197,3 +197,19 @@ def test_keep_last_n_checkpoints_prunes_older_pairs(tmp_path: Path) -> None:
     assert not (run_dir / "training_2.pth").exists()
     assert (run_dir / "model_4.pth").is_file()
     assert (run_dir / "training_4.pth").is_file()
+
+
+def test_checkpoint_steps_to_prune_selects_oldest_beyond_keep_last_n(tmp_path: Path) -> None:
+    """The pure step selector returns oldest-first steps exceeding keep_last_n,
+    unions model/training prefixes, and ignores non-checkpoint .pth files.
+    """
+    for step in (10, 20, 30):
+        (tmp_path / f"model_{step}.pth").touch()
+        (tmp_path / f"training_{step}.pth").touch()
+    # A lone prefix still counts as a step; junk names are ignored.
+    (tmp_path / "model_40.pth").touch()
+    (tmp_path / "optimizer.pth").touch()
+
+    assert _checkpoint_steps_to_prune(tmp_path, keep_last_n=2) == [10, 20]
+    assert _checkpoint_steps_to_prune(tmp_path, keep_last_n=4) == []
+    assert _checkpoint_steps_to_prune(tmp_path, keep_last_n=10) == []


### PR DESCRIPTION
## Description

`keep_last_n_checkpoints` now prunes the wandb run as well as local disk. Previously it only `unlink`ed local files, so every checkpointed step persisted on wandb forever.

The prune is split into:
- `_checkpoint_steps_to_prune` — pure step selector (the only real logic; unit-tested).
- `_delete_wandb_files` — best-effort remote deletion via the wandb public API, using `run.files(names=...)` for server-side filtering (existing matches only; no full file-list scan).
- `_prune_old_checkpoints` — thin orchestrator: local unlink + optional remote delete.

## Motivation and Context

A run with `keep_last_n_checkpoints: 2` kept only the last two `(model, training)` pairs on local disk but left all of them on wandb (e.g. `p-ec62b8cb` accumulating `model_25000/50000/75000.pth`). Disk footprint was bounded; wandb storage was not.

**Behavior change worth flagging:** wandb is no longer a durable backup of pruned checkpoints. With `keep_last_n_checkpoints` set, the remote now also keeps only the last N. Runs without that field set are unaffected (pruning is opt-in via the field, as before).

The remote delete uses a deliberately broad `except Exception`: the wandb public API raises errors that `normalize_exceptions` does **not** coerce to `CommError` (unwrapped `run.files()` pagination, non-`CommError` `Error` subclasses), so a narrow catch would let a flaky delete crash a multi-day training run. Pruning is best-effort cleanup, so failures are logged and swallowed; `BaseException` (Ctrl-C, `SystemExit`) still propagates.

## How Has This Been Tested?

- New unit test `test_checkpoint_steps_to_prune_selects_oldest_beyond_keep_last_n` covers the step selector (oldest-first, model/training union, junk-name skipping, keep-all cases).
- Existing `test_keep_last_n_checkpoints_prunes_older_pairs` still passes (local pruning unchanged).
- basedpyright + ruff clean.
- The remote-deletion error handling was validated by simulating the realistic failure modes (`ConnectionError`/timeout from paginator iteration, non-`CommError` `Error` subclasses) and confirming a narrow `CommError`-only catch lets them escape while the broad catch contains them. The remote path itself can't be unit-tested without mocking the public API.

## Does this PR introduce a breaking change?

Not API-breaking, but a behavior change: wandb checkpoints are now pruned to the same `keep_last_n_checkpoints` window as local disk, rather than being retained indefinitely. This is irreversible per-file. Only affects runs that set `keep_last_n_checkpoints`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)