### PR TITLE
push-2: clustering reads JAX runs natively (#834)

### DIFF
--- a/param_decomp_lab/clustering/CLAUDE.md
+++ b/param_decomp_lab/clustering/CLAUDE.md
@@ -23,6 +23,29 @@ pd-cluster-merge /path/to/ch-<id>/ merge_alpha_10.json
 - `HarvestConfig` (`harvest_config.py`): model_path, n_tokens, activation_threshold, batch_size, etc.
 - `MergeConfig` (`merge_config.py`): alpha, iters, merge_pair_sampling_method, etc.
 
+### JAX runs (`scripts/run_worker_jax.py`)
+
+A JAX single-pool run (`param_decomp_jax`, orbax checkpoint) is harvested into a
+membership snapshot **natively** — no torch component model, no `jsp-export` safetensors
+bridge. The run is opened with `jax_single_pool.load_run.open_jax_run` (the reusable
+"open a JAX run for consumption" pattern, shared with `harvest`); the lower-leaky CI from
+its frozen forward is sampled per token position and streamed — as the SAME torch-tensor
+dict `collect_memberships` builds — into the SAME `MembershipBuilder`, producing the SAME
+`ProcessedMemberships` snapshot. `pd-cluster-merge` then reads it unchanged.
+
+```bash
+python -m param_decomp_lab.clustering.scripts.run_worker_jax \
+    --run_dir runs/p-761bc061 --n_tokens 50000 --batch_size 16 --n_tokens_per_seq 16
+# → PARAM_DECOMP_OUT_DIR/clustering/harvests/ch-<id>/  (same layout as pd-cluster-harvest)
+```
+
+The forward runs in jax (CPU or one GPU); the `MembershipBuilder` accumulator stays torch
+— this worker is the one place both stacks meet (the pure JAX package never imports
+torch). Pre-tokenized parquet is served by the trainer's own `ShardServer` (never
+streamed from HF). Only the model/forward bit is JAX-ified: position sampling
+(`flatten_lm_activations`), filtering, snapshotting, and merge are framework-agnostic and
+shared with the torch path.
+
 ### Ensemble pipeline (for stability analysis)
 
 **`pd-clustering` / `run_pipeline.py`**: Runs multiple clustering runs (ensemble) with different seeds, then runs `calc_distances` to compute pairwise distances between results. Use this for ensemble experiments.

