### PR TITLE
chore(launcher): de-duplicate pd-jax-lm wrapper-key set

### DIFF
--- a/param_decomp_config/jax_wrapper.py
+++ b/param_decomp_config/jax_wrapper.py
@@ -1,0 +1,26 @@
+"""Canonical key set for the `pd-jax-lm` wrapper yaml — the single source of truth
+shared by the lab-side launcher (`jax_launch._validate_wrapper`, torch venv) and the
+runtime loader (`jax_single_pool.torch_config.load_torch_wrapper`, jax venv).
+
+Lives here, in the torch-free config package, because it's the only distribution both
+venvs install; neither side can import the other's package. See the wrapper schema in
+`jax_single_pool.torch_config`'s module docstring.
+
+`run_id`, `wandb_group`, and `wandb_tags` are minted from the launch (`pd-jax-lm`
+mints the id; `--group`/`--tags` supply the rest) and appended to the workspace copy
+at submit time — so a hand-authored wrapper carries `WRAPPER_KEYS_BEFORE_SUBMIT` and
+the stamped copy the loader reads carries the required `WRAPPER_KEYS` plus whichever
+`WRAPPER_OPTIONAL_KEYS` the launch supplied.
+"""
+
+RUN_ID_KEY = "run_id"
+
+WRAPPER_KEYS = frozenset(
+    {"torch_config", RUN_ID_KEY, "run_name", "out_dir", "remat_recon_forwards"}
+)
+
+WRAPPER_OPTIONAL_KEYS = frozenset({"wandb_group", "wandb_tags"})
+
+SUBMIT_MINTED_KEYS = frozenset({RUN_ID_KEY}) | WRAPPER_OPTIONAL_KEYS
+
+WRAPPER_KEYS_BEFORE_SUBMIT = WRAPPER_KEYS - SUBMIT_MINTED_KEYS

--- a/param_decomp_jax/jax_single_pool/tests/test_torch_config.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_torch_config.py
@@ -12,10 +12,18 @@ from jax_single_pool.llama8b import mlp_family_site_cs
 from jax_single_pool.lm import SiteC
 from jax_single_pool.recon import build_recon_terms
 from jax_single_pool.torch_config import (
+    WRAPPER_KEYS,
+    WRAPPER_OPTIONAL_KEYS,
     convert_torch_lm_config,
     load_run_dir_config,
     load_torch_wrapper,
 )
+from param_decomp_config.jax_wrapper import (
+    RUN_ID_KEY,
+    SUBMIT_MINTED_KEYS,
+    WRAPPER_KEYS_BEFORE_SUBMIT,
+)
+from param_decomp_config.jax_wrapper import WRAPPER_KEYS as SHARED_WRAPPER_KEYS
 from param_decomp_config.losses import PersistentPGDReconLossConfig
 
 CONFIGS = Path(__file__).parent.parent / "configs"
@@ -243,3 +251,21 @@ def test_wrapper_run_id_required_and_drives_identity(tmp_path: Path):
     bad_id.write_text(wrapper.read_text().replace(RUN_ID, "run42"))
     with pytest.raises(AssertionError, match="run_id must be"):
         load_torch_wrapper(bad_id)
+
+
+def test_loader_uses_shared_wrapper_key_set():
+    """The runtime loader's key sets are the shared constants (no hand-copied
+    literals); a hand-authored wrapper carries the required keys minus run_id, and
+    the submit-minted keys are exactly run_id + the optional wandb knobs."""
+    assert WRAPPER_KEYS is SHARED_WRAPPER_KEYS
+    assert WRAPPER_KEYS_BEFORE_SUBMIT | {RUN_ID_KEY} == WRAPPER_KEYS
+    assert {RUN_ID_KEY} | WRAPPER_OPTIONAL_KEYS == SUBMIT_MINTED_KEYS
+
+
+def test_loader_rejects_unexpected_key(tmp_path: Path):
+    wrapper = _stamped_wrapper(tmp_path, CONFIGS / "llama8b_l18_C49k_200k_from_torch.yaml")
+    raw = yaml.safe_load(wrapper.read_text())
+    raw["bogus_key"] = "x"
+    wrapper.write_text(yaml.safe_dump(raw))
+    with pytest.raises(AssertionError, match="keys must be"):
+        load_torch_wrapper(wrapper)

