### PR TITLE
push-2: harvest reads JAX runs natively

### DIFF
--- a/param_decomp_jax/jax_single_pool/load_run.py
+++ b/param_decomp_jax/jax_single_pool/load_run.py
@@ -1,0 +1,187 @@
+"""Open a finished/live JAX single-pool run for offline consumption (harvest, and the
+consumers that follow it: clustering, autointerp, slow-eval, app).
+
+This is the reusable "load a JAX run" pattern. It reads a run dir
+(`runs/<p-id>/{config.yaml, experiment_config.yaml, ckpts/}`), rebuilds the frozen
+target + `DecomposedLM` from the pinned config, restores the orbax checkpoint onto a
+reference `TrainState`, and exposes the pure forward a consumer needs:
+
+    run = open_jax_run(run_dir)                 # latest checkpoint
+    fwd = run.forward(token_ids)                # one frozen, forward-only pass
+    fwd.lower_leaky_ci[site]                    # (B, T, C) leaky CI per site
+    fwd.component_acts[site]                    # (B, T, C) ‖U_c‖ · (x @ V) per site
+    fwd.output_probs                            # (B, T, vocab) softmax of clean logits
+
+No torch, no `jsp-export` safetensors bridge: the V/U + CI fn come straight from the
+orbax checkpoint and the target is built from its own config. CPU-friendly (jax falls
+back to CPU); a single device is enough for a small harvest.
+
+`forward` mirrors the forward-only subset of `eval.make_eval_step`: clean logits +
+`site_inputs` + lower-leaky CI, plus per-component acts (the harvest extra). bf16
+compute on the components / CI fn (training's `COMPUTE_DT`) so consumed CI matches the
+trained model's; output probs are fp32 from the fp32-upcast frozen forward.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float, Int
+
+from jax_single_pool import llama_simple_mlp
+from jax_single_pool.checkpoint import make_checkpoint_manager, restore_latest, restore_step
+from jax_single_pool.config import (
+    ExperimentConfig,
+    LlamaSimpleMLPTargetConfig,
+    TargetConfig,
+    load_run_dir_config,
+)
+from jax_single_pool.llama8b import DecompVU
+from jax_single_pool.lm import DecomposedLM
+from jax_single_pool.run_state import build_optimizers, init_train_state
+from jax_single_pool.sharding import dp_mesh
+from jax_single_pool.train import COMPUTE_DT, TrainState, cast_floating
+
+
+@dataclass(frozen=True)
+class HarvestForward:
+    """One frozen forward-only pass over a token batch, the raw material every harvest
+    fn turns into per-component statistics. Site-name-keyed; `(B, T, C_site)`."""
+
+    lower_leaky_ci: dict[str, Float[Array, "B T C"]]
+    component_acts: dict[str, Float[Array, "B T C"]]
+    output_probs: Float[Array, "B T vocab"]
+
+
+def _build_target(cfg: ExperimentConfig, mesh: jax.sharding.Mesh):
+    """Frozen target + prefix-residual fn for the run's target config. SimpleMLP reads
+    its local pretrain cache (no network); llama8b reads the HF snapshot."""
+    match cfg.target:
+        case LlamaSimpleMLPTargetConfig():
+            cache_dir = llama_simple_mlp.pretrain_cache_dir(cfg.target.pretrain_run_path)
+            simple_cfg = llama_simple_mlp.load_model_config(cache_dir)
+            lm = llama_simple_mlp.llama_simple_mlp_decomposed_lm(
+                simple_cfg, llama_simple_mlp.site_specs(simple_cfg, cfg.target.sites)
+            )
+            first_layer = llama_simple_mlp.first_decomposed_layer(lm.site_names)
+            target = llama_simple_mlp.replicate_frozen(
+                llama_simple_mlp.load_target_from_pretrain_cache(
+                    cache_dir, simple_cfg, first_layer, jnp.bfloat16
+                ),
+                mesh,
+            )
+            prefix = llama_simple_mlp.replicate_frozen(
+                llama_simple_mlp.load_prefix_from_pretrain_cache(
+                    cache_dir, simple_cfg, first_layer, jnp.bfloat16
+                ),
+                mesh,
+            )
+            return lm, target, prefix, llama_simple_mlp.prefix_residual, simple_cfg.vocab_size
+        case TargetConfig():
+            raise NotImplementedError(
+                "open_jax_run currently builds the LlamaSimpleMLP target only; the "
+                "llama8b target needs HF weight loading + sharding (see run.py main)."
+            )
+
+
+def _u_norms(components: DecompVU, site_names: tuple[str, ...]) -> dict[str, Float[Array, " C"]]:
+    """Per-component output-direction magnitude ‖U_c‖ — the harvest `component_activation`
+    scale (torch `harvest_fn/param_decomp.py`: `component.U.norm(dim=1)`)."""
+    return {
+        site: jnp.linalg.norm(components.site(site)[1].astype(jnp.float32), axis=1)
+        for site in site_names
+    }
+
+
+@dataclass(frozen=True)
+class LoadedJaxRun:
+    """A JAX run opened for consumption: restored trajectory + frozen target + the pure
+    forward consumers need. `layer_activation_sizes` / `vocab_size` mirror the torch
+    `PDAdapter` fields the harvest pipeline keys on."""
+
+    run_id: str
+    step: int
+    lm: DecomposedLM
+    config: ExperimentConfig
+    vocab_size: int
+    _state: TrainState
+    _forward: Any
+
+    @property
+    def site_names(self) -> tuple[str, ...]:
+        return self.lm.site_names
+
+    @property
+    def layer_activation_sizes(self) -> list[tuple[str, int]]:
+        """`(site_name, C)` per decomposed site, in canonical order — the harvest
+        accumulator's `layers` argument."""
+        return [(s.name, s.C) for s in self.lm.sites]
+
+    def forward(self, token_ids: Int[Array, "B T"]) -> HarvestForward:
+        lower_leaky_ci, component_acts, output_probs = self._forward(
+            self._state.components, self._state.ci_fn, token_ids
+        )
+        return HarvestForward(
+            lower_leaky_ci=lower_leaky_ci,
+            component_acts=component_acts,
+            output_probs=output_probs,
+        )
+
+
+def open_jax_run(run_dir: Path, step: int | None = None) -> LoadedJaxRun:
+    """Open the run at `run_dir`; restore checkpoint `step` (latest if None)."""
+    cfg = load_run_dir_config(run_dir)
+    mesh = dp_mesh()
+    lm, target, prefix, prefix_residual_fn, vocab_size = _build_target(cfg, mesh)
+
+    opt_vu, opt_ci, _ = build_optimizers(cfg)
+    init_key, src_key = jax.random.split(jax.random.PRNGKey(cfg.seed))
+    reference = init_train_state(cfg, lm, opt_vu, opt_ci, init_key, src_key, mesh)
+
+    manager = make_checkpoint_manager(run_dir / "ckpts", cfg.cadence.keep_last)
+    if step is None:
+        restored = restore_latest(manager, reference)
+        assert restored is not None, f"no checkpoints under {run_dir / 'ckpts'}"
+        state, resolved_step = restored
+    else:
+        state, resolved_step = restore_step(manager, reference, step), step
+    assert isinstance(state.components, DecompVU)
+
+    site_names = lm.site_names
+    u_norms = _u_norms(state.components, site_names)
+
+    @jax.jit
+    def forward(
+        components: DecompVU, ci_fn: Any, token_ids: Int[Array, "B T"]
+    ) -> tuple[dict[str, Array], dict[str, Array], Array]:
+        residual = prefix_residual_fn(prefix, token_ids)
+        clean_logits = lm.clean_logits(target, residual)
+        site_inputs = lm.site_inputs(target, residual)
+
+        components_bf16 = cast_floating(components, COMPUTE_DT)
+        ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
+        lower_ci = ci_fn_bf16(site_inputs).lower
+
+        component_acts = {}
+        for site in site_names:
+            V = components_bf16.site(site)[0]
+            acts = site_inputs[site].astype(COMPUTE_DT) @ V  # (B, T, C): x @ V
+            component_acts[site] = acts.astype(jnp.float32) * u_norms[site]
+
+        return (
+            {site: lower_ci[site].astype(jnp.float32) for site in site_names},
+            component_acts,
+            jax.nn.softmax(clean_logits.astype(jnp.float32), axis=-1),
+        )
+
+    return LoadedJaxRun(
+        run_id=cfg.run_id,
+        step=resolved_step,
+        lm=lm,
+        config=cfg,
+        vocab_size=vocab_size,
+        _state=state,
+        _forward=forward,
+    )

