### PR TITLE
feat(jax): plumb wandb group/tags through pd-jax-lm to wandb.init

### DIFF
--- a/param_decomp_jax/jax_single_pool/config.py
+++ b/param_decomp_jax/jax_single_pool/config.py
@@ -130,6 +130,11 @@ class ExperimentConfig:
     cadence: CadenceConfig
     eval: EvalConfig | None
     wandb: WandbConfig | None
+    wandb_group: str | None
+    """wandb UI group (`pd-jax-lm --group`); None = ungrouped. torch threads the
+    same CLI flag to `wandb.init(group=...)`."""
+    wandb_tags: tuple[str, ...]
+    """wandb tags (`pd-jax-lm --tags a,b,c`, comma-split); empty = untagged."""
 
     @property
     def run_dir(self) -> Path:

--- a/param_decomp_jax/jax_single_pool/run.py
+++ b/param_decomp_jax/jax_single_pool/run.py
@@ -133,6 +133,8 @@ class MetricsSink:
                 entity=cfg.wandb.entity,
                 name=cfg.run_name,
                 id=cfg.run_id,
+                group=cfg.wandb_group,
+                tags=list(cfg.wandb_tags),
                 resume="allow",
                 config=raw_cfg,
             )

--- a/param_decomp_jax/jax_single_pool/torch_config.py
+++ b/param_decomp_jax/jax_single_pool/torch_config.py
@@ -13,6 +13,8 @@ Entry: a small wrapper YAML carrying what the torch schema cannot express —
     run_name: my-run          # human-readable wandb display name
     out_dir: /mnt/data/.../param-decomp/runs
     remat_recon_forwards: false                     # jax-runtime memory/compute trade
+    wandb_group: my-sweep     # optional; wandb UI group (pd-jax-lm --group)
+    wandb_tags: [a, b]        # optional; wandb tags (pd-jax-lm --tags a,b)
 
 `jsp-train` detects the `torch_config` key and routes here (`load_torch_wrapper`).
 
@@ -226,6 +228,8 @@ def convert_torch_lm_config(
     run_id: str,
     out_dir: Path,
     remat_recon_forwards: bool,
+    wandb_group: str | None = None,
+    wandb_tags: tuple[str, ...] = (),
 ) -> ExperimentConfig:
     target = _resolve_target(torch_cfg)
 
@@ -294,11 +298,24 @@ def convert_torch_lm_config(
         ),
         eval=_eval(torch_cfg),
         wandb=torch_cfg.wandb,
+        wandb_group=wandb_group,
+        wandb_tags=wandb_tags,
     )
 
 
 WRAPPER_KEYS = {"torch_config", "run_id", "run_name", "out_dir", "remat_recon_forwards"}
+WRAPPER_OPTIONAL_KEYS = {"wandb_group", "wandb_tags"}
 _RUN_ID_PATTERN = re.compile(r"^p-[0-9a-f]{8}$")
+
+
+def _wandb_group_tags(raw: dict[str, Any]) -> tuple[str | None, tuple[str, ...]]:
+    """The wandb UI knobs (`pd-jax-lm --group`/`--tags`) are stamped into the wrapper
+    at submit time, like `run_id`; both default to absent for hand-written wrappers."""
+    group = raw.get("wandb_group")
+    assert group is None or isinstance(group, str), group
+    tags = raw.get("wandb_tags", [])
+    assert isinstance(tags, list) and all(isinstance(t, str) for t in tags), tags
+    return group, tuple(tags)
 
 
 def load_torch_wrapper(wrapper_path: Path) -> tuple[ExperimentConfig, Path, dict[str, Any]]:
