### PR TITLE
Load HF targets in their native dtype, not fp32

### DIFF
--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -81,6 +81,7 @@ class HFTarget(BaseConfig):
     kind: Literal["hf"] = "hf"
     model_class: str
     model_name: str
+    dtype: str = "auto"
 
 
 class PretrainedTarget(BaseConfig):
@@ -123,7 +124,9 @@ def build_target(target_cfg: LMTargetConfig) -> nn.Module:
     cls = _resolve_class(spec.model_class)
     match spec:
         case HFTarget():
-            target_model = ensure_cached_and_call(cls.from_pretrained, spec.model_name)
+            target_model = ensure_cached_and_call(
+                cls.from_pretrained, spec.model_name, dtype=spec.dtype
+            )
         case PretrainedTarget():
             from param_decomp_lab.experiments.lm.pretrain.run_info import PretrainRunInfo
 


### PR DESCRIPTION
## Description

Load HuggingFace target models in the checkpoint's native dtype instead of fp32. Adds an
overridable `dtype` field to `HFTarget` (default `"auto"`), forwarded to `from_pretrained`
in `build_target`.

## Related Issue

(none)

## Motivation and Context

When loading a model from HF, `build_target` silently loads the weights as **fp32** regardless of the checkpoint's actual dtype. This can waste a lot of memory: for example Llama-3.1-8B uses bf16 checkpoints, but these get converted to fp32, doubling the memory footprint of the weights.

`runtime.autocast_bf16` does not help — autocast only casts compute, not the model’s stored parameters.

## How Has This Been Tested?

Ran the targeted decomposition of `LlamaForCausalLM` (layer-18 MLP) on 4×L40. The fp32 version OOM’d, but after the fix it fits.

## Does this PR introduce a breaking change?

No functional break, but one behavior change to note: **bf16/fp16-checkpoint targets now load at their native precision** instead of being upcast to fp32. This slightly shifts the frozen target's outputs (the reconstruction / KL reference the decomposition is fit against) — it's the precision the model actually runs at, and autocast already made the matmuls bf16, so it's not a regression. 
**fp32-checkpoint models (gpt2, gpt2-xl) are byte-identical to before.**
