### PR TITLE
test(jax-equiv): pin the chunk-plan static-live gate (S2)

### DIFF
--- a/param_decomp_jax/jax_single_pool/tests/equivalence/jax_equivalence.py
+++ b/param_decomp_jax/jax_single_pool/tests/equivalence/jax_equivalence.py
@@ -36,9 +36,12 @@ from jax_single_pool.llama8b import (  # noqa: E402
     FrozenAttn,
     SuffixLayer,
     Target,
+    _clean_mlp_out,  # noqa: E402  (reference suffix forward in the chunk-plan gate check)
+    _site_out,  # noqa: E402
     llama_decomposed_lm,
     llama_site_specs,
     mlp_family_site_cs,
+    rms_norm,
     site_name,
 )
 from jax_single_pool.losses import (  # noqa: E402
@@ -179,6 +182,78 @@ def compute_jax_terms(f: dict[str, np.ndarray]) -> dict[str, float]:
     ppgd = float(kl_per_position(pred, clean))
 
     return {"faith": faith, "imp": imp, "stoch": stoch, "ppgd": ppgd}
+
+
+def _suffix_with_split_mlp(
+    tgt: Target,
+    vu: DecompVU,
+    resid: jnp.ndarray,
+    live_layer: int,
+    live_kinds: tuple[str, ...],
+    masks: dict[str, jnp.ndarray],
+    delta_masks: dict[str, jnp.ndarray],
+    n_decomp_layers: int,
+) -> jnp.ndarray:
+    """Hand-rolled fp32 suffix forward where `live_layer`'s MLP runs `live_kinds`
+    through the decomposed `_site_out` path and EVERY other MLP site (including this
+    layer's NON-live sibling sites) through the frozen `x @ W` path. This is the
+    explicit S2 realization the production `subset_chunk_plan` relies on when a chunk
+    boundary splits a layer's MLP — a reference for `masked_logits(..., live=...)`."""
+    x = resid
+    for layer_offset, suffix_layer in enumerate(tgt.layers):
+        layer = layer_offset  # first decomposed layer is 0 in this harness
+        post_attn = x  # attn is zeroed -> contributes 0 (SPEC harness invariant)
+        mlp_in = rms_norm(post_attn, suffix_layer.ln2, tgt.eps)
+        if layer != live_layer or layer >= n_decomp_layers:
+            mlp_out = _clean_mlp_out(suffix_layer, mlp_in)
+        else:
+
+            def frozen_or_live(kind: str, W: jnp.ndarray, x_in: jnp.ndarray) -> jnp.ndarray:
+                site = site_name(live_layer, kind)
+                if kind not in live_kinds:
+                    return x_in @ W.T
+                V, U = vu.site(site)
+                return _site_out(x_in, V, U, W, masks[site], delta_masks[site], None)
+
+            gate = frozen_or_live("gate", suffix_layer.Wg, mlp_in)
+            up = frozen_or_live("up", suffix_layer.Wu, mlp_in)
+            down_in = jax.nn.silu(gate) * up
+            mlp_out = frozen_or_live("down", suffix_layer.Wd, down_in)
+        x = post_attn + mlp_out
+    x = rms_norm(x, tgt.norm, tgt.eps)
+    return x @ tgt.lm_head.T
+
+
+def chunk_plan_static_gate_kl(f: dict[str, np.ndarray]) -> tuple[float, float]:
+    """SPEC S2 under a layer-SPLITTING chunk plan (issue #640): drive `lm.masked_logits`
+    with `live = (l_i.gate, l_i.up)` so `l_i.down` is a fully-frozen site WITHIN an
+    otherwise-decomposed layer's MLP — the static-live-gate path the production
+    `subset_chunk_plan` exercises but the per-chunk `stoch` term (whole live chunks) and
+    the all-sites `ppgd` term never do. Returns (gate-path KL, explicit-frozen-reference
+    KL); the test asserts they agree to fp32 tolerance."""
+    lm, tgt, vu, n_layers = _build(f)
+    resid = jnp.asarray(f["resid"], dtype=FP)
+    clean = jax.lax.stop_gradient(lm.clean_logits(tgt, resid))
+
+    def per_site(prefix: str) -> dict[str, jnp.ndarray]:
+        by_kind = {k: jnp.asarray(f[f"{prefix}_{k}"], dtype=FP) for k in MLP_KINDS}
+        return {site_name(i, k): by_kind[k][:, :, i] for i in range(n_layers) for k in MLP_KINDS}
+
+    ci_lower = per_site("ci_lower")
+    stoch_u = per_site("stoch_u")
+    stoch_delta = per_site("stoch_delta")
+
+    live_layer = 0
+    live_kinds = ("gate", "up")  # `down` left non-live -> frozen `x @ W` inside the MLP
+    live = tuple(site_name(live_layer, k) for k in live_kinds)
+    masks = {s: ci_lower[s] + (1.0 - ci_lower[s]) * stoch_u[s] for s in live}
+    delta_masks = {s: stoch_delta[s] for s in live}
+
+    gate_pred = lm.masked_logits(tgt, vu, resid, masks, delta_masks, None, live)
+    ref_pred = _suffix_with_split_mlp(
+        tgt, vu, resid, live_layer, live_kinds, masks, delta_masks, n_layers
+    )
+    return float(kl_per_position(gate_pred, clean)), float(kl_per_position(ref_pred, clean))
 
 
 def main() -> None:

--- a/param_decomp_jax/jax_single_pool/tests/equivalence/test_equivalence.py
+++ b/param_decomp_jax/jax_single_pool/tests/equivalence/test_equivalence.py
@@ -14,6 +14,13 @@ Two kinds of check:
     the stochastic recon runs ONE forward PER CHUNK (S10), recon is KL not MSE (§2.3),
     and the PPGD source carries the trailing raw weight-delta channel (S1).
 
+  * **Chunk-plan static-live gate (S2).** `test_chunk_plan_static_live_gate` drives
+    `masked_logits` with a live set that splits a layer's MLP (`live = (l0.gate, l0.up)`,
+    `l0.down` frozen) — the realization the production `subset_chunk_plan` hits when a
+    chunk boundary cuts across a layer, which `stoch` (whole-layer chunks) and `ppgd`
+    (all sites live) never exercise — and asserts it equals an explicit reference that
+    hard-codes the frozen site to `x @ W`.
+
 Regenerate the cross-framework golden (only needed if the math or fixtures change):
 
     # JAX env:
