### PR TITLE
feat(jax): post-warmup source-LR decay (cosine/linear) (#581)

### DIFF
--- a/param_decomp_jax/jax_single_pool/losses.py
+++ b/param_decomp_jax/jax_single_pool/losses.py
@@ -5,6 +5,7 @@ import jax.numpy as jnp
 from jaxtyping import Array
 
 from param_decomp_config.losses import ImportanceMinimalityLossConfig
+from param_decomp_config.schedule import ScheduleConfig
 
 
 def kl_per_position(masked_logits: Array, clean_logits: Array) -> Array:
@@ -58,8 +59,31 @@ def annealed_pnorm(step_f32: Array, total_steps: int, cfg: ImportanceMinimalityL
     return jnp.asarray(cfg.pnorm + (cfg.p_anneal_final_p - cfg.pnorm) * progress)
 
 
-def warmup_then_constant_lr(
-    step_f32: Array, total_steps: int, lr: float, warmup_frac: float
-) -> Array:
-    warmup_steps = jnp.maximum(jnp.floor(total_steps * warmup_frac), 1.0)
-    return jnp.where(step_f32 < warmup_steps, lr * step_f32 / warmup_steps, lr)
+def scheduled_lr(step_f32: Array, total_steps: int, schedule: ScheduleConfig) -> Array:
+    """Linear warmup to `start_val`, then constant / linear / cosine decay to
+    `final_val_frac * start_val` — the traced mirror of torch's
+    `get_scheduled_value` (SPEC S13′). Decay spans `[warmup_steps, total_steps - 1]`."""
+    warmup_steps = int(total_steps * schedule.warmup_pct)
+    decay_steps = total_steps - warmup_steps
+    start_val = schedule.start_val
+    final_val_frac = schedule.final_val_frac
+
+    warmup_value = start_val * step_f32 / max(warmup_steps, 1)
+
+    if decay_steps <= 1:
+        decay_value = jnp.asarray(start_val)
+    else:
+        progress = (step_f32 - warmup_steps) / (decay_steps - 1)
+        match schedule.fn_type:
+            case "constant":
+                decay_value = jnp.asarray(start_val)
+            case "linear":
+                multiplier = final_val_frac + (1 - final_val_frac) * (1 - progress)
+                decay_value = start_val * multiplier
+            case "cosine":
+                multiplier = final_val_frac + (1 - final_val_frac) * 0.5 * (
+                    1 + jnp.cos(jnp.pi * progress)
+                )
+                decay_value = start_val * multiplier
+
+    return jnp.where(step_f32 < warmup_steps, warmup_value, decay_value)

--- a/param_decomp_jax/jax_single_pool/recon.py
+++ b/param_decomp_jax/jax_single_pool/recon.py
@@ -259,8 +259,6 @@ def _assert_supported_persistent(
     assert not cfg.use_sigmoid_parameterization and cfg.start_frac == 0.0, cfg
     optimizer = cfg.optimizer
     assert isinstance(optimizer, AdamPGDConfig), optimizer
-    schedule = optimizer.lr_schedule
-    assert schedule.fn_type == "constant" and schedule.final_val_frac == 1.0, schedule
 
 
 def build_recon_terms(

--- a/param_decomp_jax/jax_single_pool/tests/test_source_lr_schedule.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_source_lr_schedule.py
@@ -1,0 +1,38 @@
+"""`scheduled_lr` (the persistent-source LR) mirrors torch's `get_scheduled_value`
+across warmup + constant/linear/cosine decay, per step within fp tol (SPEC S13′)."""
+
+import jax.numpy as jnp
+import pytest
+
+from jax_single_pool.losses import scheduled_lr
+from param_decomp_config.schedule import ScheduleConfig, get_scheduled_value
+
+
+@pytest.mark.parametrize("fn_type", ["constant", "linear", "cosine"])
+@pytest.mark.parametrize("warmup_pct", [0.0, 0.1])
+def test_scheduled_lr_matches_torch(fn_type: str, warmup_pct: float):
+    final_val_frac = 1.0 if fn_type == "constant" else 0.1
+    schedule = ScheduleConfig(
+        start_val=2e-3,
+        warmup_pct=warmup_pct,
+        final_val_frac=final_val_frac,
+        fn_type=fn_type,
+    )
+    total_steps = 200
+    for step in range(total_steps + 1):
+        jax_value = float(scheduled_lr(jnp.float32(step), total_steps, schedule))
+        torch_value = get_scheduled_value(step, total_steps, schedule)
+        assert jax_value == pytest.approx(torch_value, abs=1e-9), (
+            f"step {step}: jax {jax_value} != torch {torch_value}"
+        )
+
+
+@pytest.mark.parametrize("fn_type", ["linear", "cosine"])
+def test_decaying_schedule_actually_decays(fn_type: str):
+    schedule = ScheduleConfig(start_val=2e-3, warmup_pct=0.0, final_val_frac=0.1, fn_type=fn_type)
+    total_steps = 200
+    first = float(scheduled_lr(jnp.float32(0), total_steps, schedule))
+    last = float(scheduled_lr(jnp.float32(total_steps), total_steps, schedule))
+    assert first == pytest.approx(2e-3)
+    assert last == pytest.approx(2e-4)
+    assert last < first

--- a/param_decomp_jax/jax_single_pool/train.py
+++ b/param_decomp_jax/jax_single_pool/train.py
@@ -40,7 +40,7 @@ from jax_single_pool.losses import (
     faithfulness_loss,
     importance_minimality_terms,
     kl_per_position,
-    warmup_then_constant_lr,
+    scheduled_lr,
 )
 from jax_single_pool.recon import (
     ConstantSources,
@@ -262,12 +262,7 @@ def make_train_step(
         warmup_opt_states: dict[str, SourcesAdamState] = {}
         for state_key, ppgd_cfg in loss_spec.persistent.items():
             adam = persistent_adams[state_key]
-            source_lr = warmup_then_constant_lr(
-                step_f32,
-                total_steps,
-                adam.lr_schedule.start_val,
-                adam.lr_schedule.warmup_pct,
-            )
+            source_lr = scheduled_lr(step_f32, total_steps, adam.lr_schedule)
             source_lrs[state_key] = source_lr
 
             def warmup_loss(sources: dict[str, Array]) -> Array:


### PR DESCRIPTION
Closes #581

## What changed
The persistent-source LR in `jax_single_pool` only supported linear warmup + constant; `_assert_supported_persistent` refused any post-warmup decay (`assert schedule.fn_type == "constant" and schedule.final_val_frac == 1.0`).

- `losses.py`: replaced `warmup_then_constant_lr` with `scheduled_lr(step_f32, total_steps, schedule)` — a traced mirror of torch's `get_scheduled_value` over the full `ScheduleConfig`: linear warmup to `start_val`, then constant / linear / cosine decay to `final_val_frac * start_val`. Decay spans `[warmup_steps, total_steps - 1]`, matching torch's `progress = (step - warmup_steps) / (decay_steps - 1)`.
- `train.py`: call site now passes the whole `adam.lr_schedule`.
- `recon.py`: dropped the schedule-refusing assert in `_assert_supported_persistent` (sigmoid/start_frac/scope refusals retained).
- New test `tests/test_source_lr_schedule.py`: per-step parity vs torch `get_scheduled_value` (warmup × {constant, linear, cosine}, abs tol 1e-9) and a check that a decaying schedule actually decays start→`0.1×`.

Invariant S13'. No SPEC amendment needed — `sched_src` is already generic in SPEC.md; this brings the impl up to what the spec permits.

## Verification
- Pre-commit ruff + basedpyright: passed.
- Standalone parity check (fp32) of the new formula vs torch's: max abs diff ~2.4e-10 across all 201 steps for cosine/linear with warmup — well under the test's 1e-9 tol.
- The new pytest was not executed in CI here (the JAX package runs in its own env, not the torch venv); the formula parity was verified standalone as above.