### PR TITLE
jax: persistent start_frac>0 source-LR warmup gating (#613, SPEC S25)

### DIFF
--- a/param_decomp_jax/jax_single_pool/CLAUDE.md
+++ b/param_decomp_jax/jax_single_pool/CLAUDE.md
@@ -4,11 +4,12 @@ Single-pool VPD trainer in JAX, **generic over vendored LM targets**. The semant
 source of truth is `SPEC.md` (normative pseudocode + numbered invariants, grounded in
 the stable torch `param_decomp` impl). See `README.md` for the file map.
 
-Open items: persistent-source scopes beyond `sc`, sigmoid parameterization,
-`start_frac>0`, and the hidden-acts seam are deliberately refused (LOSS_PARITY_DESIGN
-§6 stage 4); SPEC S24's two torch-parity quirks (PPGD warmup route-all, fresh-PGD
-single routing draw) are pinned pending a team decision; CI-fn numerics (gelu erf,
-rms eps) unify with torch at a run boundary.
+Open items: persistent-source scopes beyond `sc`, sigmoid parameterization, and the
+hidden-acts seam are deliberately refused (LOSS_PARITY_DESIGN §6 stage 4); persistent
+`start_frac>0` is now implemented (SPEC S25, `term_active` `where`-gating); SPEC S24's
+two torch-parity quirks (PPGD warmup route-all, fresh-PGD single routing draw) are
+pinned pending a team decision; CI-fn numerics (gelu erf, rms eps) unify with torch at
+a run boundary.
 
 ## The one rule
 

--- a/param_decomp_jax/jax_single_pool/LOSS_PARITY_DESIGN.md
+++ b/param_decomp_jax/jax_single_pool/LOSS_PARITY_DESIGN.md
@@ -1,6 +1,6 @@
 # Loss parity: every torch loss Metric in the JAX trainer — design
 
-Status: IMPLEMENTED (stages 1-3; 2026-06-11) — `recon.py` holds the strategies/terms/`build_recon_terms`, `train.py` the multi-term step, SPEC amended (S10′/S12′/S13′/S14′, S23/S24). Deferred per §6 stage 4: `nsc` scope, sigmoid parameterization, `start_frac>0`, the hidden-acts seam. Scope: the 15 `LOSS_METRIC_CLASSES` entries +
+Status: IMPLEMENTED (stages 1-3; 2026-06-11. `start_frac>0` source-LR-warmup gating: stage 4, 2026-06-16, SPEC S25) — `recon.py` holds the strategies/terms/`build_recon_terms`, `train.py` the multi-term step, SPEC amended (S10′/S12′/S13′/S14′, S23/S24/S25). Deferred per §6 stage 4: `nsc` scope, sigmoid parameterization, the hidden-acts seam. Scope: the 15 `LOSS_METRIC_CLASSES` entries +
 `ChunkwiseSubsetReconLoss` (lab) as the torch surface; `recon.py` / `adversary.py` /
 `train.py` / `SPEC.md` as the JAX surface. Every torch `update()` /
 `before_backward` / `after_backward` path was read, not just class names.
@@ -342,9 +342,11 @@ divisibility for `nsc`) becomes a converter assert.
   the analog is `coeff_t = where(step ≥ start_frac·total, coeff, 0)` plus gating
   source/moment updates with `where` — semantics match (sources init at step 0 but
   untouched until active; distributionally identical since init is RNG-pure), cost
-  is paying the adversary forward before activation. Either accept that cost or
-  keep refusing `start_frac > 0` (current assert). Propose: keep refusing until a
-  config actually needs it.
+  is paying the adversary forward before activation. IMPLEMENTED 2026-06-16 (SPEC
+  S25): `term_active = step_f32 >= start_frac·total` gates the warmup `(sources, opt)`
+  carry, the term-loss contribution, and the final-ascent `(sources, opt)` — all via
+  `_select_pytree` `where`. `start_frac == 0.0` skips the gating entirely (byte-exact
+  unchanged path).
 - **Q4 — `nsc` tiling.** Torch tiles `n_sources` over the **per-rank** batch slice
   (synced replicas ⇒ each source covers `B/n` global elements, rank-interleaved);
   JAX would tile over the global batch (contiguous). Same multiset of assignments,
