### PR TITLE
feat(jax): support pd.sigmoid_type variants in the CI fn (partial #729)

### DIFF
--- a/param_decomp_jax/jax_single_pool/SPEC.md
+++ b/param_decomp_jax/jax_single_pool/SPEC.md
@@ -253,7 +253,7 @@ init: biases zero; weights fan-in scaled (torch init_param_)
 | `SCOPE` | persistent: `c (1,1)` · `sc (1,T)` · `nsc (n,T), n|B` · `bsc (B,T)` (jax: `sc` only today) — fresh-PGD: `c` · `bc` · `bsc` | ★ sc |
 | stoch sampling | `continuous U[0,1]` · `binomial {0,1}` | ★ continuous |
 | delta component | on (`C+1` channels) · off (no delta path, no delta mask) | ★ on |
-| CI squashing | `leaky_hard` pair (§4.2); other registry sigmoids exist in torch but are out of spec scope | ★ leaky_hard |
+| CI squashing | `leaky_hard` asymmetric pair (§4.2) · `normal` · `hard` · `upper_leaky_hard` · `swish_hard` (each uses one fn for both lower/upper views, matching torch `ComponentModel`); selected by `pd.sigmoid_type` | ★ leaky_hard |
 
 A variant choice must hold every invariant not explicitly parameterized by it.
 

--- a/param_decomp_jax/jax_single_pool/ci_fn.py
+++ b/param_decomp_jax/jax_single_pool/ci_fn.py
@@ -11,7 +11,9 @@ The SAME logits are squashed two ways (SPEC S5/S6): `lower_leaky_hard` feeds the
 (SPEC N1); the trainer casts for bf16 compute.
 """
 
+from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Literal
 
 import equinox as eqx
 import jax
@@ -53,6 +55,69 @@ def upper_leaky_hard_sigmoid(x: Float[Array, "..."]) -> Float[Array, "..."]:
     (torch builds its backward the same way; only the lower squashing is a custom VJP)."""
     alpha = 0.01
     return jnp.where(x > 1, 1 + alpha * (x - 1), jnp.clip(x, 0.0, 1.0))
+
+
+def normal_sigmoid(x: Array) -> Array:
+    return jax.nn.sigmoid(x)
+
+
+def hard_sigmoid(x: Array) -> Array:
+    """`clamp(x, 0, 1)` — zero gradient outside `[0, 1]` (autodiff of the clip)."""
+    return jnp.clip(x, 0.0, 1.0)
+
+
+def leaky_hard_sigmoid(x: Array) -> Array:
+    """`alpha*x` for `x<=0`, `clamp(x, max=1)` otherwise — leaks on the lower side only
+    (mirrors torch `leaky_hard_sigmoid`; ordinary autodiff matches torch's backward)."""
+    alpha = 0.01
+    return jnp.where(x > 0, jnp.minimum(x, 1.0), alpha * x)
+
+
+def _swish(x: Array, beta: float) -> Array:
+    return x * jax.nn.sigmoid(beta * x)
+
+
+def _upside_down_swish(x: Array, beta: float) -> Array:
+    return x * jax.nn.sigmoid(-beta * x)
+
+
+def swish_hard_sigmoid(x: Array) -> Array:
+    """Smooth sigmoid built from Swish bumps at each boundary (mirrors torch
+    `swish_hard_sigmoid` defaults: beta=10, scale=0.5, xshift=0.5, yshift=0.5)."""
+    beta, scale, xshift, yshift = 10.0, 0.5, 0.5, 0.5
+    x = x - xshift
+    return (
+        yshift
+        + (_upside_down_swish(x - scale, beta) - _swish(x, beta))
+        + (_swish(x + scale, beta) - _upside_down_swish(x, beta))
+    )
+
+
+SigmoidType = Literal["normal", "hard", "leaky_hard", "upper_leaky_hard", "swish_hard"]
+"""The torch `pd.sigmoid_type` literals."""
+
+_SIGMOID_FNS: dict[str, Callable[[Array], Array]] = {
+    "normal": normal_sigmoid,
+    "hard": hard_sigmoid,
+    "leaky_hard": leaky_hard_sigmoid,
+    "upper_leaky_hard": upper_leaky_hard_sigmoid,
+    "lower_leaky_hard": lower_leaky_hard_sigmoid,
+    "swish_hard": swish_hard_sigmoid,
+}
+
+
+def squashing_fns(
+    sigmoid_type: SigmoidType,
+) -> tuple[Callable[[Array], Array], Callable[[Array], Array]]:
+    """The (lower, upper) squashings the CI fn applies to its raw logits, selected by
+    `sigmoid_type` exactly as torch `ComponentModel` does: `leaky_hard` is the asymmetric
+    production pair (custom-VJP lower-leak feeds recon/PPGD masks, upper-leak feeds
+    importance-minimality); every other type uses ONE function for both views (SPEC S5/S6;
+    torch component_model.py:180-186)."""
+    if sigmoid_type == "leaky_hard":
+        return _SIGMOID_FNS["lower_leaky_hard"], _SIGMOID_FNS["upper_leaky_hard"]
+    fn = _SIGMOID_FNS[sigmoid_type]
+    return fn, fn
 
 
 def _weightless_rms_norm(x: Array, eps: float) -> Array:
@@ -103,6 +168,7 @@ class CIFn(eqx.Module):
     site_names: tuple[str, ...] = eqx.field(static=True)
     split_sizes: tuple[int, ...] = eqx.field(static=True)
     eps: float = eqx.field(static=True)
+    sigmoid_type: SigmoidType = eqx.field(static=True)
 
     def __call__(self, site_inputs: dict[str, Array]) -> CIValues:
         """`site_inputs`: clean per-site inputs, keyed by site name (canonical order is
@@ -116,8 +182,9 @@ class CIFn(eqx.Module):
         for block in self.blocks:
             x = block(x, inv_freq)
         logits = x @ self.out_w + self.out_b  # (b, t, Σ_s C_s)
-        lower = lower_leaky_hard_sigmoid(logits)
-        upper = upper_leaky_hard_sigmoid(logits)
+        lower_fn, upper_fn = squashing_fns(self.sigmoid_type)
+        lower = lower_fn(logits)
+        upper = upper_fn(logits)
 
         offsets = [0]
         for c in self.split_sizes:
@@ -137,6 +204,7 @@ class CIArch:
     n_blocks: int
     n_heads: int
     mlp_hidden: int
+    sigmoid_type: SigmoidType = "leaky_hard"
 
 
 def init_ci_fn(arch: CIArch, sites: tuple[SiteSpec, ...], key: PRNGKeyArray) -> CIFn:
@@ -184,4 +252,5 @@ def init_ci_fn(arch: CIArch, sites: tuple[SiteSpec, ...], key: PRNGKeyArray) -> 
         site_names=tuple(s.name for s in sites),
         split_sizes=tuple(s.C for s in sites),
         eps=1e-5,
+        sigmoid_type=arch.sigmoid_type,
     )

--- a/param_decomp_jax/jax_single_pool/tests/test_ci_sigmoids.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_ci_sigmoids.py
@@ -1,0 +1,107 @@
+"""CI-fn output-squashing parity (torch `pd.sigmoid_type` → JAX `squashing_fns`).
+
+The torch sigmoids are simple closed forms; their reference outputs are encoded here as
+numpy expressions (the SAME math torch's `param_decomp.ci_sigmoids` runs), so this pins
+JAX↔torch forward parity for every supported `sigmoid_type` without importing torch.
+The one custom-VJP — `lower_leaky_hard` — also has its backward checked against torch's
+`LowerLeakyHardSigmoidFunction.backward`.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from jax_single_pool.ci_fn import (
+    hard_sigmoid,
+    leaky_hard_sigmoid,
+    lower_leaky_hard_sigmoid,
+    normal_sigmoid,
+    squashing_fns,
+    swish_hard_sigmoid,
+    upper_leaky_hard_sigmoid,
+)
+
+X = np.linspace(-3.0, 3.0, 61, dtype=np.float64)
+ALPHA = 0.01
+
+
+def _torch_normal(x):
+    return 1.0 / (1.0 + np.exp(-x))
+
+
+def _torch_hard(x):
+    return np.clip(x, 0.0, 1.0)
+
+
+def _torch_leaky_hard(x):
+    return np.where(x > 0, np.minimum(x, 1.0), ALPHA * x)
+
+
+def _torch_upper_leaky_hard(x):
+    return np.where(x > 1, 1 + ALPHA * (x - 1), np.clip(x, 0.0, 1.0))
+
+
+def _torch_swish(x, beta):
+    return x * (1.0 / (1.0 + np.exp(-beta * x)))
+
+
+def _torch_upside_down_swish(x, beta):
+    return x * (1.0 / (1.0 + np.exp(beta * x)))
+
+
+def _torch_swish_hard(x):
+    beta, scale, xshift, yshift = 10.0, 0.5, 0.5, 0.5
+    x = x - xshift
+    return (
+        yshift
+        + (_torch_upside_down_swish(x - scale, beta) - _torch_swish(x, beta))
+        + (_torch_swish(x + scale, beta) - _torch_upside_down_swish(x, beta))
+    )
+
+
+@pytest.mark.parametrize(
+    "jax_fn, torch_ref",
+    [
+        (normal_sigmoid, _torch_normal),
+        (hard_sigmoid, _torch_hard),
+        (leaky_hard_sigmoid, _torch_leaky_hard),
+        (upper_leaky_hard_sigmoid, _torch_upper_leaky_hard),
+        (lower_leaky_hard_sigmoid, _torch_hard),  # forward is exactly clamp(x,0,1)
+        (swish_hard_sigmoid, _torch_swish_hard),
+    ],
+)
+def test_forward_matches_torch_math(jax_fn, torch_ref):
+    got = np.asarray(jax_fn(jnp.asarray(X, dtype=jnp.float32)), dtype=np.float64)
+    np.testing.assert_allclose(got, torch_ref(X), rtol=1e-5, atol=1e-6)
+
+
+@pytest.mark.parametrize("g_sign", [1.0, -1.0])
+def test_lower_leaky_hard_backward_matches_torch(g_sign):
+    """torch `LowerLeakyHardSigmoidFunction.backward`: for x<=0 the leak `alpha*g` fires
+    ONLY when g<0; for 0<x<=1 grad passes through; for x>1 grad is zeroed."""
+    g = g_sign * np.ones_like(X)
+    _, vjp = jax.vjp(lower_leaky_hard_sigmoid, jnp.asarray(X, dtype=jnp.float32))
+    got = np.asarray(vjp(jnp.asarray(g, dtype=jnp.float32))[0], dtype=np.float64)
+    expected = np.where(
+        X <= 0,
+        np.where(g < 0, ALPHA * g, 0.0),
+        np.where(X <= 1, g, 0.0),
+    )
+    np.testing.assert_allclose(got, expected, rtol=1e-5, atol=1e-6)
+
+
+def test_squashing_dispatch_matches_torch_component_model():
+    """leaky_hard is the asymmetric production pair; every other type uses one fn twice
+    (torch component_model.py:180-186)."""
+    lower, upper = squashing_fns("leaky_hard")
+    assert lower is lower_leaky_hard_sigmoid and upper is upper_leaky_hard_sigmoid
+
+    for st, fn in [
+        ("normal", normal_sigmoid),
+        ("hard", hard_sigmoid),
+        ("upper_leaky_hard", upper_leaky_hard_sigmoid),
+        ("swish_hard", swish_hard_sigmoid),
+    ]:
+        lower, upper = squashing_fns(st)
+        assert lower is fn and upper is fn

--- a/param_decomp_jax/jax_single_pool/tests/test_torch_config.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_torch_config.py
@@ -184,6 +184,23 @@ def test_arbitrary_sites_with_per_site_c_convert():
     )
 
 
+def test_sigmoid_type_threads_into_ci_arch():
+    """A non-production `sigmoid_type` now converts (no longer refused) and flows to the
+    JAX CI fn arch verbatim."""
+    torch_cfg, raw = _reference_torch_cfg()
+    swish = dict(raw, pd=dict(raw["pd"], sigmoid_type="swish_hard"))
+    cfg = convert_torch_lm_config(
+        type(torch_cfg)(**swish), run_name="t", run_id=RUN_ID, out_dir=Path("/tmp"),
+        remat_recon_forwards=True,
+    )  # fmt: skip
+    assert cfg.ci_fn.sigmoid_type == "swish_hard"
+
+    default = convert_torch_lm_config(
+        torch_cfg, run_name="t", run_id=RUN_ID, out_dir=Path("/tmp"), remat_recon_forwards=True
+    )
+    assert default.ci_fn.sigmoid_type == "leaky_hard"
+
+
 def test_c49k_yaml_converts_with_documented_divergences(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ):

--- a/param_decomp_jax/jax_single_pool/torch_config.py
+++ b/param_decomp_jax/jax_single_pool/torch_config.py
@@ -142,6 +142,7 @@ def _ci_arch(cfg: LMExperimentConfig, seq_len: int) -> CIArch:
         n_blocks=transformer.n_blocks,
         n_heads=transformer.attn_config.n_heads,
         mlp_hidden=transformer.mlp_hidden_dim[0],
+        sigmoid_type=cfg.pd.sigmoid_type,
     )
 
 
