### PR TITLE
feat(jax/adversary): sign SRC_STEP for the persistent adversary

### DIFF
--- a/param_decomp_jax/jax_single_pool/SPEC.md
+++ b/param_decomp_jax/jax_single_pool/SPEC.md
@@ -298,7 +298,7 @@ refer to the `feature/fsdp-lm-trainer` lineage — those trees are not on this b
 
 The JAX implementation (`jax_single_pool/train.py`) uses these pseudocode names
 verbatim: `clean_logits`, `site_inputs`, `source_masks`, `stochastic_recon_loss`,
-`adversarial_recon_loss`, `sources_adam_ascend_project`, `ReconPlan`/`ReconForward`,
+`adversarial_recon_loss`, `sources_ascend_project`, `ReconPlan`/`ReconForward`,
 `uniform_k_routing`, `subset_chunk_plan`, `per_site_plan`.
 
 Rationale worth keeping: the two squashings give each consumer gradient only in its

--- a/param_decomp_jax/jax_single_pool/adversary.py
+++ b/param_decomp_jax/jax_single_pool/adversary.py
@@ -4,9 +4,10 @@ Two semantically distinct adversaries share the source/mask machinery but nothin
 else (SPEC §3):
 
 - **Persistent PGD (PPGD)** — `PersistentPGDReconLossConfig`. Per-site `(1, T, C+1)`
-  sources + their Adam moments live in `TrainState` across steps; each step runs
-  `n_warmup_steps` supplemental Adam ascents plus one final ascent from the main
-  backward (SPEC S13/S14), projecting to [0,1] after every update (S15).
+  sources + their SRC_STEP optimizer state live in `TrainState` across steps; each step
+  runs `n_warmup_steps` supplemental ascents plus one final ascent from the main backward
+  (SPEC S13/S14), projecting to [0,1] after every update (S15). The SRC_STEP variation
+  point (SPEC §6) is `adam` (carries bias-corrected moments) or `sign` (stateless).
 - **Fresh PGD** — `PGDReconLossConfig` (torch `PGDReconLoss` as a TRAINING loss).
   Sources are re-initialized every step, ascended `n_steps` times by
   `step_size * sign(grad)` with clamp to [0,1], and carry NO state across steps —
@@ -22,7 +23,7 @@ from jax import random
 from jaxtyping import Array, Float, PRNGKeyArray
 
 from jax_single_pool.lm import SiteSpec
-from param_decomp_config.losses import AdamPGDConfig
+from param_decomp_config.losses import AdamPGDConfig, PGDOptimizerConfig, SignPGDConfig
 
 
 @jax.tree_util.register_dataclass
@@ -31,6 +32,16 @@ class SourcesAdamState:
     m: dict[str, Array]
     v: dict[str, Array]
     step_count: Float[Array, ""]
+
+
+@jax.tree_util.register_dataclass
+@dataclass(frozen=True)
+class SourcesSignState:
+    """SRC_STEP `sign` variant carries no moments (SPEC §6); an empty pytree keeps the
+    `TrainState.sources_opt_state` slot uniform across optimizer choices."""
+
+
+SourcesOptState = SourcesAdamState | SourcesSignState
 
 
 def init_persistent_sources(
@@ -89,17 +100,23 @@ def init_sources_adam_state(sources: dict[str, Array]) -> SourcesAdamState:
     )
 
 
