### PR TITLE
feature/jax: flatten JAX wandb config dump to match torch key layout

### DIFF
--- a/param_decomp_config/wandb_config.py
+++ b/param_decomp_config/wandb_config.py
@@ -1,0 +1,85 @@
+"""Torch-free shaping of a config dict for `wandb.config`.
+
+Both impls log the same flat key layout so cross-impl config queries line up: the torch
+trainer dumps a `BaseConfig`, the JAX trainer reuses the raw torch YAML dict. The
+flattening rule and the metric `short_name` table both live here (in the shared,
+torch-free config package) so neither side has to reach into the torch metric registry.
+
+`METRIC_SHORT_NAMES` is the canonical `type -> short_name` map; the torch metric classes
+carry the same `short_name` attribute and a test guards the two against drift.
+"""
+
+from typing import Any
+
+METRIC_SHORT_NAMES: dict[str, str] = {
+    "CIMaskedReconLayerwiseLoss": "CIMaskReconLayer",
+    "CIMaskedReconLoss": "CIMaskRecon",
+    "CIMaskedReconSubsetLoss": "CIMaskReconSub",
+    "FaithfulnessLoss": "Faith",
+    "ImportanceMinimalityLoss": "ImpMin",
+    "PersistentPGDReconLoss": "PersistPGDRecon",
+    "PersistentPGDReconSubsetLoss": "PersistPGDReconSub",
+    "PGDReconLayerwiseLoss": "PGDReconLayer",
+    "PGDReconLoss": "PGDRecon",
+    "PGDReconSubsetLoss": "PGDReconSub",
+    "StochasticHiddenActsReconLoss": "StochHiddenActRecon",
+    "StochasticReconLayerwiseLoss": "StochReconLayer",
+    "StochasticReconLoss": "StochRecon",
+    "StochasticReconSubsetLoss": "StochReconSub",
+    "UnmaskedReconLoss": "UnmaskedRecon",
+    "AutointerpLabels": "Autointerp",
+    "CEandKLLosses": "CEandKL",
+    "CIHiddenActsReconLoss": "CIHiddenActRecon",
+    "CIHistograms": "CIHist",
+    "CI_L0": "CI_L0",
+    "CIMaskedAttnPatternsReconLoss": "CIAttnRecon",
+    "CIMeanPerComponent": "CIMeanPerComp",
+    "ComponentActivationDensity": "CompActDens",
+    "IdentityCIError": "IdCIErr",
+    "PermutedCIPlots": "PermCIPlots",
+    "StochasticAttnPatternsReconLoss": "StochAttnRecon",
+    "UVPlots": "UVPlots",
+}
+
+
+def flatten_typed_lists(config_dict: dict[str, Any]) -> dict[str, Any]:
+    """Flatten nested lists-of-typed-dicts (loss/eval metric lists) into queryable flat
+    keys addressed by metric `short_name`, returning a copy with the raw lists dropped.
+
+    Example: `pd.loss_metrics: [{type: "ImportanceMinimalityLoss", coeff: 0.1}]`
+    becomes `pd.loss_metrics.ImpMin.coeff: 0.1`, and the raw `pd.loss_metrics` list is
+    removed so wandb doesn't also log it as an opaque JSON blob. A metric type with no
+    entry in `METRIC_SHORT_NAMES` falls back to its raw type string.
+    """
+    flattened: dict[str, Any] = {}
+
+    def is_typed_list(obj: Any) -> bool:
+        return (
+            isinstance(obj, list)
+            and len(obj) > 0
+            and all(isinstance(x, dict) and "type" in x for x in obj)
+        )
+
+    def walk(obj: Any, path: str) -> None:
+        if isinstance(obj, dict):
+            for key in list(obj.keys()):
+                child = obj[key]
+                child_path = f"{path}.{key}" if path else key
+                if is_typed_list(child):
+                    for entry in child:
+                        short = METRIC_SHORT_NAMES.get(entry["type"], entry["type"])
+                        for k, v in entry.items():
+                            if k == "type":
+                                continue
+                            flattened[f"{child_path}.{short}.{k}"] = v
+                    del obj[key]
+                else:
+                    walk(child, child_path)
+        elif isinstance(obj, list):
+            for i, item in enumerate(obj):
+                walk(item, f"{path}.{i}")
+
+    out = dict(config_dict)
+    walk(out, "")
+    out.update(flattened)
+    return out

