### PR TITLE
jax: pin param_decomp_jax runtime standalone-dependency boundary

### DIFF
--- a/param_decomp_jax/jax_single_pool/tests/test_runtime_standalone.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_runtime_standalone.py
@@ -1,0 +1,62 @@
+"""The GPU runtime is self-contained: it imports the JAX stack + `param_decomp_config`
+ONLY — never the adjacent torch-stack distributions (`param_decomp`, `param_decomp_lab`)
+and never `torch`. This pins the dependency boundary the standalone `pyproject` declares
+(issue #809 / TRANSITION.md §5.4): `lab → param_decomp_jax` is allowed; the reverse edge
+`param_decomp_jax → adjacent` is forbidden for the runtime.
+
+The runtime is every `.py` under `jax_single_pool/` that ships in the wheel — i.e. not
+the test suite, not the torch-env `tools/` scripts (export verifier / checkpoint
+converters that run in the torch venv by design), and not the torch-side config YAMLs.
+This static AST scan is the CI form of the `grep -rniE "param_decomp\\.|param_decomp_lab\\.|import torch"`
+acceptance check, scoped to those runtime files.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+
+_RUNTIME_ROOT = Path(__file__).resolve().parent.parent
+_NON_RUNTIME_DIRS = {"tests", "tools"}
+_FORBIDDEN_ROOTS = ("param_decomp", "param_decomp_lab", "torch")
+
+
+def _is_forbidden(module: str) -> bool:
+    head = module.split(".", 1)[0]
+    if head == "param_decomp_config":
+        return False
+    return head in _FORBIDDEN_ROOTS
+
+
+def _runtime_python_files() -> list[Path]:
+    files: list[Path] = []
+    for path in _RUNTIME_ROOT.rglob("*.py"):
+        rel = path.relative_to(_RUNTIME_ROOT)
+        if rel.parts[0] in _NON_RUNTIME_DIRS:
+            continue
+        files.append(path)
+    return files
+
+
+def _forbidden_imports(path: Path) -> list[str]:
+    tree = ast.parse(path.read_text(), filename=str(path))
+    found: list[str] = []
+    for node in ast.walk(tree):
+        match node:
+            case ast.Import(names=names):
+                found += [alias.name for alias in names if _is_forbidden(alias.name)]
+            case ast.ImportFrom(module=module) if module is not None:
+                if _is_forbidden(module):
+                    found.append(module)
+    return found
+
+
+@pytest.mark.parametrize(
+    "path", _runtime_python_files(), ids=lambda p: str(p.relative_to(_RUNTIME_ROOT))
+)
+def test_runtime_imports_nothing_adjacent(path: Path):
+    forbidden = _forbidden_imports(path)
+    assert not forbidden, (
+        f"{path.relative_to(_RUNTIME_ROOT)} imports adjacent/torch modules {forbidden}; "
+        "the GPU runtime must depend on the JAX stack + param_decomp_config only"
+    )


### PR DESCRIPTION
Closes #809

## What

The `param_decomp_jax` `pyproject.toml` is already standalone on `feature/jax`: runtime deps are the JAX stack + `param-decomp-config` only (no `param_decomp`, no `param_decomp_lab`), and the `jsp-train`/`jsp-export` console scripts are intact. This PR formalizes the dependency boundary the issue asks for by adding a CI guard test.

`tests/test_runtime_standalone.py` is an AST scan asserting that every runtime `.py` under `jax_single_pool/` — excluding the test suite and the torch-env `tools/` scripts (export verifier / checkpoint converters that run in the torch venv by design) — imports nothing from `param_decomp`, `param_decomp_lab`, or `torch`. This is the CI form of the issue's `grep` acceptance check, scoped to the GPU runtime.

## Verification

- Static scan: 24 runtime files, zero forbidden imports (`param_decomp.` / `param_decomp_lab.` / `torch`); runtime imports only `param_decomp_config.*`.
- `run.py` (`jsp-train`) imports only `param_decomp_config` — adjacent-clean.
- pyproject: no torch-stack deps; `param-decomp-config==0.0.1` is the only adjacent dep; console scripts intact.
- `pytest jax_single_pool/tests/test_runtime_standalone.py` → 24 passed.
- Pre-commit ruff + basedpyright pass.

## Scope note

Remaining `torch` / adjacent imports under `jax_single_pool/` live only in `tests/`, `tools/` (torch-env scripts), torch-side config YAMLs, and an embedded slurm eval script — these are cleaned by the issue's stated dependencies (a)/(b)/(c) (config-direct, no-torch in tests/tooling, trainer retirement), which are out of scope for this packaging-boundary issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)