### PR TITLE
fix(lm): retry huggingface_hub HTTP calls to survive transient Hub timeouts

### DIFF
--- a/param_decomp_lab/experiments/lm/data.py
+++ b/param_decomp_lab/experiments/lm/data.py
@@ -15,6 +15,7 @@ from transformers import AutoTokenizer, PreTrainedTokenizer
 from param_decomp.base_config import BaseConfig
 from param_decomp.distributed import DistributedState
 from param_decomp.log import logger
+from param_decomp_lab.infra.hf_http import configure_hf_http_retries
 
 
 class LMDataConfig(BaseConfig):
@@ -164,6 +165,7 @@ def create_lm_data_loader(
     collate_fn: Callable[..., Any] | None = None,
 ) -> tuple[DataLoader[Any], PreTrainedTokenizer]:
     """Create an LM token dataloader from a HuggingFace dataset split."""
+    configure_hf_http_retries()
     dataset = load_dataset(
         cfg.dataset_name,
         data_files=cfg.data_files,

--- a/param_decomp_lab/infra/ddp_launch.py
+++ b/param_decomp_lab/infra/ddp_launch.py
@@ -16,9 +16,13 @@ GPUS_PER_NODE = 8
 
 # Surface NCCL collective failures as Python exceptions instead of hanging the job —
 # matters for multi-node where a single stalled rank otherwise hangs everyone silently.
+# HF_HUB_*_TIMEOUT raise HF's 10s default: every rank hits the Hub at startup to resolve
+# the dataset, and that burst can blow the 10s wire (hf_http.py retries catch the rest).
 DDP_ENV = {
     "NCCL_DEBUG": "WARN",
     "TORCH_NCCL_ASYNC_ERROR_HANDLING": "1",
+    "HF_HUB_ETAG_TIMEOUT": "30",
+    "HF_HUB_DOWNLOAD_TIMEOUT": "30",
 }
 
 

--- a/param_decomp_lab/infra/hf_http.py
+++ b/param_decomp_lab/infra/hf_http.py
@@ -1,0 +1,54 @@
+"""Make huggingface_hub's HTTP backend resilient to transient network flakiness.
+
+HF's default session retries file *downloads* (via `http_backoff`) but mounts a bare
+adapter for metadata calls like `HfApi.repo_info` — the call `datasets` makes to resolve
+a streaming dataset's layout at startup. A single `ReadTimeout` there raises, and in a
+DDP job that one rank's failure tears down every rank before training begins. This mounts
+a retrying adapter on the session factory so connect/read timeouts and 5xx/429 are
+retried with jittered backoff across *all* Hub HTTP calls (dataset, tokenizer, model).
+"""
+
+import requests
+from huggingface_hub import configure_http_backend
+from huggingface_hub.utils._http import UniqueRequestIdAdapter
+from urllib3.util.retry import Retry
+
+from param_decomp.log import logger
+
+_configured = False
+
+
+def configure_hf_http_retries(*, total_retries: int = 5, backoff_factor: float = 1.5) -> None:
+    """Install a retrying HTTP backend on huggingface_hub (idempotent, process-global).
+
+    `backoff_factor` with full jitter spaces retries at roughly 0, 1.5, 3, 6, 12s; the
+    jitter de-synchronizes the simultaneous retries of many DDP ranks. Only idempotent
+    methods (GET/HEAD) are retried, so non-idempotent writes are untouched.
+    """
+    global _configured
+    if _configured:
+        return
+
+    retry = Retry(
+        total=total_retries,
+        connect=total_retries,
+        read=total_retries,
+        status=total_retries,
+        backoff_factor=backoff_factor,
+        backoff_jitter=1.0,
+        status_forcelist=(429, 500, 502, 503, 504),
+        allowed_methods=frozenset({"GET", "HEAD", "OPTIONS"}),
+        respect_retry_after_header=True,
+        raise_on_status=False,
+    )
+
+    def backend_factory() -> requests.Session:
+        session = requests.Session()
+        adapter = UniqueRequestIdAdapter(max_retries=retry)
+        session.mount("http://", adapter)
+        session.mount("https://", adapter)
+        return session
+
+    configure_http_backend(backend_factory=backend_factory)
+    _configured = True
+    logger.info("Configured huggingface_hub HTTP retries (total=%d)", total_retries)


### PR DESCRIPTION
## Problem

A streaming `load_dataset` resolves the repo layout via `HfApi.repo_info` — a bare `requests.get(timeout=10)` with **no retry** (HF's default session retries downloads via `http_backoff`, but not metadata calls). Every DDP rank hits the Hub at startup, so one transient `ReadTimeout` aborts a rank and tears down the entire multi-node job before training begins. This killed a 16-GPU run at ~78s.

## Fix

- New `infra/hf_http.py::configure_hf_http_retries()` mounts a retrying adapter on huggingface_hub's session factory (5 retries, jittered exponential backoff on connect/read timeouts + 429/5xx, idempotent methods only). Process-global and idempotent; covers dataset, tokenizer, and model calls. Called at the `create_lm_data_loader` choke point so train/eval/harvest/reload all benefit.
- Raise `HF_HUB_ETAG_TIMEOUT` / `HF_HUB_DOWNLOAD_TIMEOUT` to 30s in `DDP_ENV`.

Verified live: a fresh 16-GPU run cleared dataset loading and reached training.

🤖 Generated with [Claude Code](https://claude.com/claude-code)