--- a/param_decomp_jax/jax_single_pool/run.py
+++ b/param_decomp_jax/jax_single_pool/run.py
@@ -59,6 +59,7 @@ from jax_single_pool.run_state import build_optimizers, init_train_state
 from jax_single_pool.sharding import dp_mesh, init_distributed
 from jax_single_pool.torch_config import load_torch_wrapper
 from jax_single_pool.train import TrainState, make_faith_warmup_step, make_train_step
+from param_decomp_config.wandb_config import flatten_typed_lists
 
 _sigterm_received = False
 
@@ -119,7 +120,7 @@ _METRIC_KEYS = {
 class MetricsSink:
     """Process-0 metrics fan-out: jsonl always, wandb when configured."""
 
-    def __init__(self, cfg: ExperimentConfig, raw_cfg: dict[str, object], is_main: bool):
+    def __init__(self, cfg: ExperimentConfig, wandb_config: dict[str, object], is_main: bool):
         self._jsonl = None
         self._wandb = None
         if not is_main:
@@ -134,7 +135,7 @@ class MetricsSink:
                 name=cfg.run_name,
                 id=cfg.run_id,
                 resume="allow",
-                config=raw_cfg,
+                config=wandb_config,
             )
             # slow_eval/* rides a dedicated step axis (torch convention,
             # infra/wandb.py): pd-offline-eval logs those keys retroactively into
@@ -272,18 +273,22 @@ def train(
         )
 
     # the raw torch yaml's runtime block describes the UPSTREAM run (e.g. dp: 32);
