### PR TITLE
feat(jax): persistent-PGD bsc scope onto post-refactor feature/jax (takes over #805)

### DIFF
--- a/param_decomp_config/jax_wrapper.py
+++ b/param_decomp_config/jax_wrapper.py
@@ -6,21 +6,33 @@ Lives here, in the torch-free config package, because it's the only distribution
 venvs install; neither side can import the other's package. See the wrapper schema in
 `jax_single_pool.config`'s module docstring.
 
-`run_id`, `wandb_group`, and `wandb_tags` are minted from the launch (`pd-jax-lm`
-mints the id; `--group`/`--tags` supply the rest) and appended to the workspace copy
-at submit time — so a hand-authored wrapper carries `WRAPPER_KEYS_BEFORE_SUBMIT` and
-the stamped copy the loader reads carries the required `WRAPPER_KEYS` plus whichever
-`WRAPPER_OPTIONAL_KEYS` the launch supplied.
+Three submit-time key groups:
+- `run_id` is always minted by `pd-jax-lm` and must be absent in a hand-authored wrapper.
+- `wandb_group` / `wandb_tags` come from `--group` / `--tags` and are appended only when
+  supplied; a hand-authored wrapper never carries them.
+- `out_dir` is author-overridable: a wrapper MAY set it (e.g. the llama8b wrappers'
+  `jax_runs`), and the launcher mints `PARAM_DECOMP_OUT_DIR/runs` when it is absent.
+
+So a hand-authored wrapper carries `WRAPPER_KEYS_BEFORE_SUBMIT` (the required keys plus
+an optional `out_dir`), and the stamped copy the loader reads carries the full required
+`WRAPPER_KEYS` plus whichever `WRAPPER_OPTIONAL_KEYS` the launch supplied.
 """
 
 RUN_ID_KEY = "run_id"
+OUT_DIR_KEY = "out_dir"
 
 WRAPPER_KEYS = frozenset(
-    {"torch_config", RUN_ID_KEY, "run_name", "out_dir", "remat_recon_forwards"}
+    {"torch_config", RUN_ID_KEY, "run_name", OUT_DIR_KEY, "remat_recon_forwards"}
 )
 
 WRAPPER_OPTIONAL_KEYS = frozenset({"wandb_group", "wandb_tags"})
 
+# Minted at submit and never present in a hand-authored wrapper.
 SUBMIT_MINTED_KEYS = frozenset({RUN_ID_KEY}) | WRAPPER_OPTIONAL_KEYS
 
-WRAPPER_KEYS_BEFORE_SUBMIT = WRAPPER_KEYS - SUBMIT_MINTED_KEYS
+# Minted at submit when absent, but a hand-authored wrapper MAY supply it to override.
+AUTHOR_OVERRIDABLE_KEYS = frozenset({OUT_DIR_KEY})
+
+WRAPPER_REQUIRED_BEFORE_SUBMIT = WRAPPER_KEYS - SUBMIT_MINTED_KEYS - AUTHOR_OVERRIDABLE_KEYS
+
+WRAPPER_KEYS_BEFORE_SUBMIT = WRAPPER_REQUIRED_BEFORE_SUBMIT | AUTHOR_OVERRIDABLE_KEYS

--- a/param_decomp_jax/jax_single_pool/CLAUDE.md
+++ b/param_decomp_jax/jax_single_pool/CLAUDE.md
@@ -4,12 +4,14 @@ Single-pool VPD trainer in JAX, **generic over vendored LM targets**. The semant
 source of truth is `SPEC.md` (normative pseudocode + numbered invariants, grounded in
 the stable torch `param_decomp` impl). See `README.md` for the file map.
 
-Open items: persistent-source scopes beyond `sc`, sigmoid parameterization, and the
+Open items: persistent-source scopes `c`/`nsc`, sigmoid parameterization, and the
 hidden-acts seam are deliberately refused (SPEC S31, LOSS_PARITY_DESIGN §6 stage 4 —
-hidden-acts is keep-on-bridge); persistent `start_frac>0` is now implemented (SPEC S32,
-`term_active` `where`-gating); SPEC S24's two torch-parity quirks (PPGD warmup
-route-all, fresh-PGD single routing draw) are pinned pending a team decision. CI-fn
-numerics are unified with the torch oracle (#624/#625/#730 resolved): GELU is exact-erf
+hidden-acts is keep-on-bridge). `sc` and `bsc` are supported (`bsc` is batch-sharded:
+an independent source per batch element and position, no cross-replica sync — SPEC
+S16/D1). Persistent `start_frac>0` is now implemented (SPEC S32, `term_active`
+`where`-gating); SPEC S24's two torch-parity quirks (PPGD warmup route-all, fresh-PGD
+single routing draw) are pinned pending a team decision. CI-fn numerics are unified
+with the torch oracle (#624/#625/#730 resolved): GELU is exact-erf
 (`approximate=False`) and RMSNorm eps is `finfo(fp32).eps` (`CI_FN_RMS_EPS`).
 
 ## The one rule

--- a/param_decomp_jax/jax_single_pool/CLAUDE.md
+++ b/param_decomp_jax/jax_single_pool/CLAUDE.md
@@ -4,9 +4,10 @@ Single-pool VPD trainer in JAX, **generic over vendored LM targets**. The semant
 source of truth is `SPEC.md` (normative pseudocode + numbered invariants, grounded in
 the stable torch `param_decomp` impl). See `README.md` for the file map.
 
-Open items: persistent-source scopes beyond `sc`, sigmoid parameterization,
+Open items: persistent-source scopes `c`/`nsc`, sigmoid parameterization,
 `start_frac>0`, and the hidden-acts seam are deliberately refused (LOSS_PARITY_DESIGN
-§6 stage 4); SPEC S24's two torch-parity quirks (PPGD warmup route-all, fresh-PGD
+§6 stage 4). `sc` and `bsc` are supported (`bsc` is batch-sharded, no replica sync).
+SPEC S24's two torch-parity quirks (PPGD warmup route-all, fresh-PGD
 single routing draw) are pinned pending a team decision; CI-fn numerics (gelu erf,
 rms eps) unify with torch at a run boundary.
 

--- a/param_decomp_jax/jax_single_pool/LOSS_PARITY_DESIGN.md
+++ b/param_decomp_jax/jax_single_pool/LOSS_PARITY_DESIGN.md
@@ -366,14 +366,14 @@ divisibility for `nsc`) becomes a converter assert.
 | `ImportanceMinimalityLoss` | **already-runnable** | S7–S9, D2; `p_anneal_final_p=None` (constant p) is a trivial assert-relax |
 | `ChunkwiseSubsetReconLoss` | **already-runnable** | the production stochastic term |
 | `StochasticReconSubsetLoss` (uniform_k) | **already-runnable** | converted today as 1-chunk plan |
-| `PersistentPGDReconLoss` (sc, Adam, clamp) | **already-runnable** | the production adversary |
+| `PersistentPGDReconLoss` (sc/bsc, Adam, clamp) | **already-runnable** | the production adversary; `bsc` is batch-sharded (`P("dp", None, None)`), no replica sync |
 | `PGDReconLoss` (as the single adversary; as eval probe) | **already-runnable** | both paths exist |
 | `UnmaskedReconLoss` | **composition-only** | `ConstantSources(1.0)`; optional `has_delta` static flag |
 | `CIMaskedReconLoss` / `Subset` / `Layerwise` | **composition-only** | `ConstantSources(0.0)` × plan shape; `static_probability` routing sampler is ~5 lines |
 | `StochasticReconLoss` / `Layerwise` | **composition-only** | plan shapes; `binomial` sampling = one `random.bernoulli` branch |
 | `PGDReconSubsetLoss` / `Layerwise` | **composition-only** | `FreshPGDSources` per entry + Q2 routing-draw sharing; `bc` scope shape exists in `init_fresh_pgd_sources` already |
 | `PersistentPGDReconSubsetLoss` | **composition-only** | needs warmup-plan/loss-plan split (Q1) + routed loss fwds |
-| PPGD scopes `c`/`nsc`/`bsc` | **composition-only** | source-shape variants of `init_persistent_sources` + Q4 note; `bsc` needs no replica sync (S16 already covers) |
+| PPGD scopes `c`/`nsc` | **composition-only** | source-shape variants of `init_persistent_sources` + Q4 note (`bsc` now implemented: batch-sharded, no replica sync per S16) |
 | PPGD `sign` SRC_STEP, sigmoid parameterization, `n_samples>1` | **composition-only** | SPEC §6 already names them as variation points |
 | multiple simultaneous loss/adversary terms | **composition-only** | §2.2 TrainState dicts + per-term S14 |
 | PPGD `start_frac > 0` | **implemented (2026-06-16)** | Q3 — `term_active` `where`-gating, SPEC S32 |

--- a/param_decomp_jax/jax_single_pool/LOSS_PARITY_DESIGN.md
+++ b/param_decomp_jax/jax_single_pool/LOSS_PARITY_DESIGN.md
@@ -364,14 +364,14 @@ divisibility for `nsc`) becomes a converter assert.
 | `ImportanceMinimalityLoss` | **already-runnable** | S7–S9, D2; `p_anneal_final_p=None` (constant p) is a trivial assert-relax |
 | `ChunkwiseSubsetReconLoss` | **already-runnable** | the production stochastic term |
 | `StochasticReconSubsetLoss` (uniform_k) | **already-runnable** | converted today as 1-chunk plan |
-| `PersistentPGDReconLoss` (sc, Adam, clamp) | **already-runnable** | the production adversary |
+| `PersistentPGDReconLoss` (sc/bsc, Adam, clamp) | **already-runnable** | the production adversary; `bsc` is batch-sharded (`P("dp", None, None)`), no replica sync |
 | `PGDReconLoss` (as the single adversary; as eval probe) | **already-runnable** | both paths exist |
 | `UnmaskedReconLoss` | **composition-only** | `ConstantSources(1.0)`; optional `has_delta` static flag |
 | `CIMaskedReconLoss` / `Subset` / `Layerwise` | **composition-only** | `ConstantSources(0.0)` × plan shape; `static_probability` routing sampler is ~5 lines |
 | `StochasticReconLoss` / `Layerwise` | **composition-only** | plan shapes; `binomial` sampling = one `random.bernoulli` branch |
 | `PGDReconSubsetLoss` / `Layerwise` | **composition-only** | `FreshPGDSources` per entry + Q2 routing-draw sharing; `bc` scope shape exists in `init_fresh_pgd_sources` already |
 | `PersistentPGDReconSubsetLoss` | **composition-only** | needs warmup-plan/loss-plan split (Q1) + routed loss fwds |
-| PPGD scopes `c`/`nsc`/`bsc` | **composition-only** | source-shape variants of `init_persistent_sources` + Q4 note; `bsc` needs no replica sync (S16 already covers) |
+| PPGD scopes `c`/`nsc` | **composition-only** | source-shape variants of `init_persistent_sources` + Q4 note (`bsc` now implemented: batch-sharded, no replica sync per S16) |
 | PPGD `sign` SRC_STEP, sigmoid parameterization, `n_samples>1` | **composition-only** | SPEC §6 already names them as variation points |
 | multiple simultaneous loss/adversary terms | **composition-only** | §2.2 TrainState dicts + per-term S14 |
 | PPGD `start_frac > 0` | **composition-only (deferred)** | Q3 — keep the refusing assert until needed |

--- a/param_decomp_jax/jax_single_pool/SPEC.md
+++ b/param_decomp_jax/jax_single_pool/SPEC.md
@@ -271,7 +271,7 @@ on the clean path. Refs: `ci_fn.py` GELU line + `CI_FN_RMS_EPS`; torch
 | `SAMPLE_ROUTING` | `(key, [B,T]) → tuple of routing draws`, statically sized; draws may be jointly sampled (independent repeats, antithetic/complementary subsets, per-step covers) | ★ uniform_k_routing(·, 1) |
 | `SRC_STEP` | `adam(β₁,β₂,ε)` with bias correction; `sign` (`sources += lr·sign(grad)`) | ★ adam(.5, .99, 1e-8) |
 | `PROJ` / `EFFECTIVE` | **clamp**: PROJ = clamp[0,1], EFFECTIVE = identity, init U[0,1] · **sigmoid**: PROJ = identity (unbounded raw), EFFECTIVE = sigmoid, init N(0,1) | ★ clamp |
-| `SCOPE` | persistent: `c (1,1)` · `sc (1,T)` · `nsc (n,T), n|B` · `bsc (B,T)` (jax: `sc` only today) — fresh-PGD: `c` · `bc` · `bsc` | ★ sc |
+| `SCOPE` | persistent: `c (1,1)` · `sc (1,T)` · `nsc (n,T), n|B` · `bsc (B,T)` (jax: `sc` + `bsc` today) — fresh-PGD: `c` · `bc` · `bsc` | ★ sc |
 | stoch sampling | `continuous U[0,1]` · `binomial {0,1}` | ★ continuous |
 | delta component | on (`C+1` channels) · off (no delta path, no delta mask) | ★ on |
 | CI squashing | `leaky_hard` pair (§4.2); other registry sigmoids exist in torch but are out of spec scope | ★ leaky_hard |

--- a/param_decomp_jax/jax_single_pool/SPEC.md
+++ b/param_decomp_jax/jax_single_pool/SPEC.md
@@ -250,7 +250,7 @@ init: biases zero; weights fan-in scaled (torch init_param_)
 | `SAMPLE_ROUTING` | `(key, [B,T]) → tuple of routing draws`, statically sized; draws may be jointly sampled (independent repeats, antithetic/complementary subsets, per-step covers) | ★ uniform_k_routing(·, 1) |
 | `SRC_STEP` | `adam(β₁,β₂,ε)` with bias correction; `sign` (`sources += lr·sign(grad)`) | ★ adam(.5, .99, 1e-8) |
 | `PROJ` / `EFFECTIVE` | **clamp**: PROJ = clamp[0,1], EFFECTIVE = identity, init U[0,1] · **sigmoid**: PROJ = identity (unbounded raw), EFFECTIVE = sigmoid, init N(0,1) | ★ clamp |
-| `SCOPE` | persistent: `c (1,1)` · `sc (1,T)` · `nsc (n,T), n|B` · `bsc (B,T)` (jax: `sc` only today) — fresh-PGD: `c` · `bc` · `bsc` | ★ sc |
+| `SCOPE` | persistent: `c (1,1)` · `sc (1,T)` · `nsc (n,T), n|B` · `bsc (B,T)` (jax: `sc` + `bsc` today) — fresh-PGD: `c` · `bc` · `bsc` | ★ sc |
 | stoch sampling | `continuous U[0,1]` · `binomial {0,1}` | ★ continuous |
 | delta component | on (`C+1` channels) · off (no delta path, no delta mask) | ★ on |
 | CI squashing | `leaky_hard` pair (§4.2); other registry sigmoids exist in torch but are out of spec scope | ★ leaky_hard |

--- a/param_decomp_jax/jax_single_pool/adversary.py
+++ b/param_decomp_jax/jax_single_pool/adversary.py
@@ -3,10 +3,11 @@
 Two semantically distinct adversaries share the source/mask machinery but nothing
 else (SPEC §3):
 
-- **Persistent PGD (PPGD)** — `PersistentPGDReconLossConfig`. Per-site `(1, T, C+1)`
-  sources + their Adam moments live in `TrainState` across steps; each step runs
-  `n_warmup_steps` supplemental Adam ascents plus one final ascent from the main
-  backward (SPEC S13/S14), projecting to [0,1] after every update (S15).
+- **Persistent PGD (PPGD)** — `PersistentPGDReconLossConfig`. Per-site sources + their
+  Adam moments live in `TrainState` across steps; `sc` scope is `(1, T, C+1)` (shared
+  across batch), `bsc` is `(B, T, C+1)` (independent per batch element, batch-sharded).
+  Each step runs `n_warmup_steps` supplemental Adam ascents plus one final ascent from
+  the main backward (SPEC S13/S14), projecting to [0,1] after every update (S15).
 - **Fresh PGD** — `PGDReconLossConfig` (torch `PGDReconLoss` as a TRAINING loss).
   Sources are re-initialized every step, ascended `n_steps` times by
   `step_size * sign(grad)` with clamp to [0,1], and carry NO state across steps —
@@ -37,14 +38,16 @@ def init_persistent_sources(
     site_names: tuple[str, ...],
     site_component_counts: tuple[int, ...],
     seq_len: int,
+    batch_dim: int,
     key: PRNGKeyArray,
 ) -> dict[str, Array]:
-    """PPGD `sc` scope (SPEC §1.6): `(1, T, C+1)` per site — shared across batch
-    elements, free per position — init U[0,1] (SPEC S15; clamp parameterization).
-    Trailing channel = the weight-delta source."""
+    """Per-site PPGD sources `(batch_dim, T, C+1)`, init U[0,1] (SPEC S15; clamp
+    parameterization); trailing channel = the weight-delta source. `batch_dim` spells the
+    scope's leading axis (SPEC §1.6): 1 for `sc` (shared across batch, free per position),
+    B for `bsc` (independent per batch element and position)."""
     keys = random.split(key, len(site_names))
     return {
-        name: random.uniform(k, (1, seq_len, c + 1), jnp.float32)
+        name: random.uniform(k, (batch_dim, seq_len, c + 1), jnp.float32)
         for name, c, k in zip(site_names, site_component_counts, keys, strict=True)
     }
 

--- a/param_decomp_jax/jax_single_pool/configs/pile_pgd1_from_torch.yaml
+++ b/param_decomp_jax/jax_single_pool/configs/pile_pgd1_from_torch.yaml
@@ -3,5 +3,4 @@
 # edits. Small target (4L d768): no remat needed. Launch: pd-jax-lm, 1 node.
 torch_config: torch/pile_llama_simple_mlp_4l_pgd1.yaml
 run_name: jax-pile4l-pgd1-ss1
-out_dir: /mnt/data/artifacts/mechanisms/param-decomp/runs
 remat_recon_forwards: false

--- a/param_decomp_jax/jax_single_pool/configs/pile_ppgd_bsc_from_torch.yaml
+++ b/param_decomp_jax/jax_single_pool/configs/pile_ppgd_bsc_from_torch.yaml
@@ -1,0 +1,8 @@
+# Persistent-PGD (bsc) pile run — JAX replication of torch p-20f9fc15 via the
+# shared-config route. Identical to pile_pgd1_from_torch.yaml except the adversary is
+# PersistentPGDReconLoss (scope per_batch_per_position -> bsc). Small target (4L d768):
+# no remat needed. Launch: pd-jax-lm, 2 nodes (16 GPUs, dp=16).
+torch_config: torch/pile_llama_simple_mlp_4l_ppgd_bsc.yaml
+run_name: ai-jax-pile4l-ppgd-bsc
+out_dir: /mnt/data/artifacts/mechanisms/param-decomp/runs
+remat_recon_forwards: false

--- a/param_decomp_jax/jax_single_pool/configs/pile_ppgd_bsc_from_torch.yaml
+++ b/param_decomp_jax/jax_single_pool/configs/pile_ppgd_bsc_from_torch.yaml
@@ -1,0 +1,8 @@
+# Persistent-PGD (bsc) pile run — JAX replication of torch p-20f9fc15 via the
+# shared-config route. Identical to pile_pgd1_from_torch.yaml except the adversary is
+# PersistentPGDReconLoss (scope per_batch_per_position -> bsc). Small target (4L d768):
+# no remat needed. Launch: pd-jax-lm, 2 nodes (16 GPUs, dp=16). out_dir is minted at
+# submit (PARAM_DECOMP_OUT_DIR/runs, current cluster); add an out_dir key only to override.
+torch_config: torch/pile_llama_simple_mlp_4l_ppgd_bsc.yaml
+run_name: ai-jax-pile4l-ppgd-bsc
+remat_recon_forwards: false

--- a/param_decomp_jax/jax_single_pool/configs/pile_ppgd_bsc_from_torch.yaml
+++ b/param_decomp_jax/jax_single_pool/configs/pile_ppgd_bsc_from_torch.yaml
@@ -1,8 +1,8 @@
 # Persistent-PGD (bsc) pile run — JAX replication of torch p-20f9fc15 via the
 # shared-config route. Identical to pile_pgd1_from_torch.yaml except the adversary is
 # PersistentPGDReconLoss (scope per_batch_per_position -> bsc). Small target (4L d768):
-# no remat needed. Launch: pd-jax-lm, 2 nodes (16 GPUs, dp=16).
+# no remat needed. Launch: pd-jax-lm, 2 nodes (16 GPUs, dp=16). out_dir is minted at
+# submit (PARAM_DECOMP_OUT_DIR/runs, current cluster); add an out_dir key only to override.
 torch_config: torch/pile_llama_simple_mlp_4l_ppgd_bsc.yaml
 run_name: ai-jax-pile4l-ppgd-bsc
-out_dir: /mnt/data/artifacts/mechanisms/param-decomp/runs
 remat_recon_forwards: false

--- a/param_decomp_jax/jax_single_pool/configs/torch/pile_llama_simple_mlp_4l_ppgd_bsc.yaml
+++ b/param_decomp_jax/jax_single_pool/configs/torch/pile_llama_simple_mlp_4l_ppgd_bsc.yaml
@@ -1,0 +1,178 @@
+# JAX leg of the persistent-PGD pile experiment — byte-derived from the stored config of
+# torch run p-20f9fc15 (the pile_llama_simple_mlp-4L baseline; snapshot
+# runs/p-20f9fc15/experiment_config.yaml). Target: LlamaSimpleMLP 4L pile model
+# (t-9d2b8f02), all h.* sites, per-site C. Adversary: PersistentPGDReconLoss, scope
+# per_batch_per_position (-> bsc), n_warmup_steps=2, Adam(0.5,0.99) lr const 0.01 w/
+# 2.5% warmup, clamp parameterization. Identical to pile_llama_simple_mlp_4l_pgd1.yaml
+# (p-af354eb1, fresh PGD) except this one recon term. DOCUMENTED EDITS vs upstream:
+#   1. data: streaming HF danbraunai/pile-uncopyrighted-tok-shuffled -> the staged
+#      parquet artifact (datasets/pile_neox_tok_512; same dataset, same seq 512 —
+#      the JAX trainer reads pre-tokenized parquet shards only).
+#   2. data.eval_split: val -> train (parquet loading exposes a single "train"
+#      split; the staged _val dir exists for ad-hoc use but the loaders don't
+#      address it).
+#   3. cadence.save_every: null -> 5000, keep_last null -> 2 (upstream saves
+#      nothing; the JAX leg checkpoints for requeue-resume + offline eval).
+# Everything else (pd losses/optimizers/CI fn, 400k steps, batch 64, eval set) is
+# upstream-identical.
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 5000
+  train_log_every: 200
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/pile_neox_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: EleutherAI/gpt-neox-20b
+  train_split: train
+eval:
+  batch_size: 128
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups:
+      layer_0:
+      - h.0.*
+      layer_1:
+      - h.1.*
+      layer_2:
+      - h.2.*
+      layer_3:
+      - h.3.*
+      total:
+      - '*'
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: shared_across_batch
+    n_steps: 20
+    name: PGDReconLoss_20step
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 10000
+  slow_on_first_step: true
+pd:
+  batch_size: 64
+  ci_config:
+    fn_type: global_shared_transformer
+    hidden_dims: null
+    mode: global
+    simple_transformer_ci_cfg:
+      attn_config:
+        max_len: 512
+        n_heads: 16
+        rope_base: 10000.0
+      d_model: 2048
+      mlp_hidden_dim:
+      - 8192
+      n_blocks: 8
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 3072
+    module_pattern: h.*.mlp.c_fc
+  - C: 3584
+    module_pattern: h.*.mlp.down_proj
+  - C: 512
+    module_pattern: h.*.attn.q_proj
+  - C: 512
+    module_pattern: h.*.attn.k_proj
+  - C: 1024
+    module_pattern: h.*.attn.v_proj
+  - C: 1024
+    module_pattern: h.*.attn.o_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 400
+  faithfulness_warmup_weight_decay: 0.0
+  identity_decomposition_targets: null
+  loss_metrics:
+  - beta: 0.5
+    coeff: 0.0002
+    eps: 1.0e-12
+    p_anneal_end_frac: 1.0
+    p_anneal_final_p: 0.4
+    p_anneal_start_frac: 0.0
+    pnorm: 2.0
+    type: ImportanceMinimalityLoss
+  - coeff: 0.5
+    routing:
+      type: uniform_k_subset
+    type: StochasticReconSubsetLoss
+  - coeff: 0.5
+    n_samples: 1
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.5
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: per_batch_per_position
+    start_frac: 0.0
+    type: PersistentPGDReconLoss
+    use_sigmoid_parameterization: false
+  - coeff: 10000000.0
+    type: FaithfulnessLoss
+  n_mask_samples: 1
+  sampling: continuous
+  seed: 0
+  sigmoid_type: leaky_hard
+  steps: 400000
+  tied_weights: null
+  use_delta_component: true
+runtime:
+  autocast_bf16: true
+  device: cuda:0
+  dp: 16
+target:
+  output_extract: 0
+  spec:
+    kind: pretrained
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
+    run_path: goodfire/spd/runs/t-9d2b8f02
+wandb:
+  entity: null
+  project: param-decomp

--- a/param_decomp_jax/jax_single_pool/configs/torch/pile_llama_simple_mlp_4l_ppgd_bsc.yaml
+++ b/param_decomp_jax/jax_single_pool/configs/torch/pile_llama_simple_mlp_4l_ppgd_bsc.yaml
@@ -1,0 +1,181 @@
+# JAX leg of the persistent-PGD pile experiment — byte-derived from the stored config of
+# torch run p-20f9fc15 (the pile_llama_simple_mlp-4L baseline; snapshot
+# runs/p-20f9fc15/experiment_config.yaml). This is the same config José used for the
+# paper's parameter decomposition (the "Interpreting Language Model Parameters" 4L Pile
+# run): param_decomp_lab/experiments/lm/pile_llama_simple_mlp-4L.yaml, run as p-20f9fc15.
+# Target: LlamaSimpleMLP 4L pile model
+# (t-9d2b8f02), all h.* sites, per-site C. Adversary: PersistentPGDReconLoss, scope
+# per_batch_per_position (-> bsc), n_warmup_steps=2, Adam(0.5,0.99) lr const 0.01 w/
+# 2.5% warmup, clamp parameterization. Identical to pile_llama_simple_mlp_4l_pgd1.yaml
+# (p-af354eb1, fresh PGD) except this one recon term. DOCUMENTED EDITS vs upstream:
+#   1. data: streaming HF danbraunai/pile-uncopyrighted-tok-shuffled -> the staged
+#      parquet artifact (datasets/pile_neox_tok_512; same dataset, same seq 512 —
+#      the JAX trainer reads pre-tokenized parquet shards only).
+#   2. data.eval_split: val -> train (parquet loading exposes a single "train"
+#      split; the staged _val dir exists for ad-hoc use but the loaders don't
+#      address it).
+#   3. cadence.save_every: null -> 5000, keep_last null -> 2 (upstream saves
+#      nothing; the JAX leg checkpoints for requeue-resume + offline eval).
+# Everything else (pd losses/optimizers/CI fn, 400k steps, batch 64, eval set) is
+# upstream-identical.
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 5000
+  train_log_every: 200
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/pile_neox_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: EleutherAI/gpt-neox-20b
+  train_split: train
+eval:
+  batch_size: 128
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups:
+      layer_0:
+      - h.0.*
+      layer_1:
+      - h.1.*
+      layer_2:
+      - h.2.*
+      layer_3:
+      - h.3.*
+      total:
+      - '*'
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: shared_across_batch
+    n_steps: 20
+    name: PGDReconLoss_20step
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 10000
+  slow_on_first_step: true
+pd:
+  batch_size: 64
+  ci_config:
+    fn_type: global_shared_transformer
+    hidden_dims: null
+    mode: global
+    simple_transformer_ci_cfg:
+      attn_config:
+        max_len: 512
+        n_heads: 16
+        rope_base: 10000.0
+      d_model: 2048
+      mlp_hidden_dim:
+      - 8192
+      n_blocks: 8
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 3072
+    module_pattern: h.*.mlp.c_fc
+  - C: 3584
+    module_pattern: h.*.mlp.down_proj
+  - C: 512
+    module_pattern: h.*.attn.q_proj
+  - C: 512
+    module_pattern: h.*.attn.k_proj
+  - C: 1024
+    module_pattern: h.*.attn.v_proj
+  - C: 1024
+    module_pattern: h.*.attn.o_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 400
+  faithfulness_warmup_weight_decay: 0.0
+  identity_decomposition_targets: null
+  loss_metrics:
+  - beta: 0.5
+    coeff: 0.0002
+    eps: 1.0e-12
+    p_anneal_end_frac: 1.0
+    p_anneal_final_p: 0.4
+    p_anneal_start_frac: 0.0
+    pnorm: 2.0
+    type: ImportanceMinimalityLoss
+  - coeff: 0.5
+    routing:
+      type: uniform_k_subset
+    type: StochasticReconSubsetLoss
+  - coeff: 0.5
+    n_samples: 1
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.5
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: per_batch_per_position
+    start_frac: 0.0
+    type: PersistentPGDReconLoss
+    use_sigmoid_parameterization: false
+  - coeff: 10000000.0
+    type: FaithfulnessLoss
+  n_mask_samples: 1
+  sampling: continuous
+  seed: 0
+  sigmoid_type: leaky_hard
+  steps: 400000
+  tied_weights: null
+  use_delta_component: true
+runtime:
+  autocast_bf16: true
+  device: cuda:0
+  dp: 16
+target:
+  output_extract: 0
+  spec:
+    kind: pretrained
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
+    run_path: goodfire/spd/runs/t-9d2b8f02
+wandb:
+  entity: null
+  project: param-decomp

--- a/param_decomp_jax/jax_single_pool/configs/torch/pile_llama_simple_mlp_4l_ppgd_bsc.yaml
+++ b/param_decomp_jax/jax_single_pool/configs/torch/pile_llama_simple_mlp_4l_ppgd_bsc.yaml
@@ -1,6 +1,9 @@
 # JAX leg of the persistent-PGD pile experiment — byte-derived from the stored config of
 # torch run p-20f9fc15 (the pile_llama_simple_mlp-4L baseline; snapshot
-# runs/p-20f9fc15/experiment_config.yaml). Target: LlamaSimpleMLP 4L pile model
+# runs/p-20f9fc15/experiment_config.yaml). This is the same config José used for the
+# paper's parameter decomposition (the "Interpreting Language Model Parameters" 4L Pile
+# run): param_decomp_lab/experiments/lm/pile_llama_simple_mlp-4L.yaml, run as p-20f9fc15.
+# Target: LlamaSimpleMLP 4L pile model
 # (t-9d2b8f02), all h.* sites, per-site C. Adversary: PersistentPGDReconLoss, scope
 # per_batch_per_position (-> bsc), n_warmup_steps=2, Adam(0.5,0.99) lr const 0.01 w/
 # 2.5% warmup, clamp parameterization. Identical to pile_llama_simple_mlp_4l_pgd1.yaml

--- a/param_decomp_jax/jax_single_pool/experiments/invariance_check.py
+++ b/param_decomp_jax/jax_single_pool/experiments/invariance_check.py
@@ -60,7 +60,7 @@ def _run(steps: int, sharded: bool) -> list[dict[str, float]]:
     opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)
     src = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, random.PRNGKey(3)
+        lm.site_names, tuple(s.C for s in lm.sites), seq, 1, random.PRNGKey(3)
     )
     resid = random.normal(random.PRNGKey(4), (gbatch, seq, cfg.n_embd)) * 0.5
 

--- a/param_decomp_jax/jax_single_pool/experiments/llama8b_real.py
+++ b/param_decomp_jax/jax_single_pool/experiments/llama8b_real.py
@@ -176,7 +176,9 @@ def main():
     if args.shard:
         vu = init_decomp_vu_sharded(lm.sites, random.PRNGKey(1), mesh)
         ci_fn = init_ci_fn_sharded(arch, lm.sites, random.PRNGKey(2), mesh)
-        src = init_sources_sharded(lm.site_names, site_Cs, args.seq, random.PRNGKey(3), mesh)
+        src = init_sources_sharded(
+            lm.site_names, site_Cs, args.seq, SCScope(), 1, random.PRNGKey(3), mesh
+        )
     else:
         repl = NamedSharding(mesh, P())
         put = lambda a: jax.device_put(a, repl) if eqx.is_array(a) else a  # noqa: E731
@@ -185,7 +187,7 @@ def main():
         src = {
             k: jax.device_put(v, repl)
             for k, v in init_persistent_sources(
-                lm.site_names, site_Cs, args.seq, random.PRNGKey(3)
+                lm.site_names, site_Cs, args.seq, 1, random.PRNGKey(3)
             ).items()
         }
     resid = shard_batch(resid_global, mesh)

--- a/param_decomp_jax/jax_single_pool/experiments/mem_probe.py
+++ b/param_decomp_jax/jax_single_pool/experiments/mem_probe.py
@@ -77,7 +77,7 @@ def main() -> None:
     vu = init_decomp_vu_sharded(lm.sites, random.PRNGKey(1), mesh)
     ci_fn = init_ci_fn_sharded(CIArch(4096, 4, 64, 16384), lm.sites, random.PRNGKey(2), mesh)
     src = init_sources_sharded(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, random.PRNGKey(3), mesh
+        lm.site_names, tuple(s.C for s in lm.sites), seq, SCScope(), 1, random.PRNGKey(3), mesh
     )
     opt_vu = optax.chain(
         optax.clip_by_global_norm(0.01),

--- a/param_decomp_jax/jax_single_pool/llama8b_sharding.py
+++ b/param_decomp_jax/jax_single_pool/llama8b_sharding.py
@@ -38,6 +38,7 @@ from jax_single_pool.llama8b import DecompVU, Target, init_decomp_vu
 from jax_single_pool.lm import SiteSpec
 from jax_single_pool.sharding import dp_mesh
 from jax_single_pool.sharding import shard_batch as _generic_shard_batch
+from param_decomp_config.losses import BSCScope, PersistentPGDSourceScope, SCScope
 
 __all__ = [
     "dp_mesh",
@@ -114,22 +115,37 @@ def init_sources_sharded(
     site_names: tuple[str, ...],
     site_component_counts: tuple[int, ...],
     seq_len: int,
+    scope: PersistentPGDSourceScope,
+    global_batch: int,
     key: PRNGKeyArray,
     mesh: Mesh,
 ) -> dict[str, Array]:
-    """Seeded PGD-source init `{site: (1, T, C+1)}` -> REPLICATED over `dp` (jit +
-    `out_shardings`; same no-host-tree rationale as `init_decomp_vu_sharded`).
+    """Seeded PPGD-source init -> placed per scope (jit + `out_shardings`; same
+    no-host-tree rationale as `init_decomp_vu_sharded`).
 
-    The source is a single adversarial source shared across the whole global batch
-    (leading batch axis = 1, broadcast); it combines elementwise with the batch-sharded
-    CI (`mask = ci + (1-ci)*source[..., :-1]`) and its grad is AVG-reduced across shards
-    (torch `reduce_source_grads`). Replication is the semantically correct placement and
-    the torch analog. Sharding the trailing C+1 axis is invalid anyway: with the
-    weight-delta channel C+1 is odd (8193) and not divisible by the mesh size, and would
-    also fight the batch-sharded elementwise combine."""
-    repl = NamedSharding(mesh, P())
-    init = partial(init_persistent_sources, site_names, site_component_counts, seq_len)
-    return jax.jit(init, out_shardings=repl)(key)
+    `sc`: `{site: (1, T, C+1)}` REPLICATED over `dp`. One adversarial source shared
+    across the whole global batch (leading batch axis = 1, broadcast); it combines
+    elementwise with the batch-sharded CI (`mask = ci + (1-ci)*source[..., :-1]`) and its
+    grad is AVG-reduced across shards (torch `reduce_source_grads`).
+
+    `bsc`: `{site: (B, T, C+1)}` BATCH-SHARDED over `dp` (axis 0), aligning each batch
+    element's source with that element's `shard_batch`-placed residual/CI. The source is
+    independent per element, so the per-element grad is already shard-local — NO
+    cross-rank reduction, matching torch's `_skip_all_reduce`. (Requires
+    `global_batch % n_dev == 0`, the same divisibility `shard_batch` needs.)
+
+    Sharding the trailing C+1 axis is invalid for either scope: with the weight-delta
+    channel C+1 is odd and not divisible by the mesh size, and would also fight the
+    batch-sharded elementwise combine."""
+    match scope:
+        case SCScope():
+            batch_dim, placement = 1, NamedSharding(mesh, P())
+        case BSCScope():
+            batch_dim, placement = global_batch, NamedSharding(mesh, P("dp", None, None))
+        case _:
+            raise AssertionError(f"unsupported persistent scope {scope}")
+    init = partial(init_persistent_sources, site_names, site_component_counts, seq_len, batch_dim)
+    return jax.jit(init, out_shardings=placement)(key)
 
 
 def shard_batch(resid_global: jax.Array, mesh: Mesh) -> jax.Array:

--- a/param_decomp_jax/jax_single_pool/recon.py
+++ b/param_decomp_jax/jax_single_pool/recon.py
@@ -19,6 +19,7 @@ from jaxtyping import Array, PRNGKeyArray
 from jax_single_pool.lm import chunk_sites
 from param_decomp_config.losses import (
     AdamPGDConfig,
+    BSCScope,
     ChunkwiseSubsetReconLossConfig,
     CIMaskedReconLayerwiseLossConfig,
     CIMaskedReconLossConfig,
@@ -283,7 +284,9 @@ class LossSpec:
 
 
 def _assert_supported_persistent(cfg: PersistentPGDReconLossConfig) -> None:
-    assert isinstance(cfg.scope, SCScope), f"persistent scope {cfg.scope} unsupported (sc only)"
+    assert isinstance(cfg.scope, SCScope | BSCScope), (
+        f"persistent scope {cfg.scope} unsupported (sc/bsc only)"
+    )
     assert not cfg.use_sigmoid_parameterization, cfg
     optimizer = cfg.optimizer
     assert isinstance(optimizer, AdamPGDConfig), optimizer

--- a/param_decomp_jax/jax_single_pool/recon.py
+++ b/param_decomp_jax/jax_single_pool/recon.py
@@ -19,6 +19,7 @@ from jaxtyping import Array, PRNGKeyArray
 from jax_single_pool.lm import chunk_sites
 from param_decomp_config.losses import (
     AdamPGDConfig,
+    BSCScope,
     ChunkwiseSubsetReconLossConfig,
     CIMaskedReconLayerwiseLossConfig,
     CIMaskedReconLossConfig,
@@ -255,7 +256,9 @@ class LossSpec:
 def _assert_supported_persistent(
     cfg: PersistentPGDReconLossConfig | PersistentPGDReconSubsetLossConfig,
 ) -> None:
-    assert isinstance(cfg.scope, SCScope), f"persistent scope {cfg.scope} unsupported (sc only)"
+    assert isinstance(cfg.scope, SCScope | BSCScope), (
+        f"persistent scope {cfg.scope} unsupported (sc/bsc only)"
+    )
     assert not cfg.use_sigmoid_parameterization and cfg.start_frac == 0.0, cfg
     optimizer = cfg.optimizer
     assert isinstance(optimizer, AdamPGDConfig), optimizer

--- a/param_decomp_jax/jax_single_pool/run_state.py
+++ b/param_decomp_jax/jax_single_pool/run_state.py
@@ -55,6 +55,8 @@ def init_train_state(
             lm.site_names,
             tuple(s.C for s in lm.sites),
             cfg.data.seq_len,
+            loss_spec.persistent[state_key].scope,
+            cfg.data.global_batch,
             random.fold_in(src_key, term_idx),
             mesh,
         )

--- a/param_decomp_jax/jax_single_pool/run_state.py
+++ b/param_decomp_jax/jax_single_pool/run_state.py
@@ -92,6 +92,8 @@ def init_train_state(
             lm.site_names,
             tuple(s.C for s in lm.sites),
             cfg.data.seq_len,
+            loss_spec.persistent[state_key].scope,
+            cfg.data.global_batch,
             random.fold_in(src_key, term_idx),
             mesh,
         )

--- a/param_decomp_jax/jax_single_pool/tests/stacked_parity/gen_stacked_fixtures.py
+++ b/param_decomp_jax/jax_single_pool/tests/stacked_parity/gen_stacked_fixtures.py
@@ -103,7 +103,7 @@ def main() -> None:
     vu = init_decomp_vu(cfg, C, layer_range.n_layers, random.PRNGKey(1))
     ci_fn = init_ci_fn(CI_ARCH, lm.sites, random.PRNGKey(2))
     sources = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), T, random.PRNGKey(3)
+        lm.site_names, tuple(s.C for s in lm.sites), T, 1, random.PRNGKey(3)
     )
     resid = random.normal(random.PRNGKey(4), (B, T, cfg.n_embd)) * 0.5
 

--- a/param_decomp_jax/jax_single_pool/tests/stacked_parity/test_stacked_parity.py
+++ b/param_decomp_jax/jax_single_pool/tests/stacked_parity/test_stacked_parity.py
@@ -158,7 +158,7 @@ def test_train_trajectory_matches():
     for leaf_idx, leaf in enumerate(jax.tree.leaves(eqx.filter(ci_fn, eqx.is_array))):
         np.testing.assert_array_equal(np.asarray(leaf), f[f"ci_leaf::{leaf_idx}"])
     sources = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), T, random.PRNGKey(3)
+        lm.site_names, tuple(s.C for s in lm.sites), T, 1, random.PRNGKey(3)
     )
     for name, source in sources.items():
         np.testing.assert_array_equal(np.asarray(source), f[f"src::{name}"])

--- a/param_decomp_jax/jax_single_pool/tests/stacked_parity/test_stacked_parity.py
+++ b/param_decomp_jax/jax_single_pool/tests/stacked_parity/test_stacked_parity.py
@@ -191,7 +191,7 @@ def test_train_trajectory_matches():
     for leaf_idx, leaf in enumerate(jax.tree.leaves(eqx.filter(ci_fn, eqx.is_array))):
         np.testing.assert_array_equal(np.asarray(leaf), f[f"ci_leaf::{leaf_idx}"])
     sources = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), T, random.PRNGKey(3)
+        lm.site_names, tuple(s.C for s in lm.sites), T, 1, random.PRNGKey(3)
     )
     for name, source in sources.items():
         np.testing.assert_array_equal(np.asarray(source), f[f"src::{name}"])

--- a/param_decomp_jax/jax_single_pool/tests/test_checkpoint.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_checkpoint.py
@@ -59,7 +59,7 @@ def _build(seed: int):
     opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)
     src = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, jax.random.PRNGKey(seed + 2)
+        lm.site_names, tuple(s.C for s in lm.sites), seq, 1, jax.random.PRNGKey(seed + 2)
     )
     state = TrainState(
         components=vu, ci_fn=ci_fn,
@@ -206,7 +206,13 @@ def _build_sharded(seed: int, mesh):
     opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)
     src = init_sources_sharded(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, jax.random.PRNGKey(seed + 2), mesh
+        lm.site_names,
+        tuple(s.C for s in lm.sites),
+        seq,
+        SCScope(),
+        n,
+        jax.random.PRNGKey(seed + 2),
+        mesh,
     )
     state = TrainState(
         components=vu, ci_fn=ci_fn,

--- a/param_decomp_jax/jax_single_pool/tests/test_checkpoint.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_checkpoint.py
@@ -44,7 +44,7 @@ def _build(seed: int):
     opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)
     src = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, jax.random.PRNGKey(seed + 2)
+        lm.site_names, tuple(s.C for s in lm.sites), seq, 1, jax.random.PRNGKey(seed + 2)
     )
     state = TrainState(
         components=vu, ci_fn=ci_fn,

--- a/param_decomp_jax/jax_single_pool/tests/test_checkpoint_production_topology.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_checkpoint_production_topology.py
@@ -89,7 +89,13 @@ def _build_sharded(seed: int):
     site_cs = tuple(s.C for s in lm.sites)
     sources = {
         name: init_sources_sharded(
-            lm.site_names, site_cs, seq, jax.random.fold_in(jax.random.PRNGKey(seed + 2), i), mesh
+            lm.site_names,
+            site_cs,
+            seq,
+            SCScope(),
+            mesh.devices.size,
+            jax.random.fold_in(jax.random.PRNGKey(seed + 2), i),
+            mesh,
         )
         for i, name in enumerate(PERSISTENT_TERMS)
     }

--- a/param_decomp_jax/jax_single_pool/tests/test_llama8b.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_llama8b.py
@@ -274,7 +274,7 @@ def test_step_trains_and_has_vpd_signature(site_cs: tuple[SiteC, ...]):
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)
 
     src = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, jax.random.PRNGKey(3)
+        lm.site_names, tuple(s.C for s in lm.sites), seq, 1, jax.random.PRNGKey(3)
     )
     state = TrainState(
         components=vu, ci_fn=ci_fn,

--- a/param_decomp_jax/jax_single_pool/tests/test_llama8b.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_llama8b.py
@@ -281,7 +281,7 @@ def test_step_trains_and_has_vpd_signature(site_cs: tuple[SiteC, ...]):
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)
 
     src = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, jax.random.PRNGKey(3)
+        lm.site_names, tuple(s.C for s in lm.sites), seq, 1, jax.random.PRNGKey(3)
     )
     state = TrainState(
         components=vu, ci_fn=ci_fn,

--- a/param_decomp_jax/jax_single_pool/tests/test_llama_simple_mlp.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_llama_simple_mlp.py
@@ -305,7 +305,7 @@ def test_step_trains_and_has_vpd_signature():
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)
 
     src = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, jax.random.PRNGKey(3)
+        lm.site_names, tuple(s.C for s in lm.sites), seq, 1, jax.random.PRNGKey(3)
     )
     state = TrainState(
         components=vu, ci_fn=ci_fn,

--- a/param_decomp_jax/jax_single_pool/tests/test_sharding.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_sharding.py
@@ -59,6 +59,7 @@ def test_jitted_sharded_inits_match_eager_values():
     )
     from jax_single_pool.lm import SiteC, SiteSpec
     from jax_single_pool.tests.test_llama8b import _tiny_cfg
+    from param_decomp_config.losses import BSCScope, SCScope
 
     mesh = dp_mesh()
     n = mesh.devices.size
@@ -100,10 +101,23 @@ def test_jitted_sharded_inits_match_eager_values():
 
     site_names = tuple(s.name for s in sites)
     site_Cs = tuple(s.C for s in sites)
-    src_sharded = init_sources_sharded(site_names, site_Cs, 16, jax.random.PRNGKey(3), mesh)
-    src_eager = init_persistent_sources(site_names, site_Cs, 16, jax.random.PRNGKey(3))
+    src_sharded = init_sources_sharded(
+        site_names, site_Cs, 16, SCScope(), 1, jax.random.PRNGKey(3), mesh
+    )
+    src_eager = init_persistent_sources(site_names, site_Cs, 16, 1, jax.random.PRNGKey(3))
     for name in site_names:
         src_sharding = src_sharded[name].sharding
         assert isinstance(src_sharding, NamedSharding)
         assert src_sharding.spec == P()
         assert jnp.allclose(jnp.asarray(src_sharded[name]), src_eager[name], rtol=1e-6, atol=0)
+
+    # bsc: one source per batch element, batch-sharded over dp (axis 0), no cross-rank sync.
+    bsc_global_batch = 4 * n
+    src_bsc = init_sources_sharded(
+        site_names, site_Cs, 16, BSCScope(), bsc_global_batch, jax.random.PRNGKey(3), mesh
+    )
+    for name, C in zip(site_names, site_Cs, strict=True):
+        assert src_bsc[name].shape == (bsc_global_batch, 16, C + 1), name
+        bsc_sharding = src_bsc[name].sharding
+        assert isinstance(bsc_sharding, NamedSharding)
+        assert bsc_sharding.spec == P("dp", None, None), name

--- a/param_decomp_jax/jax_single_pool/tests/test_sharding.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_sharding.py
@@ -59,6 +59,7 @@ def test_jitted_sharded_inits_match_eager_values():
     )
     from jax_single_pool.lm import SiteC, SiteSpec
     from jax_single_pool.tests.test_llama8b import _tiny_cfg
+    from param_decomp_config.losses import BSCScope, SCScope
 
     mesh = dp_mesh()
     n = mesh.devices.size
@@ -100,13 +101,26 @@ def test_jitted_sharded_inits_match_eager_values():
 
     site_names = tuple(s.name for s in sites)
     site_Cs = tuple(s.C for s in sites)
-    src_sharded = init_sources_sharded(site_names, site_Cs, 16, jax.random.PRNGKey(3), mesh)
-    src_eager = init_persistent_sources(site_names, site_Cs, 16, jax.random.PRNGKey(3))
+    src_sharded = init_sources_sharded(
+        site_names, site_Cs, 16, SCScope(), 1, jax.random.PRNGKey(3), mesh
+    )
+    src_eager = init_persistent_sources(site_names, site_Cs, 16, 1, jax.random.PRNGKey(3))
     for name in site_names:
         src_sharding = src_sharded[name].sharding
         assert isinstance(src_sharding, NamedSharding)
         assert src_sharding.spec == P()
         assert jnp.allclose(jnp.asarray(src_sharded[name]), src_eager[name], rtol=1e-6, atol=0)
+
+    # bsc: one source per batch element, batch-sharded over dp (axis 0), no cross-rank sync.
+    bsc_global_batch = 4 * n
+    src_bsc = init_sources_sharded(
+        site_names, site_Cs, 16, BSCScope(), bsc_global_batch, jax.random.PRNGKey(3), mesh
+    )
+    for name, C in zip(site_names, site_Cs, strict=True):
+        assert src_bsc[name].shape == (bsc_global_batch, 16, C + 1), name
+        bsc_sharding = src_bsc[name].sharding
+        assert isinstance(bsc_sharding, NamedSharding)
+        assert bsc_sharding.spec == P("dp", None, None), name
 
 
 def test_fresh_pgd_c_bc_sources_are_replica_identical():

--- a/param_decomp_jax/jax_single_pool/tests/test_source_grad_mean.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_source_grad_mean.py
@@ -63,7 +63,7 @@ def _source_grad(sharded: bool) -> dict[str, jax.Array]:
     vu = init_decomp_vu(sites, random.PRNGKey(1))
     ci_fn = init_ci_fn(CIArch(16, 2, 2, 32), lm.sites, random.PRNGKey(2))
     src = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, random.PRNGKey(3)
+        lm.site_names, tuple(s.C for s in lm.sites), seq, 1, random.PRNGKey(3)
     )
     resid = random.normal(random.PRNGKey(4), (gbatch, seq, cfg.n_embd)) * 0.5
 

--- a/param_decomp_jax/jax_single_pool/train.py
+++ b/param_decomp_jax/jax_single_pool/train.py
@@ -68,7 +68,8 @@ class TrainState:
     components_opt_state: optax.OptState
     ci_fn_opt_state: optax.OptState
     sources: dict[str, dict[str, Array]]
-    """Persistent adversarial sources, `state_key -> site -> (1, T, C+1)` in [0,1].
+    """Persistent adversarial sources, `state_key -> site -> source` in [0,1]; per-site
+    shape spells the scope (`sc` -> `(1, T, C+1)`, `bsc` -> `(B, T, C+1)` batch-sharded).
     One state_key per persistent loss term (SPEC S23); empty when no persistent term."""
     sources_opt_state: dict[str, SourcesAdamState]
     step: Array

