### PR TITLE
feat(metrics): allow one metric class as both a loss and an eval probe

### DIFF
--- a/param_decomp/metrics/CLAUDE.md
+++ b/param_decomp/metrics/CLAUDE.md
@@ -33,6 +33,32 @@ entry. Duplicate `type` literals in a single config are rejected.
 A metric that wants to manipulate state coupled to backward overrides `before_backward`
 and/or `after_backward` (see PPGD for the canonical example).
 
+## Metric identity (`instance_key`) and same-class loss + eval
+
+Metric instances are keyed everywhere — instance dicts, state-dict, and log-key
+suffixes — by `Metric.instance_key`, which defaults to the class name. A loss-capable
+config can override it by setting `name` (on `LossMetricConfig`). This is what lets the
+*same* metric class appear under both `pd.loss_metrics` and `eval.metrics`: without a
+distinct `name` their instance keys collide and `instantiate_metrics` rejects the
+overlap. Example — a 1-step PGD training loss plus a 20-step PGD eval probe:
+
+```yaml
+pd:
+  loss_metrics:
+    - type: PGDReconLoss        # instance_key "PGDReconLoss", auto-evaluated too
+      coeff: 0.5
+      n_steps: 1
+eval:
+  metrics:
+    - type: PGDReconLoss        # distinct instance_key -> no collision
+      name: PGDReconLoss_20step
+      n_steps: 20
+```
+
+`name` disambiguates scalar-output metrics (the log key is `{log_namespace}/{instance_key}`).
+A dict-returning metric flattens under its own internal keys, so two dict-returning
+instances of one class would still collide — namespace their keys if you need that.
+
 ## Config placement rule
 
 The default home for a config is `param_decomp/configs.py`. Move a config next to its

--- a/param_decomp/metrics/base.py
+++ b/param_decomp/metrics/base.py
@@ -63,8 +63,7 @@ class Metric[TConfig: BaseConfig](ABC):
         A loss-capable config may override it via `LossMetricConfig.name` so two
         instances of the same metric class (one loss, one eval) stay distinct.
         """
-        cfg = self.cfg
-        name = cfg.name if isinstance(cfg, LossMetricConfig) else None
+        name = self.cfg.name if isinstance(cfg, LossMetricConfig) else None
         return name if name is not None else type(self).__name__
 
     def bind(self, *, model: ComponentModel, device: str) -> None:

--- a/param_decomp/metrics/base.py
+++ b/param_decomp/metrics/base.py
@@ -21,9 +21,15 @@ class LossMetricConfig(BaseConfig):
 
     `coeff` is required when this metric is listed under `loss_metrics` (asserted by
     `PDConfig`'s field validator); ignored for eval-only instances.
+
+    `name` overrides the class name as this instance's identity (`Metric.instance_key`),
+    letting the same metric class appear under both `loss_metrics` and `eval.metrics`
+    with different settings — e.g. a 1-step PGD training loss alongside a 20-step PGD
+    eval probe. Leave `None` (the default) and the class name is used.
     """
 
     coeff: float | None = None
+    name: str | None = None
 
 
 MetricResult = Tensor | Mapping[str, Any]
@@ -49,6 +55,17 @@ class Metric[TConfig: BaseConfig](ABC):
         """Construct from a validated config. Runtime resources are attached later by `bind`."""
         self.cfg = cfg
         self._bound = False
+
+    @property
+    def instance_key(self) -> str:
+        """Identity for dict keys and log-key suffixes; defaults to the class name.
+
+        A loss-capable config may override it via `LossMetricConfig.name` so two
+        instances of the same metric class (one loss, one eval) stay distinct.
+        """
+        cfg = self.cfg
+        name = cfg.name if isinstance(cfg, LossMetricConfig) else None
+        return name if name is not None else type(self).__name__
 
     def bind(self, *, model: ComponentModel, device: str) -> None:
         """Attach the live `ComponentModel` and device, then call `reset()`.

--- a/param_decomp/metrics/dispatch.py
+++ b/param_decomp/metrics/dispatch.py
@@ -57,24 +57,25 @@ def instantiate_metrics(
     """Instantiate loss metrics from config and bind caller-supplied eval metrics.
 
     Loss metrics are auto-evaluated alongside dedicated eval metrics, so eval metrics
