### PR TITLE
push-2: autointerp reads JAX runs natively

### DIFF
--- a/param_decomp_jax/jax_single_pool/config.py
+++ b/param_decomp_jax/jax_single_pool/config.py
@@ -350,6 +350,21 @@ def _eval(cfg: LMExperimentConfig) -> EvalConfig | None:
     )
 
 
+def assert_supported_weights_dtype(cfg: LMExperimentConfig) -> None:
+    """Refuse a frozen-target weights_dtype the loader can't honour (issue #727: no
+    silent downgrade). Enforced at the train/submit boundary only — the bf16-only
+    loaders ignore `weights_dtype` when *consuming* a finished run, so opening an
+    already-trained bf16 run whose stored config predates the explicit-bf16
+    convention must not be blocked here."""
+    target = _resolve_target(cfg)
+    assert cfg.target.weights_dtype in target.supported_weights_dtypes, (
+        f"target {type(target).__name__} supports frozen-target weights_dtype "
+        f"{sorted(target.supported_weights_dtypes)}, config asks for "
+        f"{cfg.target.weights_dtype!r}. No silent downgrade (issue #727): declare a "
+        f"supported dtype in the yaml."
+    )
+
+
 def build_experiment_config(
     cfg: LMExperimentConfig,
     run_name: str,
@@ -365,13 +380,6 @@ def build_experiment_config(
     assert cfg.pd.use_delta_component and cfg.pd.tied_weights is None
     assert cfg.runtime.autocast_bf16, "JAX trainer computes in bf16 (autocast analog)"
     assert cfg.pd.faithfulness_warmup_weight_decay == 0.0
-
-    assert cfg.target.weights_dtype in target.supported_weights_dtypes, (
-        f"target {type(target).__name__} supports frozen-target weights_dtype "
-        f"{sorted(target.supported_weights_dtypes)}, config asks for "
-        f"{cfg.target.weights_dtype!r}. No silent downgrade (issue #727): declare a "
-        f"supported dtype in the yaml."
-    )
 
     vu_opt = cfg.pd.components_optimizer
     ci_opt = cfg.pd.ci_fn_optimizer
@@ -460,6 +468,7 @@ def load_wrapper(wrapper_path: Path) -> tuple[ExperimentConfig, Path, dict[str, 
     assert schema_yaml_path.exists(), f"config not found: {schema_yaml_path}"
     schema_raw = yaml.safe_load(schema_yaml_path.read_text())
     cfg = LMExperimentConfig(**schema_raw)
+    assert_supported_weights_dtype(cfg)
     wandb_group, wandb_tags = _wandb_group_tags(raw)
     experiment_config = build_experiment_config(
         cfg,

--- a/param_decomp_jax/jax_single_pool/tests/test_config.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_config.py
@@ -11,6 +11,7 @@ import yaml
 from jax_single_pool.config import (
     WRAPPER_KEYS,
     WRAPPER_OPTIONAL_KEYS,
+    assert_supported_weights_dtype,
     build_experiment_config,
     load_run_dir_config,
     load_wrapper,
@@ -316,9 +317,10 @@ def test_c49k_yaml_converts(tmp_path: Path):
 
 
 def test_fp32_frozen_target_is_refused(tmp_path: Path):
-    """A config requesting an fp32 frozen target must crash at convert time — the
-    bf16-only targets have no fp32 capability, and there is no silent downgrade
-    (issue #727)."""
+    """A config requesting an fp32 frozen target must crash at the train/submit
+    boundary — the bf16-only targets have no fp32 capability, and there is no silent
+    downgrade (issue #727). Consumption paths (`load_run_dir_config`) ignore the field,
+    so the guard lives in the wrapper route, not the shared builder."""
     wrapper = _stamped_wrapper(tmp_path, CONFIGS / "llama8b_l18_C49k_200k_from_torch.yaml")
     schema_yaml_path = (
         wrapper.parent / yaml.safe_load(wrapper.read_text())["torch_config"]
@@ -328,9 +330,7 @@ def test_fp32_frozen_target_is_refused(tmp_path: Path):
         update={"target": cfg.target.model_copy(update={"weights_dtype": "float32"})}
     )
     with pytest.raises(AssertionError, match="weights_dtype"):
-        build_experiment_config(
-            cfg, run_name="r", run_id=RUN_ID, out_dir=tmp_path, remat_recon_forwards=False
-        )
+        assert_supported_weights_dtype(cfg)
 
 
 def test_load_run_dir_config_rebuilds_wrapper_runs(tmp_path: Path):

--- a/param_decomp_lab/adapters/__init__.py
+++ b/param_decomp_lab/adapters/__init__.py
@@ -21,6 +21,11 @@ def adapter_from_config(method_config: DecompositionMethodHarvestConfig) -> Deco
 
     match method_config:
         case ParamDecompHarvestConfig():
+            from param_decomp_lab.adapters.jax_pd import JaxPDAdapter, is_jax_run
+
+            if is_jax_run(method_config.wandb_path):
+                return JaxPDAdapter(method_config.wandb_path)
+
             from param_decomp_lab.adapters.pd import PDAdapter
 
             return PDAdapter(method_config.wandb_path)

--- a/param_decomp_lab/adapters/jax_pd.py
+++ b/param_decomp_lab/adapters/jax_pd.py
@@ -1,0 +1,102 @@
+from functools import cached_property
+from pathlib import Path
+from typing import Any, override
+
+import yaml
+from torch.utils.data import DataLoader
+
+from param_decomp.decomposition_targets import resolve_decomposition_targets
+from param_decomp_config.lm import LMExperimentConfig
+from param_decomp_lab.adapters.base import DecompositionAdapter
+from param_decomp_lab.autointerp.schemas import ModelMetadata
+from param_decomp_lab.experiments.lm.run import build_target
+from param_decomp_lab.experiments.utils import EXPERIMENT_CONFIG_FILENAME
+from param_decomp_lab.harvest.schemas import get_harvest_dir
+from param_decomp_lab.topology import TransformerTopology
+
+
+def is_jax_run(decomposition_id: str) -> bool:
+    """A JAX single-pool run dir pins the `pd-jax-lm` wrapper as `config.yaml` (it carries
+    a `torch_config:` key) and checkpoints with orbax under `ckpts/`; a torch run instead
+    has `model_*.pth`. The wrapper key is the explicit marker."""
+    wrapper = get_harvest_dir(decomposition_id).parent / "config.yaml"
+    if not wrapper.exists():
+        return False
+    raw = yaml.safe_load(wrapper.read_text())
+    return isinstance(raw, dict) and "torch_config" in raw
+
+
+class JaxPDAdapter(DecompositionAdapter):
+    """Autointerp/clustering adapter for a JAX single-pool run, read from its pinned
+    config. Autointerp consumes harvest output plus run metadata only — no trained
+    components — so this builds the target *architecture* from config (no orbax restore,
+    no PD checkpoint) purely to derive `n_blocks` and canonical layer descriptions."""
+
+    def __init__(self, decomposition_id: str):
+        self._run_id = decomposition_id
+
+    @cached_property
+    def cfg(self) -> LMExperimentConfig:
+        config_path = get_harvest_dir(self._run_id).parent / EXPERIMENT_CONFIG_FILENAME
+        assert config_path.exists(), f"config not found: {config_path}"
+        return LMExperimentConfig.from_file(config_path)
+
+    @cached_property
+    def _topology(self) -> TransformerTopology:
+        return TransformerTopology(build_target(self.cfg.target))
+
+    @property
+    @override
+    def decomposition_id(self) -> str:
+        return self._run_id
+
+    @property
+    @override
+    def vocab_size(self) -> int:
+        return self._topology.embedding_module.num_embeddings
+
+    @property
+    @override
+    def layer_activation_sizes(self) -> list[tuple[str, int]]:
+        targets = resolve_decomposition_targets(
+            self._topology.target_model, self.cfg.pd.decomposition_targets
+        )
+        return [(t.module_path, t.C) for t in targets]
+
+    @override
+    def dataloader(self, batch_size: int) -> DataLoader[Any]:
+        raise NotImplementedError(
+            "JaxPDAdapter does not build a torch dataloader; the JAX harvest worker reads "
+            "pre-tokenized parquet via the trainer's ShardServer."
+        )
+
+    @property
+    @override
+    def tokenizer_name(self) -> str:
+        return self.cfg.data.tokenizer_name
+
+    @property
+    @override
+    def model_metadata(self) -> ModelMetadata:
+        cfg = self.cfg
+        return ModelMetadata(
+            n_blocks=self._topology.n_blocks,
+            dataset_name=self._semantic_dataset_name(),
+            layer_descriptions={
+                path: self._topology.target_to_canon(path)
+                for path, _ in self.layer_activation_sizes
+            },
+            seq_len=cfg.data.max_seq_len,
+            decomposition_method="pd",
+        )
+
+    def _semantic_dataset_name(self) -> str:
+        """The corpus identity for `DATASET_DESCRIPTIONS`. The JAX trainer reads
+        pre-tokenized parquet, so its `dataset_name` is the loader name `"parquet"`, not
+        the corpus — recover the corpus from the shard directory (e.g.
+        `.../pile_neox_tok_512/*.parquet` -> `pile_neox_tok_512`)."""
+        data = self.cfg.data
+        if data.dataset_name != "parquet":
+            return data.dataset_name
+        assert data.data_files is not None, "parquet data config without data_files"
+        return Path(data.data_files).parent.name

--- a/param_decomp_lab/autointerp/prompt_helpers.py
+++ b/param_decomp_lab/autointerp/prompt_helpers.py
@@ -37,6 +37,7 @@ DATASET_DESCRIPTIONS: dict[str, str] = {
     ),
     "danbraunai/pile-uncopyrighted-tok-shuffled": _PILE,
     "danbraunai/pile-uncopyrighted-tok": _PILE,
+    "pile_neox_tok_512": _PILE,
     "apollo-research/Skylion007-openwebtext-tokenizer-gpt2": (
         "OpenWebText: web pages linked from Reddit (GPT-2's pretraining distribution)."
     ),

--- a/param_decomp_lab/harvest/CLAUDE.md
+++ b/param_decomp_lab/harvest/CLAUDE.md
@@ -18,7 +18,13 @@ no torch component model, no `jsp-export` safetensors bridge. The run is opened 
 pattern — see below); its frozen forward-only pass (lower-leaky CI + ‖U‖·(x@V) component
 acts + clean-logit softmax) is converted into the SAME `HarvestBatch` the torch
 `ParamDecompHarvestFn` produces, fed to the SAME `Harvester`, and written via the SAME
-`HarvestRepo.save_results`. Autointerp / clustering / app read the output unchanged.
+`HarvestRepo.save_results`. The harvest *output* (DB + `token_stats.pt`) is byte-identical
+to the torch contract, so consumers read it unchanged. Run *metadata* (tokenizer, layer
+descriptions) is the one place that differs: a JAX run has no torch `.pth`, so
+`adapter_from_id` routes it (via `adapters.jax_pd.is_jax_run` — detects the `pd-jax-lm`
+wrapper's `torch_config:` key) to `JaxPDAdapter`, which reads metadata from the pinned
+config and builds only the target *architecture* (no orbax restore). The torch `PDAdapter`
+stays the torch-run path.
 
 ```bash
 python -m param_decomp_lab.harvest.scripts.run_worker_jax \

--- a/param_decomp_lab/tests/autointerp/test_jax_adapter_routing.py
+++ b/param_decomp_lab/tests/autointerp/test_jax_adapter_routing.py
@@ -1,0 +1,42 @@
+"""The PD adapter routing discriminator: a JAX single-pool run dir (orbax `ckpts/` +
+a `pd-jax-lm` wrapper `config.yaml` carrying `torch_config:`) routes to `JaxPDAdapter`,
+not the torch `PDAdapter` (which needs a `model_*.pth` JAX runs don't have)."""
+
+from pathlib import Path
+
+import pytest
+
+from param_decomp_lab.adapters import jax_pd
+from param_decomp_lab.adapters.jax_pd import is_jax_run
+
+
+@pytest.fixture
+def runs_root(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    monkeypatch.setattr(jax_pd, "get_harvest_dir", lambda rid: tmp_path / "runs" / rid / "harvest")
+    return tmp_path / "runs"
+
+
+def _make_run(runs_root: Path, run_id: str, config_yaml: str | None) -> None:
+    run_dir = runs_root / run_id
+    run_dir.mkdir(parents=True)
+    if config_yaml is not None:
+        (run_dir / "config.yaml").write_text(config_yaml)
+
+
+def test_jax_wrapper_is_detected(runs_root: Path):
+    _make_run(
+        runs_root,
+        "p-jax0001",
+        "torch_config: torch/foo.yaml\nrun_name: r\nrun_id: p-jax0001\n",
+    )
+    assert is_jax_run("p-jax0001")
+
+
+def test_torch_run_without_wrapper_key_is_not_jax(runs_root: Path):
+    _make_run(runs_root, "p-torch001", "pd:\n  seed: 0\nruntime:\n  device: cuda:0\n")
+    assert not is_jax_run("p-torch001")
+
+
+def test_missing_config_is_not_jax(runs_root: Path):
+    _make_run(runs_root, "p-bare0001", config_yaml=None)
+    assert not is_jax_run("p-bare0001")


### PR DESCRIPTION
Closes #833.

Verify-first task: confirm the autointerp pipeline runs end-to-end on a JAX-harvested run, fix only real gaps.

## Result
Autointerp's labelling pipeline is framework-agnostic — it reads harvest OUTPUT (component DB + token_stats), which the harvest port writes byte-identical to the torch contract. Two real gaps, both **upstream of the LLM call**, blocked end-to-end on a JAX run:

1. **load_run dtype guard (regression from #727):** the fp32-frozen-target assert lived in the shared `build_experiment_config`, which the consumption path (`load_run_dir_config`) also calls. Older JAX runs pin a config with no explicit `weights_dtype` (schema default `float32`), so `open_jax_run` tripped the assert even though the loaders hardcode bf16. Moved the guard to the train/submit boundary (`load_wrapper`, as `assert_supported_weights_dtype`).

2. **PDAdapter is torch-only:** autointerp's run-metadata source loads a torch ComponentModel from a `model_*.pth` JAX runs don't have (orbax `ckpts/`). Added `JaxPDAdapter` — reads `tokenizer_name` + `ModelMetadata` from the pinned config, builds only the target *architecture* (no orbax restore, no PD checkpoint). `adapter_from_id` routes JAX runs to it via `is_jax_run` (detects the `pd-jax-lm` wrapper's `torch_config:` key). Also maps the JAX `dataset_name: parquet` back to its corpus (`pile_neox_tok_512 -> _PILE`).

## Evidence
Native JAX harvest of `p-761bc061` (LlamaSimpleMLP 4L, step 5000) -> autointerp via Anthropic Haiku. Sane, data-grounded labels:
- `h.0.attn.v_proj:563 -> "document boundary detector (endoftext token)"`
- `h.0.attn.o_proj:30 -> "period followed by identifier or operator patterns"`
- `h.0.attn.v_proj:178 -> "numeric/technical token spacing and formatting"`

## Tests
basedpyright clean; new adapter-routing test (3) + autointerp (14) + harvest (66) + jax config (13) suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)