@@ -32,7 +39,10 @@ import pytest
 import jax_single_pool.adversary as adversary_mod
 import jax_single_pool.losses as losses_mod
 import jax_single_pool.train as train_mod
-from jax_single_pool.tests.equivalence.jax_equivalence import compute_jax_terms
+from jax_single_pool.tests.equivalence.jax_equivalence import (
+    chunk_plan_static_gate_kl,
+    compute_jax_terms,
+)
 
 HERE = Path(__file__).resolve().parent
 RTOL = 2e-4
@@ -48,6 +58,22 @@ def test_jax_matches_torch_reference(term: str) -> None:
     jv, tv = jaxv[term], ref[term]
     assert abs(jv - tv) <= ATOL + RTOL * abs(tv), (
         f"{term}: jax {jv:.8e} vs torch {tv:.8e} (rel {abs(jv - tv) / (abs(tv) + 1e-30):.2e})"
+    )
+
+
+def test_chunk_plan_static_live_gate() -> None:
+    """SPEC S2 under a layer-SPLITTING chunk plan (issue #640). The production
+    `subset_chunk_plan` partitions sites into sequential groups that can cut across a
+    layer's MLP, leaving whole sites frozen (`x @ W`) inside an otherwise-decomposed
+    layer. The `stoch` term here uses whole-layer live chunks and `ppgd` decomposes
+    every site, so neither pins this static-live gate. Drive `masked_logits` with
+    `live = (l0.gate, l0.up)` (so `l0.down` is the frozen sibling) and assert it equals
+    an explicit reference forward that hard-codes `l0.down` to `x @ W`."""
+    f = dict(np.load(HERE / "fixtures.npz"))
+    gate_kl, ref_kl = chunk_plan_static_gate_kl(f)
+    assert abs(gate_kl - ref_kl) <= ATOL + RTOL * abs(ref_kl), (
+        f"static-live gate {gate_kl:.8e} vs explicit-frozen reference {ref_kl:.8e} "
+        f"(rel {abs(gate_kl - ref_kl) / (abs(ref_kl) + 1e-30):.2e})"
     )
 
 


### PR DESCRIPTION
Closes #640

## What

The cross-framework equivalence harness never exercised the **static live-set** realization of SPEC **S2** — a whole site frozen to `x @ W` *inside* an otherwise-decomposed layer's MLP. The existing `stoch` term uses whole-layer live chunks (every site in a live chunk is decomposed) and `ppgd` decomposes every site, so the per-site frozen gate that production `subset_chunk_plan` hits when a chunk boundary splits a layer was unverified.

Adds `test_chunk_plan_static_live_gate` (in `param_decomp_jax/jax_single_pool/tests/equivalence/`):
- drives `lm.masked_logits` with `live = (l0.gate, l0.up)` so `l0.down` is a fully-frozen sibling within the decomposed layer's MLP (`_masked_site_out`'s `if site not in live_set: return x @ W` path);
- asserts it equals an explicit reference forward (`_suffix_with_split_mlp`) that hard-codes the frozen site to `x @ W`, reusing the harness's `_clean_mlp_out` / `_site_out` math.

## Verification

Ran in the JAX env (`param_decomp_jax/.venv`, CPU):
- `test_chunk_plan_static_live_gate` PASSES — static-live gate `0.07435650` vs explicit-frozen reference `0.07435650`, rel_err `0.0`. The KL is non-trivial (~0.074), so the live gate/up sites genuinely perturb the forward.
- Full `tests/equivalence/test_equivalence.py` suite: 8 passed (the 4 cross-framework numeric terms still match the committed torch golden).
- ruff + repo-wide basedpyright clean (pre-commit hooks pass; the JAX package is out of pyright's include per its CLAUDE.md, by design).

## Note on the acceptance "OR"

The issue offered an alternative: cite stacked-parity trajectory fixtures as the pin. That isn't viable — `tests/stacked_parity/gen_stacked_fixtures.py` imports a stacked-era `llama8b` API (`KINDS`, `LayerRange`, `init_decomp_vu`) that no longer exists in the current `llama8b.py` (`llama_decomposed_lm(cfg, sites)`), so those fixtures are stale. Hence the direct fixture test.

This pins the gate as a JAX-internal numeric identity (data routing, no new math); the underlying masked `_site_out` and frozen `x @ W` math are already pinned against torch by the existing `stoch`/`ppgd` terms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)