-    whose class name collides with a loss metric are rejected. Returns
-    `(loss_instances, eval_instances)`: `loss_instances` is keyed by `type` literal;
-    `eval_instances` is the full eval-pass set (loss + eval-only) keyed by class name.
+    whose `instance_key` collides with a loss metric are rejected — give one of them a
+    distinct `name` to run the same class in both. Returns `(loss_instances,
+    eval_instances)`, both keyed by `Metric.instance_key` (class name unless overridden).
     """
     loss_instances: dict[str, Metric[Any]] = {}
     for cfg in pd_config.loss_metrics:
-        assert cfg.type not in loss_instances, f"duplicate loss metric {cfg.type!r}"
         m = LOSS_METRIC_CLASSES[cfg.type](cfg)
+        assert m.instance_key not in loss_instances, f"duplicate loss metric {m.instance_key!r}"
         m.bind(model=component_model, device=device)
-        loss_instances[cfg.type] = m
+        loss_instances[m.instance_key] = m
 
     eval_only_instances: dict[str, Metric[Any]] = {}
     if eval_metrics is not None:
         for m in eval_metrics:
             m.bind(model=component_model, device=device)
-            metric_name = type(m).__name__
-            assert metric_name not in eval_only_instances, f"duplicate eval metric {metric_name!r}"
-            eval_only_instances[metric_name] = m
+            assert m.instance_key not in eval_only_instances, (
+                f"duplicate eval metric {m.instance_key!r}"
+            )
+            eval_only_instances[m.instance_key] = m
         overlap = sorted(set(loss_instances) & set(eval_only_instances))
         assert not overlap, (
             f"eval metrics overlap with pd_config.loss_metrics: {overlap}. Loss metrics "

--- a/param_decomp/metrics/output.py
+++ b/param_decomp/metrics/output.py
@@ -48,7 +48,7 @@ def collect_metric_outputs(active: list[Metric[Any]]) -> MetricOutType:
     for m in active:
         cleaned = _clean_metric_output(
             log_namespace=m.log_namespace,
-            metric_name=type(m).__name__,
+            metric_name=m.instance_key,
             computed_raw=m.compute(),
         )
         assert not set(outputs) & set(cleaned)

--- a/param_decomp/optimize.py
+++ b/param_decomp/optimize.py
@@ -390,22 +390,21 @@ class Trainer:
         eval_loop: "EvalLoop | None",
         device: str,
     ) -> dict[str, "Metric[Any]"]:
-        """Merge loss + eval-only metric instances keyed by class name.
+        """Merge loss + eval-only metric instances keyed by `Metric.instance_key`.
 
-        Binds each eval-only metric, rejects duplicate names within eval_loop, and
-        rejects overlap between eval-only and loss metrics (loss metrics are
-        auto-evaluated; duplicating them as eval metrics is a config error since
-        ``evaluate()`` keys by class name).
+        Binds each eval-only metric, rejects duplicate instance keys within eval_loop,
+        and rejects overlap between eval-only and loss metrics (loss metrics are
+        auto-evaluated). To run the same metric class as both a loss and an eval probe,
+        give one a distinct `name` so their instance keys don't collide.
         """
         eval_only_instances: dict[str, Metric[Any]] = {}
         if eval_loop is not None:
             for m in eval_loop.metrics:
                 m.bind(model=self.component_model, device=device)
