### PR TITLE
test(jax-checkpoint): sharded TrainState round-trip at production per-rank shape (S22)

### DIFF
--- a/param_decomp_jax/jax_single_pool/tests/test_checkpoint.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_checkpoint.py
@@ -9,8 +9,16 @@ import jax
 import jax.numpy as jnp
 import optax
 
-from jax_single_pool.adversary import init_persistent_sources, init_sources_adam_state
-from jax_single_pool.checkpoint import make_checkpoint_manager, restore_latest, save_state
+from jax_single_pool.adversary import (
+    init_persistent_sources,
+    init_sources_adam_state,
+)
+from jax_single_pool.checkpoint import (
+    make_checkpoint_manager,
+    restore_latest,
+    restore_step,
+    save_state,
+)
 from jax_single_pool.ci_fn import CIArch, init_ci_fn
 from jax_single_pool.llama8b import (
     init_decomp_vu,
@@ -18,7 +26,13 @@ from jax_single_pool.llama8b import (
     llama_site_specs,
     mlp_family_site_cs,
 )
+from jax_single_pool.llama8b_sharding import (
+    init_ci_fn_sharded,
+    init_decomp_vu_sharded,
+    init_sources_sharded,
+)
 from jax_single_pool.recon import build_recon_terms
+from jax_single_pool.sharding import dp_mesh
 from jax_single_pool.tests.test_llama8b import _tiny_cfg, _tiny_target
 from jax_single_pool.train import TrainState, make_train_step
 from param_decomp_config.losses import (
@@ -117,3 +131,65 @@ def test_no_checkpoint_returns_none(tmp_path: Path):
     _, fresh, _, _ = _build(seed=7)
     mgr = make_checkpoint_manager(tmp_path / "empty", keep_last=2)
     assert restore_latest(mgr, fresh) is None
+
+
+def _build_sharded(seed: int, mesh):
+    """A `TrainState` placed exactly as the production trainer places it
+    (`run_state.init_train_state`): C-sharded V/U + ci_fn, replicated sources, over the
+    `dp` mesh. Built directly from the `*_sharded` init fns so the saved/restored
+    leaves carry real `NamedSharding`s — the production checkpoint path, not `mesh=None`."""
+    cfg = _tiny_cfg()
+    n = mesh.devices.size
+    C, seq = 8 * n, 16
+    sites = llama_site_specs(cfg, mlp_family_site_cs(3, 4, C))
+    lm = llama_decomposed_lm(cfg, sites)
+    vu = init_decomp_vu_sharded(sites, jax.random.PRNGKey(seed), mesh)
+    ci_fn = init_ci_fn_sharded(CIArch(16, 2, 2, 32), lm.sites, jax.random.PRNGKey(seed + 1), mesh)
+    opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
+    opt_ci = optax.adamw(1e-3, weight_decay=0.0)
+    src = init_sources_sharded(
+        lm.site_names, tuple(s.C for s in lm.sites), seq, jax.random.PRNGKey(seed + 2), mesh
+    )
+    state = TrainState(
+        components=vu, ci_fn=ci_fn,
+        components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
+        ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
+        sources={"PersistentPGDReconLoss": src},
+        sources_opt_state={"PersistentPGDReconLoss": init_sources_adam_state(src)},
+        step=jnp.asarray(7, jnp.int32),
+    )  # fmt: skip
+    return state
+
+
+def test_sharded_roundtrip_bit_equal(tmp_path: Path):
+    """S22 at the PRODUCTION per-rank shape: a sharded `TrainState` (the failure-prone
+    path that bit the torch job-34446 save and the jsp SIGTERM saves) must round-trip
+    through orbax onto a sharded reference bit-equal, leaf shardings preserved.
+
+    Run this at `XLA_FLAGS=--xla_force_host_platform_device_count=4` to exercise the
+    real multi-shard write/read; at the default 1 device it degrades to the replicated
+    case (still a real save->restore, just one shard)."""
+    from jax.sharding import NamedSharding
+
+    mesh = dp_mesh()
+    state = _build_sharded(seed=1, mesh=mesh)
+
+    # The big V/U + ci_fn + sources leaves must be genuinely C-sharded over the mesh
+    # (the multi-shard write path); only the small scalars (step) stay single-device.
+    n_named = sum(isinstance(x.sharding, NamedSharding) for x in jax.tree.leaves(state))
+    assert n_named >= len(jax.tree.leaves(state.components)), n_named
+
+    mgr = make_checkpoint_manager(tmp_path / "ckpts", keep_last=2)
+    save_state(mgr, 3, state)
+
+    # Restore onto a DIFFERENTLY-seeded sharded reference: every leaf comes from disk,
+    # but its placement comes from the (correctly-placed) reference.
+    reference = _build_sharded(seed=7, mesh=mesh)
+    loaded = restore_step(mgr, reference, 3)
+
+    state_leaves = jax.tree.leaves(state)
+    loaded_leaves = jax.tree.leaves(loaded)
+    ref_leaves = jax.tree.leaves(reference)
+    for saved, got, ref in zip(state_leaves, loaded_leaves, ref_leaves, strict=True):
+        assert jnp.array_equal(jnp.asarray(saved), jnp.asarray(got))
+        assert got.sharding == ref.sharding


### PR DESCRIPTION
Closes #684

## What

Adds `test_sharded_roundtrip_bit_equal` to `param_decomp_jax/jax_single_pool/tests/test_checkpoint.py`, encoding the "smoke must exercise save AND resume at the production per-rank shape" invariant (CLAUDE.md "The training pipeline"; SPEC S22) as a runnable guard.

The existing `test_roundtrip_and_exact_resume` already covers bit-equal save->restore + exact trajectory continuation, but only at `mesh=None` (single default device). It does NOT exercise the **sharded** orbax write/read — which is the failure-prone path the lore points at (the torch job-34446 save crash; the jsp SIGTERM saves).

The new test builds a `TrainState` placed exactly as the production trainer places it (`run_state.init_train_state`): C-sharded V/U + ci_fn, replicated sources over the `dp` mesh, via the `*_sharded` init fns. It saves through orbax, restores onto a differently-seeded sharded reference, and asserts:
- every leaf is bit-equal to the saved leaf (data comes from disk), and
- each restored leaf's sharding equals the reference's sharding (placement preserved),
- the big component leaves are genuinely `NamedSharding`-placed over the mesh.

This realizes acceptance criterion (b): a save->restore round-trip test in `tests/` at the 4-sim-device config asserting the restored `TrainState` is bit-equal to the pre-save state — and goes further than the existing test by exercising the sharded (production per-rank) path rather than `mesh=None`.

## Verification

Ran against `param_decomp_jax/.venv`:
- `pytest .../test_checkpoint.py::test_sharded_roundtrip_bit_equal` at default device count: **passed**.
- `pytest .../test_checkpoint.py` (all 3) at `XLA_FLAGS=--xla_force_host_platform_device_count=4`: **3 passed** (real multi-shard write/read; no regression in the existing two tests).

pre-commit ruff + basedpyright passed on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)