@@ -374,7 +376,7 @@ divisibility for `nsc`) becomes a converter assert.
 | PPGD scopes `c`/`nsc`/`bsc` | **composition-only** | source-shape variants of `init_persistent_sources` + Q4 note; `bsc` needs no replica sync (S16 already covers) |
 | PPGD `sign` SRC_STEP, sigmoid parameterization, `n_samples>1` | **composition-only** | SPEC §6 already names them as variation points |
 | multiple simultaneous loss/adversary terms | **composition-only** | §2.2 TrainState dicts + per-term S14 |
-| PPGD `start_frac > 0` | **composition-only (deferred)** | Q3 — keep the refusing assert until needed |
+| PPGD `start_frac > 0` | **implemented (2026-06-16)** | Q3 — `term_active` `where`-gating, SPEC S25 |
 | `StochasticHiddenActsReconLoss` | **needs-new-seam → recommend-keep-on-bridge** | `masked_site_outputs` fn per target; conflicts with the one-recon-semantics rule; already offline (§4c) |
 | attn-pattern eval losses | **keep-on-bridge** | eval-only in torch too (§4d) |
 

--- a/param_decomp_jax/jax_single_pool/SPEC.md
+++ b/param_decomp_jax/jax_single_pool/SPEC.md
@@ -240,6 +240,7 @@ init: biases zero; weights fan-in scaled (torch init_param_)
 | S22 | Checkpoints round-trip ALL trajectory state of §3 — including every persistent term's sources + SRC_STEP moments + step/schedule counters — such that a resumed run continues the same trajectory (modulo RNG streams and kernel nondeterminism, cf. D4). |
 | S23 | A persistent source bundle feeds exactly ONE loss term. (The fused-backward S14′ unscaling divides that term's coeff out of the source gradient; a bundle shared across terms would make the division wrong.) |
 | S24 | A persistent term's WARMUP ascents forward all sites, routed everywhere — regardless of the term's loss plan (torch parity: `persistent_pgd_state.warmup` hardcodes route-all). A fresh-PGD entry draws its routing ONCE per step, shared by all its ascents and its main loss forward (torch parity: `pgd_masked_recon_loss_update`). |
+| S25 | A persistent term with `start_frac > 0` contributes nothing — no loss, no source/optimizer update — until `step/total_steps >= start_frac` (torch parity: `update()` returns `None` before `start_frac`, the term absent and its state frozen at init). Sources are RNG-initialized at step 0 but untouched while inactive, so activation is distributionally identical to lazy construction. `start_frac == 0.0` is the always-active common case and keeps the unguarded, byte-exact path. The source-LR schedule (S13) is a pure function of `step`, so the LR used at the activation step already reflects whatever warmup/decay that step's schedule prescribes. |
 
 ## 6. Variation points
 

--- a/param_decomp_jax/jax_single_pool/losses.py
+++ b/param_decomp_jax/jax_single_pool/losses.py
@@ -61,5 +61,13 @@ def annealed_pnorm(step_f32: Array, total_steps: int, cfg: ImportanceMinimalityL
 def warmup_then_constant_lr(
     step_f32: Array, total_steps: int, lr: float, warmup_frac: float
 ) -> Array:
-    warmup_steps = jnp.maximum(jnp.floor(total_steps * warmup_frac), 1.0)
+    """Linear ramp `0 → lr` over `int(total_steps * warmup_frac)` steps, then constant.
+
+    `warmup_frac == 0` short-circuits to full `lr` at every step (torch
+    `get_scheduled_value`: `warmup_steps = int(total_steps * 0) = 0`, so the
+    `step < warmup_steps` warmup branch never fires). `warmup_frac` is a static
+    config float, so this is a trace-time branch."""
+    warmup_steps = int(total_steps * warmup_frac)
+    if warmup_steps == 0:
+        return jnp.asarray(lr, jnp.float32)
     return jnp.where(step_f32 < warmup_steps, lr * step_f32 / warmup_steps, lr)

--- a/param_decomp_jax/jax_single_pool/recon.py
+++ b/param_decomp_jax/jax_single_pool/recon.py
@@ -256,7 +256,7 @@ def _assert_supported_persistent(
     cfg: PersistentPGDReconLossConfig | PersistentPGDReconSubsetLossConfig,
 ) -> None:
     assert isinstance(cfg.scope, SCScope), f"persistent scope {cfg.scope} unsupported (sc only)"
-    assert not cfg.use_sigmoid_parameterization and cfg.start_frac == 0.0, cfg
+    assert not cfg.use_sigmoid_parameterization, cfg
     optimizer = cfg.optimizer
     assert isinstance(optimizer, AdamPGDConfig), optimizer
     schedule = optimizer.lr_schedule

--- a/param_decomp_jax/jax_single_pool/train.py
+++ b/param_decomp_jax/jax_single_pool/train.py
@@ -60,6 +60,15 @@ def cast_floating(tree: Any, dtype: Any) -> Any:
     return jax.tree.map(lambda a: a.astype(dtype) if eqx.is_inexact_array(a) else a, tree)
 
 
+def _select_pytree(active: Array, when_active: Any, when_inactive: Any) -> Any:
+    """Element-wise `where(active, when_active, when_inactive)` over matching pytrees.
+
+    Gates a persistent term's source/optimizer updates on `start_frac` (SPEC S25):
+    when inactive the leaf is left untouched, matching torch's `update()`-returns-None
+    (the term is absent, its state frozen at init until `step/total >= start_frac`)."""
+    return jax.tree.map(lambda a, b: jnp.where(active, a, b), when_active, when_inactive)
+
+
 @jax.tree_util.register_dataclass
 @dataclass(frozen=True)
 class TrainState:
@@ -260,8 +269,16 @@ def make_train_step(
         source_lrs: dict[str, Array] = {}
         warmed_sources: dict[str, dict[str, Array]] = {}
         warmup_opt_states: dict[str, SourcesAdamState] = {}
+        # `start_frac` gating (SPEC S25): a term contributes nothing — no loss, no
+        # source/optimizer update — until `step/total_steps >= start_frac`. `start_frac`
+        # is a static config float, so the no-gating common case (`== 0.0`) keeps the
+        # zero-overhead path; a positive `start_frac` pays the adversary forward before
+        # activation and `where`-gates every state update (LOSS_PARITY_DESIGN Q3).
+        term_active: dict[str, Array] = {}
         for state_key, ppgd_cfg in loss_spec.persistent.items():
             adam = persistent_adams[state_key]
+            if ppgd_cfg.start_frac > 0.0:
+                term_active[state_key] = step_f32 >= ppgd_cfg.start_frac * total_steps
             source_lr = warmup_then_constant_lr(
                 step_f32,
                 total_steps,
@@ -291,12 +308,18 @@ def make_train_step(
                 )
                 return (sources, adam_state), None
 
+            base_sources = state.sources[state_key]
+            base_opt = state.sources_opt_state[state_key]
             (warmed, warmed_opt), _ = jax.lax.scan(
                 warmup_body,
-                (state.sources[state_key], state.sources_opt_state[state_key]),
+                (base_sources, base_opt),
                 None,
                 length=ppgd_cfg.n_warmup_steps,
             )
+            if ppgd_cfg.start_frac > 0.0:
+                warmed, warmed_opt = _select_pytree(
+                    term_active[state_key], (warmed, warmed_opt), (base_sources, base_opt)
+                )
             warmed_sources[state_key] = jax.lax.stop_gradient(warmed)
             warmup_opt_states[state_key] = warmed_opt
 
@@ -415,7 +438,14 @@ def make_train_step(
                         total = total + kl_per_position(masked, clean_logits)
                         n_forwards += 1
                 assert n_forwards > 0, f"term {term.name!r} produced no forwards"
-                term_losses.append(total / n_forwards)
+                term_loss = total / n_forwards
+                first_sources = term.plan[0].sources
+                if (
+                    isinstance(first_sources, PersistentSources)
+                    and loss_spec.persistent[first_sources.state_key].start_frac > 0.0
+                ):
+                    term_loss = term_active[first_sources.state_key] * term_loss
+                term_losses.append(term_loss)
 
             total_loss = faith_coeff * faith_loss + imp_coeff * imp_loss
             for term, term_loss in zip(recon_terms, term_losses, strict=True):
@@ -447,6 +477,12 @@ def make_train_step(
                 source_lrs[state_key],
                 persistent_adams[state_key],
             )
+            if loss_spec.persistent[state_key].start_frac > 0.0:
+                ascended, ascended_opt = _select_pytree(
+                    term_active[state_key],
+                    (ascended, ascended_opt),
+                    (warmed_sources[state_key], warmup_opt_states[state_key]),
+                )
             new_sources[state_key] = ascended
             new_sources_opt_state[state_key] = ascended_opt
 


### PR DESCRIPTION
Closes #613

## What changed
Implements the JAX single-pool persistent-PGD `start_frac>0` source-LR warmup feature (torch parity), and resolves the `warmup_pct==0` step-0 LR edge (P4).

- **recon.py** — relax `_assert_supported_persistent`: drop the `start_frac == 0.0` clause (refusal relaxed). Sigmoid parameterization stays refused.
- **train.py** — per-persistent-term `term_active = step_f32 >= start_frac * total_steps` gates, via a new `_select_pytree` (`jnp.where` over matching pytrees):
  - the warmup `(sources, opt_state)` carry,
  - the term-loss contribution (so V/U/CI grads are zero while inactive),
  - the final-ascent `(sources, opt_state)`.
  - `start_frac == 0.0` (the common case) skips all gating — the byte-exact unchanged path.
  - Matches torch `update()` returning `None` before `start_frac`: term absent, source/optimizer state frozen at its RNG init until activation (distributionally identical to torch's lazy state construction since init is RNG-pure).
- **losses.py** — `warmup_then_constant_lr` now matches torch `get_scheduled_value`'s step-0 full-LR short-circuit: `warmup_pct==0` → `warmup_steps = int(total_steps*0) = 0` → full `lr` at every step (was LR=0 at step 0 under the old `max(floor(...),1)`). The `int()` denominator now matches torch exactly; the `warmup_pct>0` path is numerically unchanged.
- **SPEC.md** — new invariant **S25** documenting `start_frac` gating. **LOSS_PARITY_DESIGN.md** Q3 / effort-map / status + **CLAUDE.md** open-items updated.

## Verification (JAX CPU venv)
- `pytest jax_single_pool/tests/stacked_parity/` — 4 passed (byte-exact `src_lr` + V/U trajectory preserved; `warmup_pct=0.025` path unchanged).
- `pytest jax_single_pool/tests/test_llama_simple_mlp.py jax_single_pool/tests/test_torch_config.py` — 20 passed.
- Focused gating check (ad-hoc, not committed):
  - inactive step (start_frac=0.6, step 0 < 60): sources / Adam moments / step_count unchanged; term loss gated to exactly 0.0.
  - active step (step 70 ≥ 60): sources change, term loss nonzero, step_count = n_warmup+1 = 2.
  - `start_frac=0.0` vs `start_frac=0.6` at an active step (70) produce bit-identical next state — gating is a pure activation switch.
  - `warmup_pct=0`: lr@step0 = 0.01 (full); `warmup_pct=0.025`: step0=0, step1=0.005, step2+=0.01 (byte-exact with prior).
- pre-commit: ruff + basedpyright passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)