--- a/param_decomp_jax/jax_single_pool/torch_config.py
+++ b/param_decomp_jax/jax_single_pool/torch_config.py
@@ -52,6 +52,7 @@ from jax_single_pool.llama8b import SITE_NAME_PATTERN, canonical_site_cs
 from jax_single_pool.lm import SiteC
 from jax_single_pool.recon import build_recon_terms
 from param_decomp_config.eval_metrics import CEandKLLossesConfig, CI_L0Config
+from param_decomp_config.jax_wrapper import WRAPPER_KEYS, WRAPPER_OPTIONAL_KEYS
 from param_decomp_config.lm import (
     HFTarget,
     HFWeightsInVendored,
@@ -303,8 +304,6 @@ def convert_torch_lm_config(
     )
 
 
-WRAPPER_KEYS = {"torch_config", "run_id", "run_name", "out_dir", "remat_recon_forwards"}
-WRAPPER_OPTIONAL_KEYS = {"wandb_group", "wandb_tags"}
 _RUN_ID_PATTERN = re.compile(r"^p-[0-9a-f]{8}$")
 
 

--- a/param_decomp_lab/experiments/lm/jax_launch.py
+++ b/param_decomp_lab/experiments/lm/jax_launch.py
@@ -18,6 +18,11 @@ import fire
 import yaml
 
 from param_decomp.log import logger
+from param_decomp_config.jax_wrapper import (
+    RUN_ID_KEY,
+    SUBMIT_MINTED_KEYS,
+    WRAPPER_KEYS_BEFORE_SUBMIT,
+)
 from param_decomp_config.lm import LMExperimentConfig
 from param_decomp_lab.infra.git import create_git_snapshot
 from param_decomp_lab.infra.run_files import generate_run_id
@@ -132,13 +137,16 @@ def _wrapper_path_relative_to_repo(config_path: str) -> Path:
 
 
 def _validate_wrapper(wrapper_path: Path) -> tuple[LMExperimentConfig, str]:
-    """Lab-side mirror of `jax_single_pool.torch_config.load_torch_wrapper`'s checks
-    (which can't be imported here — that module pulls jax)."""
+    """Validate a not-yet-stamped wrapper against the same key set the runtime loader
+    (`jax_single_pool.torch_config.load_torch_wrapper`) enforces. The loader's module
+    pulls jax and can't be imported in this venv, but both sides read the shared
+    `param_decomp_config.jax_wrapper` constants — `run_id`/`wandb_group`/`wandb_tags`
+    are minted and appended at submit, so a hand-authored wrapper carries exactly
+    `WRAPPER_KEYS_BEFORE_SUBMIT`."""
     raw = yaml.safe_load(wrapper_path.read_text())
-    expected = {"torch_config", "run_name", "out_dir", "remat_recon_forwards"}
-    assert set(raw) == expected, (
-        f"{wrapper_path}: keys must be {sorted(expected)} "
-        f"(run_id/wandb_group/wandb_tags are stamped at submit), got {sorted(raw)}"
+    assert set(raw) == WRAPPER_KEYS_BEFORE_SUBMIT, (
+        f"{wrapper_path}: keys must be {sorted(WRAPPER_KEYS_BEFORE_SUBMIT)} "
+        f"({sorted(SUBMIT_MINTED_KEYS)} are stamped at submit), got {sorted(raw)}"
     )
     torch_yaml_path = (wrapper_path.parent / raw["torch_config"]).resolve()
     assert torch_yaml_path.exists(), f"torch config not found: {torch_yaml_path}"
@@ -180,11 +188,12 @@ def _build_workspace(
     run(["make", "install-jax-cuda"], cwd=workspace)
 
     wrapper = workspace / wrapper_rel
-    stamped: dict[str, str | list[str]] = {"run_id": run_id}
+    stamped: dict[str, str | list[str]] = {RUN_ID_KEY: run_id}
     if group is not None:
         stamped["wandb_group"] = group
     if tags:
         stamped["wandb_tags"] = tags
+    assert set(stamped) <= SUBMIT_MINTED_KEYS
     assert not (set(stamped) & set(yaml.safe_load(wrapper.read_text())))
     with wrapper.open("a") as f:
         f.write("\n" + yaml.safe_dump(stamped, sort_keys=False))

--- a/param_decomp_lab/tests/test_jax_launch.py
+++ b/param_decomp_lab/tests/test_jax_launch.py
@@ -1,0 +1,31 @@
+"""The lab-side wrapper validator (`pd-jax-lm`, torch venv) and the runtime loader
+(`jax_single_pool.torch_config`, jax venv) share one key set; the jax side can't be
+imported here, so this exercises only the lab half. The shared-set contract itself is
+asserted in `param_decomp_config` terms below."""
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from param_decomp_config.jax_wrapper import (
+    RUN_ID_KEY,
+    SUBMIT_MINTED_KEYS,
+    WRAPPER_KEYS,
+    WRAPPER_KEYS_BEFORE_SUBMIT,
+    WRAPPER_OPTIONAL_KEYS,
+)
+from param_decomp_lab.experiments.lm.jax_launch import _validate_wrapper
+
+
+def test_submit_minted_keys_reconstitute_the_required_set():
+    assert WRAPPER_KEYS_BEFORE_SUBMIT | {RUN_ID_KEY} == WRAPPER_KEYS
+    assert {RUN_ID_KEY} | WRAPPER_OPTIONAL_KEYS == SUBMIT_MINTED_KEYS
+
+
+def test_validate_wrapper_rejects_unexpected_key(tmp_path: Path):
+    wrapper = tmp_path / "wrapper.yaml"
+    raw = {key: "x" for key in WRAPPER_KEYS_BEFORE_SUBMIT} | {"bogus_key": "x"}
+    wrapper.write_text(yaml.safe_dump(raw))
+    with pytest.raises(AssertionError, match="keys must be"):
+        _validate_wrapper(wrapper)


### PR DESCRIPTION
Closes #732

## What changed

The allowed wrapper-yaml key set was defined in three places (PARITY_MATRIX §12 row 1, EDGES E29 — a flagged drift risk):

1. a hand-copied literal in `jax_launch._validate_wrapper` ("Lab-side mirror …"),
2. `WRAPPER_KEYS` / `WRAPPER_OPTIONAL_KEYS` in `jax_single_pool.torch_config`,
3. the bare `"run_id"` literal in the launcher's submit-time append path.

Single source of truth: new torch-free module `param_decomp_config/jax_wrapper.py` exporting `WRAPPER_KEYS` (required), `WRAPPER_OPTIONAL_KEYS` (the `wandb_group`/`wandb_tags` knobs added by #774), `SUBMIT_MINTED_KEYS` (`run_id` + the wandb knobs), and `WRAPPER_KEYS_BEFORE_SUBMIT` (what a hand-authored wrapper carries). It lives in `param_decomp_config` because that's the only distribution **both** venvs install — the lab launcher (torch venv) cannot import `torch_config` (it pulls jax), so re-exporting from `torch_config` wouldn't be importable lab-side.

- `torch_config.py` imports the key sets from the shared module (re-exported, public names unchanged).
- `_validate_wrapper` reads `WRAPPER_KEYS_BEFORE_SUBMIT` / `SUBMIT_MINTED_KEYS` instead of a literal; its docstring no longer describes itself as a manual "mirror". The submit-append path uses `RUN_ID_KEY` and asserts the stamped keys are a subset of `SUBMIT_MINTED_KEYS`.
- The lab validator checks the pre-stamp set; the loader checks the required+optional set — the relationship is asserted in tests rather than maintained by hand.

## Tests

- `param_decomp_lab/tests/test_jax_launch.py` (new): `_validate_wrapper` rejects an unexpected key; the submit-minted-key reconstitution contract holds.
- `test_torch_config.py` (extended): the loader's `WRAPPER_KEYS` **is** the shared constant; the loader rejects an unexpected key via the same set.

## Verification

- `pytest param_decomp_lab/tests/test_jax_launch.py` — 2 passed (torch venv).
- pre-commit (ruff + basedpyright) clean.
- Rebased onto current feature/jax to reconcile with #774 (wandb_group/tags); conflicts resolved so those keys are modeled as `SUBMIT_MINTED_KEYS` from the shared module.
- The extended `test_torch_config.py` runs in the jax (`.venv-cuda`) venv, not built here; additions are syntax-checked and follow the existing fixture pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)