### PR TITLE
jax: match torch on cosine-LR denominator + grad-clip eps (S19, S20)

### DIFF
--- a/param_decomp_jax/jax_single_pool/run_state.py
+++ b/param_decomp_jax/jax_single_pool/run_state.py
@@ -7,11 +7,12 @@ optimizer-state structure.
 """
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import optax
 from jax import random
 from jax.sharding import Mesh
-from jaxtyping import PRNGKeyArray
+from jaxtyping import Array, PRNGKeyArray
 
 from jax_single_pool.adversary import init_sources_adam_state
 from jax_single_pool.config import ExperimentConfig
@@ -25,13 +26,49 @@ from jax_single_pool.recon import build_recon_terms
 from jax_single_pool.train import TrainState
 
 
+def torch_cosine_schedule(peak_lr: float, total_steps: int, alpha: float) -> optax.Schedule:
+    """Cosine decay matching torch's `get_scheduled_value` denominator: `progress =
+    step / (total_steps - 1)` (no warmup), so `0.1×` is reached at `step = total_steps - 1`.
+    optax's `cosine_decay_schedule` divides by `total_steps`, reaching it one step later
+    (SPEC S20). `total_steps == 1` collapses to a constant `peak_lr`."""
+    denom = max(total_steps - 1, 1)
+
+    def schedule(count: Array) -> Array:
+        progress = jnp.asarray(count, jnp.float32) / denom
+        return peak_lr * (alpha + (1 - alpha) * 0.5 * (1 + jnp.cos(jnp.pi * progress)))
+
+    return schedule
+
+
+def clip_by_global_norm_with_eps(max_norm: float, eps: float) -> optax.GradientTransformation:
+    """Global-norm clip matching torch's `clip_grad_norm_`: scale by
+    `clip(max_norm / (global_norm + eps), max=1)`. optax's `clip_by_global_norm` omits
+    `eps`; at small `max_norm` (0.01) the clip fires almost every step so this ~1e-4
+    relative offset is per-step (SPEC S19)."""
+
+    def init(params: optax.Params) -> optax.EmptyState:
+        del params
+        return optax.EmptyState()
+
+    def update(
+        updates: optax.Updates, state: optax.EmptyState, params: optax.Params | None = None
+    ) -> tuple[optax.Updates, optax.EmptyState]:
+        del params
+        global_norm = optax.global_norm(updates)
+        scale = jnp.minimum(max_norm / (global_norm + eps), 1.0)
+        updates = jax.tree.map(lambda g: g * scale, updates)
+        return updates, state
+
+    return optax.GradientTransformation(init, update)
+
+
 def build_optimizers(cfg: ExperimentConfig):
     """Returns (opt_vu, opt_ci, schedules): the schedule fns are returned too so the
     log path reports the exact LR the optimizer applies (single source of truth)."""
-    sched_vu = optax.cosine_decay_schedule(cfg.vu_optimizer.lr, cfg.steps, alpha=0.1)
-    sched_ci = optax.cosine_decay_schedule(cfg.ci_optimizer.lr, cfg.steps, alpha=0.1)
+    sched_vu = torch_cosine_schedule(cfg.vu_optimizer.lr, cfg.steps, alpha=0.1)
+    sched_ci = torch_cosine_schedule(cfg.ci_optimizer.lr, cfg.steps, alpha=0.1)
     opt_vu = optax.chain(
-        optax.clip_by_global_norm(cfg.vu_optimizer.grad_clip_norm),
+        clip_by_global_norm_with_eps(cfg.vu_optimizer.grad_clip_norm, eps=1e-6),
         optax.adamw(sched_vu, b1=0.9, b2=0.999, eps=1e-8, weight_decay=0.0),
     )
     opt_ci = optax.adamw(sched_ci, b1=0.9, b2=0.999, eps=1e-8, weight_decay=0.0)

--- a/param_decomp_jax/jax_single_pool/tests/test_optim_torch_parity.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_optim_torch_parity.py
@@ -1,0 +1,74 @@
+"""Component/CI optimizer seams match torch's formulas exactly (SPEC S19, S20).
+
+- cosine LR uses torch's `step / (total_steps - 1)` denominator, NOT optax's
+  `cosine_decay_schedule` `count / total_steps` (reaches `0.1×` one step later).
+- global-norm grad clip uses torch's `clip(max_norm / (norm + 1e-6), max=1)`, NOT
+  optax's eps-free `clip_by_global_norm`.
+"""
+
+import jax.numpy as jnp
+import optax
+import pytest
+
+from jax_single_pool.run_state import clip_by_global_norm_with_eps, torch_cosine_schedule
+
+
+def torch_cosine_reference(peak_lr: float, total_steps: int, alpha: float, step: int) -> float:
+    import math
+
+    progress = step / (total_steps - 1)
+    return peak_lr * (alpha + (1 - alpha) * 0.5 * (1 + math.cos(math.pi * progress)))
+
+
+def test_cosine_schedule_matches_torch_denominator():
+    peak_lr = 1.5e-4
+    total_steps = 400_000
+    alpha = 0.1
+    sched = torch_cosine_schedule(peak_lr, total_steps, alpha)
+    for step in (0, total_steps // 2, total_steps - 1):
+        jax_value = float(sched(jnp.int32(step)))
+        torch_value = torch_cosine_reference(peak_lr, total_steps, alpha, step)
+        assert jax_value == pytest.approx(torch_value, rel=1e-7), f"step {step}"
+    assert float(sched(jnp.int32(total_steps - 1))) == pytest.approx(alpha * peak_lr, rel=1e-6)
+
+
+def test_cosine_schedule_differs_from_optax():
+    peak_lr = 1.5e-4
+    total_steps = 400_000
+    optax_sched = optax.cosine_decay_schedule(peak_lr, total_steps, alpha=0.1)
+    ours = torch_cosine_schedule(peak_lr, total_steps, alpha=0.1)
+    endpoint = total_steps - 1
+    assert float(ours(jnp.int32(endpoint))) == pytest.approx(0.1 * peak_lr, rel=1e-6)
+    assert float(optax_sched(jnp.int32(endpoint))) != pytest.approx(0.1 * peak_lr, rel=1e-6)
+
+
+def test_grad_clip_matches_torch_eps():
+    max_norm = 0.01
+    eps = 1e-6
+    clip = clip_by_global_norm_with_eps(max_norm, eps)
+    grads = {"a": jnp.array([3.0, 4.0]), "b": jnp.array([0.0])}
+    global_norm = 5.0
+    state = clip.init(grads)
+    out, _ = clip.update(grads, state)
+    torch_coef = min(max_norm / (global_norm + eps), 1.0)
+    assert float(out["a"][0]) == pytest.approx(3.0 * torch_coef, rel=1e-7)
+    assert float(out["a"][1]) == pytest.approx(4.0 * torch_coef, rel=1e-7)
+
+
+def test_grad_clip_differs_from_optax_when_clipping():
+    max_norm = 0.01
+    grads = {"a": jnp.array([3.0, 4.0])}
+    ours = clip_by_global_norm_with_eps(max_norm, eps=1e-6)
+    out_ours, _ = ours.update(grads, ours.init(grads))
+    optax_clip = optax.clip_by_global_norm(max_norm)
+    out_optax, _ = optax_clip.update(grads, optax_clip.init(grads))
+    assert float(out_ours["a"][0]) != pytest.approx(float(out_optax["a"][0]), rel=1e-9)
+
+
+def test_grad_clip_noop_below_threshold():
+    max_norm = 100.0
+    clip = clip_by_global_norm_with_eps(max_norm, eps=1e-6)
+    grads = {"a": jnp.array([3.0, 4.0])}
+    out, _ = clip.update(grads, clip.init(grads))
+    assert float(out["a"][0]) == pytest.approx(3.0)
+    assert float(out["a"][1]) == pytest.approx(4.0)


### PR DESCRIPTION
Closes #642
Closes #643

Two `run_state.py` optimizer seams diverged from the torch oracle by a small per-step amount. Both are now matched (option (a) in each issue):

**#642 — cosine LR denominator (S20).** `optax.cosine_decay_schedule(lr, steps, alpha=0.1)` divides progress by `count/steps`, reaching `0.1×` one update later than torch. Replaced with `torch_cosine_schedule`, whose `progress = step/(total_steps-1)` matches `get_scheduled_value` (`param_decomp_config/schedule.py:52`) — `0.1×` is hit at `step = total_steps-1`.

**#643 — grad-clip eps (S19).** `optax.clip_by_global_norm` has no eps; torch's `clip_grad_norm_` uses `clip(max_norm/(norm+1e-6), max=1)`. Added `clip_by_global_norm_with_eps(0.01, eps=1e-6)` matching `param_decomp/grad_clip.py:57` exactly (`jnp.minimum(max_norm/(norm+1e-6), 1.0)`).

Per-step delta against torch is now **zero** on both seams (was ~2.5e-6 rel/step on LR at 400k, ~1e-4 rel/step on clipped grads).

`test_optim_torch_parity.py` asserts agreement with torch's formulas at `step ∈ {0, steps//2, steps-1}` and the clip at a known norm, plus divergence from the optax forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)