--- a/param_decomp_jax/jax_single_pool/train.py
+++ b/param_decomp_jax/jax_single_pool/train.py
@@ -77,7 +77,8 @@ class TrainState:
     components_opt_state: optax.OptState
     ci_fn_opt_state: optax.OptState
     sources: dict[str, dict[str, Array]]
-    """Persistent adversarial sources, `state_key -> site -> (1, T, C+1)` in [0,1].
+    """Persistent adversarial sources, `state_key -> site -> source` in [0,1]; per-site
+    shape spells the scope (`sc` -> `(1, T, C+1)`, `bsc` -> `(B, T, C+1)` batch-sharded).
     One state_key per persistent loss term (SPEC S23); empty when no persistent term."""
     sources_opt_state: dict[str, SourcesAdamState]
     step: Array

--- a/param_decomp_lab/experiments/lm/jax_launch.py
+++ b/param_decomp_lab/experiments/lm/jax_launch.py
@@ -53,9 +53,10 @@ def main(
     """Submit a jsp-train run.
 
     Args:
-        config_path: Wrapper yaml (`{torch_config, run_name, out_dir,
-            remat_recon_forwards}`), inside the repo. `run_id` must be absent —
-            this launcher mints it.
+        config_path: Wrapper yaml (`{torch_config, run_name, remat_recon_forwards}`,
+            with an optional `out_dir` override), inside the repo. `run_id` and
+            `out_dir` are minted here and stamped into the workspace copy; `out_dir`
+            defaults to `PARAM_DECOMP_OUT_DIR/runs` (the current cluster) when absent.
         nodes: Node count (8 GPUs each).
         time: SLURM time limit.
         qos: SLURM QoS (e.g. `opportunistic`); None is the normal QoS.
