### PR TITLE
jax: drop train/loss/*_no_beta key to match torch (#647)

### DIFF
--- a/param_decomp_jax/jax_single_pool/losses.py
+++ b/param_decomp_jax/jax_single_pool/losses.py
@@ -33,8 +33,9 @@ def importance_minimality_terms(
     ci_upper: dict[str, Array], pnorm: Array, eps: float
 ) -> tuple[Array, Array]:
     """`(lp, entropy)` with per-site grouping and the global-batch sum inside the log2
-    (SPEC S7/S8); the loss is `lp + beta * entropy` and `lp` alone is the torch
-    `ImportanceMinimalityLoss_no_beta` metric.
+    (SPEC S7/S8); the loss is `lp + beta * entropy`. Torch's `_no_beta` diagnostic (`lp`
+    alone) is emitted only on the eval path (`Metric.compute`), never from the train
+    step, so this trainer does not log a `train/loss/*_no_beta` key.
 
     Under GSPMD the `(b, t)` axes are the global batch, so `jnp.sum` IS the exact
     global per-component sum — XLA reduces across shards inside the graph."""

--- a/param_decomp_jax/jax_single_pool/run.py
+++ b/param_decomp_jax/jax_single_pool/run.py
@@ -110,7 +110,6 @@ _METRIC_KEYS = {
     "total": "train/loss/total",
     "faith": "train/loss/FaithfulnessLoss",
     "imp": "train/loss/ImportanceMinimalityLoss",
-    "imp_no_beta": "train/loss/ImportanceMinimalityLoss_no_beta",
     "p_imp": "train/schedules/p_imp",
     "src_lr": "train/schedules/lr/src",
     "step_time_s": "train/perf/step_time_s",

--- a/param_decomp_jax/jax_single_pool/tests/test_recon_log_keys.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_recon_log_keys.py
@@ -108,3 +108,14 @@ def test_fixed_scalar_loss_keys_use_torch_class_names():
     faith, imp = _non_recon_configs()
     assert _METRIC_KEYS["faith"] == f"train/loss/{faith.type}"
     assert _METRIC_KEYS["imp"] == f"train/loss/{imp.type}"
+
+
+def test_no_train_loss_no_beta_key():
+    """Torch's `ImportanceMinimalityLoss_no_beta` diagnostic is emitted only by
+    `Metric.compute` (the eval path), never from the train step. The JAX trainer must
+    not emit a `train/loss/*_no_beta` key — doing so was a logged-key divergence from
+    torch (#647)."""
+    from jax_single_pool.run import _METRIC_KEYS  # pyright: ignore[reportPrivateUsage]
+
+    assert not any(k.endswith("_no_beta") for k in _METRIC_KEYS), _METRIC_KEYS
+    assert not any(v.endswith("_no_beta") for v in _METRIC_KEYS.values()), _METRIC_KEYS

--- a/param_decomp_jax/jax_single_pool/train.py
+++ b/param_decomp_jax/jax_single_pool/train.py
@@ -392,7 +392,7 @@ def make_train_step(
         # gets too (sources are leaves). ──
         def loss_fn(
             trainable: tuple[Any, CIFn, dict[str, dict[str, Array]]],
-        ) -> tuple[Array, tuple[Array, Array, Array, tuple[Array, ...]]]:
+        ) -> tuple[Array, tuple[Array, Array, tuple[Array, ...]]]:
             components, ci_fn, persistent_sources = trainable
             components_bf16 = cast_floating(components, COMPUTE_DT)
             ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
@@ -459,13 +459,11 @@ def make_train_step(
             total_loss = faith_coeff * faith_loss + imp_coeff * imp_loss
             for term, term_loss in zip(recon_terms, term_losses, strict=True):
                 total_loss = total_loss + term.coeff * term_loss
-            return total_loss, (faith_loss, imp_loss, imp_lp, tuple(term_losses))
+            return total_loss, (faith_loss, imp_loss, tuple(term_losses))
 
-        (total_loss, (faith_loss, imp_loss, imp_lp, term_losses)), grads = (
-            eqx.filter_value_and_grad(loss_fn, has_aux=True)(
-                (state.components, state.ci_fn, warmed_sources)
-            )
-        )
+        (total_loss, (faith_loss, imp_loss, term_losses)), grads = eqx.filter_value_and_grad(
+            loss_fn, has_aux=True
+        )((state.components, state.ci_fn, warmed_sources))
         components_grad, ci_fn_grad, persistent_grads_scaled = grads
         grad_norm_metrics = _grad_norm_metrics(components_grad, ci_fn_grad)
 
@@ -519,7 +517,6 @@ def make_train_step(
             "total": total_loss,
             "faith": faith_loss,
             "imp": imp_loss,
-            "imp_no_beta": imp_lp,
             "p_imp": pnorm,
             **{f"loss/{t.name}": v for t, v in zip(recon_terms, term_losses, strict=True)},
             **grad_norm_metrics,


### PR DESCRIPTION
Closes #647

## What

Torch's `ImportanceMinimalityLoss_no_beta` diagnostic is emitted **only** by `Metric.compute` (the eval path: `importance_minimality.py:182-185`, surfaced via `collect_metric_outputs` in `run_eval_pass`). Torch's train step (`train_step.py:236-250`) logs only the scalar `update()` return as `loss/<metric_name>`, so torch never emits a `train/loss/*_no_beta` key.

The JAX trainer was logging `train/loss/ImportanceMinimalityLoss_no_beta` — a logged-key namespace divergence found in the parity matrix (§6).

## Change

Default = match torch:
- `train.py`: stop threading `imp_lp` out as loss-fn aux; drop the `imp_no_beta` entry from the step metrics dict (`imp_lp` is still computed locally to form `imp_loss`).
- `run.py`: drop the `imp_no_beta` -> `train/loss/ImportanceMinimalityLoss_no_beta` mapping from `_METRIC_KEYS`.
- `losses.py`: docstring now states the `_no_beta` diagnostic is eval-only.
- `tests/test_recon_log_keys.py`: new `test_no_train_loss_no_beta_key` pins the absence of any `train/loss/*_no_beta` key.

JAX-only namespaces (`train/perf/*`, `mem/*`, `schedules/p_imp`, `lr/src`) remain intentional extras.

🤖 Generated with [Claude Code](https://claude.com/claude-code)