-    # record what this run actually executes on so wandb never lies about topology
-    raw_cfg = dict(
-        raw_cfg,
-        jax_runtime={
-            "n_devices": ndev,
-            "n_processes": n_proc,
-            "remat_recon_forwards": cfg.remat_recon_forwards,
-            "run_id": cfg.run_id,
-            "run_dir": str(cfg.run_dir),
-        },
+    # record what this run actually executes on so wandb never lies about topology.
+    # flatten the metric lists into the same flat keys torch logs (E14) so cross-impl
+    # wandb config queries line up.
+    wandb_config = flatten_typed_lists(
+        dict(
+            raw_cfg,
+            jax_runtime={
+                "n_devices": ndev,
+                "n_processes": n_proc,
+                "remat_recon_forwards": cfg.remat_recon_forwards,
+                "run_id": cfg.run_id,
+                "run_dir": str(cfg.run_dir),
+            },
+        )
     )
-    sink = MetricsSink(cfg, raw_cfg, is_main)
+    sink = MetricsSink(cfg, wandb_config, is_main)
     tokens_per_step = cfg.data.global_batch * cfg.data.seq_len
     window_t0 = time.time()
     last_logged = start_step

--- a/param_decomp_lab/eval_metrics/__init__.py
+++ b/param_decomp_lab/eval_metrics/__init__.py
@@ -13,6 +13,7 @@ from param_decomp.metrics.dispatch import LOSS_METRIC_CLASSES
 from param_decomp.metrics.pgd_masked_recon import PGDReconLoss
 from param_decomp.metrics.stochastic_hidden_acts_recon import StochasticHiddenActsReconLoss
 from param_decomp_config.base import BaseConfig
+from param_decomp_config.wandb_config import flatten_typed_lists
 from param_decomp_lab.eval_metrics.attn_patterns_recon_loss import (
     CIMaskedAttnPatternsReconLoss,
     StochasticAttnPatternsReconLoss,
@@ -49,10 +50,11 @@ EVAL_METRIC_CLASSES: dict[str, type[Metric[Any]]] = {
 }
 
 
-def _metric_short_names() -> dict[str, str]:
-    """Map metric class name (== config `type`) to `short_name`, for wandb key prettifying.
-
-    Covers both loss and eval metrics.
+def metric_short_names() -> dict[str, str]:
+    """Map metric class name (== config `type`) to `short_name`, derived from the loss +
+    eval metric registries. The canonical wandb-facing copy is the torch-free
+    `param_decomp_config.wandb_config.METRIC_SHORT_NAMES`; a test guards the two against
+    drift.
     """
     return {
         cls.__name__: cls.short_name
@@ -66,39 +68,9 @@ def wandb_config_dict(config: BaseConfig) -> dict[str, Any]:
 
     Nested lists-of-typed-dicts (loss/eval metric lists) are flattened into queryable
     flat keys addressed by metric `short_name`, and the raw lists dropped so wandb
-    doesn't also log them as opaque JSON blobs. Lives here (not in `infra/wandb`) so the
-    infra layer doesn't depend upward on the metric registries.
+    doesn't also log them as opaque JSON blobs. The flattening (and the `short_name`
+    table) live in `param_decomp_config.wandb_config` so the JAX trainer can produce the
+    identical key layout without reaching into the torch metric registry; the table there
+    is guarded against this registry-derived one by a test.
     """
-    short_names = _metric_short_names()
-    config_dict = config.model_dump(mode="json")
-    flattened: dict[str, Any] = {}
-
-    def is_typed_list(obj: Any) -> bool:
-        return (
-            isinstance(obj, list)
-            and len(obj) > 0
-            and all(isinstance(x, dict) and "type" in x for x in obj)
-        )
-
-    def walk(obj: Any, path: str) -> None:
-        if isinstance(obj, dict):
-            for key in list(obj.keys()):
-                child = obj[key]
-                child_path = f"{path}.{key}" if path else key
-                if is_typed_list(child):
-                    for entry in child:
-                        short = short_names.get(entry["type"], entry["type"])
-                        for k, v in entry.items():
-                            if k == "type":
-                                continue
-                            flattened[f"{child_path}.{short}.{k}"] = v
-                    del obj[key]
-                else:
-                    walk(child, child_path)
-        elif isinstance(obj, list):
-            for i, item in enumerate(obj):
-                walk(item, f"{path}.{i}")
-
-    walk(config_dict, "")
-    config_dict.update(flattened)
-    return config_dict
+    return flatten_typed_lists(config.model_dump(mode="json"))

--- a/param_decomp_lab/experiments/CLAUDE.md
+++ b/param_decomp_lab/experiments/CLAUDE.md
@@ -156,7 +156,10 @@ No central registry to update — post-processing callers `import` the new
 - If `cfg.wandb is None` → `RunSink.local(out_dir)`.
 - Otherwise → `RunSink.with_wandb(...)` with the full `ExperimentConfig` dumped into
   `wandb.config`. Nested lists of typed configs (loss / eval metrics) are flattened
-  into queryable flat keys via `flatten_typed_lists` in `infra/wandb.py`.
+  into queryable flat keys via `flatten_typed_lists` in
+  `param_decomp_config/wandb_config.py` (torch-free, so the JAX trainer logs the same
+  key layout; the `short_name` table there is drift-guarded against the torch metric
+  registry).
 
 Non-main DDP ranks get `RunSink.silent()`.
 

--- a/param_decomp_lab/tests/test_wandb_config_short_names.py
+++ b/param_decomp_lab/tests/test_wandb_config_short_names.py
@@ -1,0 +1,8 @@
+from param_decomp_config.wandb_config import METRIC_SHORT_NAMES
+from param_decomp_lab.eval_metrics import metric_short_names
+
+
+def test_config_short_name_table_matches_metric_registry():
+    """The torch-free `METRIC_SHORT_NAMES` (consumed by the JAX trainer for an identical
+    wandb config key layout) must stay in lockstep with the torch metric classes."""
+    assert metric_short_names() == METRIC_SHORT_NAMES


### PR DESCRIPTION
Closes #695

## Problem
The JAX trainer passed the raw nested torch-YAML dict straight to `wandb.config` (plus the `jax_runtime` topology sub-dict). Torch flattens its config via `flatten_typed_lists`, so cross-impl config queries in the wandb UI didn't line up — filtering by a flattened metric key (e.g. `pd.loss_metrics.ImpMin.coeff`) worked on torch runs but not JAX ones.

## Change
- Moved the pure flattening logic + the canonical `type -> short_name` table into the torch-free `param_decomp_config/wandb_config.py` (`flatten_typed_lists`, `METRIC_SHORT_NAMES`), so the JAX trainer can produce the identical flat-key layout without reaching into the torch metric registry.
- `param_decomp_lab/eval_metrics/wandb_config_dict` now delegates to the shared flattener; `_metric_short_names` -> public `metric_short_names` (registry-derived ground truth).
- JAX `run.py` flattens its config dump (raw torch YAML + `jax_runtime`) before `wandb.init`. The `jax_runtime` sub-dict has no typed lists and passes through unchanged.
- Added a drift-guard test asserting `METRIC_SHORT_NAMES == metric_short_names()` (torch registry) so the two never silently diverge.

Note: `view_meta/` is never populated on the torch side either (always `None`), so there's nothing to mirror there — the substantive divergence was the flattening.

## Verification
- `make type` clean; pre-commit (ruff + basedpyright) passed.
- `pytest param_decomp_lab/tests/test_wandb_config_short_names.py` passed (27 short-name entries match).
- Manually verified the flatten round-trip: typed metric lists -> flat `short_name` keys, raw lists dropped, `jax_runtime` preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)