@@ -129,10 +130,11 @@ def _validate_wrapper(wrapper_path: Path) -> tuple[LMExperimentConfig, str]:
     """Lab-side mirror of `jax_single_pool.torch_config.load_torch_wrapper`'s checks
     (which can't be imported here — that module pulls jax)."""
     raw = yaml.safe_load(wrapper_path.read_text())
-    expected = {"torch_config", "run_name", "out_dir", "remat_recon_forwards"}
-    assert set(raw) == expected, (
-        f"{wrapper_path}: keys must be {sorted(expected)} (run_id is minted at submit), "
-        f"got {sorted(raw)}"
+    required = {"torch_config", "run_name", "remat_recon_forwards"}
+    allowed = required | {"out_dir"}
+    assert required <= set(raw) <= allowed, (
+        f"{wrapper_path}: keys must include {sorted(required)} and may add an out_dir "
+        f"override (run_id and out_dir are minted at submit), got {sorted(raw)}"
     )
     torch_yaml_path = (wrapper_path.parent / raw["torch_config"]).resolve()
     assert torch_yaml_path.exists(), f"torch config not found: {torch_yaml_path}"
@@ -167,9 +169,12 @@ def _build_workspace(workspace: Path, snapshot_ref: str, run_id: str, wrapper_re
     run(["make", "install-jax-cuda"], cwd=workspace)
 
     wrapper = workspace / wrapper_rel
-    assert "run_id" not in yaml.safe_load(wrapper.read_text())
+    stamped = yaml.safe_load(wrapper.read_text())
+    assert "run_id" not in stamped
     with wrapper.open("a") as f:
         f.write(f"\nrun_id: {run_id}\n")
+        if "out_dir" not in stamped:
+            f.write(f"out_dir: {PARAM_DECOMP_OUT_DIR / 'runs'}\n")
 
 
 def _wandb_url(torch_cfg: LMExperimentConfig, run_id: str) -> str | None:

--- a/param_decomp_lab/experiments/lm/jax_launch.py
+++ b/param_decomp_lab/experiments/lm/jax_launch.py
@@ -19,9 +19,12 @@ import yaml
 
 from param_decomp.log import logger
 from param_decomp_config.jax_wrapper import (
+    AUTHOR_OVERRIDABLE_KEYS,
+    OUT_DIR_KEY,
     RUN_ID_KEY,
     SUBMIT_MINTED_KEYS,
     WRAPPER_KEYS_BEFORE_SUBMIT,
+    WRAPPER_REQUIRED_BEFORE_SUBMIT,
 )
 from param_decomp_config.lm import LMExperimentConfig
 from param_decomp_lab.infra.git import create_git_snapshot
@@ -61,9 +64,10 @@ def main(
     """Submit a jsp-train run.
 
     Args:
-        config_path: Wrapper yaml (`{torch_config, run_name, out_dir,
-            remat_recon_forwards}`), inside the repo. `run_id` must be absent —
-            this launcher mints it.
+        config_path: Wrapper yaml (`{torch_config, run_name, remat_recon_forwards}`,
+            with an optional `out_dir` override), inside the repo. `run_id` and
+            `out_dir` are minted here and stamped into the workspace copy; `out_dir`
+            defaults to `PARAM_DECOMP_OUT_DIR/runs` (the current cluster) when absent.
         nodes: Node count (8 GPUs each).
         time: SLURM time limit.
         qos: SLURM QoS (e.g. `opportunistic`); None is the normal QoS.
@@ -146,9 +150,11 @@ def _validate_wrapper(wrapper_path: Path) -> tuple[LMExperimentConfig, str]:
     are minted and appended at submit, so a hand-authored wrapper carries exactly
     `WRAPPER_KEYS_BEFORE_SUBMIT`."""
     raw = yaml.safe_load(wrapper_path.read_text())
-    assert set(raw) == WRAPPER_KEYS_BEFORE_SUBMIT, (
-        f"{wrapper_path}: keys must be {sorted(WRAPPER_KEYS_BEFORE_SUBMIT)} "
-        f"({sorted(SUBMIT_MINTED_KEYS)} are stamped at submit), got {sorted(raw)}"
+    assert WRAPPER_REQUIRED_BEFORE_SUBMIT <= set(raw) <= WRAPPER_KEYS_BEFORE_SUBMIT, (
+        f"{wrapper_path}: keys must include {sorted(WRAPPER_REQUIRED_BEFORE_SUBMIT)} "
+        f"and may add {sorted(AUTHOR_OVERRIDABLE_KEYS)} "
+        f"({sorted(SUBMIT_MINTED_KEYS)} are stamped at submit, {sorted(AUTHOR_OVERRIDABLE_KEYS)} "
+        f"minted if absent), got {sorted(raw)}"
     )
     torch_yaml_path = (wrapper_path.parent / raw["torch_config"]).resolve()
     assert torch_yaml_path.exists(), f"torch config not found: {torch_yaml_path}"
@@ -190,13 +196,16 @@ def _build_workspace(
     run(["make", "install-jax-cuda"], cwd=workspace)
 
     wrapper = workspace / wrapper_rel
+    authored = yaml.safe_load(wrapper.read_text())
     stamped: dict[str, str | list[str]] = {RUN_ID_KEY: run_id}
     if group is not None:
         stamped["wandb_group"] = group
     if tags:
         stamped["wandb_tags"] = tags
-    assert set(stamped) <= SUBMIT_MINTED_KEYS
-    assert not (set(stamped) & set(yaml.safe_load(wrapper.read_text())))
+    if OUT_DIR_KEY not in authored:
+        stamped[OUT_DIR_KEY] = str(PARAM_DECOMP_OUT_DIR / "runs")
+    assert set(stamped) <= SUBMIT_MINTED_KEYS | AUTHOR_OVERRIDABLE_KEYS
+    assert not (set(stamped) & set(authored))
     with wrapper.open("a") as f:
         f.write("\n" + yaml.safe_dump(stamped, sort_keys=False))
 


### PR DESCRIPTION
## What

Lands Dan's persistent-PGD **`bsc` (batch-sharded) source scope** (originally #805, `feature/jax-bsc`) onto the post-refactor `feature/jax`. Taken over with Oli's OK; Dan's commits are preserved in this branch's history (`9c6b8af0`, `681ec7dd`), and he is credited as co-author.

`bsc` (`per_batch_per_position`) gives each batch element its own `(B, T, C+1)` source, **batch-sharded over `dp`** (`P("dp", None, None)`) so each element's source rides the same rank as its `shard_batch`-placed residual/CI. Per-element grads are **shard-local — no cross-rank source-grad reduction** (matching torch's `_skip_all_reduce`); the loss `1/B` supplies the averaging. This contrasts with `sc` (replicated `P()`, AVG-reduced grad). This is the SPEC S16/D1 invariant, and it's the gap for replicating José's paper run p-20f9fc15.

## Reconciliation against the post-refactor `feature/jax`

The merge conflicted on exactly 4 files. The semantic one was `recon._assert_supported_persistent`: our chunkwise refactor collapsed `_PersistentPGDBaseConfig` and removed `PersistentPGDReconSubsetLossConfig`, so the persistent registry now holds a single `PersistentPGDReconLossConfig`. Reconciled to the new single-config shape while taking Dan's un-refusal — the assertion now admits `SCScope | BSCScope` on the one config type (and keeps our HEAD's dropped `start_frac == 0.0` assert, since post-refactor `start_frac>0` is implemented).

Dan's `out_dir`-derived-cluster-side feature was reconciled against our restructured wrapper-key constants: `out_dir` is now an **author-overridable, submit-minted** key (`AUTHOR_OVERRIDABLE_KEYS` in `param_decomp_config/jax_wrapper.py`) — present-or-minted, sitting alongside the `--comment` flag and the `wandb_group`/`wandb_tags` minting our HEAD added. The `init_persistent_sources`/`init_sources_sharded` signature changes (new `batch_dim` / `scope` + `global_batch`) cascaded to a few of our HEAD's test call sites, which the text-merge left on the old signatures; those were re-pointed (`sc` -> `batch_dim=1`).

## Validation

- Full `jax_single_pool` suite — **148 passed** at BOTH 1 and 4 simulated devices (the 4-device run exercises bsc's batch-sharded DP). Goldens (`test_equivalence`, `test_stacked_parity`) stayed green.
- `basedpyright jax_single_pool` — back to the `feature/jax` baseline (zero NEW errors) — and torch-side `make type` — 0 errors.
- bsc config validates + builds + batch-sharded source-grad confirmed shard-local (`P("dp",None,None)`) at 4 devices.

Co-authored-by: danbraunai-goodfire <dan.braun@goodfire.ai>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
