### PR TITLE
feat(jax-adversary): persistent sigmoid source parameterization (#614)

### DIFF
--- a/param_decomp_jax/jax_single_pool/CLAUDE.md
+++ b/param_decomp_jax/jax_single_pool/CLAUDE.md
@@ -4,9 +4,10 @@ Single-pool VPD trainer in JAX, **generic over vendored LM targets**. The semant
 source of truth is `SPEC.md` (normative pseudocode + numbered invariants, grounded in
 the stable torch `param_decomp` impl). See `README.md` for the file map.
 
-Open items: persistent-source scopes beyond `sc`, sigmoid parameterization,
-`start_frac>0`, and the hidden-acts seam are deliberately refused (LOSS_PARITY_DESIGN
-§6 stage 4); SPEC S24's two torch-parity quirks (PPGD warmup route-all, fresh-PGD
+Open items: persistent-source scopes beyond `sc`, `start_frac>0`, and the hidden-acts
+seam are deliberately refused (LOSS_PARITY_DESIGN §6 stage 4); the sigmoid source
+parameterization (§6 `PROJ`/`EFFECTIVE`) IS implemented (`adversary.py`
+`SourceParameterization`); SPEC S24's two torch-parity quirks (PPGD warmup route-all, fresh-PGD
 single routing draw) are pinned pending a team decision; CI-fn numerics (gelu erf,
 rms eps) unify with torch at a run boundary.
 

--- a/param_decomp_jax/jax_single_pool/LOSS_PARITY_DESIGN.md
+++ b/param_decomp_jax/jax_single_pool/LOSS_PARITY_DESIGN.md
@@ -1,6 +1,6 @@
 # Loss parity: every torch loss Metric in the JAX trainer — design
 