-                metric_name = type(m).__name__
-                assert metric_name not in eval_only_instances, (
-                    f"duplicate eval metric {metric_name!r}"
+                assert m.instance_key not in eval_only_instances, (
+                    f"duplicate eval metric {m.instance_key!r}"
                 )
-                eval_only_instances[metric_name] = m
+                eval_only_instances[m.instance_key] = m
             overlap = sorted(set(self.loss_metrics) & set(eval_only_instances))
             assert not overlap, (
                 f"eval_loop.metrics overlap with pd_config.loss_metrics: {overlap}. Loss "
@@ -575,9 +574,7 @@ class Trainer:
                 cfg = cast(LossMetricConfig, self.loss_metrics[metric_name].cfg)
                 assert cfg.coeff is not None
                 total_loss = total_loss + cfg.coeff * loss_val
-                batch_log_data[f"loss/{type(self.loss_metrics[metric_name]).__name__}"] = (
-                    loss_val.item()
-                )
+                batch_log_data[f"loss/{metric_name}"] = loss_val.item()
             assert active_loss_names, (
                 f"No active loss metrics returned a loss at step {step}. "
                 f"Configured loss metrics: {list(self.loss_metrics)}"

--- a/param_decomp/tests/test_optimize.py
+++ b/param_decomp/tests/test_optimize.py
@@ -18,7 +18,7 @@ from param_decomp.configs import (
 )
 from param_decomp.decomposition_targets import DecompositionTargetConfig
 from param_decomp.metrics.base import Metric, MetricResult
-from param_decomp.metrics.faithfulness import FaithfulnessLossConfig
+from param_decomp.metrics.faithfulness import FaithfulnessLoss, FaithfulnessLossConfig
 from param_decomp.optimize import EvalLoop, Trainer
 from param_decomp.schedule import ScheduleConfig
 
@@ -190,6 +190,55 @@ def test_optimize_rejects_duplicate_eval_metric_names() -> None:
             eval_loop=make_eval_loop(
                 loader,
                 metrics=[DummyEvalMetric(DummyEvalConfig()), DummyEvalMetric(DummyEvalConfig())],
+            ),
+        )
+
+
+def test_same_metric_class_as_loss_and_eval_with_distinct_name() -> None:
+    """A `name` override lets one metric class run as both a loss and an eval probe."""
+    sink = CaptureSink()
+    loader = make_loader()
+    trainer = Trainer(
+        target_model=TinyLinear(),
+        run_batch=run_batch_passthrough,
+        reconstruction_loss=recon_loss_mse,
+        pd_config=make_pd_config(loss_metrics=[FaithfulnessLossConfig(coeff=1.0)]),
+        runtime_config=RuntimeConfig(device="cpu", autocast_bf16=False),
+    )
+    trainer.run(
+        loader,
+        sink,
+        make_cadence(train_log_every=1),
+        eval_loop=make_eval_loop(
+            loader,
+            metrics=[FaithfulnessLoss(FaithfulnessLossConfig(coeff=1.0, name="Faithfulness_eval"))],
+            every=1,
+        ),
+    )
+
+    eval_logs = [m for _, m in sink.logged if any(k.startswith("eval/") for k in m)]
+    assert eval_logs, "expected at least one eval log"
+    keys = eval_logs[-1]
+    assert "eval/loss/FaithfulnessLoss" in keys  # auto-evaluated training loss
+    assert "eval/loss/Faithfulness_eval" in keys  # distinct eval-only instance
+
+
+def test_same_metric_class_in_loss_and_eval_without_name_collides() -> None:
+    loader = make_loader()
+    with pytest.raises(AssertionError, match="overlap"):
+        trainer = Trainer(
+            target_model=TinyLinear(),
+            run_batch=run_batch_passthrough,
+            reconstruction_loss=recon_loss_mse,
+            pd_config=make_pd_config(loss_metrics=[FaithfulnessLossConfig(coeff=1.0)]),
+            runtime_config=RuntimeConfig(device="cpu", autocast_bf16=False),
+        )
+        trainer.run(
+            loader,
+            CaptureSink(),
+            make_cadence(),
+            eval_loop=make_eval_loop(
+                loader, metrics=[FaithfulnessLoss(FaithfulnessLossConfig(coeff=1.0))], every=1
             ),
         )
 


### PR DESCRIPTION
## Problem

Metric instances are keyed by class name everywhere — instance dicts, state-dict, and log-key suffixes. So the same metric class can't appear under both `pd.loss_metrics` and `eval.metrics`: the instantiation overlap check rejects it. This blocks a natural setup — a cheap 1-step PGD training loss plus a stronger 20-step PGD eval probe — since both are `PGDReconLoss`.

## Fix

- Add optional `name` to `LossMetricConfig` and a `Metric.instance_key` property: the class name unless `name` overrides it.
- Route every keying site (`dispatch.py`, `optimize.py` instance dict / loss-log key / overlap check, `output.py`) through `instance_key`.

Default behavior is unchanged — `instance_key` falls back to the class name, which equals the existing `type` literal. Two tests cover the new coexistence and the still-rejected collision.

```yaml
pd.loss_metrics:
  - type: PGDReconLoss        # 1-step, auto-evaluated too
eval.metrics:
  - type: PGDReconLoss
    name: PGDReconLoss_20step  # distinct instance_key -> no collision
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)