### PR TITLE
test(jax-equivalence): static-live-set chunk-plan parity golden (#579)

### DIFF
--- a/param_decomp_jax/jax_single_pool/tests/equivalence/jax_equivalence.py
+++ b/param_decomp_jax/jax_single_pool/tests/equivalence/jax_equivalence.py
@@ -12,6 +12,11 @@ Term wiring (all `jax_single_pool.train` + the `DecomposedLM` boundary):
   * stoch — per chunk: `mask = ci+(1-ci)*u`, fixed delta mask, fixed route over the
             chunk's 3 sites; `lm.masked_logits(..., live=chunk)`; `kl_per_position`
             vs `lm.clean_logits` (the frozen path, SPEC S3). Mean over chunks.
+  * stoch_route_all — identical chunk plan as `stoch` but routing is `all` (`routes=None`)
+            so the LIVE chunk's sites have NO per-position fallback. This isolates the
+            STATIC live-set frozen-site path (SPEC S2: every non-chunk site runs frozen
+            `x@W`, no `(B,T,C)` acts) from the per-position routing fallback they share in
+            `stoch` — the R-2 concern in the parity matrix.
   * ppgd  — `source_masks` + `lm.masked_logits(..., live=all)`.
 
 Bit-identical is impossible across RNG/FP backends; we assert each term within
@@ -172,13 +177,29 @@ def compute_jax_terms(f: dict[str, np.ndarray]) -> dict[str, float]:
         stoch_total += float(kl_per_position(pred, clean))
     stoch = stoch_total / n_layers
 
+    # ---- stoch_route_all (per-chunk, FIXED masks, routing=all → static live-set only) ----
+    stoch_route_all_total = 0.0
+    for i in range(n_layers):
+        chunk = tuple(site_name(i, k) for k in MLP_KINDS)
+        masks = {s: ci_lower[s] + (1.0 - ci_lower[s]) * stoch_u[s] for s in chunk}
+        delta_masks = {s: stoch_delta[s] for s in chunk}
+        pred = lm.masked_logits(tgt, vu, resid, masks, delta_masks, None, chunk)
+        stoch_route_all_total += float(kl_per_position(pred, clean))
+    stoch_route_all = stoch_route_all_total / n_layers
+
     # ---- ppgd (FIXED sources) ----
     source = per_site("ppgd_source")  # {site: (1, T, C+1)}
     masks, delta_masks = source_masks(ci_lower, source, lm.site_names)
     pred = lm.masked_logits(tgt, vu, resid, masks, delta_masks, None, lm.site_names)
     ppgd = float(kl_per_position(pred, clean))
 
-    return {"faith": faith, "imp": imp, "stoch": stoch, "ppgd": ppgd}
+    return {
+        "faith": faith,
+        "imp": imp,
+        "stoch": stoch,
+        "stoch_route_all": stoch_route_all,
+        "ppgd": ppgd,
+    }
 
 
 def main() -> None:
@@ -187,7 +208,7 @@ def main() -> None:
     jaxv = compute_jax_terms(f)
     print(f"{'term':6} {'jax':>16} {'torch':>16} {'rel_err':>12}  ok")
     all_ok = True
-    for term in ("faith", "imp", "stoch", "ppgd"):
+    for term in ("faith", "imp", "stoch", "stoch_route_all", "ppgd"):
         jv, tv = jaxv[term], ref[term]
         rel = abs(jv - tv) / (abs(tv) + 1e-30)
         ok = abs(jv - tv) <= ATOL + RTOL * abs(tv)

--- a/param_decomp_jax/jax_single_pool/tests/equivalence/test_equivalence.py
+++ b/param_decomp_jax/jax_single_pool/tests/equivalence/test_equivalence.py
@@ -41,11 +41,17 @@ RTOL = 2e-4
 ATOL = 1e-5
 
 
-@pytest.mark.parametrize("term", ["faith", "imp", "stoch", "ppgd"])
+@pytest.mark.parametrize("term", ["faith", "imp", "stoch", "stoch_route_all", "ppgd"])
 def test_jax_matches_torch_reference(term: str) -> None:
+    """`stoch_route_all` pins the static live-set frozen-site recon (SPEC S2): a
+    `subset_chunk_plan` forward where the live chunk routes ALL positions (`routes=None`),
+    so every non-chunk site runs frozen `x@W` with no `(B,T,C)` acts — isolated from the
+    per-position routing fallback `stoch` also exercises (parity matrix R-2)."""
     ref_path = HERE / "torch_reference.json"
     assert ref_path.exists(), "run torch_reference.py (torch env) to produce the golden first"
     ref = json.loads(ref_path.read_text())
+    if term not in ref:
+        pytest.skip(f"golden missing '{term}'; regenerate via torch_reference.py (torch env)")
     jaxv = compute_jax_terms(dict(np.load(HERE / "fixtures.npz")))
     jv, tv = jaxv[term], ref[term]
     assert abs(jv - tv) <= ATOL + RTOL * abs(tv), (

--- a/param_decomp_jax/jax_single_pool/tests/equivalence/torch_reference.py
+++ b/param_decomp_jax/jax_single_pool/tests/equivalence/torch_reference.py
@@ -14,6 +14,10 @@ functions (the load-bearing math), on the byte-identical fixtures, and writes
     from the fixtures, run the masked suffix forward (real `LinearComponents.forward` for
     the chunk's sites; frozen `F.linear` for every other layer + the tail), and
     `recon_loss_kl(pred, clean)/n_positions`. Mean over the chunks.
+  * **stoch_route_all** — the same per-chunk subset recon as `stoch`, but every chunk
+    `ComponentsMaskInfo` carries `routing_mask="all"` so the live sites have no
+    per-position `torch.where` fallback. Isolates the static live-set frozen-site path
+    (every non-chunk layer runs the frozen MLP) from per-position routing (parity R-2).
   * **ppgd** — `get_ppgd_mask_infos` (real) builds the component masks (`ci+(1-ci)*src`)
     + the weight-delta channel from the fixed sources; masked suffix forward over ALL
     sites; `recon_loss_kl/n_positions`.
@@ -207,6 +211,27 @@ def main() -> None:
         stoch_sum += (kl_sum / n).item()
     stoch = stoch_sum / s.n_layers
 
+    # ---- stoch_route_all (per-chunk subset recon, routing=all → static live-set only) ----
+    stoch_route_all_sum = 0.0
+    for i in range(s.n_layers):
+        mask_infos = {}
+        for k in KINDS:
+            ci_s = ci_lower_layer[k][:, :, i, :]  # (B,T,C)
+            u = torch.tensor(f[f"stoch_u_{k}"][:, :, i, :], dtype=torch.float32)
+            comp_mask = ci_s + (1 - ci_s) * u
+            delta = s.comp[i][k].target_weight - s.comp[i][k].weight
+            delta_mask = torch.tensor(f[f"stoch_delta_{k}"][:, :, i], dtype=torch.float32)
+            mask_infos[f"l{i}.{k}"] = ComponentsMaskInfo(
+                component_mask=comp_mask,
+                routing_mask="all",
+                weight_delta_and_mask=(delta, delta_mask),
+            )
+        pred = s.forward(mask_infos=mask_infos, decompose_layers={i})
+        kl_sum, n = recon_loss_kl(pred=pred, target=clean)
+        assert n == n_positions
+        stoch_route_all_sum += (kl_sum / n).item()
+    stoch_route_all = stoch_route_all_sum / s.n_layers
+
     # ---- ppgd (all sites, persistent sources via get_ppgd_mask_infos) ----
     # Build per-site ci + weight_deltas + sources keyed by site, then the real mask infos.
     ci_site = {f"l{i}.{k}": ci_lower_layer[k][:, :, i, :] for i in range(s.n_layers) for k in KINDS}
@@ -228,7 +253,14 @@ def main() -> None:
     kl_sum, n = recon_loss_kl(pred=pred, target=clean)
     ppgd = (kl_sum / n).item()
 
-    out = {"faith": faith, "imp": imp, "stoch": stoch, "ppgd": ppgd, "n_chunks": s.n_layers}
+    out = {
+        "faith": faith,
+        "imp": imp,
+        "stoch": stoch,
+        "stoch_route_all": stoch_route_all,
+        "ppgd": ppgd,
+        "n_chunks": s.n_layers,
+    }
     (HERE / "torch_reference.json").write_text(json.dumps(out, indent=2))
     print(json.dumps(out, indent=2))
 


### PR DESCRIPTION
Closes #579

## What

Adds a cross-framework parity golden (`stoch_route_all`) that isolates the **static live-set frozen-site recon forward** (SPEC S2) — a `subset_chunk_plan` forward where every non-chunk site runs the frozen `x@W` path with no `(B,T,C)` acts.

The existing `stoch` term already drives a chunk plan, but its live chunk uses **per-position uniform-k routing**, so the static-live-set path is entangled with the per-position routing fallback — exactly the R-2 concern flagged in the parity matrix. The new `stoch_route_all` term runs the same chunk plan with routing=all (`routes=None` on JAX → no `where`; `routing_mask="all"` on torch → no `torch.where` fallback), so the only thing under test between live sites and frozen sites is the static-live-set gate.

- `jax_equivalence.py`: `compute_jax_terms` now also returns `stoch_route_all` (chunk loop, `lm.masked_logits(..., routes=None, live=chunk)`).
- `torch_reference.py`: matching reference via `ComponentsMaskInfo(routing_mask="all")` + `decompose_layers={i}`; writes `stoch_route_all` into the golden json.
- `test_equivalence.py`: parametrizes the numeric test over the new term; skips it (with a clear regenerate message) until `torch_reference.json` carries the key.

Reuses the existing `fixtures.npz` (`stoch_u` / `stoch_delta` / `ci_lower`) — `gen_fixtures.py` is unchanged; only `torch_reference.json` needs regeneration in the torch env.

Invariants: S2 / S10 / S11.

## Verification status

- All three edited files `py_compile` clean; `make format` + `make type` (basedpyright) pass via the pre-commit hooks.
- The numeric cross-framework comparison was **not executed** here: it needs both the JAX and torch venvs, and the committed `torch_reference.json` predates the new key, so the new parametrization currently **skips** rather than asserting a value. To finish: run `gen_fixtures.py` (no change needed) then `torch_reference.py` in the torch env to regenerate the golden, after which the `stoch_route_all` assertion goes live. The JAX-side term mirrors the already-passing `stoch` term exactly (same `masked_logits` call, `routes=None`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)