-Status: IMPLEMENTED (stages 1-3; 2026-06-11) — `recon.py` holds the strategies/terms/`build_recon_terms`, `train.py` the multi-term step, SPEC amended (S10′/S12′/S13′/S14′, S23/S24). Deferred per §6 stage 4: `nsc` scope, sigmoid parameterization, `start_frac>0`, the hidden-acts seam. Scope: the 15 `LOSS_METRIC_CLASSES` entries +
+Status: IMPLEMENTED (stages 1-3; 2026-06-11) — `recon.py` holds the strategies/terms/`build_recon_terms`, `train.py` the multi-term step, SPEC amended (S10′/S12′/S13′/S14′, S23/S24). Deferred per §6 stage 4: `nsc` scope, `start_frac>0`, the hidden-acts seam (the sigmoid `PROJ`/`EFFECTIVE` parameterization landed later, #614 — `adversary.py` `SourceParameterization`). Scope: the 15 `LOSS_METRIC_CLASSES` entries +
 `ChunkwiseSubsetReconLoss` (lab) as the torch surface; `recon.py` / `adversary.py` /
 `train.py` / `SPEC.md` as the JAX surface. Every torch `update()` /
 `before_backward` / `after_backward` path was read, not just class names.

--- a/param_decomp_jax/jax_single_pool/adversary.py
+++ b/param_decomp_jax/jax_single_pool/adversary.py
@@ -22,7 +22,23 @@ from jax import random
 from jaxtyping import Array, Float, PRNGKeyArray
 
 from jax_single_pool.lm import SiteSpec
-from param_decomp_config.losses import AdamPGDConfig
+from param_decomp_config.losses import (
+    AdamPGDConfig,
+    PersistentPGDReconLossConfig,
+    PersistentPGDReconSubsetLossConfig,
+)
+
+SourceParameterization = Literal["clamp", "sigmoid"]
+"""The `PROJ`/`EFFECTIVE` variation point (SPEC §6, line `PROJ`/`EFFECTIVE`). `clamp`:
+sources live in `[0,1]`, projected by clamp after each ascent, read as-is, init U[0,1].
+`sigmoid`: latent sources are unbounded (no projection), read through a sigmoid, init
+N(0,1). Torch counterpart: `use_sigmoid_parameterization` in `persistent_pgd_state.py`."""
+
+
+def source_parameterization(
+    cfg: PersistentPGDReconLossConfig | PersistentPGDReconSubsetLossConfig,
+) -> SourceParameterization:
+    return "sigmoid" if cfg.use_sigmoid_parameterization else "clamp"
 
 
 @jax.tree_util.register_dataclass
@@ -37,14 +53,17 @@ def init_persistent_sources(
     site_names: tuple[str, ...],
     site_component_counts: tuple[int, ...],
     seq_len: int,
+    parameterization: SourceParameterization,
     key: PRNGKeyArray,
 ) -> dict[str, Array]:
     """PPGD `sc` scope (SPEC §1.6): `(1, T, C+1)` per site — shared across batch
-    elements, free per position — init U[0,1] (SPEC S15; clamp parameterization).
-    Trailing channel = the weight-delta source."""
+    elements, free per position. Init is U[0,1] under `clamp`, N(0,1) (unbounded
+    latent) under `sigmoid` (SPEC S15 / §6 `PROJ`/`EFFECTIVE`). Trailing channel =
+    the weight-delta source."""
     keys = random.split(key, len(site_names))
+    init_fn = random.normal if parameterization == "sigmoid" else random.uniform
     return {
-        name: random.uniform(k, (1, seq_len, c + 1), jnp.float32)
+        name: init_fn(k, (1, seq_len, c + 1), jnp.float32)
         for name, c, k in zip(site_names, site_component_counts, keys, strict=True)
     }
 
@@ -95,8 +114,11 @@ def sources_adam_ascend_project(
     adam_state: SourcesAdamState,
     lr: Array,
     adam: AdamPGDConfig,
+    parameterization: SourceParameterization,
 ) -> tuple[dict[str, Array], SourcesAdamState]:
-    """One Adam ASCENT on the persistent sources, then project to [0,1] (SPEC S13/S15).
+    """One Adam ASCENT on the persistent sources, then `PROJ` (SPEC S13/S15). `PROJ` is
+    clamp to [0,1] under `clamp`, identity under `sigmoid` (the latent stays unbounded
+    and is squashed at read time by `source_masks`; SPEC §6 `PROJ`/`EFFECTIVE`).
 
     The variation point `SRC_STEP` (SPEC §6): a `sign` variant would replace the Adam
     update with `lr * sign(grad)` (stateless) — same projection contract."""
@@ -108,29 +130,37 @@ def sources_adam_ascend_project(
     }
     bias_correction1 = 1 - adam.beta1**step_count
     bias_correction2 = 1 - adam.beta2**step_count
-    new_sources = {
-        s: jnp.clip(
-            sources[s]
-            + lr * (m[s] / bias_correction1) / (jnp.sqrt(v[s] / bias_correction2) + adam.eps),
-            0.0,
-            1.0,
-        )
+    ascended = {
+        s: sources[s]
+        + lr * (m[s] / bias_correction1) / (jnp.sqrt(v[s] / bias_correction2) + adam.eps)
         for s in sources
     }
+    new_sources = (
+        ascended
+        if parameterization == "sigmoid"
+        else {s: jnp.clip(a, 0.0, 1.0) for s, a in ascended.items()}
+    )
     return new_sources, SourcesAdamState(m=m, v=v, step_count=step_count)
 
 
 def source_masks(
-    ci_lower: dict[str, Array], sources: dict[str, Array], site_names: tuple[str, ...]
+    ci_lower: dict[str, Array],
+    sources: dict[str, Array],
+    site_names: tuple[str, ...],
+    parameterization: SourceParameterization,
 ) -> tuple[dict[str, Array], dict[str, Array]]:
-    """`mask = ci + (1−ci)·source[:, :C]`; delta mask = raw trailing channel (SPEC S1).
-    Shared by both adversaries; sources broadcast over whatever leading dims their
-    scope left singleton. The fp32 source state is cast to the CI dtype here
-    (torch-under-autocast behavior); the source gradient flows back through the cast."""
+    """`mask = ci + (1−ci)·EFFECTIVE(source)[:, :C]`; delta mask = `EFFECTIVE(source)`
+    trailing channel (SPEC S1). `EFFECTIVE` is identity under `clamp`, sigmoid under
+    `sigmoid` (SPEC §6 `PROJ`/`EFFECTIVE`). Shared by both adversaries; sources
+    broadcast over whatever leading dims their scope left singleton. The fp32 source
+    state is cast to the CI dtype here (torch-under-autocast behavior); the source
+    gradient flows back through the cast (and through the sigmoid)."""
     masks = {}
     delta_masks = {}
     for site in site_names:
         source = sources[site].astype(ci_lower[site].dtype)
+        if parameterization == "sigmoid":
+            source = jax.nn.sigmoid(source)
         masks[site] = ci_lower[site] + (1.0 - ci_lower[site]) * source[..., :-1]
         delta_masks[site] = source[..., -1]
     return masks, delta_masks

--- a/param_decomp_jax/jax_single_pool/experiments/invariance_check.py
+++ b/param_decomp_jax/jax_single_pool/experiments/invariance_check.py
@@ -60,7 +60,7 @@ def _run(steps: int, sharded: bool) -> list[dict[str, float]]:
     opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)
     src = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, random.PRNGKey(3)
+        lm.site_names, tuple(s.C for s in lm.sites), seq, "clamp", random.PRNGKey(3)
     )
     resid = random.normal(random.PRNGKey(4), (gbatch, seq, cfg.n_embd)) * 0.5
 

