### PR TITLE
docs(jax-eval): confirm in-loop eval aggregation is mean-safe vs torch (#691)

### DIFF
--- a/param_decomp_jax/jax_single_pool/eval.py
+++ b/param_decomp_jax/jax_single_pool/eval.py
@@ -11,6 +11,35 @@ variant is a masked forward with ALL sites live and no routing; only `stoch_mask
 carries a weight-delta mask (torch `make_mask_infos` without weight deltas drops the
 delta term — delta mask 0 here). CE is next-token cross-entropy with the first label
 ignored; KL is per-position vs the clean (frozen) logits.
+
+Cross-batch aggregation (the multi-`n_steps` eval pass in `run.py`): every key this
+function returns is a per-BATCH scalar that the caller averages uniformly over the
+eval batches. This is mean-safe against the torch reference — i.e. it matches torch's
+accumulate-then-`compute()` to within float reassociation — only because every emitted
+key is itself a per-batch reduction that torch *also* averages across batches, and the
+eval batches are uniform `(B, T)`. The S8/D2 Jensen trap (a nonlinearity applied AFTER
+the cross-batch reduction, so mean-of-batch-results ≠ result-of-global-batch) does NOT
+arise here, because no emitted key wraps the cross-batch axis in a nonlinearity:
+
+- `ce_kl/kl_<variant>`: torch `CEandKLLosses` accumulates `kl * n_positions` and divides
+  by total positions (token-weighted mean of a per-batch mean). Uniform `(B, T)` makes
+  token-weighting equal to the uniform `1/n_steps` average here.
+- `ce_kl/ce_difference_<variant>` = `ce_v - ce_target`: torch averages this per-batch
+  DIFFERENCE (computed inside `_calc_ce_and_kl_losses`), not a difference of grand means.
+  Linear, so uniform-average parity holds.
+- `ce_kl/ce_unrecovered_<variant>` = `(ce_v - ce_target) / (ce_zero - ce_target)`: the
+  potential Jensen term. But torch forms this RATIO per-batch too, then averages the
+  per-batch ratios — it never divides grand-mean numerator by grand-mean denominator. So
+  averaging JAX's per-batch ratios matches torch exactly; no global-sum-before-divide is
+  needed.
+- `l0/<threshold>_<site|group>`: torch `CI_L0` collects per-batch L0 and averages them
+  uniformly (`sum / count`); group L0 is a per-batch sum of member L0s. Linear.
+- `loss/PGDReconLoss`: torch `PGDReconLoss` accumulates `kl * n` over batches and divides
+  by total `n` (example-weighted mean of a per-batch mean KL); equals the uniform average
+  under uniform `(B, T)`.
+
+Both production yamls run `eval.n_steps: 1`, so today the cross-batch average is a no-op;
+the parity argument above is what keeps it correct if `n_steps` is raised.
 """
 
 from fnmatch import fnmatch

--- a/param_decomp_jax/jax_single_pool/run.py
+++ b/param_decomp_jax/jax_single_pool/run.py
@@ -320,6 +320,10 @@ def train(
         if cfg.eval is not None and now_step % cfg.eval.every == 0:
             assert eval_step_fn is not None and eval_server is not None
             eval_pass_index = now_step // cfg.eval.every
+            # uniform-average of per-batch scalars; mean-safe vs torch's accumulate-then-
+            # compute() ONLY because every emitted key is a per-batch reduction that torch
+            # also averages across batches AND eval batches are uniform (B, T). See
+            # eval.py's module docstring for the per-key parity argument (cites SPEC S8/D2).
             metric_sums: dict[str, jax.Array] = {}
             for j in range(cfg.eval.n_steps):
                 eval_tokens = _global_token_batch(


### PR DESCRIPTION
Closes #691

## Finding

The JAX in-loop eval pass (`run.py`) averages per-batch metric scalars uniformly (`sum / n_steps`); torch (`optimize.py` → `run_eval_pass` → `Metric.compute()`) accumulates state then computes. The issue raised the S8/D2 Jensen concern: for any non-mean eval metric these two aggregations diverge.

Enumerated **every key** the JAX `eval_step` emits and checked each against its torch reference:

| key | torch aggregation | mean-safe? |
|---|---|---|
| `ce_kl/kl_<variant>` | token-weighted mean of per-batch mean (`CEandKLLosses`) | yes (uniform `(B,T)` ⇒ token-weight = uniform `1/n_steps`) |
| `ce_kl/ce_difference_<variant>` | per-batch difference, then averaged | yes (linear) |
| `ce_kl/ce_unrecovered_<variant>` | per-batch **ratio**, then averaged (NOT ratio of grand means) | yes — torch never divides grand-mean num/den, so averaging JAX's per-batch ratios matches |
| `l0/<threshold>_<site\|group>` | per-batch L0 averaged uniformly; group = per-batch sum of members (`CI_L0`) | yes (linear) |
| `loss/PGDReconLoss` | example-weighted mean of per-batch mean KL | yes (uniform `(B,T)`) |

The Jensen trap (S8/D2) is a nonlinearity applied **after** the cross-batch reduction. No emitted key wraps the cross-batch axis in a nonlinearity — in particular `ce_unrecovered` forms its ratio *per batch* in both impls — so uniform-averaging the per-batch scalars matches torch to within float reassociation.

Both production yamls (`llama8b_l18_C49k_200k_1pool`, `pile_llama_simple_mlp_4l_pgd1`) run `eval.n_steps: 1`, so the cross-batch average is currently a no-op; the per-key argument above is what keeps it correct if `n_steps` is raised. The plot-type metrics (CIHistograms, ComponentActivationDensity, CIMeanPerComponent, hidden-acts recon) are not emitted in-loop — they ride the offline `jsp-export` → `pd-offline-eval` path.

## Change

Documentation-only: no behavioral change is warranted because JAX already matches torch. Recorded the per-key parity argument in `eval.py`'s module docstring and a pointer comment at the `run.py` aggregation site.

## Verification

`py_compile` clean; pre-commit ruff + basedpyright passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)