### PR TITLE
refactor(jax): chunkwise is the one recon-plan impl; remove PPGD+subset (#584, #610)

### DIFF
--- a/param_decomp/metrics/CLAUDE.md
+++ b/param_decomp/metrics/CLAUDE.md
@@ -86,6 +86,7 @@ These two concepts both show up in the PGD metrics and are easy to confuse:
 
 ## PPGD note
 
-PPGD's state machine lives in `persistent_pgd_state.py` (shared); its `Metric`
-classes + configs live in `persistent_pgd_recon.py`. The split is so the subset
-variant (`PersistentPGDReconSubsetLoss`) can reuse the same state machine.
+PPGD's state machine lives in `persistent_pgd_state.py`; its `Metric` class
+(`PersistentPGDReconLoss`, route-all only) lives in `persistent_pgd_recon.py`. There is
+no subset variant — PPGD+subset is structurally banned (#584): persistent adversarial
+sources only ever route to all layers.

--- a/param_decomp/metrics/dispatch.py
+++ b/param_decomp/metrics/dispatch.py
@@ -12,10 +12,7 @@ from param_decomp.metrics.ci_masked_recon_layerwise import CIMaskedReconLayerwis
 from param_decomp.metrics.ci_masked_recon_subset import CIMaskedReconSubsetLoss
 from param_decomp.metrics.faithfulness import FaithfulnessLoss
 from param_decomp.metrics.importance_minimality import ImportanceMinimalityLoss
-from param_decomp.metrics.persistent_pgd_recon import (
-    PersistentPGDReconLoss,
-    PersistentPGDReconSubsetLoss,
-)
+from param_decomp.metrics.persistent_pgd_recon import PersistentPGDReconLoss
 from param_decomp.metrics.pgd_masked_recon import PGDReconLoss
 from param_decomp.metrics.pgd_masked_recon_layerwise import PGDReconLayerwiseLoss
 from param_decomp.metrics.pgd_masked_recon_subset import PGDReconSubsetLoss
@@ -35,7 +32,6 @@ LOSS_METRIC_CLASSES: dict[str, type[Metric[Any]]] = {
         FaithfulnessLoss,
         ImportanceMinimalityLoss,
         PersistentPGDReconLoss,
-        PersistentPGDReconSubsetLoss,
         PGDReconLayerwiseLoss,
         PGDReconLoss,
         PGDReconSubsetLoss,

--- a/param_decomp/metrics/persistent_pgd_recon.py
+++ b/param_decomp/metrics/persistent_pgd_recon.py
@@ -15,7 +15,7 @@ from jaxtyping import Float
 from torch import Tensor
 
 from param_decomp.distributed import active_reduction_group, all_reduce, is_distributed
-from param_decomp.masks import AllLayersRouter, Router, get_subset_router
+from param_decomp.masks import AllLayersRouter
 from param_decomp.metrics.base import Metric, MetricResult
 from param_decomp.metrics.context import MetricContext
 from param_decomp.metrics.persistent_pgd_state import (
@@ -28,23 +28,7 @@ from param_decomp.metrics.stochastic_hidden_acts_recon import (
     calc_hidden_acts_mse,
     compute_per_module_metrics,
 )
-from param_decomp_config.losses import (
-    LossMetricConfig,
-    NSCScope,
-    PersistentPGDReconLossConfig,
-    PersistentPGDReconSubsetLossConfig,
-)
-
-
-def _router_for_cfg(
-    cfg: PersistentPGDReconLossConfig | PersistentPGDReconSubsetLossConfig,
-    device: torch.device | str,
-) -> Router:
-    match cfg:
-        case PersistentPGDReconLossConfig():
-            return AllLayersRouter()
-        case PersistentPGDReconSubsetLossConfig(routing=routing):
-            return get_subset_router(routing, device)
+from param_decomp_config.losses import LossMetricConfig, NSCScope, PersistentPGDReconLossConfig
 
 
 def validate_pgd_scope(
@@ -63,9 +47,7 @@ def validate_pgd_scope(
     )
     per_rank = batch_size // world_size
     for cfg in loss_metrics:
-        if isinstance(
-            cfg, PersistentPGDReconLossConfig | PersistentPGDReconSubsetLossConfig
-        ) and isinstance(cfg.scope, NSCScope):
+        if isinstance(cfg, PersistentPGDReconLossConfig) and isinstance(cfg.scope, NSCScope):
             n = cfg.scope.n_sources
             assert per_rank % n == 0, (
                 f"{cfg.type}: repeat_across_batch n_sources={n} must divide "
@@ -73,10 +55,11 @@ def validate_pgd_scope(
             )
 
 
-class _PersistentPGDReconBase[
-    TConfig: PersistentPGDReconLossConfig | PersistentPGDReconSubsetLossConfig
-](Metric[TConfig]):
-    """Shared logic between all-layers and subset PPGD recon metrics.
+class PersistentPGDReconLoss(Metric[PersistentPGDReconLossConfig]):
+    """PPGD adversarial-mask recon loss (routes to all layers).
+
+    Drives components to reconstruct the target output under adversarially-optimised
+    masks whose source tensors persist across training steps.
 
     Lazily constructs the `PersistentPGDState` on the first `update` so it can snapshot
     the live batch shape. Returns the live recon loss on training steps and, on eval
@@ -85,10 +68,11 @@ class _PersistentPGDReconBase[
     and `after_backward`.
     """
 
+    short_name = "PersistPGDRecon"
     log_namespace: ClassVar[str] = "loss"
     slow: ClassVar[bool] = True
 
-    def __init__(self, cfg: TConfig) -> None:
+    def __init__(self, cfg: PersistentPGDReconLossConfig) -> None:
         super().__init__(cfg)
         self.state: PersistentPGDState | None = None
         self._pending_source_grads: PPGDSources | None = None
@@ -116,7 +100,7 @@ class _PersistentPGDReconBase[
             use_sigmoid_parameterization=self.cfg.use_sigmoid_parameterization,
             n_warmup_steps=self.cfg.n_warmup_steps,
             n_samples=self.cfg.n_samples,
-            router=_router_for_cfg(self.cfg, self.device),
+            router=AllLayersRouter(),
             reconstruction_loss=ctx.reconstruction_loss,
             replica_sync_group=replica_sync_group,
         )
@@ -242,19 +226,3 @@ class _PersistentPGDReconBase[
             self._pending_resume_state = state
         else:
             self.state.load_state_dict(state)
-
-
-class PersistentPGDReconLoss(_PersistentPGDReconBase[PersistentPGDReconLossConfig]):
-    """PPGD adversarial-mask recon loss (routes to all layers).
-
-    Drives components to reconstruct the target output under adversarially-optimised
-    masks whose source tensors persist across training steps.
-    """
-
-    short_name = "PersistPGDRecon"
-
-
-class PersistentPGDReconSubsetLoss(_PersistentPGDReconBase[PersistentPGDReconSubsetLossConfig]):
-    """`PersistentPGDReconLoss` variant that masks only a routed subset of layers per forward."""
-
-    short_name = "PersistPGDReconSub"

--- a/param_decomp_config/losses.py
+++ b/param_decomp_config/losses.py
@@ -100,9 +100,10 @@ class ChunkwiseSubsetReconLossConfig(LossMetricConfig):
     clean logits (when `use_fused_kl`). The total is the mean over all chunk forwards of
     `recon_loss / n_positions`, matching the 2-pool's per-step recon.
 
-    The impl (`param_decomp_lab.metrics.chunkwise_subset_recon`) lives lab-side: it
-    needs the vendored `LMComponentModel` (fused-KL LM-head bypass) and the lab
-    recon-plan machinery. The lab FSDP trainer dispatches this `type` to the lab class.
+    The JAX single-pool trainer implements this natively: `recon.build_recon_terms`
+    maps this `type` onto `recon.subset_chunk_plan` (a parameterization of the one
+    `chunkwise_plan` builder), and the jitted step runs the chunk forwards directly —
+    no vendored `LMComponentModel` or lab recon-plan machinery is involved.
     """
 
     type: Literal["ChunkwiseSubsetReconLoss"] = "ChunkwiseSubsetReconLoss"
@@ -236,14 +237,16 @@ PersistentPGDSourceScope = Annotated[
 ]
 
 
-class _PersistentPGDBaseConfig(LossMetricConfig):
-    """Shared fields for persistent PGD configs.
+class PersistentPGDReconLossConfig(LossMetricConfig):
+    """Persistent-PGD recon loss: adversarial mask sources persist across train steps,
+    routed to all layers every forward.
 
     `update()` returns `None` before `start_frac` of training. Under
     `use_sigmoid_parameterization=True` sources are unconstrained and read via sigmoid;
     otherwise sources are clamped to `[0, 1]` after each step.
     """
 
+    type: Literal["PersistentPGDReconLoss"] = "PersistentPGDReconLoss"
     optimizer: Annotated[PGDOptimizerConfig, Field(discriminator="type")]
     scope: PersistentPGDSourceScope
     use_sigmoid_parameterization: bool = False
@@ -256,14 +259,3 @@ class _PersistentPGDBaseConfig(LossMetricConfig):
     )
     start_frac: Probability = 0.0
     n_samples: PositiveInt = 1
-
-
-class PersistentPGDReconLossConfig(_PersistentPGDBaseConfig):
-    type: Literal["PersistentPGDReconLoss"] = "PersistentPGDReconLoss"
-
-
-class PersistentPGDReconSubsetLossConfig(_PersistentPGDBaseConfig):
-    type: Literal["PersistentPGDReconSubsetLoss"] = "PersistentPGDReconSubsetLoss"
-    routing: Annotated[
-        SubsetRoutingType, Field(discriminator="type", default=UniformKSubsetRoutingConfig())
-    ]

--- a/param_decomp_config/pd.py
+++ b/param_decomp_config/pd.py
@@ -28,7 +28,6 @@ from param_decomp_config.losses import (
     FaithfulnessLossConfig,
     ImportanceMinimalityLossConfig,
     PersistentPGDReconLossConfig,
-    PersistentPGDReconSubsetLossConfig,
     PGDReconLayerwiseLossConfig,
     PGDReconLossConfig,
     PGDReconSubsetLossConfig,
@@ -62,7 +61,6 @@ AnyLossMetricConfig = Annotated[
     | FaithfulnessLossConfig
     | ImportanceMinimalityLossConfig
     | PersistentPGDReconLossConfig
-    | PersistentPGDReconSubsetLossConfig
     | PGDReconLayerwiseLossConfig
     | PGDReconLossConfig
     | PGDReconSubsetLossConfig

--- a/param_decomp_jax/jax_single_pool/recon.py
+++ b/param_decomp_jax/jax_single_pool/recon.py
@@ -26,7 +26,6 @@ from param_decomp_config.losses import (
     FaithfulnessLossConfig,
     ImportanceMinimalityLossConfig,
     PersistentPGDReconLossConfig,
-    PersistentPGDReconSubsetLossConfig,
     PGDReconLayerwiseLossConfig,
     PGDReconLossConfig,
     PGDReconSubsetLossConfig,
@@ -214,7 +213,31 @@ def routing_sampler_from_config(
             return route_all_n(n_draws)
 
 
-# ───────────────────────────── plan builders ─────────────────────────────
+# ───────────────────────────── the chunkwise plan ─────────────────────────────
+
+
+def chunkwise_plan(
+    site_names: tuple[str, ...],
+    sites_per_chunk: int,
+    sampler_for_chunk: Callable[[tuple[str, ...]], RoutingSampler],
+    sources: MaskSourceStrategy,
+) -> ReconPlan:
+    """The ONE recon-plan builder. Partition the sites into sequential
+    `sites_per_chunk`-groups in canonical order (SPEC S10), one `ReconForward` per chunk
+    with that chunk live and the rest frozen `x@W` (SPEC S2). `sampler_for_chunk` turns
+    each chunk into its routing draws; `sources` is shared by every entry.
+
+    The torch loss-class plan shapes are this builder's endpoints:
+      * `sites_per_chunk = len(site_names)` → one chunk = every site (the `all_sites`
+        shape: a single entry with everything live).
+      * `sites_per_chunk = 1` → `len(site_names)` one-site chunks (the `*Layerwise`
+        shape).
+      * `1 < sites_per_chunk < N` with `uniform_k_routing` → the production
+        `ChunkwiseSubsetReconLoss` (torch `SubsetReconPlan` over the chunk topology)."""
+    return tuple(
+        ReconForward(live_sites=chunk, sample_routing=sampler_for_chunk(chunk), sources=sources)
+        for chunk in chunk_sites(site_names, sites_per_chunk)
+    )
 
 
 def subset_chunk_plan(
@@ -223,31 +246,25 @@ def subset_chunk_plan(
     n_samples: int,
     sources: MaskSourceStrategy,
 ) -> ReconPlan:
-    """The production plan: partition into sequential chunks, `n_samples` uniform-k
-    forwards per chunk (torch `SubsetReconPlan` over `ThreePoolTopology` chunks)."""
-    return tuple(
-        ReconForward(
-            live_sites=chunk,
-            sample_routing=uniform_k_routing(chunk, n_samples),
-            sources=sources,
-        )
-        for chunk in chunk_sites(site_names, sites_per_chunk)
+    """The production plan: `n_samples` uniform-k forwards per chunk (torch
+    `SubsetReconPlan` over `ThreePoolTopology` chunks)."""
+    return chunkwise_plan(
+        site_names, sites_per_chunk, lambda chunk: uniform_k_routing(chunk, n_samples), sources
     )
 
 
 def per_site_plan(site_names: tuple[str, ...], sources: MaskSourceStrategy) -> ReconPlan:
-    """One forward per site, routed everywhere — the torch `*Layerwise` plan shape."""
-    return tuple(
-        ReconForward(live_sites=(site,), sample_routing=route_all, sources=sources)
-        for site in site_names
-    )
+    """One forward per site, routed everywhere — the torch `*Layerwise` plan shape
+    (`chunkwise_plan` with `sites_per_chunk = 1`)."""
+    return chunkwise_plan(site_names, 1, lambda _chunk: route_all, sources)
 
 
 def all_sites_plan(
     site_names: tuple[str, ...], sample_routing: RoutingSampler, sources: MaskSourceStrategy
 ) -> ReconPlan:
-    """One entry with every site live."""
-    return (ReconForward(live_sites=site_names, sample_routing=sample_routing, sources=sources),)
+    """One entry with every site live — `chunkwise_plan` with the whole site list as a
+    single chunk."""
+    return chunkwise_plan(site_names, len(site_names), lambda _chunk: sample_routing, sources)
 
 
 # ───────────────────────────── shared-config -> terms ─────────────────────────────
@@ -262,12 +279,10 @@ class LossSpec:
     faith_coeff: float
     imp_min: ImportanceMinimalityLossConfig
     recon_terms: ReconLossTerms
-    persistent: dict[str, PersistentPGDReconLossConfig | PersistentPGDReconSubsetLossConfig]
+    persistent: dict[str, PersistentPGDReconLossConfig]
 
 
-def _assert_supported_persistent(
-    cfg: PersistentPGDReconLossConfig | PersistentPGDReconSubsetLossConfig,
-) -> None:
+def _assert_supported_persistent(cfg: PersistentPGDReconLossConfig) -> None:
     assert isinstance(cfg.scope, SCScope), f"persistent scope {cfg.scope} unsupported (sc only)"
     assert not cfg.use_sigmoid_parameterization, cfg
     optimizer = cfg.optimizer
@@ -290,7 +305,7 @@ def build_recon_terms(
     faith_coeff: float | None = None
     imp_min: ImportanceMinimalityLossConfig | None = None
     terms: list[ReconLossTerm] = []
-    persistent: dict[str, PersistentPGDReconLossConfig | PersistentPGDReconSubsetLossConfig] = {}
+    persistent: dict[str, PersistentPGDReconLossConfig] = {}
 
     def instance_key(cfg: AnyLossMetricConfig) -> str:
         name = cfg.name if cfg.name is not None else cfg.type
@@ -328,13 +343,11 @@ def build_recon_terms(
                 plan = all_sites_plan(site_names, sampler, StochasticSources(sampling))
                 terms.append(ReconLossTerm(instance_key(cfg), cfg.coeff, plan))
             case StochasticReconLayerwiseLossConfig():
-                plan = tuple(
-                    ReconForward(
-                        live_sites=(site,),
-                        sample_routing=route_all_n(n_mask_samples),
-                        sources=StochasticSources(sampling),
-                    )
-                    for site in site_names
+                plan = chunkwise_plan(
+                    site_names,
+                    sites_per_chunk=1,
+                    sampler_for_chunk=lambda _chunk: route_all_n(n_mask_samples),
+                    sources=StochasticSources(sampling),
                 )
                 terms.append(ReconLossTerm(instance_key(cfg), cfg.coeff, plan))
             case ChunkwiseSubsetReconLossConfig():
@@ -356,17 +369,14 @@ def build_recon_terms(
                 fresh = FreshPGDSources(cfg.init, cfg.n_steps, cfg.step_size, cfg.mask_scope)
                 plan = per_site_plan(site_names, fresh)
                 terms.append(ReconLossTerm(instance_key(cfg), cfg.coeff, plan))
-            case PersistentPGDReconLossConfig() | PersistentPGDReconSubsetLossConfig():
+            case PersistentPGDReconLossConfig():
                 _assert_supported_persistent(cfg)
                 key = instance_key(cfg)
                 assert key not in persistent
                 persistent[key] = cfg
-                sampler = (
-                    routing_sampler_from_config(cfg.routing, site_names, cfg.n_samples)
-                    if isinstance(cfg, PersistentPGDReconSubsetLossConfig)
-                    else route_all_n(cfg.n_samples)
+                plan = all_sites_plan(
+                    site_names, route_all_n(cfg.n_samples), PersistentSources(state_key=key)
                 )
-                plan = all_sites_plan(site_names, sampler, PersistentSources(state_key=key))
                 terms.append(ReconLossTerm(key, cfg.coeff, plan))
             case _:
                 # StochasticHiddenActsReconLoss lands here by design: it is keep-on-bridge

--- a/param_decomp_jax/jax_single_pool/tests/test_recon_log_keys.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_recon_log_keys.py
@@ -25,7 +25,6 @@ from param_decomp_config.losses import (
     FaithfulnessLossConfig,
     ImportanceMinimalityLossConfig,
     PersistentPGDReconLossConfig,
-    PersistentPGDReconSubsetLossConfig,
     PGDReconLayerwiseLossConfig,
     PGDReconLossConfig,
     PGDReconSubsetLossConfig,
@@ -61,9 +60,6 @@ RECON_CONFIGS = (
     ),
     PGDReconSubsetLossConfig(coeff=1.0, init="random", step_size=0.1, n_steps=1, mask_scope="bsc"),
     PersistentPGDReconLossConfig(coeff=1.0, optimizer=_persistent_optimizer(), scope=SCScope()),
-    PersistentPGDReconSubsetLossConfig(
-        coeff=1.0, optimizer=_persistent_optimizer(), scope=SCScope()
-    ),
 )
 
 


### PR DESCRIPTION
## What

`subset_chunk_plan` (chunkwise) is now the **single** JAX recon-plan implementation. `all_sites_plan` / `per_site_plan` / `subset_chunk_plan` are thin wrappers over one parameterized builder `chunkwise_plan(site_names, sites_per_chunk, sampler_for_chunk, sources)`, with the torch loss-class plan shapes as its endpoints:

- **all_sites** ≡ `sites_per_chunk = N` (one chunk = every site)
- **per_site** ≡ `sites_per_chunk = 1` (N one-site chunks, routed-all)
- **production** ≡ `1 < sites_per_chunk < N` with `uniform_k_routing`

`build_recon_terms` stays the seam: each hardcoded config `type` maps to a specific parameterization.

**Semantically neutral** — the plans/sources/order produced for every existing config type are identical. Proven by the stacked-parity bit-identical train trajectory, the per-term equivalence goldens, the chunk-plan static-live-set tests, and log-key parity (all green).

## Config-layer changes (the only schema edits)

1. **Remove `PersistentPGDReconSubsetLossConfig`** and collapse `_PersistentPGDBaseConfig` into the single route-all `PersistentPGDReconLossConfig`. This structurally bans PPGD+subset (**#584**). All references repaired:
   - `param_decomp_config/pd.py` union + import
   - torch `param_decomp/metrics/persistent_pgd_recon.py` — subset `Metric` class + `_router_for_cfg` removed, router inlined to `AllLayersRouter()`, generic base collapsed to one concrete class
   - `param_decomp/metrics/dispatch.py`, `param_decomp/metrics/CLAUDE.md`
   - JAX `recon.py` arm + subset-routing branch, `test_recon_log_keys.py`
2. **Fix `ChunkwiseSubsetReconLossConfig` docstring** — it claimed the impl lives lab-side and the lab FSDP trainer dispatches it; corrected to reflect the JAX trainer implementing it natively via `recon.subset_chunk_plan`.

**#610** resolved at the impl layer (chunkwise unification); `n_samples` stays a plan param, the config is untouched.

## Validation

- JAX suite GREEN at both device counts: **143 passed** (default) + **143 passed** (`--xla_force_host_platform_device_count=4`).
- `make type` (torch workspace basedpyright): **0 errors**.
- Torch metrics tests (persistent/pgd/recon/dispatch/losses): 54 passed.

No stored YAML configs reference the removed type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)