--- a/param_decomp_jax/jax_single_pool/experiments/llama8b_real.py
+++ b/param_decomp_jax/jax_single_pool/experiments/llama8b_real.py
@@ -176,7 +176,9 @@ def main():
     if args.shard:
         vu = init_decomp_vu_sharded(lm.sites, random.PRNGKey(1), mesh)
         ci_fn = init_ci_fn_sharded(arch, lm.sites, random.PRNGKey(2), mesh)
-        src = init_sources_sharded(lm.site_names, site_Cs, args.seq, random.PRNGKey(3), mesh)
+        src = init_sources_sharded(
+            lm.site_names, site_Cs, args.seq, "clamp", random.PRNGKey(3), mesh
+        )
     else:
         repl = NamedSharding(mesh, P())
         put = lambda a: jax.device_put(a, repl) if eqx.is_array(a) else a  # noqa: E731
@@ -185,7 +187,7 @@ def main():
         src = {
             k: jax.device_put(v, repl)
             for k, v in init_persistent_sources(
-                lm.site_names, site_Cs, args.seq, random.PRNGKey(3)
+                lm.site_names, site_Cs, args.seq, "clamp", random.PRNGKey(3)
             ).items()
         }
     resid = shard_batch(resid_global, mesh)

--- a/param_decomp_jax/jax_single_pool/experiments/mem_probe.py
+++ b/param_decomp_jax/jax_single_pool/experiments/mem_probe.py
@@ -77,7 +77,7 @@ def main() -> None:
     vu = init_decomp_vu_sharded(lm.sites, random.PRNGKey(1), mesh)
     ci_fn = init_ci_fn_sharded(CIArch(4096, 4, 64, 16384), lm.sites, random.PRNGKey(2), mesh)
     src = init_sources_sharded(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, random.PRNGKey(3), mesh
+        lm.site_names, tuple(s.C for s in lm.sites), seq, "clamp", random.PRNGKey(3), mesh
     )
     opt_vu = optax.chain(
         optax.clip_by_global_norm(0.01),

--- a/param_decomp_jax/jax_single_pool/llama8b_sharding.py
+++ b/param_decomp_jax/jax_single_pool/llama8b_sharding.py
@@ -32,7 +32,7 @@ from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, PRNGKeyArray
 
-from jax_single_pool.adversary import init_persistent_sources
+from jax_single_pool.adversary import SourceParameterization, init_persistent_sources
 from jax_single_pool.ci_fn import CIArch, CIFn, init_ci_fn
 from jax_single_pool.llama8b import DecompVU, Target, init_decomp_vu
 from jax_single_pool.lm import SiteSpec
@@ -114,6 +114,7 @@ def init_sources_sharded(
     site_names: tuple[str, ...],
     site_component_counts: tuple[int, ...],
     seq_len: int,
+    parameterization: SourceParameterization,
     key: PRNGKeyArray,
     mesh: Mesh,
 ) -> dict[str, Array]:
@@ -128,7 +129,9 @@ def init_sources_sharded(
     weight-delta channel C+1 is odd (8193) and not divisible by the mesh size, and would
     also fight the batch-sharded elementwise combine."""
     repl = NamedSharding(mesh, P())
-    init = partial(init_persistent_sources, site_names, site_component_counts, seq_len)
+    init = partial(
+        init_persistent_sources, site_names, site_component_counts, seq_len, parameterization
+    )
     return jax.jit(init, out_shardings=repl)(key)
 
 

--- a/param_decomp_jax/jax_single_pool/recon.py
+++ b/param_decomp_jax/jax_single_pool/recon.py
@@ -256,7 +256,7 @@ def _assert_supported_persistent(
     cfg: PersistentPGDReconLossConfig | PersistentPGDReconSubsetLossConfig,
 ) -> None:
     assert isinstance(cfg.scope, SCScope), f"persistent scope {cfg.scope} unsupported (sc only)"
-    assert not cfg.use_sigmoid_parameterization and cfg.start_frac == 0.0, cfg
+    assert cfg.start_frac == 0.0, cfg
     optimizer = cfg.optimizer
     assert isinstance(optimizer, AdamPGDConfig), optimizer
     schedule = optimizer.lr_schedule

--- a/param_decomp_jax/jax_single_pool/run_state.py
+++ b/param_decomp_jax/jax_single_pool/run_state.py
@@ -13,7 +13,7 @@ from jax import random
 from jax.sharding import Mesh
 from jaxtyping import PRNGKeyArray
 
-from jax_single_pool.adversary import init_sources_adam_state
+from jax_single_pool.adversary import init_sources_adam_state, source_parameterization
 from jax_single_pool.config import ExperimentConfig
 from jax_single_pool.llama8b_sharding import (
     init_ci_fn_sharded,
@@ -55,6 +55,7 @@ def init_train_state(
             lm.site_names,
             tuple(s.C for s in lm.sites),
             cfg.data.seq_len,
+            source_parameterization(loss_spec.persistent[state_key]),
             random.fold_in(src_key, term_idx),
             mesh,
         )

--- a/param_decomp_jax/jax_single_pool/tests/equivalence/jax_equivalence.py
+++ b/param_decomp_jax/jax_single_pool/tests/equivalence/jax_equivalence.py
@@ -174,7 +174,7 @@ def compute_jax_terms(f: dict[str, np.ndarray]) -> dict[str, float]:
 
     # ---- ppgd (FIXED sources) ----
     source = per_site("ppgd_source")  # {site: (1, T, C+1)}
-    masks, delta_masks = source_masks(ci_lower, source, lm.site_names)
+    masks, delta_masks = source_masks(ci_lower, source, lm.site_names, "clamp")
     pred = lm.masked_logits(tgt, vu, resid, masks, delta_masks, None, lm.site_names)
     ppgd = float(kl_per_position(pred, clean))
 

--- a/param_decomp_jax/jax_single_pool/tests/equivalence/test_equivalence.py
+++ b/param_decomp_jax/jax_single_pool/tests/equivalence/test_equivalence.py
@@ -76,3 +76,61 @@ def test_structure_ppgd_has_delta_channel() -> None:
     assert "ci_lower[site] + (1.0 - ci_lower[site]) * source[..., :-1]" in src, (
         "ppgd must interpolate mask=ci+(1-ci)*source"
     )
+
+
+def test_sigmoid_parameterization_matches_torch_effective_sources() -> None:
+    """SPEC S15/S16, §6 `PROJ`/`EFFECTIVE` (sigmoid variant). Torch's
+    `get_effective_sources` applies `sigmoid` to the WHOLE latent (incl. the trailing
+    delta channel) before `get_ppgd_mask_infos` interpolates
+    `mask = ci + (1-ci)*EFFECTIVE(src)[..., :C]` / `delta = EFFECTIVE(src)[..., -1]`.
+    `source_masks(..., "sigmoid")` must reproduce that math from the SAME unbounded
+    latent (the leaf the ascent updates without projection)."""
+    import jax
+    import jax.numpy as jnp
+
+    key = jax.random.PRNGKey(0)
+    ci_key, src_key = jax.random.split(key)
+    sites = ("a", "b")
+    B, T, C = 2, 3, 4
+    ci_lower = {
+        s: jax.random.uniform(jax.random.fold_in(ci_key, i), (B, T, C)) for i, s in enumerate(sites)
+    }
+    latent = {
+        s: jax.random.normal(jax.random.fold_in(src_key, i), (1, T, C + 1)) * 3.0
+        for i, s in enumerate(sites)
+    }
+
+    masks, delta_masks = adversary_mod.source_masks(ci_lower, latent, sites, "sigmoid")
+    for s in sites:
+        effective = jax.nn.sigmoid(latent[s])
+        expected_mask = ci_lower[s] + (1.0 - ci_lower[s]) * effective[..., :-1]
+        np.testing.assert_allclose(
+            np.asarray(masks[s]), np.asarray(expected_mask), rtol=1e-6, atol=1e-6
+        )
+        np.testing.assert_allclose(
+            np.asarray(delta_masks[s]), np.asarray(effective[..., -1]), rtol=1e-6, atol=1e-6
+        )
+        assert jnp.all((masks[s] >= 0.0) & (masks[s] <= 1.0)), "sigmoid masks must stay in [0,1]"
+
+
+def test_sigmoid_parameterization_init_is_normal_and_proj_is_identity() -> None:
+    """SPEC §6: sigmoid init is N(0,1) (unbounded latent, range exceeds [0,1]); `PROJ`
+    is identity so an ascent that drives a source past 1 is NOT clamped back."""
+    import jax
+    import jax.numpy as jnp
+
+    sites = ("a",)
+    src = adversary_mod.init_persistent_sources(sites, (8,), 16, "sigmoid", jax.random.PRNGKey(1))
+    assert jnp.max(src["a"]) > 1.0 and jnp.min(src["a"]) < 0.0, "N(0,1) init must escape [0,1]"
+
+    from param_decomp_config.schedule import ScheduleConfig
+
+    adam = adversary_mod.AdamPGDConfig(
+        lr_schedule=ScheduleConfig(fn_type="constant", start_val=1.0)
+    )
+    state = adversary_mod.init_sources_adam_state(src)
+    grad = {"a": jnp.ones_like(src["a"])}
+    ascended, _ = adversary_mod.sources_adam_ascend_project(
+        src, grad, state, jnp.asarray(50.0), adam, "sigmoid"
+    )
+    assert jnp.max(ascended["a"]) > 1.0, "sigmoid PROJ must be identity (no clamp to [0,1])"

--- a/param_decomp_jax/jax_single_pool/tests/stacked_parity/gen_stacked_fixtures.py
+++ b/param_decomp_jax/jax_single_pool/tests/stacked_parity/gen_stacked_fixtures.py
@@ -103,7 +103,7 @@ def main() -> None:
     vu = init_decomp_vu(cfg, C, layer_range.n_layers, random.PRNGKey(1))
     ci_fn = init_ci_fn(CI_ARCH, lm.sites, random.PRNGKey(2))
     sources = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), T, random.PRNGKey(3)
+        lm.site_names, tuple(s.C for s in lm.sites), T, "clamp", random.PRNGKey(3)
     )
     resid = random.normal(random.PRNGKey(4), (B, T, cfg.n_embd)) * 0.5
 

--- a/param_decomp_jax/jax_single_pool/tests/stacked_parity/test_stacked_parity.py
+++ b/param_decomp_jax/jax_single_pool/tests/stacked_parity/test_stacked_parity.py
@@ -158,7 +158,7 @@ def test_train_trajectory_matches():
     for leaf_idx, leaf in enumerate(jax.tree.leaves(eqx.filter(ci_fn, eqx.is_array))):
         np.testing.assert_array_equal(np.asarray(leaf), f[f"ci_leaf::{leaf_idx}"])
     sources = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), T, random.PRNGKey(3)
+        lm.site_names, tuple(s.C for s in lm.sites), T, "clamp", random.PRNGKey(3)
     )
     for name, source in sources.items():
         np.testing.assert_array_equal(np.asarray(source), f[f"src::{name}"])

--- a/param_decomp_jax/jax_single_pool/tests/test_checkpoint.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_checkpoint.py
@@ -58,7 +58,7 @@ def _build(seed: int):
     opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)
     src = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, jax.random.PRNGKey(seed + 2)
+        lm.site_names, tuple(s.C for s in lm.sites), seq, "clamp", jax.random.PRNGKey(seed + 2)
     )
     state = TrainState(
         components=vu, ci_fn=ci_fn,
@@ -148,7 +148,12 @@ def _build_sharded(seed: int, mesh):
     opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)
     src = init_sources_sharded(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, jax.random.PRNGKey(seed + 2), mesh
+        lm.site_names,
+        tuple(s.C for s in lm.sites),
+        seq,
+        "clamp",
+        jax.random.PRNGKey(seed + 2),
+        mesh,
     )
     state = TrainState(
         components=vu, ci_fn=ci_fn,

--- a/param_decomp_jax/jax_single_pool/tests/test_llama8b.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_llama8b.py
@@ -274,7 +274,7 @@ def test_step_trains_and_has_vpd_signature(site_cs: tuple[SiteC, ...]):
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)
 
     src = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, jax.random.PRNGKey(3)
+        lm.site_names, tuple(s.C for s in lm.sites), seq, "clamp", jax.random.PRNGKey(3)
     )
     state = TrainState(
         components=vu, ci_fn=ci_fn,

--- a/param_decomp_jax/jax_single_pool/tests/test_llama_simple_mlp.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_llama_simple_mlp.py
@@ -305,7 +305,7 @@ def test_step_trains_and_has_vpd_signature():
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)
 
     src = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, jax.random.PRNGKey(3)
+        lm.site_names, tuple(s.C for s in lm.sites), seq, "clamp", jax.random.PRNGKey(3)
     )
     state = TrainState(
         components=vu, ci_fn=ci_fn,

--- a/param_decomp_jax/jax_single_pool/tests/test_sharding.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_sharding.py
@@ -100,8 +100,10 @@ def test_jitted_sharded_inits_match_eager_values():
 
     site_names = tuple(s.name for s in sites)
     site_Cs = tuple(s.C for s in sites)
-    src_sharded = init_sources_sharded(site_names, site_Cs, 16, jax.random.PRNGKey(3), mesh)
-    src_eager = init_persistent_sources(site_names, site_Cs, 16, jax.random.PRNGKey(3))
+    src_sharded = init_sources_sharded(
+        site_names, site_Cs, 16, "clamp", jax.random.PRNGKey(3), mesh
+    )
+    src_eager = init_persistent_sources(site_names, site_Cs, 16, "clamp", jax.random.PRNGKey(3))
     for name in site_names:
         src_sharding = src_sharded[name].sharding
         assert isinstance(src_sharding, NamedSharding)

--- a/param_decomp_jax/jax_single_pool/tests/test_torch_config.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_torch_config.py
@@ -113,24 +113,6 @@ def test_unsupported_settings_refuse():
             out_dir=Path("/tmp"), remat_recon_forwards=True,
         )  # fmt: skip
 
-    sigmoid_ppgd = dict(
-        raw,
-        pd=dict(
-            raw["pd"],
-            loss_metrics=[
-                dict(m, use_sigmoid_parameterization=True)
-                if m["type"] == "PersistentPGDReconLoss"
-                else m
-                for m in raw["pd"]["loss_metrics"]
-            ],
-        ),
-    )
-    with pytest.raises(AssertionError):
-        convert_torch_lm_config(
-            type(torch_cfg)(**sigmoid_ppgd), run_name="t", run_id=RUN_ID, out_dir=Path("/tmp"),
-            remat_recon_forwards=True,
-        )  # fmt: skip
-
     non_site_target = dict(
         raw,
         pd=dict(

--- a/param_decomp_jax/jax_single_pool/train.py
+++ b/param_decomp_jax/jax_single_pool/train.py
@@ -28,9 +28,11 @@ from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, Float, PRNGKeyArray
 
 from jax_single_pool.adversary import (
+    SourceParameterization,
     SourcesAdamState,
     init_fresh_pgd_sources,
     source_masks,
+    source_parameterization,
     sources_adam_ascend_project,
 )
 from jax_single_pool.ci_fn import CIFn, CIValues
@@ -129,10 +131,12 @@ def make_train_step(
     }
     assert set(term_coeff_by_state_key) == set(loss_spec.persistent)
     persistent_adams: dict[str, AdamPGDConfig] = {}
+    persistent_parameterizations: dict[str, SourceParameterization] = {}
     for state_key, ppgd_cfg in loss_spec.persistent.items():
         optimizer = ppgd_cfg.optimizer
         assert isinstance(optimizer, AdamPGDConfig)
         persistent_adams[state_key] = optimizer
+        persistent_parameterizations[state_key] = source_parameterization(ppgd_cfg)
 
     def batch_sharded(x: Array) -> Array:
         if mesh is None:
@@ -226,9 +230,11 @@ def make_train_step(
         clean_logits: Array,
         forward_fn: Any,
     ) -> Array:
-        """Mean KL over the entry's draws with FIXED source values — the adversarial
-        ascent objective (shared by fresh and persistent ascents, SPEC S12')."""
-        masks, delta_masks = source_masks(ci_lower, sources, entry.live_sites)
+        """Mean KL over the entry's draws with FIXED source values — the fresh-PGD
+        adversarial ascent objective (SPEC S12'). Fresh PGD is always clamp-parameterized
+        (its sources are projected to [0,1] each ascent); persistent ascents read sources
+        through `source_masks` directly with their own parameterization."""
+        masks, delta_masks = source_masks(ci_lower, sources, entry.live_sites, "clamp")
         total = jnp.zeros((), jnp.float32)
         for routes in routes_per_draw:
             masked = forward_fn(
@@ -262,6 +268,7 @@ def make_train_step(
         warmup_opt_states: dict[str, SourcesAdamState] = {}
         for state_key, ppgd_cfg in loss_spec.persistent.items():
             adam = persistent_adams[state_key]
+            parameterization = persistent_parameterizations[state_key]
             source_lr = warmup_then_constant_lr(
                 step_f32,
                 total_steps,
@@ -270,8 +277,13 @@ def make_train_step(
             )
             source_lrs[state_key] = source_lr
 
-            def warmup_loss(sources: dict[str, Array]) -> Array:
-                masks, delta_masks = source_masks(ci_lower_detached, sources, site_names)
+            def warmup_loss(
+                sources: dict[str, Array],
+                parameterization: SourceParameterization = parameterization,
+            ) -> Array:
+                masks, delta_masks = source_masks(
+                    ci_lower_detached, sources, site_names, parameterization
+                )
                 masked = masked_forward(
                     frozen, components_detached, residual, masks, delta_masks, None, site_names
                 )
@@ -282,12 +294,13 @@ def make_train_step(
                 _: None,
                 source_lr: Array = source_lr,
                 adam: AdamPGDConfig = adam,
+                parameterization: SourceParameterization = parameterization,
                 warmup_loss: Callable[[dict[str, Array]], Array] = warmup_loss,
             ) -> tuple[tuple[dict[str, Array], SourcesAdamState], None]:
                 sources, adam_state = carry
                 sources_grad = jax.grad(warmup_loss)(sources)
                 sources, adam_state = sources_adam_ascend_project(
-                    sources, sources_grad, adam_state, source_lr, adam
+                    sources, sources_grad, adam_state, source_lr, adam, parameterization
                 )
                 return (sources, adam_state), None
 
@@ -398,10 +411,14 @@ def make_train_step(
                                     ci.lower,
                                     fresh_sources[(term_idx, entry_idx)],
                                     entry.live_sites,
+                                    "clamp",
                                 )
                             case PersistentSources(state_key=state_key):
                                 masks, delta_masks = source_masks(
-                                    ci.lower, persistent_sources[state_key], entry.live_sites
+                                    ci.lower,
+                                    persistent_sources[state_key],
+                                    entry.live_sites,
+                                    persistent_parameterizations[state_key],
                                 )
                         masked = checkpointed_masked_forward(
                             frozen,
@@ -446,6 +463,7 @@ def make_train_step(
                 warmup_opt_states[state_key],
                 source_lrs[state_key],
                 persistent_adams[state_key],
+                persistent_parameterizations[state_key],
             )
             new_sources[state_key] = ascended
             new_sources_opt_state[state_key] = ascended_opt


### PR DESCRIPTION
Closes #614

## What

Implements the sigmoid source parameterization for the JAX single-pool persistent adversary, achieving torch parity. The torch persistent adversary (`persistent_pgd_state.py`) supports reading sources through `sigmoid` (an unconstrained latent) instead of clamping to `[0,1]`; the JAX trainer previously refused it via `_assert_supported_persistent`.

This is SPEC §6's `PROJ`/`EFFECTIVE` variation point (invariants S15/S16):

- **`clamp`** (production default): `PROJ` = clamp to `[0,1]`, `EFFECTIVE` = identity, init `U[0,1]`.
- **`sigmoid`**: `PROJ` = identity (latent stays unbounded), `EFFECTIVE` = sigmoid, init `N(0,1)`.

## How

A `SourceParameterization = Literal["clamp", "sigmoid"]` is derived from the shared config's `use_sigmoid_parameterization` (`source_parameterization()` helper) and threaded through the three adversary primitives:

- `init_persistent_sources` — `random.normal` (sigmoid) vs `random.uniform` (clamp).
- `sources_adam_ascend_project` — skips the `[0,1]` clamp under sigmoid (identity `PROJ`).
- `source_masks` — applies `jax.nn.sigmoid` to the whole latent (including the trailing weight-delta channel, matching torch `get_effective_sources`) before `mask = ci + (1-ci)*EFFECTIVE(src)`.

Fresh-PGD stays clamp-only (it projects every ascent). The refusal in `recon._assert_supported_persistent` drops the sigmoid guard but keeps the `start_frac == 0.0` guard (a separate deferred feature).

## Verification

- `make check` (ruff + basedpyright) passes via pre-commit.
- Added two equivalence tests in `test_equivalence.py`:
  - `test_sigmoid_parameterization_matches_torch_effective_sources` — pins `source_masks(..., "sigmoid")` against the torch `get_effective_sources` + interpolation math (`sigmoid` applied to whole latent, delta channel = `sigmoid(src)[..., -1]`).
  - `test_sigmoid_parameterization_init_is_normal_and_proj_is_identity` — verifies N(0,1) init escapes `[0,1]` and that `PROJ` does not clamp an over-1 ascent.
- Tests not executed in this worktree (no JAX runtime installed); compiled clean and the math mirrors torch's reference functions exactly. A full cross-framework golden regen (`gen_fixtures.py` JAX env → `torch_reference.py` torch env) would be the watertight numeric check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)