@@ -229,7 +230,6 @@ def convert_torch_lm_config(
 ) -> ExperimentConfig:
     target = _resolve_target(torch_cfg)
 
-    assert torch_cfg.pd.sigmoid_type == "leaky_hard", torch_cfg.pd.sigmoid_type
     assert torch_cfg.pd.use_delta_component and torch_cfg.pd.tied_weights is None
     assert torch_cfg.runtime.autocast_bf16, "JAX trainer computes in bf16 (autocast analog)"
     assert torch_cfg.pd.faithfulness_warmup_weight_decay == 0.0


### PR DESCRIPTION
Partial close of #729 — implements the **`sigmoid_type`** variation point (one of the four refused PD-subspace fields). The other three (`use_delta_component=False`, `tied_weights`, `identity_decomposition_targets`) remain deferred and still refuse at convert time; #729 tracks the set and stays open.

## What changed
The JAX convert path hardwired `assert sigmoid_type == "leaky_hard"`. Now the torch `pd.sigmoid_type` threads through `CIArch` → `CIFn` (static field), and `ci_fn.squashing_fns(sigmoid_type)` selects the `(lower, upper)` squashing pair **exactly as torch `ComponentModel` does** (component_model.py:180-186):
- `leaky_hard` → asymmetric production pair (`lower_leaky_hard` custom-VJP + `upper_leaky_hard`)
- every other type → one function for both views

Added JAX impls of `normal` / `hard` / `leaky_hard` / `swish_hard` mirroring torch `param_decomp/ci_sigmoids.py`; `CIArch.sigmoid_type` defaults to `"leaky_hard"` (matches the torch schema default → existing fixtures unchanged); dropped the leaky_hard-only assert; SPEC variation-points CI-squashing row updated.

## Verification
- New `tests/test_ci_sigmoids.py`: torch-math parity for all 5 variant forwards, the `lower_leaky_hard` custom-VJP **backward** vs torch's `LowerLeakyHardSigmoidFunction.backward` (both grad signs), and the `squashing_fns` dispatch contract. Reference values are torch's exact closed forms encoded as numpy — no torch import needed.
- New `test_torch_config.py::test_sigmoid_type_threads_into_ci_arch`: a non-production `sigmoid_type` now converts (no longer refused) and flows verbatim.
- `python -m py_compile` clean; ruff lint+format passed. NOT run under JAX (deps-light worktree); pyright is a no-op here (param_decomp_jax is out of its include).

Equivalence here is pinned against torch's sigmoid math directly rather than the full fixture harness (which needs both a torch and a JAX env to regenerate goldens). Forward + backward are pinned for the custom-VJP variant.