--- a/param_decomp_lab/harvest/CLAUDE.md
+++ b/param_decomp_lab/harvest/CLAUDE.md
@@ -10,6 +10,37 @@ core `ComponentModel` (single-pool, and pre-`e8ff5a64` 3-pool) and the vendored
 satisfy the `HarvestableComponentModel` protocol; `SavedThreePoolLMRun.load_model`
 sniffs the state-dict key prefixes (`detect_checkpoint_format`) and dispatches.
 
+## JAX runs (`scripts/run_worker_jax.py`)
+
+A JAX single-pool run (`param_decomp_jax`, orbax checkpoint) is harvested **natively** —
+no torch component model, no `jsp-export` safetensors bridge. The run is opened with
+`jax_single_pool.load_run.open_jax_run` (the reusable "open a JAX run for consumption"
+pattern — see below); its frozen forward-only pass (lower-leaky CI + ‖U‖·(x@V) component
+acts + clean-logit softmax) is converted into the SAME `HarvestBatch` the torch
+`ParamDecompHarvestFn` produces, fed to the SAME `Harvester`, and written via the SAME
+`HarvestRepo.save_results`. Autointerp / clustering / app read the output unchanged.
+
+```bash
+python -m param_decomp_lab.harvest.scripts.run_worker_jax \
+    --run_dir runs/p-761bc061 --n_batches 50 --batch_size 16
+```
+
+The forward runs in jax (CPU or one GPU); the accumulator stays torch — this worker is
+the one place both stacks meet (the pure JAX package never imports torch). Pre-tokenized
+parquet is served by the trainer's own `ShardServer` (never streamed from HF). On CPU the
+dense component co-occurrence (`O(C²)` + `O(C·vocab)` per batch) dominates; pass
+`--no_cooccurrence` for a quick spot-check (drops only `component_correlations.pt`).
+
+### The reusable run-loading pattern (for clustering / autointerp / slow-eval / app)
+
+`jax_single_pool.load_run.open_jax_run(run_dir, step=None) -> LoadedJaxRun` is the single
+entry point any consumer of a JAX run should use. It rebuilds the frozen target +
+`DecomposedLM` from the run's pinned config (`load_run_dir_config`), restores the orbax
+checkpoint onto a reference `TrainState`, and exposes `run.forward(token_ids) ->
+HarvestForward` plus the metadata torch consumers key on (`layer_activation_sizes`,
+`vocab_size`, `site_names`). Pure JAX, torch-free, single-device-friendly. Add the
+forward outputs a new consumer needs there; don't re-open checkpoints ad hoc.
+
 ## Usage (SLURM)
 
 ```bash

--- a/param_decomp_lab/harvest/scripts/run_worker_jax.py
+++ b/param_decomp_lab/harvest/scripts/run_worker_jax.py
@@ -1,0 +1,122 @@
+"""Harvest a JAX single-pool run natively — no torch component model, no `jsp-export`
+safetensors bridge.
+
+    python -m param_decomp_lab.harvest.scripts.run_worker_jax \
+        --run_dir runs/p-761bc061 --n_batches 50 --batch_size 16
+
+The run is opened with `jax_single_pool.load_run.open_jax_run` (the reusable JAX
+"open a run for consumption" pattern); the frozen forward-only pass it exposes is
+turned into the SAME `HarvestBatch` the torch harvest fn produces, fed to the SAME
+`Harvester`, and written via the SAME `HarvestRepo.save_results`. Downstream
+autointerp / clustering / app therefore read the output unchanged.
+
+The JAX forward runs in jax (CPU or one GPU); the accumulator stays torch. This worker
+imports both — the only place the two stacks meet. Pre-tokenized parquet is read with
+the trainer's own `ShardServer` (never streamed from HF).
+"""
+
+import argparse
+from datetime import datetime
+from pathlib import Path
+
+import jax.numpy as jnp
+import numpy as np
+import torch
+from jax_single_pool.data import BatchSchedule, ShardServer, scan_shards
+from jax_single_pool.load_run import HarvestForward, LoadedJaxRun, open_jax_run
+
+from param_decomp.log import logger
+from param_decomp_lab.harvest.accumulator import Harvester
+from param_decomp_lab.harvest.config import HarvestConfig, ParamDecompHarvestConfig
+from param_decomp_lab.harvest.repo import HarvestRepo
+from param_decomp_lab.harvest.schemas import HarvestBatch, get_harvest_subrun_dir
+
+
+def _to_torch(array: object) -> torch.Tensor:
+    """Host a JAX/numpy array as a CPU torch tensor (copy: the accumulator's reservoir
+    writes into the token windows in place)."""
+    return torch.from_numpy(np.array(np.asarray(array)))
+
+
+def harvest_batch_from_forward(
+    tokens: np.ndarray, fwd: HarvestForward, activation_threshold: float
+) -> HarvestBatch:
+    """JAX forward outputs -> the torch `HarvestBatch` (matching the torch
+    `ParamDecompHarvestFn`: lower-leaky CI as `causal_importance`, ‖U‖·(x@V) as
+    `component_activation`, firing = CI > threshold)."""
+    ci = {site: _to_torch(v) for site, v in fwd.lower_leaky_ci.items()}
+    acts = {site: _to_torch(v) for site, v in fwd.component_acts.items()}
+    return HarvestBatch(
+        tokens=_to_torch(tokens).long(),  # torch harvest path is int64-keyed
+        firings={site: ci[site] > activation_threshold for site in ci},
+        activations={
+            site: {"causal_importance": ci[site], "component_activation": acts[site]} for site in ci
+        },
+        output_probs=_to_torch(fwd.output_probs),
+    )
+
+
+def harvest_jax_run(
+    run: LoadedJaxRun, config: HarvestConfig, activation_threshold: float, output_dir: Path
+) -> None:
+    data, seed = run.config.data, run.config.seed
+    schedule = BatchSchedule(scan_shards(data.dir), config.batch_size, seed)
+    server = ShardServer(schedule, data.seq_len, process_index=0, process_count=1)
+
+    harvester = Harvester(
+        layers=run.layer_activation_sizes,
+        vocab_size=run.vocab_size,
+        max_examples_per_component=config.activation_examples_per_component,
+        context_tokens_per_side=config.activation_context_tokens_per_side,
+        max_examples_per_batch_per_component=config.max_examples_per_batch_per_component,
+        collect_component_cooccurrence=config.collect_component_cooccurrence,
+        device=torch.device("cpu"),
+    )
+
+    assert isinstance(config.n_batches, int), "JAX harvest needs an explicit n_batches"
+    for batch_idx in range(config.n_batches):
+        tokens = server.local_batch(batch_idx)
+        fwd = run.forward(jnp.asarray(tokens))
+        hb = harvest_batch_from_forward(tokens, fwd, activation_threshold)
+        harvester.process_batch(hb.tokens, hb.firings, hb.activations, hb.output_probs)
+        logger.info(f"{batch_idx + 1}/{config.n_batches} batches")
+
+    logger.info(
+        f"Harvest complete: {config.n_batches} batches, {harvester.total_tokens_processed:,} tokens"
+    )
+    HarvestRepo.save_results(harvester, config, output_dir)
+    logger.info(f"Saved results to {output_dir}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--run_dir", type=Path, required=True)
+    ap.add_argument("--step", type=int, default=None, help="checkpoint step (default: latest)")
+    ap.add_argument("--n_batches", type=int, required=True)
+    ap.add_argument("--batch_size", type=int, default=16)
+    ap.add_argument("--activation_threshold", type=float, default=0.0)
+    ap.add_argument("--subrun_id", type=str, default=None)
+    ap.add_argument(
+        "--no_cooccurrence",
+        action="store_true",
+        help="skip the O(C²) component-cooccurrence matrix (slow on CPU; on for production)",
+    )
+    args = ap.parse_args()
+
+    run = open_jax_run(args.run_dir, args.step)
+    subrun_id = args.subrun_id or "h-" + datetime.now().strftime("%Y%m%d_%H%M%S")
+    config = HarvestConfig(
+        method_config=ParamDecompHarvestConfig(
+            wandb_path=run.run_id, activation_threshold=args.activation_threshold
+        ),
+        n_batches=args.n_batches,
+        batch_size=args.batch_size,
+        collect_component_cooccurrence=not args.no_cooccurrence,
+    )
+    output_dir = get_harvest_subrun_dir(run.run_id, subrun_id)
+    logger.info(f"JAX harvest: run {run.run_id} step {run.step}, subrun {subrun_id}")
+    harvest_jax_run(run, config, args.activation_threshold, output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/param_decomp_lab/tests/harvest/test_jax_harvest_batch.py
+++ b/param_decomp_lab/tests/harvest/test_jax_harvest_batch.py
@@ -1,0 +1,33 @@
+"""The JAX->torch `HarvestBatch` bridge matches the torch `ParamDecompHarvestFn` shape
+and semantics: lower-leaky CI as `causal_importance`, ‖U‖·(x@V) as
+`component_activation`, firing = CI > threshold, int64 tokens."""
+
+import jax.numpy as jnp
+import numpy as np
+import torch
+from jax_single_pool.load_run import HarvestForward
+
+from param_decomp_lab.harvest.scripts.run_worker_jax import harvest_batch_from_forward
+
+
+def test_harvest_batch_from_forward_matches_torch_harvest_fn_semantics() -> None:
+    rng = np.random.default_rng(0)
+    tokens = rng.integers(0, 100, size=(2, 5)).astype(np.int32)
+    ci = rng.uniform(0.0, 1.0, size=(2, 5, 3)).astype(np.float32)
+    acts = rng.normal(size=(2, 5, 3)).astype(np.float32)
+    probs = rng.uniform(size=(2, 5, 100)).astype(np.float32)
+    fwd = HarvestForward(
+        lower_leaky_ci={"h.0.mlp.c_fc": jnp.asarray(ci)},
+        component_acts={"h.0.mlp.c_fc": jnp.asarray(acts)},
+        output_probs=jnp.asarray(probs),
+    )
+
+    hb = harvest_batch_from_forward(tokens, fwd, activation_threshold=0.3)
+
+    assert hb.tokens.dtype == torch.int64  # torch harvest path keys on long tokens
+    assert torch.equal(hb.tokens, torch.from_numpy(tokens).long())
+    site = "h.0.mlp.c_fc"
+    assert torch.allclose(hb.activations[site]["causal_importance"], torch.from_numpy(ci))
+    assert torch.allclose(hb.activations[site]["component_activation"], torch.from_numpy(acts))
+    assert torch.equal(hb.firings[site], torch.from_numpy(ci) > 0.3)
+    assert torch.allclose(hb.output_probs, torch.from_numpy(probs))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,10 @@ known-third-party = ["wandb"]
 [tool.pyright]
 include = ["param_decomp", "param_decomp_config", "param_decomp_lab", "nano_param_decomp"]
 exclude = ["**/wandb/**", "**/_scratch/**", "param_decomp_lab/_linear_sum_assignment.py", "param_decomp_lab/app/frontend"]
+# Resolve (don't type-check) the JAX distribution: lab consumes it through the
+# editable-install import hook pyright can't follow. The package stays out of `include`
+# (it is type-checked in its own torch-free pass; see param_decomp_jax CLAUDE.md).
+extraPaths = ["param_decomp_jax"]
 stubPath = "typings" # Having type stubs for transformers shaves 10 seconds off basedpyright calls
 
 strictListInference = true


### PR DESCRIPTION
Closes #826.

First consumer migration off the torch export bridge, and the keystone that sets the "open a JAX run for consumption" pattern every other consumer (clustering, autointerp, slow-eval, app) will reuse.

## What
Harvest now reads a JAX single-pool run (orbax checkpoint + `DecomposedLM` target) **natively** — no torch component model, no `jsp-export` safetensors round-trip.

- **`jax_single_pool/load_run.py`** — `open_jax_run(run_dir, step=None) -> LoadedJaxRun`, the reusable run-loading pattern. Rebuilds the frozen target + `DecomposedLM` from the run's pinned config (`load_run_dir_config`), restores the orbax checkpoint onto a reference `TrainState`, and exposes `run.forward(token_ids) -> HarvestForward` (lower-leaky CI + `‖U‖·(x@V)` component acts + clean-logit softmax) plus the metadata torch consumers key on (`layer_activation_sizes`, `vocab_size`, `site_names`). Pure JAX, torch-free, single-device-friendly.
- **`harvest/scripts/run_worker_jax.py`** — the one place the JAX forward and the torch accumulator meet. Converts the forward into the SAME `HarvestBatch` the torch `ParamDecompHarvestFn` produces, feeds the SAME `Harvester`, writes via the SAME `HarvestRepo.save_results`. Downstream autointerp / clustering / app read the output unchanged. Parquet served by the trainer's own `ShardServer`.
- **`pyproject.toml`** — `extraPaths = ["param_decomp_jax"]` so lab files resolve `jax_single_pool` (the editable-install import hook pyright can't follow); the package stays out of `include` (type-checked in its own torch-free pass).

## Reused vs reimplemented
- **Reused unchanged** (pure `HarvestBatch` consumers, never touch the model): `Harvester` (accumulator), `HarvestRepo` / `HarvestDB` / `CorrelationStorage` / `TokenStatsStorage` (output format), `reservoir`, `sampling`, the `HarvestBatch` / `ComponentData` schemas, the `HarvestConfig`.
- **New**: the JAX forward + run loader (`load_run.py`) and the bridge worker.

## Validation (real run)
Ran on `runs/p-761bc061` (SimpleMLP, step 5000): **38912 component records** with sane firing densities (~0.02–0.05), mean `causal_importance` + `component_activation`, 15 activation examples each (token windows + firings), input/output token PMI; `token_stats.pt` written (vocab 50277). Output format byte-identical to the torch harvest contract.

`make type` clean; new bridge test + full harvest suite (66) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)