### PR TITLE
fix(jax): assert finite logged losses in train step (#703)

### DIFF
--- a/param_decomp_jax/jax_single_pool/run.py
+++ b/param_decomp_jax/jax_single_pool/run.py
@@ -15,6 +15,7 @@ process computes the same global schedule and contributes its local batch slice.
 import argparse
 import dataclasses
 import json
+import math
 import signal
 import subprocess
 import time
@@ -306,6 +307,10 @@ def train(
             per_step = dt / max(now_step - last_logged, 1)
             last_logged = now_step
             record = {k: float(v) for k, v in metrics.items()}
+            for loss_name in ("total", *(k for k in record if k.startswith("loss/"))):
+                assert math.isfinite(record[loss_name]), (
+                    f"non-finite loss {loss_name!r} at step {now_step}: {record[loss_name]}"
+                )
             record["step_time_s"] = per_step
             record["tok_per_s"] = tokens_per_step / per_step
             record["tok_per_s_per_gpu"] = tokens_per_step / per_step / ndev


### PR DESCRIPTION
Closes #703

## What changed
Adds a fail-fast finiteness guard at the JAX host boundary in `param_decomp_jax/jax_single_pool/run.py`, where per-step scalars are pulled to host for logging. The total loss and every per-term recon loss (`loss/*`) are asserted finite each logged step; a NaN/inf now aborts the run with a step-stamped message instead of silently logging it and burning multi-day compute.

This mirrors torch's existing guard in `param_decomp/train_step.py:246-259` (per-metric `assert torch.isfinite(...)` + total-loss assert).

## Verification
- `python3 -m py_compile` on `run.py` passes.
- Pre-commit (ruff + basedpyright) passes after `make install-dev`.
- The check fires on the exact dict (`record`) already materialized from device — no extra device transfer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)