### PR TITLE
test(jax): refuse decaying PPGD source lr_schedule in torch_config conversion

### DIFF
--- a/param_decomp_jax/jax_single_pool/tests/test_torch_config.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_torch_config.py
@@ -240,6 +240,40 @@ def test_unsupported_model_family_refuses_and_supported_families_dispatch():
     assert LlamaSimpleMLPTargetConfig is not None  # the `pretrained` happy-path type
 
 
+def test_decaying_persistent_source_schedule_refuses():
+    """The JAX source schedule is `warmup_then_constant_lr` (no post-warmup decay);
+    a torch PPGD source `lr_schedule` that decays would silently flatten, so the
+    conversion gate must refuse it (issue #646; matrix S13/S20)."""
+    torch_cfg, raw = _reference_torch_cfg()
+    decaying_source = dict(
+        raw,
+        pd=dict(
+            raw["pd"],
+            loss_metrics=[
+                dict(
+                    m,
+                    optimizer=dict(
+                        m["optimizer"],
+                        lr_schedule=dict(
+                            m["optimizer"]["lr_schedule"],
+                            fn_type="cosine",
+                            final_val_frac=0.1,
+                        ),
+                    ),
+                )
+                if m["type"] == "PersistentPGDReconLoss"
+                else m
+                for m in raw["pd"]["loss_metrics"]
+            ],
+        ),
+    )
+    with pytest.raises(AssertionError):
+        convert_torch_lm_config(
+            type(torch_cfg)(**decaying_source), run_name="t", run_id=RUN_ID,
+            out_dir=Path("/tmp"), remat_recon_forwards=True,
+        )  # fmt: skip
+
+
 def test_arbitrary_sites_with_per_site_c_convert():
     """Attention + MLP sites across non-contiguous layers with heterogeneous C —
     the general site space this trainer now implements."""


### PR DESCRIPTION
Closes #646

## What

The JAX persistent source schedule is `warmup_then_constant_lr` (`losses.py:61`) — it supports NO post-warmup decay. A torch PPGD source `lr_schedule` that decays (e.g. `fn_type: cosine, final_val_frac: 0.1`) would be silently flattened in JAX (matrix S13/S20).

The conversion gate already asserts this: `recon.py:263` (`_assert_supported_persistent`) requires `schedule.fn_type == "constant" and schedule.final_val_frac == 1.0` for the PPGD source optimizer's `lr_schedule`. It's reached from `convert_torch_lm_config` → `_losses` → `build_recon_terms`.

This PR adds the parity unit test the issue asks for: `test_decaying_persistent_source_schedule_refuses` injects a decaying cosine source schedule into the reference torch config's `PersistentPGDReconLoss.optimizer.lr_schedule` and confirms `convert_torch_lm_config` raises `AssertionError`. Follows the existing `test_unsupported_settings_refuse` pattern in the same file.

## Why the assert is the right gate

A decaying *cosine* source schedule passes pydantic validation (only `constant` with `final_val_frac != 1.0` is rejected by `ScheduleConfig.validate_constant_schedule`), so it reaches the JAX gate rather than being caught at parse time — exactly the silent-non-decay case the gate must refuse.

## Verification

- `make format` + `make type` (basedpyright) pass via pre-commit.
- Isolated logic check confirmed: a `cosine`/`final_val_frac=0.1` `ScheduleConfig` is valid pydantic and the `recon.py:263` condition refuses it, while the reference `constant`/`1.0` schedule passes.
- The full pytest was NOT executed here: the JAX package (`param_decomp_jax`) keeps its own CUDA venv (separate from the torch workspace venv), and building it is out of scope for this change. The test is a pure-config refusal test that follows a proven sibling test, so it should pass once run in the JAX env / CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)