### PR TITLE
feat(metrics): log beta-independent importance-minimality (no_beta) term

### DIFF
--- a/param_decomp/metrics/importance_minimality.py
+++ b/param_decomp/metrics/importance_minimality.py
@@ -67,20 +67,33 @@ def _per_component_sums(
     return out, n_examples
 
 
+def _lp_and_entropy_terms(
+    per_component_sums: dict[str, Float[Tensor, " C"]],
+    n_examples: int,
+    world_size: int,
+) -> tuple[Float[Tensor, ""], Float[Tensor, ""]]:
+    """The two additive parts of the loss, summed over components: `(lp, entropy)`.
+
+    Full loss is `lp + beta * entropy`; `lp` alone is the beta-independent sparsity proxy.
+    """
+    device = next(iter(per_component_sums.values())).device
+    lp = torch.zeros((), device=device)
+    entropy = torch.zeros((), device=device)
+    for layer_sums in per_component_sums.values():
+        per_component_mean = layer_sums / n_examples
+        lp = lp + per_component_mean.sum()
+        entropy = entropy + (per_component_mean * torch.log2(1 + layer_sums * world_size)).sum()
+    return lp, entropy
+
+
 def _finalize(
     per_component_sums: dict[str, Float[Tensor, " C"]],
     n_examples: int,
     beta: float,
     world_size: int,
 ) -> Float[Tensor, ""]:
-    total_loss = torch.zeros((), device=next(iter(per_component_sums.values())).device)
-    for layer_sums in per_component_sums.values():
-        per_component_mean = layer_sums / n_examples
-        layer_loss = (
-            per_component_mean + beta * per_component_mean * torch.log2(1 + layer_sums * world_size)
-        ).sum()
-        total_loss = total_loss + layer_loss
-    return total_loss
+    lp, entropy = _lp_and_entropy_terms(per_component_sums, n_examples, world_size)
+    return lp + beta * entropy
 
 
 def importance_minimality_loss(
@@ -164,9 +177,9 @@ class ImportanceMinimalityLoss(Metric[ImportanceMinimalityLossConfig]):
             k: all_reduce(v, op=ReduceOp.SUM) for k, v in self.per_component_sums.items()
         }
         n_examples = int(all_reduce(self.n_examples, op=ReduceOp.SUM))
-        return _finalize(
-            per_component_sums=reduced_sums,
-            n_examples=n_examples,
-            beta=self.cfg.beta,
-            world_size=1,
-        )
+        lp, entropy = _lp_and_entropy_terms(reduced_sums, n_examples, world_size=1)
+        name = type(self).__name__
+        return {
+            name: lp + self.cfg.beta * entropy,
+            f"{name}_no_beta": lp,
+        }

--- a/param_decomp/tests/metrics/test_importance_minimality_loss.py
+++ b/param_decomp/tests/metrics/test_importance_minimality_loss.py
@@ -1,6 +1,12 @@
+import math
+
 import torch
 
-from param_decomp.metrics.importance_minimality import importance_minimality_loss
+from param_decomp.metrics.importance_minimality import (
+    ImportanceMinimalityLoss,
+    ImportanceMinimalityLossConfig,
+    importance_minimality_loss,
+)
 
 
 class TestImportanceMinimalityLoss:
@@ -187,8 +193,6 @@ class TestImportanceMinimalityLoss:
         2. beta > 0 produces larger loss than beta = 0
         3. Penalty is finite for edge cases (small/large values)
         """
-        import math
-
         ci_upper_leaky = {
             "layer1": torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=torch.float32),
         }
@@ -257,3 +261,26 @@ class TestImportanceMinimalityLoss:
             p_anneal_end_frac=1.0,
         )
         assert torch.isfinite(result_large)
+
+    def test_compute_logs_beta_and_no_beta(self: object) -> None:
+        """`compute()` emits both the headline (beta-weighted) loss and a `no_beta` term
+        that is the pure L_p value — a sparsity proxy independent of the tuned `beta`."""
+        cfg = ImportanceMinimalityLossConfig(coeff=1.0, pnorm=1.0, beta=1.0, eps=0.0)
+        metric = ImportanceMinimalityLoss(cfg)
+        # Bypass `bind` (no ComponentModel needed) — set the accumulator state directly.
+        metric.device = "cpu"
+        metric.per_component_sums = {"layer1": torch.tensor([4.0, 6.0])}
+        metric.n_examples = torch.tensor(2, dtype=torch.long)
+
+        out = metric.compute()
+        assert isinstance(out, dict)
+        assert set(out) == {"ImportanceMinimalityLoss", "ImportanceMinimalityLoss_no_beta"}
+
+        # per_component_mean = [2, 3]; no_beta = sum = 5; beta=1 adds log2 term => larger.
+        expected_no_beta = 5.0
+        expected_with_beta = 2.0 * (1 + math.log2(5)) + 3.0 * (1 + math.log2(7))
+        assert torch.allclose(
+            out["ImportanceMinimalityLoss_no_beta"], torch.tensor(expected_no_beta)
+        )
+        assert torch.allclose(out["ImportanceMinimalityLoss"], torch.tensor(expected_with_beta))
+        assert out["ImportanceMinimalityLoss"] > out["ImportanceMinimalityLoss_no_beta"]


### PR DESCRIPTION
## Summary
`ImportanceMinimalityLoss.compute()` now returns two values: the existing headline term and a new `{name}/no_beta` term — the pure L_p term evaluated at `beta=0`.

`no_beta` is a beta-independent sparsity proxy. Unlike the headline importance-minimality loss (which folds in the configured `beta`) and unlike L0, it stays comparable across experiments that tune `beta`, making it a stable sparsity yardstick.

## Test plan
- `make check` (ruff + basedpyright) passes.
- `python -m pytest param_decomp/tests/metrics/test_importance_minimality_loss.py` — 12 passed (includes new coverage for the `no_beta` key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)