### PR TITLE
fix(lm): retry HTTP 408 from the HF CDN in the hub retry backend

### DIFF
--- a/param_decomp_lab/infra/hf_http.py
+++ b/param_decomp_lab/infra/hf_http.py
@@ -4,7 +4,7 @@ HF's default session retries file *downloads* (via `http_backoff`) but mounts a 
 adapter for metadata calls like `HfApi.repo_info` — the call `datasets` makes to resolve
 a streaming dataset's layout at startup. A single `ReadTimeout` there raises, and in a
 DDP job that one rank's failure tears down every rank before training begins. This mounts
-a retrying adapter on the session factory so connect/read timeouts and 5xx/429 are
+a retrying adapter on the session factory so connect/read timeouts and 408/429/5xx are
 retried with jittered backoff across *all* Hub HTTP calls (dataset, tokenizer, model).
 """
 
@@ -36,7 +36,7 @@ def configure_hf_http_retries(*, total_retries: int = 5, backoff_factor: float =
         status=total_retries,
         backoff_factor=backoff_factor,
         backoff_jitter=1.0,
-        status_forcelist=(429, 500, 502, 503, 504),
+        status_forcelist=(408, 429, 500, 502, 503, 504),
         allowed_methods=frozenset({"GET", "HEAD", "OPTIONS"}),
         respect_retry_after_header=True,
         raise_on_status=False,


### PR DESCRIPTION
## Description

Adds `408` to the `status_forcelist` of the retrying HTTP backend installed by `configure_hf_http_retries` (and updates the module docstring to match).

## Related Issue

Follow-up to #557.

## Motivation and Context

Job 703812 (16-rank multi-node pd-lm) died ~2 minutes in, at dataloader setup: a ranged parquet read of a Pile shard got a **408 Request Time-out** from the HF CDN, one rank raised `HfHubHTTPError`, and torchrun tore down the whole job (the TCPStore broken-pipe spam in the log is just the other ranks reacting).

The #557 retry backend was active (`Configured huggingface_hub HTTP retries (total=5)` in the log) but its `status_forcelist` only covered 429/5xx, so urllib3 handed the 408 back unretried and `hf_raise_for_status` raised. `datasets`' own `read_with_retries` doesn't retry `HfHubHTTPError` either, so nothing caught it.

408 is exactly the transient-timeout class that backend exists for, and the retry config already restricts itself to idempotent methods (GET/HEAD/OPTIONS), so retrying a ranged read is safe.

## How Has This Been Tested?

`basedpyright` + `ruff` pass. Behavior change is a one-element addition to urllib3's `Retry` forcelist; the retry machinery itself is unchanged from #557 and has been exercised on cluster since.

## Does this PR introduce a breaking change?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)