### PR TITLE
pd-jax-lm: optional --comment flag for SLURM job comment

### DIFF
--- a/param_decomp_lab/experiments/lm/jax_launch.py
+++ b/param_decomp_lab/experiments/lm/jax_launch.py
@@ -56,6 +56,7 @@ def main(
     run_id: str | None = None,
     group: str | None = None,
     tags: str | None = None,
+    comment: str | None = None,
 ) -> None:
     """Submit a jsp-train run.
 
@@ -71,6 +72,7 @@ def main(
             (the original workspace wrapper already carries them).
         group: wandb UI group (no-op when the torch config omits `wandb:`).
         tags: Comma-separated wandb tags (no-op when `wandb:` is omitted).
+        comment: SLURM `--comment`; defaults to the wandb run URL (or run id).
     """
     wrapper_rel = _wrapper_path_relative_to_repo(config_path)
     torch_cfg, run_name = _validate_wrapper(REPO_ROOT / wrapper_rel)
@@ -100,7 +102,7 @@ def main(
         time=time,
         signal="TERM@300",
         requeue=True,
-        comment=wandb_url or run_id,
+        comment=comment if comment is not None else (wandb_url or run_id),
     )
     jax_dir = workspace / "param_decomp_jax"
     rank_command = f"source .venv-cuda/bin/activate\n{_RANK_ENV}\nexec jsp-train {wrapper_rel.relative_to('param_decomp_jax')}"


### PR DESCRIPTION
Adds an optional `--comment <str>` flag to `pd-jax-lm` (`jax_launch.py`). When given, it sets the sbatch `--comment` (via `SlurmConfig.comment`); when omitted, today's default (wandb run URL / run id) is preserved. Org policy wants descriptive SLURM comments.

`make type` clean; launcher imports and `--help` shows the flag. No real SLURM job submitted.

Closes #830

🤖 Generated with [Claude Code](https://claude.com/claude-code)