### PR TITLE
fix(jax): swallow wandb CommError in MetricsSink.log (robustness parity)

### DIFF
--- a/param_decomp_jax/jax_single_pool/run.py
+++ b/param_decomp_jax/jax_single_pool/run.py
@@ -160,7 +160,12 @@ class MetricsSink:
             flush=True,
         )
         if self._wandb is not None:
-            self._wandb.log(record, step=step)
+            # CommError catches wandb-server hiccups (a transient outage must not kill a
+            # multi-day run) while letting genuine misuse (e.g. a non-dict record) raise.
+            try:
+                self._wandb.log(record, step=step)
+            except self._wandb.errors.CommError as e:
+                print(f"wandb communication error, skipping log: {e}", flush=True)
 
 
 def train(


### PR DESCRIPTION
Closes #697

## What changed
JAX `MetricsSink.log` called `self._wandb.log(record, step=step)` raw, so a transient wandb-server outage would crash a multi-day JAX run that torch (via `try_wandb`) survives.

Now wraps the `wandb.log` call to catch `wandb.errors.CommError` only — transient server hiccups warn-and-continue, while genuine misuse (e.g. a non-dict record, which raises `TypeError`) still fails fast. This matches torch's `try_wandb` (`param_decomp_lab/infra/wandb.py`), which catches only `CommError`.

## Verification
- `python3 -m py_compile param_decomp_jax/jax_single_pool/run.py` passes.
- Pre-commit ruff + basedpyright pass.
- The catch is scoped to `CommError` (not bare `Exception`), so a `TypeError`-style misuse still raises per the acceptance criteria.

🤖 Generated with [Claude Code](https://claude.com/claude-code)