### PR TITLE
perf(multipool): fuse PPGD source-grad into the main backward

### DIFF
--- a/param_decomp/metrics/persistent_pgd_recon.py
+++ b/param_decomp/metrics/persistent_pgd_recon.py
@@ -30,7 +30,6 @@ from param_decomp.metrics.persistent_pgd_state import (
     PersistentPGDSourceScope,
     PersistentPGDState,
     PGDOptimizerConfig,
-    PPGDSources,
     RepeatAcrossBatchScope,
     get_ppgd_mask_infos,
     scope_needs_replica_sync,
@@ -129,7 +128,7 @@ class _PersistentPGDReconBase[
     def __init__(self, cfg: TConfig) -> None:
         super().__init__(cfg)
         self.state: PersistentPGDState | None = None
-        self._pending_source_grads: PPGDSources | None = None
+        self._source_step_active = False
         # Stash from `load_state_dict` if called before the first `update()` —
         # `PersistentPGDState` needs batch_dims, which we only learn from a live ctx.
         self._pending_resume_state: dict[str, Any] | None = None
@@ -250,18 +249,18 @@ class _PersistentPGDReconBase[
 
     @override
     def before_backward(self, live_loss: Tensor | None) -> None:
-        if live_loss is None or self.state is None:
-            return
-        grads = self.state.get_grads(live_loss, retain_graph=True)
-        self._pending_source_grads = self.state.reduce_source_grads(grads)
+        # Sources are leaves in total_loss; the main backward fills source.grad — no extra pass.
+        self._source_step_active = live_loss is not None and self.state is not None
 
     @override
     def after_backward(self) -> None:
-        if self._pending_source_grads is None:
+        if not self._source_step_active:
             return
         assert self.state is not None
-        self.state.step(self._pending_source_grads)
-        self._pending_source_grads = None
+        assert self.cfg.coeff is not None
+        grads = self.state.reduce_source_grads(self.state.collect_source_grads(self.cfg.coeff))
+        self.state.step(grads)
+        self._source_step_active = False
 
     @override
     def state_dict(self) -> dict[str, Any]:

--- a/param_decomp/metrics/persistent_pgd_state.py
+++ b/param_decomp/metrics/persistent_pgd_state.py
@@ -293,6 +293,16 @@ class PersistentPGDState:
         grads = torch.autograd.grad(loss, list(self.sources.values()), retain_graph=retain_graph)
         return dict(zip(self.sources.keys(), grads, strict=True))
 
+    def collect_source_grads(self, loss_coeff: float) -> PPGDSources:
+        """Raw ``∂loss/∂source`` read from ``.grad`` (the main backward filled it, scaled by the
+        loss's ``loss_coeff``); clears ``.grad``. Reduce/step as for ``get_grads`` output."""
+        grads: PPGDSources = {}
+        for name, source in self.sources.items():
+            assert source.grad is not None, f"source {name!r}: no grad after backward"
+            grads[name] = source.grad / loss_coeff
+            source.grad = None
+        return grads
+
     def reduce_source_grads(self, grads: PPGDSources) -> PPGDSources:
         """AVG-reduce per-rank source grads over the replica-sync group, else a no-op.
 

--- a/param_decomp/tests/test_spd_losses.py
+++ b/param_decomp/tests/test_spd_losses.py
@@ -824,6 +824,40 @@ class TestPersistentPGDReconLoss:
         assert scope_needs_replica_sync(BroadcastAcrossBatchScope()) is True
         assert scope_needs_replica_sync(RepeatAcrossBatchScope(n_sources=2)) is True
 
+    def test_collect_source_grads_matches_get_grads(self: object) -> None:
+        # Fused backward: source.grad/coeff from the main backward == the separate get_grads pass.
+        fc_weight = torch.tensor([[1.0, 0.0], [0.0, 1.0]], dtype=torch.float32)
+        model = _make_seq_component_model(weight=fc_weight)
+        batch = torch.tensor([[[1.0, 2.0], [0.5, 1.5]]], dtype=torch.float32)
+        target_out = torch.tensor([[[0.3, 0.7], [0.9, 0.1]]], dtype=torch.float32)
+        ci = {"fc": torch.tensor([[[0.5], [0.5]]], dtype=torch.float32)}
+
+        cfg = PersistentPGDReconLossConfig(
+            optimizer=SignPGDConfig(lr_schedule=ScheduleConfig(start_val=0.1)),
+            scope=SingleSourceScope(),
+        )
+        state = _ppgd_state_from_cfg(
+            cfg,
+            module_to_c=model.module_to_c,
+            batch_dims=batch.shape[:2],
+            device="cpu",
+            use_delta_component=False,
+            reconstruction_loss=recon_loss_mse,
+        )
+
+        sum_loss, n = state.compute_recon_sum_and_n(
+            model=model, batch=batch, target_out=target_out, ci=ci, weight_deltas=None
+        )
+        loss = sum_loss / n
+        separate = state.get_grads(loss, retain_graph=True)
+        assert any(g.abs().sum() > 0 for g in separate.values()), "grads all zero — vacuous test"
+
+        coeff = 0.5
+        (coeff * loss).backward()
+        fused = state.collect_source_grads(coeff)
+        for name in state.sources:
+            assert torch.allclose(fused[name], separate[name], atol=1e-6)
+
     def test_masks_persist_across_calls(self: object) -> None:
         """Test that masks persist and accumulate updates across calls."""
         fc_weight = torch.tensor([[2.0, 0.0], [0.0, 2.0]], dtype=torch.float32)


### PR DESCRIPTION
## Summary
The final PPGD forward was backproped **twice** per step: `before_backward` ran a separate `autograd.grad(recon_loss, sources, retain_graph=True)` (a full backward through the recon forward) and then `total_loss.backward()` ran another full backward for the component grads. The sources are leaves in the `total_loss` graph, so the main backward already populates `source.grad` — the separate pass is redundant.

This drops it: `before_backward` just flags the step, and `after_backward` harvests `source.grad / coeff` via a new `PersistentPGDState.collect_source_grads`, then runs the **unchanged** `reduce_source_grads` (replica-sync AVG) + `step`. `total_loss` adds the recon term scaled by `coeff` and nothing else depends on the sources, so `source.grad == coeff · ∂recon/∂source`; dividing by `coeff` recovers exactly what `get_grads(recon_loss)` returned.

Saves ~one full backward per step. This is the multipool port of the same change measured at **~7% faster** on the base 4L path (dp2, batch 16).

## Equivalence
Gradients are identical, not approximate — only *how the raw per-rank grad is obtained* changes; `reduce_source_grads` and `step` are untouched. New unit test `test_collect_source_grads_matches_get_grads` asserts `source.grad/coeff` == the separate `get_grads` pass.

## Test plan
- `make check` clean; full PPGD suite (`test_spd_losses.py`) passes (35, incl. the new test).
- ⚠️ **Not run locally:** the 8-GPU distributed pooled grad-check (`test_three_pool_grad_check_distributed`, `@slow`, `nproc_per_node=8`) — this node has 1 GPU. Submitting it on an 8-GPU node to validate the replica-sync path; will post the result here. The replica-sync logic is unchanged, so it should pass given the unit-test equivalence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)