@@ -310,19 +327,25 @@ def load_torch_wrapper(wrapper_path: Path) -> tuple[ExperimentConfig, Path, dict
     `pd-jax-lm` at submit time, so resumes derive the same identity and the
     byte-compare pins it."""
     raw = yaml.safe_load(wrapper_path.read_text())
-    assert set(raw) == WRAPPER_KEYS, f"{wrapper_path}: keys must be {sorted(WRAPPER_KEYS)}"
+    assert WRAPPER_KEYS <= set(raw) <= WRAPPER_KEYS | WRAPPER_OPTIONAL_KEYS, (
+        f"{wrapper_path}: keys must be {sorted(WRAPPER_KEYS)} "
+        f"(optional: {sorted(WRAPPER_OPTIONAL_KEYS)}), got {sorted(raw)}"
+    )
     run_id = raw["run_id"]
     assert _RUN_ID_PATTERN.match(run_id), f"run_id must be p-<8hex>, got {run_id!r}"
     torch_yaml_path = (wrapper_path.parent / raw["torch_config"]).resolve()
     assert torch_yaml_path.exists(), f"torch config not found: {torch_yaml_path}"
     torch_raw = yaml.safe_load(torch_yaml_path.read_text())
     torch_cfg = LMExperimentConfig(**torch_raw)
+    wandb_group, wandb_tags = _wandb_group_tags(raw)
     cfg = convert_torch_lm_config(
         torch_cfg,
         run_name=raw["run_name"],
         run_id=run_id,
         out_dir=Path(raw["out_dir"]),
         remat_recon_forwards=raw["remat_recon_forwards"],
+        wandb_group=wandb_group,
+        wandb_tags=wandb_tags,
     )
     return cfg, torch_yaml_path, torch_raw
 
@@ -336,12 +359,18 @@ def load_run_dir_config(run_dir: Path) -> ExperimentConfig:
     wrapper's own (launch-relative) path field is ignored — the pinned copy is the
     source of truth."""
     raw = yaml.safe_load((run_dir / "config.yaml").read_text())
-    assert set(raw) == WRAPPER_KEYS, f"{run_dir}/config.yaml: keys must be {sorted(WRAPPER_KEYS)}"
+    assert WRAPPER_KEYS <= set(raw) <= WRAPPER_KEYS | WRAPPER_OPTIONAL_KEYS, (
+        f"{run_dir}/config.yaml: keys must be {sorted(WRAPPER_KEYS)} "
+        f"(optional: {sorted(WRAPPER_OPTIONAL_KEYS)}), got {sorted(raw)}"
+    )
     torch_raw = yaml.safe_load((run_dir / "experiment_config.yaml").read_text())
+    wandb_group, wandb_tags = _wandb_group_tags(raw)
     return convert_torch_lm_config(
         LMExperimentConfig(**torch_raw),
         run_name=raw["run_name"],
         run_id=raw["run_id"],
         out_dir=Path(raw["out_dir"]),
         remat_recon_forwards=raw["remat_recon_forwards"],
+        wandb_group=wandb_group,
+        wandb_tags=wandb_tags,
     )

--- a/param_decomp_lab/experiments/lm/jax_launch.py
+++ b/param_decomp_lab/experiments/lm/jax_launch.py
@@ -49,6 +49,8 @@ def main(
     time: str = "72:00:00",
     qos: str | None = None,
     run_id: str | None = None,
+    group: str | None = None,
+    tags: str | None = None,
 ) -> None:
     """Submit a jsp-train run.
 
@@ -60,17 +62,21 @@ def main(
         time: SLURM time limit.
         qos: SLURM QoS (e.g. `opportunistic`); None is the normal QoS.
         run_id: Resubmit an existing launch — reuses its workspace (and identity)
-            instead of building a new one.
+            instead of building a new one. `group`/`tags` are ignored on resubmit
+            (the original workspace wrapper already carries them).
+        group: wandb UI group (no-op when the torch config omits `wandb:`).
+        tags: Comma-separated wandb tags (no-op when `wandb:` is omitted).
     """
     wrapper_rel = _wrapper_path_relative_to_repo(config_path)
     torch_cfg, run_name = _validate_wrapper(REPO_ROOT / wrapper_rel)
+    tag_list = [s.strip() for s in tags.split(",")] if tags is not None else []
 
     if run_id is None:
         run_id = generate_run_id("param_decomp")
         snapshot_ref, commit_hash = create_git_snapshot(snapshot_id=run_id)
         logger.info(f"Created git snapshot: {snapshot_ref} ({commit_hash[:8]})")
         workspace = WORKSPACES_DIR / run_id
-        _build_workspace(workspace, snapshot_ref, run_id, wrapper_rel)
+        _build_workspace(workspace, snapshot_ref, run_id, wrapper_rel, group, tag_list)
     else:
         snapshot_ref = f"refs/runs/snapshot/{run_id}"
         workspace = WORKSPACES_DIR / run_id
@@ -131,8 +137,8 @@ def _validate_wrapper(wrapper_path: Path) -> tuple[LMExperimentConfig, str]:
     raw = yaml.safe_load(wrapper_path.read_text())
     expected = {"torch_config", "run_name", "out_dir", "remat_recon_forwards"}
     assert set(raw) == expected, (
-        f"{wrapper_path}: keys must be {sorted(expected)} (run_id is minted at submit), "
-        f"got {sorted(raw)}"
+        f"{wrapper_path}: keys must be {sorted(expected)} "
+        f"(run_id/wandb_group/wandb_tags are stamped at submit), got {sorted(raw)}"
     )
     torch_yaml_path = (wrapper_path.parent / raw["torch_config"]).resolve()
     assert torch_yaml_path.exists(), f"torch config not found: {torch_yaml_path}"
@@ -143,7 +149,14 @@ def _validate_wrapper(wrapper_path: Path) -> tuple[LMExperimentConfig, str]:
     return torch_cfg, raw["run_name"]
 
 
-def _build_workspace(workspace: Path, snapshot_ref: str, run_id: str, wrapper_rel: Path) -> None:
+def _build_workspace(
+    workspace: Path,
+    snapshot_ref: str,
+    run_id: str,
+    wrapper_rel: Path,
+    group: str | None,
+    tags: list[str],
+) -> None:
     """Materialize the snapshot as an immutable shared-FS checkout with both venvs."""
     assert not workspace.exists(), f"workspace already exists: {workspace}"
     workspace.parent.mkdir(parents=True, exist_ok=True)
@@ -167,9 +180,14 @@ def _build_workspace(workspace: Path, snapshot_ref: str, run_id: str, wrapper_re
     run(["make", "install-jax-cuda"], cwd=workspace)
 
     wrapper = workspace / wrapper_rel
-    assert "run_id" not in yaml.safe_load(wrapper.read_text())
+    stamped: dict[str, str | list[str]] = {"run_id": run_id}
+    if group is not None:
+        stamped["wandb_group"] = group
+    if tags:
+        stamped["wandb_tags"] = tags
+    assert not (set(stamped) & set(yaml.safe_load(wrapper.read_text())))
     with wrapper.open("a") as f:
-        f.write(f"\nrun_id: {run_id}\n")
+        f.write("\n" + yaml.safe_dump(stamped, sort_keys=False))
 
 
 def _wandb_url(torch_cfg: LMExperimentConfig, run_id: str) -> str | None:


### PR DESCRIPTION
Closes #693

## What changed
JAX `jsp-train` runs could not be UI-grouped or tagged in wandb — `wandb.init` was called with no `group=`/`tags=`. This threads the torch CLI convention through the JAX launch path.

- `pd-jax-lm` (`jax_launch.py`) now accepts `--group` / `--tags`. Tags are comma-split with the same idiom as torch (`[s.strip() for s in tags.split(',')]`). Both are stamped into the workspace's wrapper yaml at submit time, alongside `run_id` (so requeues/resumes carry them via the immutable workspace; ignored on `--run_id` resubmit).
- `torch_config.py`: `wandb_group` / `wandb_tags` are optional wrapper keys (absent for hand-written wrappers). `load_torch_wrapper` and `load_run_dir_config` parse them and thread them onto `ExperimentConfig`; the exporter roundtrips them.
- `config.py`: `ExperimentConfig` carries `wandb_group: str | None` and `wandb_tags: tuple[str, ...]`.
- `run.py`: `MetricsSink` passes `group=`/`tags=` to `wandb.init`.

Group/tags live as CLI flags + stamped wrapper keys, NOT on the `WandbConfig` schema — matching torch, where they're threaded to `with_wandb` rather than the config schema.

## Verification
- `py_compile` on all four files.
- pre-commit (ruff + basedpyright) green after `make install-dev`.
- Existing `convert_torch_lm_config` / `load_torch_wrapper` / `load_run_dir_config` tests unaffected (new params default to absent; relaxed wrapper-key assertion still accepts the no-optional-keys case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)