### PR TITLE
jax recon: static has_delta flag skips x@Δ matmul for constant-source entries (#582)

### DIFF
--- a/param_decomp_jax/jax_single_pool/eval.py
+++ b/param_decomp_jax/jax_single_pool/eval.py
@@ -81,7 +81,7 @@ def make_eval_step(
     ) -> Array:  # fmt: skip
         return batch_sharded(
             lm.masked_logits(
-                frozen, components_bf16, residual, masks, delta_masks, None, site_names
+                frozen, components_bf16, residual, masks, delta_masks, None, site_names, True
             )
         )
 

--- a/param_decomp_jax/jax_single_pool/llama8b.py
+++ b/param_decomp_jax/jax_single_pool/llama8b.py
@@ -287,22 +287,25 @@ def _site_out(
     U: Array,
     W: Array,
     mask: Array | None,
-    delta_mask: Array,
+    delta_mask: Array | None,
     route: Array | None,
 ) -> Array:
     """One decomposed linear (SPEC §1.3): `((x@V)*m)@U + (x@Δ)*d`, routed per position
     against the frozen `x @ W.T`. `mask` may be None (fully on); `route` None routes
-    everywhere. `delta_mask`/`route` broadcast over batch; trailing dim added here."""
+    everywhere. `delta_mask` None drops the delta path entirely (constant-source entries
+    carry no delta, LOSS_PARITY_DESIGN §4b). `delta_mask`/`route` broadcast over batch;
+    trailing dim added here."""
     acts = x @ V
     if mask is not None:
         acts = acts * mask
     out = acts @ U
-    # DIVERGENCE from torch-under-autocast (documented, accepted): this delta is
-    # computed in bf16 from the cast components; torch computes W − V@U in fp32 then
-    # casts at the einsum. bf16-rounding-level difference on the delta PATH only —
-    # the faithfulness loss uses the fp32 `weight_deltas` (SPEC N2), not this.
-    delta = W - (V @ U).T  # (d_out, d_in)
-    out = out + delta_mask[..., None] * (x @ delta.T)
+    if delta_mask is not None:
+        # DIVERGENCE from torch-under-autocast (documented, accepted): this delta is
+        # computed in bf16 from the cast components; torch computes W − V@U in fp32 then
+        # casts at the einsum. bf16-rounding-level difference on the delta PATH only —
+        # the faithfulness loss uses the fp32 `weight_deltas` (SPEC N2), not this.
+        delta = W - (V @ U).T  # (d_out, d_in)
+        out = out + delta_mask[..., None] * (x @ delta.T)
     if route is not None:
         out = jnp.where(route[..., None], out, x @ W.T)
     return out
@@ -369,12 +372,13 @@ def _masked_site_out(
     delta_masks: dict[str, Array],
     routes: dict[str, Array] | None,
     live_set: frozenset[str],
+    has_delta: bool,
 ) -> Array:
     if site not in live_set:
         return x_in @ W.T
     V, U = components.site(site)
     return _site_out(
-        x_in, V, U, W, masks[site], delta_masks[site],
+        x_in, V, U, W, masks[site], delta_masks[site] if has_delta else None,
         None if routes is None else routes[site],
     )  # fmt: skip
 
@@ -388,18 +392,20 @@ def masked_suffix_logits(
     delta_masks: dict[str, Array],
     routes: dict[str, Array] | None,
     live: tuple[str, ...],
+    has_delta: bool,
 ) -> Array:
     """Masked decomposed suffix forward (SPEC §1.3, S2): sites in `live` run their
     decomposed forward with `masks[s]` / `delta_masks[s]` / `routes[s]`; every other
     site — and every site absent from the decomposition entirely — runs the frozen
-    `x @ W` path. `live` is static under jit."""
+    `x @ W` path. `live` and `has_delta` are static under jit; `has_delta` False skips
+    the `x @ Δ` matmul (LOSS_PARITY_DESIGN §4b)."""
     live_set = frozenset(live)
     x = resid
     for layer_offset, suffix_layer in enumerate(target.layers):
         layer = first_layer + layer_offset
         live_kinds = {kind for kind in KIND_ORDER if site_name(layer, kind) in live_set}
         attn = suffix_layer.attn
-        site_args = (masks, delta_masks, routes, live_set)
+        site_args = (masks, delta_masks, routes, live_set, has_delta)
         h1 = rms_norm(x, suffix_layer.ln1, target.eps)
         if not live_kinds & set(ATTN_KINDS):
             attn_out = attn(h1, target.inv_freq)
@@ -457,9 +463,16 @@ def llama_decomposed_lm(cfg: LlamaConfig, sites: tuple[SiteSpec, ...]) -> Decomp
         sites=sites,
         clean_logits=lambda frozen, resid: clean_suffix_logits(frozen, resid),
         site_inputs=lambda frozen, resid: clean_site_inputs(frozen, first_layer, site_names, resid),
-        masked_logits=lambda frozen, components, resid, masks, delta_masks, routes, live: (
+        masked_logits=lambda frozen,
+        components,
+        resid,
+        masks,
+        delta_masks,
+        routes,
+        live,
+        has_delta: (
             masked_suffix_logits(
-                frozen, components, first_layer, resid, masks, delta_masks, routes, live
+                frozen, components, first_layer, resid, masks, delta_masks, routes, live, has_delta
             )
         ),
         weight_deltas=lambda frozen, components: weight_deltas_fp32(

--- a/param_decomp_jax/jax_single_pool/llama_simple_mlp.py
+++ b/param_decomp_jax/jax_single_pool/llama_simple_mlp.py
@@ -270,20 +270,22 @@ def _site_out(
     U: Array,
     W: Array,
     mask: Array | None,
-    delta_mask: Array,
+    delta_mask: Array | None,
     route: Array | None,
 ) -> Array:
     """One decomposed linear (SPEC §4.1), same as `llama8b._site_out`: `((x@V)*m)@U +
     (x@Δ)*d`, routed per position against the frozen `x @ W.T`. `mask` may be None
-    (fully on); `route` None routes everywhere. The delta on this PATH is bf16-computed
-    from the cast components (documented divergence; the faithfulness loss uses the
-    fp32 `weight_deltas`, SPEC N2)."""
+    (fully on); `route` None routes everywhere. `delta_mask` None drops the delta path
+    entirely (constant-source entries carry no delta, LOSS_PARITY_DESIGN §4b). The delta
+    on this PATH is bf16-computed from the cast components (documented divergence; the
+    faithfulness loss uses the fp32 `weight_deltas`, SPEC N2)."""
     acts = x @ V
     if mask is not None:
         acts = acts * mask
     out = acts @ U
-    delta = W - (V @ U).T  # (d_out, d_in)
-    out = out + delta_mask[..., None] * (x @ delta.T)
+    if delta_mask is not None:
+        delta = W - (V @ U).T  # (d_out, d_in)
+        out = out + delta_mask[..., None] * (x @ delta.T)
     if route is not None:
         out = jnp.where(route[..., None], out, x @ W.T)
     return out
@@ -355,12 +357,13 @@ def _masked_site_out(
     delta_masks: dict[str, Array],
     routes: dict[str, Array] | None,
     live_set: frozenset[str],
+    has_delta: bool,
 ) -> Array:
     if site not in live_set:
         return x_in @ W.T
     V, U = components.site(site)
     return _site_out(
-        x_in, V, U, W, masks[site], delta_masks[site],
+        x_in, V, U, W, masks[site], delta_masks[site] if has_delta else None,
         None if routes is None else routes[site],
     )  # fmt: skip
 
@@ -374,11 +377,13 @@ def masked_suffix_logits(
     delta_masks: dict[str, Array],
     routes: dict[str, Array] | None,
     live: tuple[str, ...],
+    has_delta: bool,
 ) -> Array:
     """Masked decomposed suffix forward (SPEC §4.1, S2): sites in `live` run their
     decomposed forward with `masks[s]` / `delta_masks[s]` / `routes[s]`; every other
     site — and every site absent from the decomposition entirely — runs the frozen
-    `x @ W` path. `live` is static under jit."""
+    `x @ W` path. `live` and `has_delta` are static under jit; `has_delta` False skips
+    the `x @ Δ` matmul (LOSS_PARITY_DESIGN §4b)."""
     assert resid.shape[1] <= target.n_ctx, (resid.shape, target.n_ctx)
     live_set = frozenset(live)
     x = resid
@@ -386,7 +391,7 @@ def masked_suffix_logits(
         layer_idx = first_layer + layer_offset
         live_kinds = {kind for kind in KIND_ORDER if site_name(layer_idx, kind) in live_set}
         attn = layer.attn
-        site_args = (masks, delta_masks, routes, live_set)
+        site_args = (masks, delta_masks, routes, live_set, has_delta)
         h1 = rms_norm(x, layer.ln1, target.eps)
         if not live_kinds & set(ATTN_KINDS):
             attn_out = attn(h1, target.inv_freq)
@@ -452,9 +457,16 @@ def llama_simple_mlp_decomposed_lm(
         sites=sites,
         clean_logits=lambda frozen, resid: clean_suffix_logits(frozen, resid),
         site_inputs=lambda frozen, resid: clean_site_inputs(frozen, first_layer, site_names, resid),
-        masked_logits=lambda frozen, components, resid, masks, delta_masks, routes, live: (
+        masked_logits=lambda frozen,
+        components,
+        resid,
+        masks,
+        delta_masks,
+        routes,
+        live,
+        has_delta: (
             masked_suffix_logits(
-                frozen, components, first_layer, resid, masks, delta_masks, routes, live
+                frozen, components, first_layer, resid, masks, delta_masks, routes, live, has_delta
             )
         ),
         weight_deltas=lambda frozen, components: weight_deltas_fp32(

--- a/param_decomp_jax/jax_single_pool/lm.py
+++ b/param_decomp_jax/jax_single_pool/lm.py
@@ -48,10 +48,12 @@ class DecomposedLM:
     `sites` fixes the canonical site order — chunking (SPEC S10) and the CI fn's
     input/output concatenation both follow it.
 
-    `masked_logits(frozen, vu, resid, masks, delta_masks, routes, live)`:
+    `masked_logits(frozen, vu, resid, masks, delta_masks, routes, live, has_delta)`:
     `live` (a tuple of site names, static under jit) lists the sites running their
     decomposed forward; all other sites MUST run the frozen `x @ W` path (SPEC S2).
     `masks`/`delta_masks` may broadcast over the batch dim (the PPGD source case).
+    `has_delta` (static) False skips the `x @ Δ` matmul for constant-source entries
+    whose delta mask is a constant 0 (LOSS_PARITY_DESIGN §4b).
 
     `clean_logits` is the all-frozen forward — the recon target (SPEC S3); never the
     `mask=1` decomposed identity.
@@ -63,7 +65,16 @@ class DecomposedLM:
     clean_logits: Callable[[Any, Float[Array, "B T d"]], Float[Array, "B T vocab"]]
     site_inputs: Callable[[Any, Float[Array, "B T d"]], dict[str, Float[Array, "B T d_in"]]]
     masked_logits: Callable[
-        [Any, Any, Float[Array, "B T d"], SiteMasks, SiteDeltaMasks, SiteRoutes, tuple[str, ...]],
+        [
+            Any,
+            Any,
+            Float[Array, "B T d"],
+            SiteMasks,
+            SiteDeltaMasks,
+            SiteRoutes,
+            tuple[str, ...],
+            bool,
+        ],
         Float[Array, "B T vocab"],
     ]
     weight_deltas: Callable[[Any, Any], dict[str, Float[Array, "d_out d_in"]]]

--- a/param_decomp_jax/jax_single_pool/recon.py
+++ b/param_decomp_jax/jax_single_pool/recon.py
@@ -100,16 +100,29 @@ class PersistentSources:
 MaskSourceStrategy = StochasticSources | ConstantSources | FreshPGDSources | PersistentSources
 
 
+def strategy_has_delta(sources: MaskSourceStrategy) -> bool:
+    """`ConstantSources` carries no delta path (torch passes no `weight_deltas` for the
+    Unmasked/CIMasked losses); its `delta_mask` would be a constant 0, so the `x @ Δ`
+    matmul is skipped entirely (static, retrace-safe — LOSS_PARITY_DESIGN §4b). Every
+    other strategy drives a live delta mask."""
+    return not isinstance(sources, ConstantSources)
+
+
 @dataclass(frozen=True)
 class ReconForward:
     """One plan entry: which sites run their decomposed path (`live_sites` — everything
     else takes the frozen `x @ W` path, the ~9x-cheaper non-decomposed matmul), a
     sampler producing this entry's family of routing draws, and the strategy that
-    generates each draw's mask/delta sources."""
+    generates each draw's mask/delta sources. `has_delta` (static, derived from the
+    strategy) skips the `x @ Δ` matmul for constant-source entries."""
 
     live_sites: tuple[str, ...]
     sample_routing: RoutingSampler
     sources: MaskSourceStrategy
+
+    @property
+    def has_delta(self) -> bool:
+        return strategy_has_delta(self.sources)
 
 
 ReconPlan = tuple[ReconForward, ...]

--- a/param_decomp_jax/jax_single_pool/tests/equivalence/jax_equivalence.py
+++ b/param_decomp_jax/jax_single_pool/tests/equivalence/jax_equivalence.py
@@ -168,14 +168,14 @@ def compute_jax_terms(f: dict[str, np.ndarray]) -> dict[str, float]:
         masks = {s: ci_lower[s] + (1.0 - ci_lower[s]) * stoch_u[s] for s in chunk}
         delta_masks = {s: stoch_delta[s] for s in chunk}
         routes = {site_name(i, k): jnp.asarray(f[f"route_chunk{i}_{k}"]) for k in MLP_KINDS}
-        pred = lm.masked_logits(tgt, vu, resid, masks, delta_masks, routes, chunk)
+        pred = lm.masked_logits(tgt, vu, resid, masks, delta_masks, routes, chunk, True)
         stoch_total += float(kl_per_position(pred, clean))
     stoch = stoch_total / n_layers
 
     # ---- ppgd (FIXED sources) ----
     source = per_site("ppgd_source")  # {site: (1, T, C+1)}
     masks, delta_masks = source_masks(ci_lower, source, lm.site_names)
-    pred = lm.masked_logits(tgt, vu, resid, masks, delta_masks, None, lm.site_names)
+    pred = lm.masked_logits(tgt, vu, resid, masks, delta_masks, None, lm.site_names, True)
     ppgd = float(kl_per_position(pred, clean))
 
     return {"faith": faith, "imp": imp, "stoch": stoch, "ppgd": ppgd}

--- a/param_decomp_jax/jax_single_pool/tests/stacked_parity/gen_stacked_fixtures.py
+++ b/param_decomp_jax/jax_single_pool/tests/stacked_parity/gen_stacked_fixtures.py
@@ -144,7 +144,7 @@ def main() -> None:
     jm = {k: jax.numpy.asarray(v) for k, v in masks.items()}
     jdm = {k: jax.numpy.asarray(v) for k, v in delta_masks.items()}
     arrays["out::masked_all"] = np.asarray(
-        lm.masked_logits(tgt, vu, resid, jm, jdm, None, lm.site_names)
+        lm.masked_logits(tgt, vu, resid, jm, jdm, None, lm.site_names, True)
     )
     arrays["out::masked_subset"] = np.asarray(
         lm.masked_logits(
@@ -155,6 +155,7 @@ def main() -> None:
             {s: jdm[s] for s in chunk0},
             {s: jax.numpy.asarray(routes0[s]) for s in chunk0},
             chunk0,
+            True,
         )  # fmt: skip
     )
 

--- a/param_decomp_jax/jax_single_pool/tests/stacked_parity/test_stacked_parity.py
+++ b/param_decomp_jax/jax_single_pool/tests/stacked_parity/test_stacked_parity.py
@@ -134,14 +134,14 @@ def test_masked_logits_match():
     f, lm, tgt, vu, resid = _load()
     masks = {s: jnp.asarray(f[f"mask::{s}"]) for s in lm.site_names}
     delta_masks = {s: jnp.asarray(f[f"delta_mask::{s}"]) for s in lm.site_names}
-    masked_all = lm.masked_logits(tgt, vu, resid, masks, delta_masks, None, lm.site_names)
+    masked_all = lm.masked_logits(tgt, vu, resid, masks, delta_masks, None, lm.site_names, True)
     _assert_close(masked_all, f["out::masked_all"], "masked_logits (all live)")
 
     chunk0 = lm.site_names[:3]
     routes0 = {s: jnp.asarray(f[f"route0::{s}"]) for s in chunk0}
     masked_subset = lm.masked_logits(
         tgt, vu, resid,
-        {s: masks[s] for s in chunk0}, {s: delta_masks[s] for s in chunk0}, routes0, chunk0,
+        {s: masks[s] for s in chunk0}, {s: delta_masks[s] for s in chunk0}, routes0, chunk0, True,
     )  # fmt: skip
     _assert_close(masked_subset, f["out::masked_subset"], "masked_logits (subset live)")
 

--- a/param_decomp_jax/jax_single_pool/tests/test_llama8b.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_llama8b.py
@@ -167,7 +167,7 @@ def test_clean_path_and_masked_identity(first: int, last: int):
 
     # SPEC S2: a masked forward with NO live sites is the frozen path — bit-identical
     # to the clean target.
-    none_masked = lm.masked_logits(tgt, vu, resid, {}, {}, None, ())
+    none_masked = lm.masked_logits(tgt, vu, resid, {}, {}, None, (), True)
     assert jnp.array_equal(clean, none_masked), "live=() must be the exact frozen path"
 
     # All-live, masks=1, delta=1, route-everywhere reconstructs the frozen path up to
@@ -175,7 +175,7 @@ def test_clean_path_and_masked_identity(first: int, last: int):
     names = lm.site_names
     ones_masks = {s: jnp.ones((b, t, C)) for s in names}
     ones_delta = {s: jnp.ones((b, t)) for s in names}
-    full = lm.masked_logits(tgt, vu, resid, ones_masks, ones_delta, None, names)
+    full = lm.masked_logits(tgt, vu, resid, ones_masks, ones_delta, None, names, True)
     assert jnp.allclose(clean, full, atol=1e-4), "mask=1 identity drifted"
 
     site_in = lm.site_inputs(tgt, resid)
@@ -204,13 +204,13 @@ def test_attention_sites_clean_and_masked_identity():
         assert V.shape == (spec.d_in, spec.C) and U.shape == (spec.C, spec.d_out)
 
     clean = lm.clean_logits(tgt, resid)
-    none_masked = lm.masked_logits(tgt, vu, resid, {}, {}, None, ())
+    none_masked = lm.masked_logits(tgt, vu, resid, {}, {}, None, (), True)
     assert jnp.array_equal(clean, none_masked), "live=() must be the exact frozen path"
 
     names = lm.site_names
     ones_masks = {s.name: jnp.ones((b, t, s.C)) for s in lm.sites}
     ones_delta = {s: jnp.ones((b, t)) for s in names}
-    full = lm.masked_logits(tgt, vu, resid, ones_masks, ones_delta, None, names)
+    full = lm.masked_logits(tgt, vu, resid, ones_masks, ones_delta, None, names, True)
     assert jnp.allclose(clean, full, atol=1e-4), "mask=1 identity drifted (attention sites)"
 
     # zero-mask + zero-delta on q alone must CHANGE the logits (the site is live on
@@ -218,7 +218,7 @@ def test_attention_sites_clean_and_masked_identity():
     q_site = "layers.4.self_attn.q_proj"
     zero_mask = {q_site: jnp.zeros((b, t, 8))}
     zero_delta = {q_site: jnp.zeros((b, t))}
-    ablated = lm.masked_logits(tgt, vu, resid, zero_mask, zero_delta, None, (q_site,))
+    ablated = lm.masked_logits(tgt, vu, resid, zero_mask, zero_delta, None, (q_site,), True)
     assert not jnp.allclose(clean, ablated, atol=1e-4), "ablating q did nothing"
 
     site_in = lm.site_inputs(tgt, resid)
@@ -246,7 +246,14 @@ def test_o_site_masks_attention_output():
 
     clean = lm.clean_logits(tgt, resid)
     ones = lm.masked_logits(
-        tgt, vu, resid, {o_site: jnp.ones((b, t, 8))}, {o_site: jnp.ones((b, t))}, None, (o_site,)
+        tgt,
+        vu,
+        resid,
+        {o_site: jnp.ones((b, t, 8))},
+        {o_site: jnp.ones((b, t))},
+        None,
+        (o_site,),
+        True,
     )
     assert jnp.allclose(clean, ones, atol=1e-4)
     # o's clean site input is the pre-o_proj attention output, shape (b, t, qd)

--- a/param_decomp_jax/jax_single_pool/tests/test_llama_simple_mlp.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_llama_simple_mlp.py
@@ -218,7 +218,7 @@ def test_clean_path_and_masked_identity():
     assert clean.shape == (b, t, cfg.vocab_size)
 
     # SPEC S2: a masked forward with NO live sites is the frozen path — bit-identical.
-    none_masked = lm.masked_logits(target, vu, resid, {}, {}, None, ())
+    none_masked = lm.masked_logits(target, vu, resid, {}, {}, None, (), True)
     assert jnp.array_equal(clean, none_masked), "live=() must be the exact frozen path"
 
     # All-live, masks=1, delta=1, route-everywhere reconstructs the frozen path up to
@@ -226,7 +226,7 @@ def test_clean_path_and_masked_identity():
     names = lm.site_names
     ones_masks = {s.name: jnp.ones((b, t, s.C)) for s in lm.sites}
     ones_delta = {s: jnp.ones((b, t)) for s in names}
-    full = lm.masked_logits(target, vu, resid, ones_masks, ones_delta, None, names)
+    full = lm.masked_logits(target, vu, resid, ones_masks, ones_delta, None, names, True)
     assert jnp.allclose(clean, full, atol=1e-4), "mask=1 identity drifted"
 
     site_in = lm.site_inputs(target, resid)
@@ -263,7 +263,7 @@ def test_zero_masking_one_site_changes_logits(ablated_site: str):
     ablated = lm.masked_logits(
         target, vu, resid,
         {ablated_site: jnp.zeros((b, t, C))}, {ablated_site: jnp.zeros((b, t))},
-        None, (ablated_site,),
+        None, (ablated_site,), True,
     )  # fmt: skip
     assert not jnp.allclose(clean, ablated, atol=1e-4), f"ablating {ablated_site} did nothing"
 
@@ -281,7 +281,7 @@ def test_o_site_masks_attention_output():
     clean = lm.clean_logits(target, resid)
     ones = lm.masked_logits(
         target, vu, resid, {o_site: jnp.ones((b, t, 8))}, {o_site: jnp.ones((b, t))}, None,
-        (o_site,),
+        (o_site,), True,
     )  # fmt: skip
     assert jnp.allclose(clean, ones, atol=1e-4)
     # o's clean site input is the pre-o_proj attention output, shape (b, t, qd)

--- a/param_decomp_jax/jax_single_pool/train.py
+++ b/param_decomp_jax/jax_single_pool/train.py
@@ -159,10 +159,11 @@ def make_train_step(
         delta_masks: dict[str, Array],
         routes: dict[str, Array] | None,
         live_sites: tuple[str, ...],
+        has_delta: bool,
     ) -> Array:
         return batch_sharded(
             lm.masked_logits(
-                frozen, components_bf16, residual, masks, delta_masks, routes, live_sites
+                frozen, components_bf16, residual, masks, delta_masks, routes, live_sites, has_delta
             )
         )
 
@@ -170,7 +171,7 @@ def make_train_step(
     # forward at a time (the torch 2-pool streaming profile) at the cost of the
     # recompute; with few recon forwards and memory headroom, remat off is faster.
     checkpointed_masked_forward = (
-        jax.checkpoint(masked_forward, static_argnums=(6,))
+        jax.checkpoint(masked_forward, static_argnums=(6, 7))
         if remat_recon_forwards
         else masked_forward
     )
@@ -205,15 +206,13 @@ def make_train_step(
         strategy: ConstantSources,
         ci_lower: dict[str, Array],
         live_sites: tuple[str, ...],
-        batch_seq: tuple[int, int],
     ) -> tuple[dict[str, Array], dict[str, Array]]:
-        masks = {}
-        delta_masks = {}
-        for site in live_sites:
-            ci_site = ci_lower[site]
-            masks[site] = ci_site + (1.0 - ci_site) * strategy.value
-            delta_masks[site] = jnp.zeros(batch_seq, ci_site.dtype)
-        return masks, delta_masks
+        """No delta masks: `has_delta` is False for constant sources, so the forward
+        skips the `x @ Δ` matmul and never indexes the (empty) delta dict (§4b)."""
+        masks = {
+            site: ci_lower[site] + (1.0 - ci_lower[site]) * strategy.value for site in live_sites
+        }
+        return masks, {}
 
     def entry_loss_for_sources(
         entry: ReconForward,
@@ -232,7 +231,14 @@ def make_train_step(
         total = jnp.zeros((), jnp.float32)
         for routes in routes_per_draw:
             masked = forward_fn(
-                frozen, components_bf16, residual, masks, delta_masks, routes, entry.live_sites
+                frozen,
+                components_bf16,
+                residual,
+                masks,
+                delta_masks,
+                routes,
+                entry.live_sites,
+                entry.has_delta,
             )
             total = total + kl_per_position(masked, clean_logits)
         return total / len(routes_per_draw)
@@ -273,7 +279,14 @@ def make_train_step(
             def warmup_loss(sources: dict[str, Array]) -> Array:
                 masks, delta_masks = source_masks(ci_lower_detached, sources, site_names)
                 masked = masked_forward(
-                    frozen, components_detached, residual, masks, delta_masks, None, site_names
+                    frozen,
+                    components_detached,
+                    residual,
+                    masks,
+                    delta_masks,
+                    None,
+                    site_names,
+                    True,
                 )
                 return kl_per_position(masked, clean_logits)
 
@@ -391,7 +404,7 @@ def make_train_step(
                                 )
                             case ConstantSources() as strategy:
                                 masks, delta_masks = constant_entry_masks(
-                                    strategy, ci.lower, entry.live_sites, (batch, seq)
+                                    strategy, ci.lower, entry.live_sites
                                 )
                             case FreshPGDSources():
                                 masks, delta_masks = source_masks(
@@ -411,6 +424,7 @@ def make_train_step(
                             delta_masks,
                             routes,
                             entry.live_sites,
+                            entry.has_delta,
                         )
                         total = total + kl_per_position(masked, clean_logits)
                         n_forwards += 1


### PR DESCRIPTION
Closes #582

## What changed

For `ConstantSources` strategies (Unmasked / CIMasked / CIMaskedSubset / CIMaskedLayerwise), torch passes no delta path at all (`weight_deltas_and_masks=None`). JAX was instead materializing a constant `delta_mask=0` and running the `x @ Δ` matmul, whose contribution is always zero — a compute-only deviation.

This adds a static `has_delta: bool` on `ReconForward` (derived from the strategy via `strategy_has_delta`: True for every strategy except `ConstantSources`) and threads it through the forward:

- `recon.py` — `strategy_has_delta` + `ReconForward.has_delta` property.
- `train.py` — `constant_entry_masks` now returns an empty delta dict (no `jnp.zeros` per site); `has_delta` passed to `masked_forward`/the inlined forward; `jax.checkpoint` `static_argnums` extended to cover the new arg.
- `lm.py` — `DecomposedLM.masked_logits` signature gains the static `has_delta`.
- `llama8b.py` / `llama_simple_mlp.py` — `_site_out` takes `delta_mask: Array | None`; when None it drops the `delta = W - (V@U).T` compute and the `(x @ Δ)` matmul entirely. `_masked_site_out` / `masked_suffix_logits` thread `has_delta`, passing `delta_masks[site] if has_delta else None`.
- tests + fixture gen — all `masked_logits` callers updated (they pass `True`, exercising the live delta path); in-loop eval passes `True` (real PPGD deltas).

Static under jit, retrace-safe (LOSS_PARITY_DESIGN §4b). Invariant S1.

## Verification

- Trajectory bit-identical by construction: the skipped term contributed exactly 0 (`(x@Δ)*0`) today; constant-source entries never index the now-empty delta dict.
- `ruff check` + `ruff format`: clean (pre-commit hooks passed).
- `basedpyright`: 0 errors over the configured scope (pre-commit `type` hook passed).
- Did not execute the JAX test suite here (no GPU/JAX runtime spin-up per the wave policy); CI runs the stacked-parity + equivalence suites, whose `masked_logits` callers are updated.