-def sources_adam_ascend_project(
+def init_sources_opt_state(
+    sources: dict[str, Array], optimizer: PGDOptimizerConfig
+) -> SourcesOptState:
+    match optimizer:
+        case AdamPGDConfig():
+            return init_sources_adam_state(sources)
+        case SignPGDConfig():
+            return SourcesSignState()
+
+
+def _sources_adam_ascend(
     sources: dict[str, Array],
     sources_grad: dict[str, Array],
     adam_state: SourcesAdamState,
     lr: Array,
     adam: AdamPGDConfig,
 ) -> tuple[dict[str, Array], SourcesAdamState]:
-    """One Adam ASCENT on the persistent sources, then project to [0,1] (SPEC S13/S15).
-
-    The variation point `SRC_STEP` (SPEC §6): a `sign` variant would replace the Adam
-    update with `lr * sign(grad)` (stateless) — same projection contract."""
     step_count = adam_state.step_count + 1.0
     m = {s: adam.beta1 * adam_state.m[s] + (1 - adam.beta1) * sources_grad[s] for s in sources}
     v = {
@@ -109,15 +126,34 @@ def sources_adam_ascend_project(
     bias_correction1 = 1 - adam.beta1**step_count
     bias_correction2 = 1 - adam.beta2**step_count
     new_sources = {
-        s: jnp.clip(
-            sources[s]
-            + lr * (m[s] / bias_correction1) / (jnp.sqrt(v[s] / bias_correction2) + adam.eps),
-            0.0,
-            1.0,
-        )
+        s: sources[s]
+        + lr * (m[s] / bias_correction1) / (jnp.sqrt(v[s] / bias_correction2) + adam.eps)
         for s in sources
     }
     return new_sources, SourcesAdamState(m=m, v=v, step_count=step_count)
+
+
+def sources_ascend_project(
+    sources: dict[str, Array],
+    sources_grad: dict[str, Array],
+    opt_state: SourcesOptState,
+    lr: Array,
+    optimizer: PGDOptimizerConfig,
+) -> tuple[dict[str, Array], SourcesOptState]:
+    """One ASCENT on the persistent sources via the SRC_STEP variation point (SPEC §6),
+    then project to [0,1] (SPEC S13/S15). `adam` carries bias-corrected moments across
+    steps; `sign` is stateless (`sources += lr * sign(grad)`)."""
+    match optimizer:
+        case AdamPGDConfig():
+            assert isinstance(opt_state, SourcesAdamState)
+            new_sources, new_opt_state = _sources_adam_ascend(
+                sources, sources_grad, opt_state, lr, optimizer
+            )
+        case SignPGDConfig():
+            assert isinstance(opt_state, SourcesSignState)
+            new_sources = {s: sources[s] + lr * jnp.sign(sources_grad[s]) for s in sources}
+            new_opt_state = opt_state
+    return {s: jnp.clip(v, 0.0, 1.0) for s, v in new_sources.items()}, new_opt_state
 
 
 def source_masks(

--- a/param_decomp_jax/jax_single_pool/recon.py
+++ b/param_decomp_jax/jax_single_pool/recon.py
@@ -31,6 +31,7 @@ from param_decomp_config.losses import (
     PGDReconLossConfig,
     PGDReconSubsetLossConfig,
     SCScope,
+    SignPGDConfig,
     StochasticReconLayerwiseLossConfig,
     StochasticReconLossConfig,
     StochasticReconSubsetLossConfig,
@@ -258,7 +259,7 @@ def _assert_supported_persistent(
     assert isinstance(cfg.scope, SCScope), f"persistent scope {cfg.scope} unsupported (sc only)"
     assert not cfg.use_sigmoid_parameterization and cfg.start_frac == 0.0, cfg
     optimizer = cfg.optimizer
-    assert isinstance(optimizer, AdamPGDConfig), optimizer
+    assert isinstance(optimizer, AdamPGDConfig | SignPGDConfig), optimizer
     schedule = optimizer.lr_schedule
     assert schedule.fn_type == "constant" and schedule.final_val_frac == 1.0, schedule
 

--- a/param_decomp_jax/jax_single_pool/run_state.py
+++ b/param_decomp_jax/jax_single_pool/run_state.py
@@ -13,7 +13,7 @@ from jax import random
 from jax.sharding import Mesh
 from jaxtyping import PRNGKeyArray
 
-from jax_single_pool.adversary import init_sources_adam_state
+from jax_single_pool.adversary import init_sources_opt_state
 from jax_single_pool.config import ExperimentConfig
 from jax_single_pool.llama8b_sharding import (
     init_ci_fn_sharded,
@@ -66,6 +66,9 @@ def init_train_state(
         components_opt_state=opt_vu.init(eqx.filter(components, eqx.is_array)),
         ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
         sources=sources,
-        sources_opt_state={k: init_sources_adam_state(v) for k, v in sources.items()},
+        sources_opt_state={
+            k: init_sources_opt_state(v, loss_spec.persistent[k].optimizer)
+            for k, v in sources.items()
+        },
         step=jnp.zeros((), jnp.int32),
     )

--- a/param_decomp_jax/jax_single_pool/tests/test_adversary_sign.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_adversary_sign.py
@@ -1,0 +1,111 @@
+"""Sign SRC_STEP variant for the persistent adversary (SPEC §6, S15).
+
+`sign` is the stateless persistent ascent (`sources += lr * sign(grad)` then clamp to
+[0,1]); `adam` is the moment-carrying default. These check the per-step math and that
+`build_recon_terms` now accepts a sign-optimizer persistent term.
+"""
+
+import jax.numpy as jnp
+
+from jax_single_pool.adversary import (
+    SourcesSignState,
+    init_sources_opt_state,
+    sources_ascend_project,
+)
+from jax_single_pool.recon import build_recon_terms
+from param_decomp_config.losses import (
+    AdamPGDConfig,
+    FaithfulnessLossConfig,
+    ImportanceMinimalityLossConfig,
+    PersistentPGDReconLossConfig,
+    SCScope,
+    SignPGDConfig,
+    StochasticReconLossConfig,
+)
+from param_decomp_config.schedule import ScheduleConfig
+
+
+def _sign_optimizer(lr: float) -> SignPGDConfig:
+    return SignPGDConfig(lr_schedule=ScheduleConfig(start_val=lr, warmup_pct=0.0))
+
+
+def test_sign_state_is_stateless() -> None:
+    sources = {"s": jnp.array([0.1, 0.9])}
+    state = init_sources_opt_state(sources, _sign_optimizer(0.05))
+    assert isinstance(state, SourcesSignState)
+
+
+def test_sign_ascend_is_lr_times_sign_then_clamp() -> None:
+    lr = 0.25
+    optimizer = _sign_optimizer(lr)
+    sources = {"s": jnp.array([0.5, 0.5, 0.9, 0.1])}
+    grad = {"s": jnp.array([3.0, -2.0, 7.0, -7.0])}  # ascent follows the SIGN only
+    state = init_sources_opt_state(sources, optimizer)
+
+    new_sources, new_state = sources_ascend_project(
+        sources, grad, state, jnp.asarray(lr), optimizer
+    )
+
+    # +lr where grad>0, -lr where grad<0, then projected to [0,1].
+    expected = jnp.array([0.75, 0.25, 1.0, 0.0])
+    assert jnp.allclose(new_sources["s"], expected)
+    assert isinstance(new_state, SourcesSignState)
+
+
+def test_sign_ascend_ignores_grad_magnitude() -> None:
+    optimizer = _sign_optimizer(0.1)
+    sources = {"s": jnp.array([0.5, 0.5])}
+    state = init_sources_opt_state(sources, optimizer)
+
+    small, _ = sources_ascend_project(
+        sources, {"s": jnp.array([1e-6, -1e-6])}, state, jnp.asarray(0.1), optimizer
+    )
+    large, _ = sources_ascend_project(
+        sources, {"s": jnp.array([1e6, -1e6])}, state, jnp.asarray(0.1), optimizer
+    )
+    assert jnp.allclose(small["s"], large["s"])
+
+
+def test_build_recon_terms_accepts_sign_persistent() -> None:
+    site_names = ("a", "b")
+    loss_spec = build_recon_terms(
+        (
+            FaithfulnessLossConfig(coeff=1.0),
+            ImportanceMinimalityLossConfig(
+                coeff=1e-6,
+                pnorm=2.0,
+                beta=0.1,
+                p_anneal_start_frac=0.0,
+                p_anneal_final_p=0.5,
+                p_anneal_end_frac=1.0,
+            ),
+            StochasticReconLossConfig(coeff=0.5),
+            PersistentPGDReconLossConfig(
+                coeff=0.5,
+                scope=SCScope(),
+                optimizer=_sign_optimizer(0.01),
+                n_warmup_steps=2,
+            ),
+        ),
+        site_names,
+        n_mask_samples=1,
+        sampling="continuous",
+    )
+    (cfg,) = loss_spec.persistent.values()
+    assert isinstance(cfg.optimizer, SignPGDConfig)
+
+
+def test_adam_and_sign_diverge_after_one_step() -> None:
+    sources = {"s": jnp.array([0.5, 0.5])}
+    grad = {"s": jnp.array([0.2, -0.2])}
+    lr = jnp.asarray(0.1)
+
+    adam = AdamPGDConfig(lr_schedule=ScheduleConfig(start_val=0.1, warmup_pct=0.0))
+    sign = _sign_optimizer(0.1)
+    adam_out, _ = sources_ascend_project(
+        sources, grad, init_sources_opt_state(sources, adam), lr, adam
+    )
+    sign_out, _ = sources_ascend_project(
+        sources, grad, init_sources_opt_state(sources, sign), lr, sign
+    )
+    assert not jnp.allclose(adam_out["s"], sign_out["s"])

--- a/param_decomp_jax/jax_single_pool/train.py
+++ b/param_decomp_jax/jax_single_pool/train.py
@@ -28,10 +28,10 @@ from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, Float, PRNGKeyArray
 
 from jax_single_pool.adversary import (
-    SourcesAdamState,
+    SourcesOptState,
     init_fresh_pgd_sources,
     source_masks,
-    sources_adam_ascend_project,
+    sources_ascend_project,
 )
 from jax_single_pool.ci_fn import CIFn, CIValues
 from jax_single_pool.lm import DecomposedLM
@@ -51,7 +51,7 @@ from jax_single_pool.recon import (
     Routes,
     StochasticSources,
 )
-from param_decomp_config.losses import AdamPGDConfig
+from param_decomp_config.losses import PGDOptimizerConfig
 
 COMPUTE_DT = jnp.bfloat16
 
@@ -70,7 +70,7 @@ class TrainState:
     sources: dict[str, dict[str, Array]]
     """Persistent adversarial sources, `state_key -> site -> (1, T, C+1)` in [0,1].
     One state_key per persistent loss term (SPEC S23); empty when no persistent term."""
-    sources_opt_state: dict[str, SourcesAdamState]
+    sources_opt_state: dict[str, SourcesOptState]
     step: Array
 
 
@@ -128,11 +128,9 @@ def make_train_step(
         if isinstance(entry.sources, PersistentSources)
     }
     assert set(term_coeff_by_state_key) == set(loss_spec.persistent)
-    persistent_adams: dict[str, AdamPGDConfig] = {}
-    for state_key, ppgd_cfg in loss_spec.persistent.items():
-        optimizer = ppgd_cfg.optimizer
-        assert isinstance(optimizer, AdamPGDConfig)
-        persistent_adams[state_key] = optimizer
+    persistent_optimizers: dict[str, PGDOptimizerConfig] = {
+        state_key: ppgd_cfg.optimizer for state_key, ppgd_cfg in loss_spec.persistent.items()
+    }
 
     def batch_sharded(x: Array) -> Array:
         if mesh is None:
@@ -259,14 +257,14 @@ def make_train_step(
         # loss plan), sequential per term as in torch.
         source_lrs: dict[str, Array] = {}
         warmed_sources: dict[str, dict[str, Array]] = {}
-        warmup_opt_states: dict[str, SourcesAdamState] = {}
+        warmup_opt_states: dict[str, SourcesOptState] = {}
         for state_key, ppgd_cfg in loss_spec.persistent.items():
-            adam = persistent_adams[state_key]
+            optimizer = persistent_optimizers[state_key]
             source_lr = warmup_then_constant_lr(
                 step_f32,
                 total_steps,
-                adam.lr_schedule.start_val,
-                adam.lr_schedule.warmup_pct,
+                optimizer.lr_schedule.start_val,
+                optimizer.lr_schedule.warmup_pct,
             )
             source_lrs[state_key] = source_lr
 
@@ -278,18 +276,18 @@ def make_train_step(
                 return kl_per_position(masked, clean_logits)
 
             def warmup_body(
-                carry: tuple[dict[str, Array], SourcesAdamState],
+                carry: tuple[dict[str, Array], SourcesOptState],
                 _: None,
                 source_lr: Array = source_lr,
-                adam: AdamPGDConfig = adam,
+                optimizer: PGDOptimizerConfig = optimizer,
                 warmup_loss: Callable[[dict[str, Array]], Array] = warmup_loss,
-            ) -> tuple[tuple[dict[str, Array], SourcesAdamState], None]:
-                sources, adam_state = carry
+            ) -> tuple[tuple[dict[str, Array], SourcesOptState], None]:
+                sources, opt_state = carry
                 sources_grad = jax.grad(warmup_loss)(sources)
-                sources, adam_state = sources_adam_ascend_project(
-                    sources, sources_grad, adam_state, source_lr, adam
+                sources, opt_state = sources_ascend_project(
+                    sources, sources_grad, opt_state, source_lr, optimizer
                 )
-                return (sources, adam_state), None
+                return (sources, opt_state), None
 
             (warmed, warmed_opt), _ = jax.lax.scan(
                 warmup_body,
@@ -434,18 +432,18 @@ def make_train_step(
         # the backward saw coeff·L_term, the adversary ascends on L_term itself, and the
         # division is exact because each source bundle feeds exactly one term (S23). ──
         new_sources: dict[str, dict[str, Array]] = {}
-        new_sources_opt_state: dict[str, SourcesAdamState] = {}
+        new_sources_opt_state: dict[str, SourcesOptState] = {}
         for state_key in loss_spec.persistent:
             coeff = term_coeff_by_state_key[state_key]
             sources_grad = {
                 site: g / coeff for site, g in persistent_grads_scaled[state_key].items()
             }
-            ascended, ascended_opt = sources_adam_ascend_project(
+            ascended, ascended_opt = sources_ascend_project(
                 warmed_sources[state_key],
                 sources_grad,
                 warmup_opt_states[state_key],
                 source_lrs[state_key],
-                persistent_adams[state_key],
+                persistent_optimizers[state_key],
             )
             new_sources[state_key] = ascended
             new_sources_opt_state[state_key] = ascended_opt


### PR DESCRIPTION
Closes #612

## What changed

The JAX persistent PPGD adversary was Adam-only and refused the `sign` optimizer in `build_recon_terms`. Torch supports both (`SignPGDOptimizer` / `AdamPGDOptimizer`). This adds the sign SRC_STEP variation point (SPEC §6) to the persistent path for full parity.

- **`adversary.py`**: `SourcesSignState` (empty registered pytree) + `SourcesOptState = SourcesAdamState | SourcesSignState`. New `init_sources_opt_state(sources, optimizer)` and `sources_ascend_project(sources, grad, opt_state, lr, optimizer)` dispatch on the optimizer config. Sign step is `sources += lr * sign(grad)` then PROJ to [0,1] (S15), stateless. The Adam branch is factored out unchanged; the projection (`clip`) now happens once in the wrapper for both branches — mathematically bit-identical to before for Adam (clip is the last op either way), so the stacked-parity fixtures are preserved.
- **`recon.py`**: `_assert_supported_persistent` accepts `SignPGDConfig` as well as `AdamPGDConfig`.
- **`train.py`**: threads `PGDOptimizerConfig` (not `AdamPGDConfig`) through the warmup `scan` and the final fused-graph ascent (S13'/S14').
- **`run_state.py`**: inits each persistent key's opt state from `loss_spec.persistent[k].optimizer`.
- **`SPEC.md`**: rename the cited fn `sources_adam_ascend_project` -> `sources_ascend_project`.
- **`tests/test_adversary_sign.py`**: unit tests for the sign step (lr·sign, magnitude-independence, clamp), statelessness, `build_recon_terms` acceptance of a sign-persistent term, and adam≠sign divergence.

## Verification status

- `python -m py_compile` clean on all changed files; pre-commit ruff + basedpyright pass.
- New JAX unit tests were **not executed** — this worktree has no JAX venv and the cheap-verification policy precludes installing one. The tests are pure arithmetic verified by inspection.
- **Acceptance criterion 3 (torch persistent-sign parity FIXTURE) is NOT done** — it requires a torch reference run, which is out of scope for this worktree. Left for human verification. PR kept OPEN for that reason.

🤖 Generated with [Claude Code](https://claude.com/claude-code)