### PR TITLE
fix: hard-exit distributed error path to avoid hung SLURM jobs

### DIFF
--- a/param_decomp_lab/distributed.py
+++ b/param_decomp_lab/distributed.py
@@ -7,6 +7,7 @@ collectives.
 
 import os
 import sys
+import traceback
 from collections.abc import Callable
 from functools import wraps
 
@@ -89,18 +90,24 @@ def cleanup_distributed() -> None:
 
 
 def with_distributed_cleanup[**P, T](fn: Callable[P, T]) -> Callable[P, T]:
-    """Run `fn`, then tear distributed down — hard-exiting on the success path.
+    """Run `fn`, then tear distributed down — hard-exiting on both distributed paths.
 
     On a distributed run that returns normally, every rank barriers (so rank 0's
-    end-of-run wandb flush lands before any peer exits) and then `os._exit`. The
+    end-of-run wandb flush lands before any peer exits) and then `os._exit(0)`. The
     hard exit is load-bearing: it skips CPython finalization, where a C-extension
     daemon thread releasing the GIL after the interpreter starts finalizing aborts
     the process with `PyGILState_Release` (SIGABRT). That abort fails the SLURM job,
     and torchrun's peer teardown can kill rank 0 mid-flush so the final step never
     syncs — even though training succeeded.
 
-    On error, or when not distributed, just `cleanup_distributed` and propagate: no
-    barrier, since a dead peer would hang the collective.
+    On a distributed run that raises, print the traceback and `os._exit(1)` without
+    any collective. The error may itself be a wedged NCCL comm (e.g. an OOM raised
+    mid-`all_gather`), and `destroy_process_group` would then deadlock — leaving the
+    rank alive holding its GPUs, so torchrun never sees a failure and SLURM runs the
+    zombie job until its time limit. The non-zero hard exit makes torchrun reap the
+    peers and SLURM fail the job fast.
+
+    When not distributed, `cleanup_distributed` and propagate normally.
     """
 
     @wraps(fn)
@@ -108,8 +115,13 @@ def with_distributed_cleanup[**P, T](fn: Callable[P, T]) -> Callable[P, T]:
         try:
             result = fn(*args, **kwargs)
         except BaseException:
-            cleanup_distributed()
-            raise
+            if not is_distributed():
+                cleanup_distributed()
+                raise
+            traceback.print_exc()
+            sys.stdout.flush()
+            sys.stderr.flush()
+            os._exit(1)
         if not is_distributed():
             cleanup_distributed()
             return result

--- a/param_decomp_lab/distributed.py
+++ b/param_decomp_lab/distributed.py
@@ -100,14 +100,11 @@ def with_distributed_cleanup[**P, T](fn: Callable[P, T]) -> Callable[P, T]:
     and torchrun's peer teardown can kill rank 0 mid-flush so the final step never
     syncs — even though training succeeded.
 
-    On a distributed run that raises, print the traceback and `os._exit(1)` without
-    any collective. The error may itself be a wedged NCCL comm (e.g. an OOM raised
-    mid-`all_gather`), and `destroy_process_group` would then deadlock — leaving the
-    rank alive holding its GPUs, so torchrun never sees a failure and SLURM runs the
-    zombie job until its time limit. The non-zero hard exit makes torchrun reap the
-    peers and SLURM fail the job fast.
-
-    When not distributed, `cleanup_distributed` and propagate normally.
+    On a distributed run that raises, print the traceback and `os._exit(1)` with no
+    collective: the failure may be a wedged NCCL comm (e.g. an OOM mid-`all_gather`),
+    so `destroy_process_group` would deadlock and leave the rank alive holding its
+    GPUs — a zombie SLURM job. The hard exit makes torchrun reap the peers and fail
+    fast. Not distributed: `cleanup_distributed` and propagate normally.
     """
 
     @wraps(fn)


### PR DESCRIPTION
## Description

On the distributed error path, `with_distributed_cleanup` now prints the traceback and `os._exit(1)` with no collective, instead of calling `cleanup_distributed()` → `destroy_process_group()` and re-raising. Non-distributed runs are unchanged (graceful cleanup + re-raise). Extends the `#548` success-path hard-exit to the error path.

## Motivation and Context

Two 64-GPU `llama-3.1-8b` runs (jobs 640423, 640424) died but their SLURM jobs stayed `RUNNING` as no-op zombies for ~9h, holding 128 H100s until the 7-day time limit.

Root cause: every rank OOM'd during an `all_gather` inside the `ci_histograms` eval metric (`gather_all_tensors(torch.cat(ci_list, dim=0))`). The error path then called `destroy_process_group()`, but an OOM raised mid-`all_gather` leaves the NCCL communicator wedged, so the graceful teardown deadlocks on a futex. The rank never exits (still holding ~78 GB/GPU), so:

- torchrun never observes a failed worker → keeps polling forever;
- `srun --kill-on-bad-exit=1` never fires (it only triggers on a task that *exits* non-zero);
- slurmstepd sees a live step → job runs until its `--time` limit.

`TORCH_NCCL_ASYNC_ERROR_HANDLING=1` never helped — its abort path needs to tear down the same wedged comm, so no watchdog/timeout line ever appeared in the logs.

The non-zero hard exit makes torchrun reap the peers and SLURM fail the job fast.

## How Has This Been Tested?

`make check` passes (basedpyright + ruff). The fix mirrors the established `os._exit` teardown pattern from #548; the failure mode it addresses was diagnosed from the live hung jobs (ranks stuck in `futex_wait_queue` / `destroy_process_group`, full GPU memory still allocated, torchrun in `hrtimer_nanosleep`).

## Does this PR introduce a breaking change?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)