--- a/param_decomp_lab/clustering/memberships.py
+++ b/param_decomp_lab/clustering/memberships.py
@@ -365,7 +365,7 @@ def _lm_sample_positions(
     return torch.arange(batch_size).unsqueeze(1).expand_as(positions), positions
 
 
-def _flatten_lm_activations(
+def flatten_lm_activations(
     act: Float[Tensor, "batch n_ctx C"],
     *,
     batch_size: int,
@@ -423,7 +423,7 @@ def collect_memberships(
         n_remaining = config.n_tokens - n_collected
         batch_take = min(batch_size * tokens_per_seq, n_remaining)
         sampled: dict[str, Float[Tensor, "samples C"]] = {
-            key: _flatten_lm_activations(
+            key: flatten_lm_activations(
                 act,
                 batch_size=batch_size,
                 n_ctx=n_ctx,

--- a/param_decomp_lab/clustering/scripts/run_worker_jax.py
+++ b/param_decomp_lab/clustering/scripts/run_worker_jax.py
@@ -1,0 +1,141 @@
+"""Harvest clustering memberships from a JAX single-pool run natively — no torch
+component model, no `jsp-export` safetensors bridge.
+
+    python -m param_decomp_lab.clustering.scripts.run_worker_jax \
+        --run_dir runs/p-761bc061 --n_tokens 50000 --batch_size 16 --n_tokens_per_seq 8
+
+The run is opened with `jax_single_pool.load_run.open_jax_run` (the reusable JAX
+"open a run for consumption" pattern); the lower-leaky CI from its frozen forward is
+sampled per token position and streamed — as the SAME torch-tensor dict the torch
+`collect_memberships` builds — into the SAME `MembershipBuilder`, producing the SAME
+`ProcessedMemberships` snapshot `pd-cluster-merge` consumes unchanged.
+
+The JAX forward runs in jax (CPU or one GPU); the `MembershipBuilder` accumulator stays
+torch. This worker imports both — the only place the two stacks meet. Pre-tokenized
+parquet is read with the trainer's own `ShardServer` (never streamed from HF).
+"""
+
+import argparse
+from pathlib import Path
+
+import jax.numpy as jnp
+import numpy as np
+import torch
+from jax_single_pool.data import BatchSchedule, ShardServer, scan_shards
+from jax_single_pool.load_run import LoadedJaxRun, open_jax_run
+
+from param_decomp.log import logger
+from param_decomp_lab.clustering.harvest_config import HarvestConfig
+from param_decomp_lab.clustering.memberships import MembershipBuilder, flatten_lm_activations
+from param_decomp_lab.clustering.paths import clustering_harvest_dir, new_harvest_id
+
+
+def _to_torch(array: object) -> torch.Tensor:
+    """Host a JAX/numpy array as a CPU torch tensor."""
+    return torch.from_numpy(np.array(np.asarray(array)))
+
+
+def sampled_ci_from_forward(
+    lower_leaky_ci: dict[str, jnp.ndarray],
+    *,
+    n_tokens_per_seq: int | None,
+    use_all_tokens_per_seq: bool,
+    rng: torch.Generator,
+) -> dict[str, torch.Tensor]:
+    """Per-site lower-leaky CI `(B, T, C)` -> `(samples, C)`, sampling token positions
+    the same way the torch `collect_memberships` path does (`flatten_lm_activations`)."""
+    site_ci = {site: _to_torch(ci) for site, ci in lower_leaky_ci.items()}
+    batch_size, n_ctx, _ = next(iter(site_ci.values())).shape
+    return {
+        site: flatten_lm_activations(
+            ci,
+            batch_size=batch_size,
+            n_ctx=n_ctx,
+            n_tokens_per_seq=n_tokens_per_seq,
+            use_all_tokens_per_seq=use_all_tokens_per_seq,
+            rng=rng,
+        )
+        for site, ci in site_ci.items()
+    }
+
+
+def harvest_jax_run(run: LoadedJaxRun, config: HarvestConfig, output_dir: Path) -> None:
+    assert config.use_all_tokens_per_seq or config.n_tokens_per_seq is not None, (
+        "n_tokens_per_seq required when use_all_tokens_per_seq is False"
+    )
+
+    data = run.config.data
+    schedule = BatchSchedule(scan_shards(data.dir), config.batch_size, config.dataset_seed)
+    server = ShardServer(schedule, data.seq_len, process_index=0, process_count=1)
+
+    rng = torch.Generator().manual_seed(config.dataset_seed)
+    builder = MembershipBuilder(
+        activation_threshold=config.activation_threshold,
+        filter_dead_threshold=config.filter_dead_threshold,
+        filter_dead_stat=config.filter_dead_stat,
+        filter_modules=config.filter_modules,
+    )
+
+    n_collected = 0
+    batch_idx = 0
+    while n_collected < config.n_tokens:
+        tokens = server.local_batch(batch_idx)
+        batch_size, n_ctx = tokens.shape
+        fwd = run.forward(jnp.asarray(tokens))
+        sampled = sampled_ci_from_forward(
+            fwd.lower_leaky_ci,
+            n_tokens_per_seq=config.n_tokens_per_seq,
+            use_all_tokens_per_seq=config.use_all_tokens_per_seq,
+            rng=rng,
+        )
+
+        tokens_per_seq = n_ctx if config.use_all_tokens_per_seq else config.n_tokens_per_seq
+        assert tokens_per_seq is not None
+        batch_take = min(batch_size * tokens_per_seq, config.n_tokens - n_collected)
+        builder.add_batch({site: ci[:batch_take] for site, ci in sampled.items()})
+
+        n_collected += batch_take
+        batch_idx += 1
+        logger.info(f"{n_collected}/{config.n_tokens} tokens ({batch_idx} batches)")
+
+    logger.info(f"Collected {n_collected} token activations (requested {config.n_tokens})")
+    processed = builder.finalize()
+    logger.info(f"Saving: {processed.n_components_alive} alive, {processed.n_samples} samples")
+    processed.save(output_dir)
+    logger.info(f"Harvest complete: {output_dir}")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--run_dir", type=Path, required=True)
+    ap.add_argument("--step", type=int, default=None, help="checkpoint step (default: latest)")
+    ap.add_argument("--n_tokens", type=int, required=True)
+    ap.add_argument("--batch_size", type=int, default=16)
+    ap.add_argument("--n_tokens_per_seq", type=int, default=None)
+    ap.add_argument("--use_all_tokens_per_seq", action="store_true")
+    ap.add_argument("--dataset_seed", type=int, default=0)
+    ap.add_argument("--activation_threshold", type=float, default=0.0)
+    ap.add_argument("--filter_dead_threshold", type=float, default=0.001)
+    args = ap.parse_args()
+
+    run = open_jax_run(args.run_dir, args.step)
+    config = HarvestConfig(
+        model_path=args.run_dir,
+        batch_size=args.batch_size,
+        n_tokens=args.n_tokens,
+        n_tokens_per_seq=args.n_tokens_per_seq,
+        use_all_tokens_per_seq=args.use_all_tokens_per_seq,
+        dataset_seed=args.dataset_seed,
+        activation_threshold=args.activation_threshold,
+        filter_dead_threshold=args.filter_dead_threshold,
+    )
+    harvest_id = new_harvest_id()
+    output_dir = clustering_harvest_dir(harvest_id)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    config.to_file(output_dir / "harvest_config.json")
+    logger.info(f"JAX clustering harvest: run {run.run_id} step {run.step}, harvest {harvest_id}")
+    harvest_jax_run(run, config, output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/param_decomp_lab/tests/clustering/test_jax_membership_bridge.py
+++ b/param_decomp_lab/tests/clustering/test_jax_membership_bridge.py
@@ -1,0 +1,51 @@
+"""The JAX clustering bridge turns per-site lower-leaky CI `(B, T, C)` into the
+`(samples, C)` torch dict `MembershipBuilder` consumes, sampling token positions the
+same way the torch `collect_memberships` path does (`flatten_lm_activations`)."""
+
+import jax.numpy as jnp
+import numpy as np
+import torch
+
+from param_decomp_lab.clustering.memberships import flatten_lm_activations
+from param_decomp_lab.clustering.scripts.run_worker_jax import sampled_ci_from_forward
+
+
+def test_sampled_ci_all_positions_matches_flatten() -> None:
+    rng = np.random.default_rng(0)
+    ci = rng.uniform(0.0, 1.0, size=(2, 5, 3)).astype(np.float32)
+    site = "h.0.mlp.c_fc"
+
+    sampled = sampled_ci_from_forward(
+        {site: jnp.asarray(ci)},
+        n_tokens_per_seq=None,
+        use_all_tokens_per_seq=True,
+        rng=torch.Generator().manual_seed(0),
+    )
+
+    assert sampled[site].shape == (2 * 5, 3)
+    assert torch.allclose(sampled[site], torch.from_numpy(ci).reshape(2 * 5, 3))
+
+
+def test_sampled_ci_random_positions_matches_torch_path_under_same_rng() -> None:
+    rng = np.random.default_rng(1)
+    ci = rng.uniform(0.0, 1.0, size=(4, 7, 6)).astype(np.float32)
+    site = "h.0.mlp.c_fc"
+
+    sampled = sampled_ci_from_forward(
+        {site: jnp.asarray(ci)},
+        n_tokens_per_seq=3,
+        use_all_tokens_per_seq=False,
+        rng=torch.Generator().manual_seed(123),
+    )
+
+    expected = flatten_lm_activations(
+        torch.from_numpy(ci),
+        batch_size=4,
+        n_ctx=7,
+        n_tokens_per_seq=3,
+        use_all_tokens_per_seq=False,
+        rng=torch.Generator().manual_seed(123),
+    )
+
+    assert sampled[site].shape == (4 * 3, 6)
+    assert torch.allclose(sampled[site], expected)


### PR DESCRIPTION
Closes #834.

Mirrors the harvest port (#832): clustering's activation harvest now reads JAX single-pool runs natively.

## What changed
- **New** `clustering/scripts/run_worker_jax.py`: opens a JAX run via `jax_single_pool.load_run.open_jax_run`, runs the frozen forward, samples token positions, and streams lower-leaky CI — as the SAME torch-tensor dict the torch `collect_memberships` path builds — into the SAME `MembershipBuilder`. Produces the SAME `ProcessedMemberships` snapshot `pd-cluster-merge` consumes unchanged.
- **Reused unchanged**: the entire membership snapshot / merge / ensemble stack (array consumers, not model consumers). Promoted `_flatten_lm_activations` -> `flatten_lm_activations` as the shared position-sampling primitive across torch and JAX paths.
- **New** bridge test `tests/clustering/test_jax_membership_bridge.py`.
- CLAUDE.md documents the JAX path.

## Model touch-points replaced (the only torch-coupled bits)
- `scripts/run_harvest.py`: `SavedLMRun.from_path` + `load_model()` + `build_lm_loader`
- `memberships.collect_memberships(model, dataloader, ...)` -> `activations.component_activations(model, ...)` (`ComponentModel` + `calc_causal_importances().lower_leaky`)

The torch path is untouched; the JAX worker is an additive sibling.

## Validation (end-to-end on `runs/p-761bc061`, step 5000)
- JAX harvest -> membership snapshot (lower-leaky CI, position sampling, dead-component filtering)
- `pd-cluster-merge` -> MDL merge iterations (k decreasing, MDL monotonically decreasing), `history.zip` round-trips via `MergeHistory.read`
- basedpyright clean on new JAX-side code; 60 clustering tests green (incl. 2 new bridge tests) + harvest bridge test green

🤖 Generated with [Claude Code](https://claude.com/claude-code)