### PR TITLE
refactor: rename DecomposedLM → DecomposedModel; clean/masked_logits → _output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,8 +82,8 @@ venv). The semantics source of truth is its `SPEC.md` (normative pseudocode + nu
 invariants, grounded in the torch oracle — JAX **conforms** to it). For the real entry
 points, read `param_decomp_jax/jax_single_pool/CLAUDE.md` and `SPEC.md`. In one breath:
 
-- **`DecomposedLM`** (`jax_single_pool/lm.py`) — THE model interface: ordered `sites` +
-  pure fns (`clean_logits` / `site_inputs` / `masked_logits` / `weight_deltas`) over
+- **`DecomposedModel`** (`jax_single_pool/lm.py`) — THE model interface: ordered `sites` +
+  pure fns (`clean_output` / `site_inputs` / `masked_output` / `weight_deltas`) over
   `(frozen, vu)` pytrees. Generic over vendored LM targets. There is one recon
   semantics: chunkwise masking through the suffix forward, KL on final logits.
 - **`jsp-train <config.yaml>`** (`jax_single_pool/run.py`) — the composition root and the

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ install-dev: bridge-jax-into-main-venv
 # the workspace lock — including jax, which `param_decomp_jax` is NOT a member of. But the
 # JAX-run consumers in the lab venv (harvest's run_worker_jax.py, the app backend) `import
 # jax` + `from jax_single_pool ...` and call `open_jax_run` (restores an orbax checkpoint,
-# builds a `DecomposedLM`), and `make type` over them needs both stacks resolvable. So
+# builds a `DecomposedModel`), and `make type` over them needs both stacks resolvable. So
 # re-add the JAX runtime right after the sync: jax/jaxlib CPU + the JAX trainer's own
 # runtime deps (equinox/optax/jaxtyping/orbax — orbax pulls pure-python absl/etils/
 # tensorstore/...), all jax-pinned so nothing bumps jax; then the editable

--- a/param_decomp_jax/jax_single_pool/CLAUDE.md
+++ b/param_decomp_jax/jax_single_pool/CLAUDE.md
@@ -22,15 +22,15 @@ never silently diverge. Cite IDs (`S14`, `N1`, …) in commit messages and revie
 
 ## Architecture in one breath
 
-`lm.py` defines `DecomposedLM` — ordered `sites` + four pure fns (`clean_logits`,
-`site_inputs`, `masked_logits`, `weight_deltas`) plus a pluggable `recon_loss_fn`
+`lm.py` defines `DecomposedModel` — ordered `sites` + four pure fns (`clean_output`,
+`site_inputs`, `masked_output`, `weight_deltas`) plus a pluggable `recon_loss_fn`
 (default `kl_per_position`), flat site-name-keyed dicts at the boundary, frozen pytree
 always a runtime arg (never a jit closure constant — an 8B target becomes a multi-GB
 HLO constant). The `[B,T,d]` residual is the FIXED WAIST: masking / routing / sources /
 imp-min / the CI fn all stay `(B,T)`-shaped. Only three EDGES are generic so non-LM
 (bio-style) targets fit (#828): the model INPUT (`prefix_residual_fn(prefix, inputs)`
 in `run.py` takes `Any` — tokens for an LM, a dict for bio), the model OUTPUT
-(`clean_logits`/`masked_logits` return `Any` — logits, a tuple of heads, coords; field
+(`clean_output`/`masked_output` return `Any` — logits, a tuple of heads, coords; field
 NAMES stay `*_logits` pending a deferred rename), and the recon comparison
 (`recon_loss_fn(clean_output, masked_output) -> scalar`, default
 `kl_per_position` so the LM path is byte-identical). `train.py` is the generic step factory
@@ -55,7 +55,7 @@ SimpleMLP target via `jsp-slow-eval` (`slow_eval.py`) — no torch export round-
 
 ## Invariants with sharp teeth (the ones that have actually bitten)
 
-- **S3**: the recon target is the FROZEN-path forward (`clean_logits`), never the
+- **S3**: the recon target is the FROZEN-path forward (`clean_output`), never the
   `mask=1` decomposed identity (bf16 rounding + V/U in the stopped graph).
 - **S13/S15**: source updates go through the persistent Adam AND project to [0,1]
   after EVERY ascent — an unprojected drift past 1 has zero `clip` gradient and the

--- a/param_decomp_jax/jax_single_pool/LOSS_PARITY_DESIGN.md
+++ b/param_decomp_jax/jax_single_pool/LOSS_PARITY_DESIGN.md
@@ -25,7 +25,7 @@ The exceptions:
 - `FaithfulnessLoss`, `ImportanceMinimalityLoss` — not recons (weight-space /
   CI-space objectives). Already implemented; nothing to do.
 - `StochasticHiddenActsReconLoss` — a recon in spirit but its objective is MSE on
-  *internal* activations, which the `DecomposedLM` fn-table deliberately does not
+  *internal* activations, which the `DecomposedModel` fn-table deliberately does not
   expose. The one genuine seam-breaker. Recommendation: keep on the offline bridge
   (it is already in `torch_config.OFFLINE_EVAL_METRIC_TYPES`), per Oli's stance
   that hidden-acts is an eval metric; see §4c.
@@ -143,12 +143,12 @@ generalization lands between runs).
 
 ```python
 def recon_term_loss(term, frozen, components_bf16, ci_lower, persistent_sources_for_term,
-                    residual, clean_logits, key) -> Array:
+                    residual, clean_output, key) -> Array:
     total, n = 0, 0
     for entry in term.plan:
         for routes in entry.sample_routing(entry_key, (B, T)):
             masks, delta_masks = materialize(entry.sources, ci_lower, entry.live_sites, draw_key)
-            total += kl_per_position(masked_forward(..., routes, entry.live_sites), clean_logits)
+            total += kl_per_position(masked_forward(..., routes, entry.live_sites), clean_output)
             n += 1
     return total / n
 ```
@@ -275,7 +275,7 @@ always full `(B,T)` fresh draws regardless of anything — consistent with torch
 **(c) Hidden-acts losses.** `StochasticHiddenActsReconLoss.update` calls
 `model.forward_with_output_acts(batch)` twice (target acts, then masked acts) and
 MSEs per module — it needs every target module's *output activation*, which
-`DecomposedLM` deliberately does not expose (the fn-table returns final logits
+`DecomposedModel` deliberately does not expose (the fn-table returns final logits
 only). The seam would be a fifth fn,
 `masked_site_outputs(frozen, vu, residual, masks, delta_masks, routes, live) ->
 dict[site, (B,T,d_out)]`, implemented per target. That is mechanical but it (i)

--- a/param_decomp_jax/jax_single_pool/PARITY_MATRIX.md
+++ b/param_decomp_jax/jax_single_pool/PARITY_MATRIX.md
@@ -104,7 +104,7 @@ All recon KL terms share one normalization: `Σ sum_kl / Σ n_positions` (torch)
 | `mask = ci + (1-ci)*source` | `masks.py:165-175,222-228` | `adversary.py:134`; `train.py:198,214` | done | S1/S5 | Identical across all 3 JAX source paths + torch. |
 | Non-live site frozen `x@W` — two realizations (S2) | `component_model.py:369-377,304-308`; `ci_masked_recon_subset.py:26` | `llama8b.py:363-431`; `recon.py:207-237` | done | S2 | (a) static `live`-set gate (chunk plan); (b) per-position route fallback. torch single-pool subset uses only (b); JAX (a) only via `subset_chunk_plan`. **Verify the equivalence harness exercises a chunk plan.** |
 | Per-position routing fallback `where(route, y_dec, x@W)` | `component_model.py:369-373`; `masks.py:127-152` | `llama8b.py:306-307`; `recon.py:135-145` | done | S2/S11 | uniform-k draw distribution matches (S11). |
-| `clean_logits` = frozen-path forward, not mask=1 identity | `train_step.py:141,150`; `component_model.py:298,379` | `llama8b.py:319-326`; `llama_simple_mlp.py:303`; `train.py:249` | done | S3 | **Structural diff**: torch single-pool reference here is WHOLE-frozen-forward, NOT residual-start; JAX uses suffix-only over harvested residual. Equivalent under stop-grad, but SPEC S3/S18 describe residual-start as contract — tighten wording. |
+| `clean_output` = frozen-path forward, not mask=1 identity | `train_step.py:141,150`; `component_model.py:298,379` | `llama8b.py:319-326`; `llama_simple_mlp.py:303`; `train.py:249` | done | S3 | **Structural diff**: torch single-pool reference here is WHOLE-frozen-forward, NOT residual-start; JAX uses suffix-only over harvested residual. Equivalent under stop-grad, but SPEC S3/S18 describe residual-start as contract — tighten wording. |
 | CI inputs = clean frozen-path site inputs (S4) | `train_step.py:141-146`; `component_model.py:350` | `llama8b.py:329-360`; `llama_simple_mlp.py:313-346` | done | S4 | SimpleMLP uses gelu(tanh) for down_in vs Llama silu — target-specific, correct. |
 | Delta component C+1 channel sizing | `masks.py:230-238`; `components.py:71-74` | `adversary.py:47,73`; `train.py:199-201` | done | S1 | Stochastic delta is a separate `[B,T]` draw (not a C+1 channel). Constant path zeros delta vs torch skips it — identical value, compute diff. |
 | Per-site C (heterogeneous) | `decomposition_targets.py:21`; `component_model.py:165`; `components.py:255` | `lm.py:36-42`; `llama8b.py:258-278`; `ci_fn.py:185` | done | S5 | Production uses one C; machinery per-site both sides. |
@@ -323,8 +323,8 @@ L 1000–3000, XL > 3000).
 
 ### JAX package core
 
-**PR-8 — JAX `DecomposedLM` + CI transformer + sigmoids**
-- **Scope**: `lm.py` (`DecomposedLM` protocol, four pure fns, flat site-name dicts), `ci_fn.py` (shared transformer, lower/upper leaky-hard custom VJP), `llama8b.py` site machinery + clean_site_inputs + masked_forward.
+**PR-8 — JAX `DecomposedModel` + CI transformer + sigmoids**
+- **Scope**: `lm.py` (`DecomposedModel` protocol, four pure fns, flat site-name dicts), `ci_fn.py` (shared transformer, lower/upper leaky-hard custom VJP), `llama8b.py` site machinery + clean_site_inputs + masked_forward.
 - **Depends on**: PR-6, PR-2.
 - **Rationale**: The pure forward/CI surface, no optimization yet. **Ships with two acknowledged numeric deviations** (GELU tanh vs erf, rms eps 1e-5 vs finfo) and the site-order convention (KIND_ORDER) — document all three in the PR and SPEC. **Must add the missing `lower_leaky_hard` grad-check unit test here** (the single most subtle numeric, currently untested).
 - **Size**: L.
@@ -397,7 +397,7 @@ flowchart LR
     PR5["PR-5 · dead-code drop"]
     PR6["PR-6 · vendored Llama-8B"]
     PR7["PR-7 · SimpleMLP (jax)"]
-    PR8["PR-8 · DecomposedLM + CI"]
+    PR8["PR-8 · DecomposedModel + CI"]
     PR9["PR-9 · loss terms"]
     PR10["PR-10 · adversary + recon"]
     PR11["PR-11 · train step + sharding"]

--- a/param_decomp_jax/jax_single_pool/README.md
+++ b/param_decomp_jax/jax_single_pool/README.md
@@ -15,7 +15,7 @@ replaces the hand-written-NCCL multi-pool design with zero manual collectives.
 
 | file | what |
 |---|---|
-| `lm.py` | `DecomposedLM` — the interface a vendored LM target implements (ordered sites, flat site-keyed dicts, frozen pytree as runtime arg) + generic chunking |
+| `lm.py` | `DecomposedModel` — the interface a vendored LM target implements (ordered sites, flat site-keyed dicts, frozen pytree as runtime arg) + generic chunking |
 | `train.py` | the step factory: one fused jit step over faith + imp-min + the recon loss TERMS, per-persistent-term fused final ascents, fp32 masters + bf16 compute |
 | `losses.py` | the pure loss terms (KL/(B·T), faithfulness, imp-min lp+entropy split) + schedules (p-anneal, source-LR warmup) |
 | `adversary.py` | adversarial source machinery: persistent state + Adam ascents, fresh sign-PGD init, `source_masks` |
@@ -65,8 +65,8 @@ python -m jax_single_pool.experiments.llama8b_real --real_weights --first_layer 
 
 ## Design
 
-- **Generic over vendored LMs.** The trainer sees only the `DecomposedLM` fn-table
-  (`lm.py`): ordered `sites`, `clean_logits`, `site_inputs`, `masked_logits`,
+- **Generic over vendored LMs.** The trainer sees only the `DecomposedModel` fn-table
+  (`lm.py`): ordered `sites`, `clean_output`, `site_inputs`, `masked_output`,
   `weight_deltas` — all pure, all taking the frozen pytree as a *runtime arg* (a frozen
   8B target closed over as a jit constant bakes multi-GB weights into the HLO). Adding
   a target (e.g. GPT-2) = implementing that table; no TMS/ResidMLP-style generality.

--- a/param_decomp_jax/jax_single_pool/SPEC.md
+++ b/param_decomp_jax/jax_single_pool/SPEC.md
@@ -104,7 +104,7 @@ def masked_forward(residual[B,T,d], live_sites, masks, delta_masks, routes) -> l
     each site s ∈ live_sites computes site_out(x, s, masks[s], delta_masks[s], routes[s]);
     each site s ∉ live_sites computes x @ W_s            # frozen path, NOT y_dec(mask=1)   (S2)
 
-def clean_logits(residual)   = masked_forward(residual, live_sites=∅)                       (S3)
+def clean_output(residual)   = masked_forward(residual, live_sites=∅)                       (S3)
 def site_inputs(residual)    = the activation entering each site's weight on the clean path
     # MLP sites: gate_in = up_in = post-ln2 residual; down_in = silu(gate)·up               (S4)
     # attn sites: q_in = k_in = v_in = post-ln1 residual; o_in = pre-o_proj attn output
@@ -130,8 +130,8 @@ def make_masks(ci_lower_s[B,T,C], source_s[B,T,C+1]) -> (mask, delta_mask):
     mask       = ci_lower_s + (1 − ci_lower_s) * source_s[..., :C]
     delta_mask = source_s[..., C]              # delta channel raw: NO ci interpolation     (S1)
 
-def kl_per_position(masked_logits, clean_logits) =
-    Σ_{b,t} KL(softmax(clean_logits[b,t]) ‖ softmax(masked_logits[b,t])) / (B·T)    # fp32 (N3)
+def kl_per_position(masked_output, clean_output) =
+    Σ_{b,t} KL(softmax(clean_output[b,t]) ‖ softmax(masked_output[b,t])) / (B·T)    # fp32 (N3)
 
 def faithfulness_loss(components) = ( Σ_s ‖W_s − V_s@U_s‖_F² ) / ( Σ_s numel(W_s) )        (S17)
 
@@ -141,20 +141,20 @@ def importance_minimality_loss(ci_upper, pnorm):         # per-site grouping    
 
 # RECON_PLAN: a static list of entries (live_sites, SAMPLE_ROUTING); each entry's sampler
 # returns a statically-sized FAMILY of routing draws, each draw = one forward (§6).
-def stochastic_recon_loss(components, ci_lower, residual, clean_logits):
+def stochastic_recon_loss(components, ci_lower, residual, clean_output):
     total, n_forwards = 0, 0
     for (live_sites, SAMPLE_ROUTING) in RECON_PLAN:
         for routes in SAMPLE_ROUTING(key, [B,T]):        # fresh per step                 (R1,S11)
             masks, delta_masks = make_masks(ci_lower_s, source_s ~ U[0,1]^[B,T,C+1])  ∀ s ∈ live_sites
             total += kl_per_position(masked_forward(residual, live_sites, masks, delta_masks, routes),
-                                     clean_logits)
+                                     clean_output)
             n_forwards += 1
     return total / n_forwards                                                               (S10)
 
-def adversarial_recon_loss(components, ci_lower, sources, residual, clean_logits):     # all sites (S12)
+def adversarial_recon_loss(components, ci_lower, sources, residual, clean_output):     # all sites (S12)
     masks, delta_masks = make_masks(ci_lower_s, expand(SCOPE, sources[s]))    ∀ s ∈ sites
     return kl_per_position(masked_forward(residual, ALL_SITES, masks, delta_masks, ALL),
-                           clean_logits)
+                           clean_output)
 ```
 
 ### 4.4 The adversary
@@ -170,7 +170,7 @@ def sources_update(sources, sources_grad, opt_state):
 ```
 def train_step(state, batch, step):
     residual = sg[ prefix_forward(batch) ]           # per fresh batch                      (S18)
-    cln      = sg[ clean_logits(residual) ]                                                  (S3)
+    cln      = sg[ clean_output(residual) ]                                                  (S3)
     ci_lower, ci_upper = ci(ci_fn, site_inputs(residual))   # ONE conceptual CI eval/step;
                                                             # recompute allowed (deterministic)
     # -- supplemental adversary ascents (components & CI detached) --
@@ -231,7 +231,7 @@ on the clean path. Refs: `ci_fn.py` GELU line + `CI_FN_RMS_EPS`; torch
 |---|---|
 | S1 | `mask = ci + (1−ci)·source` per component channel; the delta channel is the raw source value, never ci-interpolated; CI has no delta output. |
 | S2 | A site not live in a forward runs the frozen `x @ W_s` path — zero V/U gradient, zero decomposition rounding, and none of the live path's ~9× compute or `(B,T,C)` activations. |
-| S3 | The recon target `clean_logits` is the frozen-path forward, stop-gradient. Never the `mask=1, delta=1` decomposed identity (differs in bf16 and pollutes the graph). Under residual-start (S18), `clean_logits` is the SUFFIX-only clean forward over the harvested residual (`clean_suffix_logits`); this equals the whole-model frozen forward because the frozen prefix is stop-gradient'd and runs once outside the graph — the two forms are identical under sg of the frozen prefix. The on-branch torch single-pool reference computes the whole-model frozen forward; JAX computes the suffix-only form; they agree by this equivalence. |
+| S3 | The recon target `clean_output` is the frozen-path forward, stop-gradient. Never the `mask=1, delta=1` decomposed identity (differs in bf16 and pollutes the graph). Under residual-start (S18), `clean_output` is the SUFFIX-only clean forward over the harvested residual (`clean_suffix_logits`); this equals the whole-model frozen forward because the frozen prefix is stop-gradient'd and runs once outside the graph — the two forms are identical under sg of the frozen prefix. The on-branch torch single-pool reference computes the whole-model frozen forward; JAX computes the suffix-only form; they agree by this equivalence. |
 | S4 | CI inputs are the clean site inputs from the frozen path of the same batch. |
 | S5 | `ci_lower` and `ci_upper` are two squashings of the SAME logits. `ci_lower` feeds every mask; `ci_upper` feeds imp-min only; no other crossing. |
 | S6 | The squashings' forward/backward are exactly §4.2 — including `lower_leaky_hard`'s grad-sign-gated lower leak (a custom VJP, not autodiff of the forward). The backward is a nested `where` with `<=` boundaries: on `0 < x <= 1` pass `g`; at `x <= 0` pass `α·g` ONLY where `g < 0`, else `0`; at `x > 1` pass `0`; `α=0.01`. The boundary tie at `x=0` resolves to the LOWER (`x <= 0`) branch — this `<=` placement is exactly what makes torch (`ci_sigmoids.py`) and JAX (`ci_fn.py`, `_lhs_b`) bit-identical and is load-bearing, not incidental. Grad-checked by `tests/test_lower_leaky_hard_grad.py` (`g<0` vs `g>0` at `x<0`, `x∈(0,1]`, `x>1`; #789). |
@@ -253,13 +253,13 @@ on the clean path. Refs: `ci_fn.py` GELU line + `CI_FN_RMS_EPS`; torch
 | S22 | Checkpoints round-trip ALL trajectory state of §3 — including every persistent term's sources + SRC_STEP moments + step/schedule counters — such that a resumed run continues the same trajectory (modulo RNG streams and kernel nondeterminism, cf. D4). **SIGTERM lifecycle (decision):** a SLURM-delivered SIGTERM sets a flag that is serviced at the main train-step boundary (synchronous save of the completed step, then exit for requeue), inside the faith-warmup loop (clean exit WITHOUT a save — no valid checkpoint exists pre-step-0, and resume skips warmup whenever any checkpoint is present, so a partial step-0 save would resume as if fully warmed; the requeue redoes warmup), and inside the in-loop eval pass (abandon the partial pass unlogged, fall through to the step-boundary save). The **first-jit-compile window remains unserviced** — a SIGTERM there is honored only once compilation finishes and control reaches the next servicing point. Periodic `save_every` is the BACKSTOP guarantee for every window; the SIGTERM→save path is the low-latency fast path, not the sole guarantee (lore `jsp_sigterm_save_never_fired`: 6/6 historical preemptions fell back to periodic ckpts; warmup/eval servicing closes the two largest unserviced windows). |
 | S23 | A persistent source bundle feeds exactly ONE loss term. (The fused-backward S14′ unscaling divides that term's coeff out of the source gradient; a bundle shared across terms would make the division wrong.) |
 | S24 | A persistent term's WARMUP ascents forward all sites, routed everywhere — regardless of the term's loss plan (torch parity: `persistent_pgd_state.warmup` hardcodes route-all). A fresh-PGD entry draws its routing ONCE per step, shared by all its ascents and its main loss forward (torch parity: `pgd_masked_recon_loss_update`). |
-| S25 | Recon KL direction is `KL(softmax(clean_logits) ‖ softmax(masked_logits))` — `P = clean`, `Q = masked`. Equivalently `Σ p_clean · (log p_clean − log p_masked)`. Torch `recon_loss_kl` realizes this as `F.kl_div(log_softmax(pred=masked), softmax(target=clean), reduction='sum')` (`batch_and_loss_fns.py::recon_loss_kl`); reversing the arguments is a silent, plausible bug, so the direction is semantic, not incidental. |
+| S25 | Recon KL direction is `KL(softmax(clean_output) ‖ softmax(masked_output))` — `P = clean`, `Q = masked`. Equivalently `Σ p_clean · (log p_clean − log p_masked)`. Torch `recon_loss_kl` realizes this as `F.kl_div(log_softmax(pred=masked), softmax(target=clean), reduction='sum')` (`batch_and_loss_fns.py::recon_loss_kl`); reversing the arguments is a silent, plausible bug, so the direction is semantic, not incidental. |
 | S26 | Normalization identity: `(Σ_forwards sum_kl) / (Σ_forwards n_positions) == mean_forwards(sum_kl / n_positions)`, valid **iff** every forward shares the same `(B,T)` (so `n_positions` is constant across forwards). This precondition is what makes JAX's mean-over-forwards (S10′) equal torch's `(Σ sum_kl)/(Σ n_positions)` accumulator; uniform `(B,T)` across all forwards in a term is therefore required. (Stated in LOSS_PARITY_DESIGN §4e; cross-ref S10′.) |
 | S27 | The CI transformer's RoPE `inv_freq` (§4.6) is a non-trained buffer and MUST be stop-gradient'd in the CI fn. In JAX it is a pytree leaf and would otherwise be optax-updated, silently drifting the rotary frequencies; torch carries it as a registered buffer (no grad). Ref `ci_fn.py:115`. |
 | S28 | Eval splits across two processes (§10): a FAST scalar tier run in-loop on cadence `eval.every`, and a SLOW/plot tier delegated entirely to `pd-offline-eval` on exported checkpoints. The torch `slow_every` / `slow_on_first_step` cadence (`optimize.py`'s `EvalLoop`) has NO JAX in-loop analog — the slow tier is offline, keyed off the checkpoint-save cadence, by design. |
 | S29 | JAX `EvalConfig` carries `batch_size`, `every`, `n_steps` (+ `rounding_threshold`, `ci_alive_threshold`) and DELIBERATELY omits `slow_every` / `slow_on_first_step` (those have no in-loop tier — S28). `eval` is atomic-optional (`EvalConfig | None`): `None` disables in-loop eval. |
 | S30 | `cfg.cadence.log_every` divides `cfg.eval.every` (`eval.every % log_every == 0`, asserted at `run.py:255`) so every eval step is also a train-log step. |
-| S31 | `StochasticHiddenActsReconLoss` is NOT a JAX training loss — `build_recon_terms` refuses it (`recon.py` final `case _`: `raise AssertionError(f"unsupported training loss {cfg.type!r}")`). Its objective is per-element MSE on each target module's OUTPUT activations, which `DecomposedLM`'s four-fn table deliberately does not expose (the table returns final logits only); porting it would need a fifth per-target seam `masked_site_outputs(...) -> dict[site, (B,T,d_out)]` plus a per-element (not per-position) normalization, and as a training loss it is exactly the site-local recon the trainer treats as a conceptual no-no (LOSS_PARITY_DESIGN §4c). It rides the OFFLINE BRIDGE instead: it lives only in `torch_config.OFFLINE_EVAL_METRIC_TYPES`, and `pd-offline-eval` computes it bit-faithfully on exported checkpoints (S28's slow tier). Keep-on-bridge is the decision; the seam is built ONLY if a training-loss use case appears, and then as an explicit amendment to this invariant (LOSS_PARITY_DESIGN §6 stage 4). |
+| S31 | `StochasticHiddenActsReconLoss` is NOT a JAX training loss — `build_recon_terms` refuses it (`recon.py` final `case _`: `raise AssertionError(f"unsupported training loss {cfg.type!r}")`). Its objective is per-element MSE on each target module's OUTPUT activations, which `DecomposedModel`'s four-fn table deliberately does not expose (the table returns final logits only); porting it would need a fifth per-target seam `masked_site_outputs(...) -> dict[site, (B,T,d_out)]` plus a per-element (not per-position) normalization, and as a training loss it is exactly the site-local recon the trainer treats as a conceptual no-no (LOSS_PARITY_DESIGN §4c). It rides the OFFLINE BRIDGE instead: it lives only in `torch_config.OFFLINE_EVAL_METRIC_TYPES`, and `pd-offline-eval` computes it bit-faithfully on exported checkpoints (S28's slow tier). Keep-on-bridge is the decision; the seam is built ONLY if a training-loss use case appears, and then as an explicit amendment to this invariant (LOSS_PARITY_DESIGN §6 stage 4). |
 | S32 | A persistent term with `start_frac > 0` contributes nothing — no loss, no source/optimizer update — until `step/total_steps >= start_frac` (torch parity: `persistent_pgd_recon.update()` returns `None` before `start_frac`, the term absent and its state frozen at init). Sources are RNG-initialized at step 0 but untouched while inactive, so activation is distributionally identical to torch's lazy state construction (the init draw is RNG-pure). `start_frac == 0.0` is the always-active common case and keeps the unguarded, byte-exact path (`train.py` only inserts the `term_active` `where`-gating when `start_frac > 0`). The source-LR schedule (S13′) is a pure function of `step`, so the LR at the activation step already reflects whatever warmup/decay that step prescribes. |
 
 ## 6. Variation points
@@ -324,7 +324,7 @@ ancestry are on-branch (rows below).
 | §4.6 CI arch | `param_decomp/ci_fns.py::GlobalSharedTransformerCiFn` (`:156`), `param_decomp/ci_nn_blocks.py` |
 
 The JAX implementation (`jax_single_pool/train.py`) uses these pseudocode names
-verbatim: `clean_logits`, `site_inputs`, `source_masks`, `stochastic_recon_loss`,
+verbatim: `clean_output`, `site_inputs`, `source_masks`, `stochastic_recon_loss`,
 `adversarial_recon_loss`, `sources_adam_ascend_project`, `ReconPlan`/`ReconForward`,
 `uniform_k_routing`, `subset_chunk_plan`, `per_site_plan`.
 

--- a/param_decomp_jax/jax_single_pool/SPEC_AUDIT.md
+++ b/param_decomp_jax/jax_single_pool/SPEC_AUDIT.md
@@ -113,7 +113,7 @@ These are real, load-bearing on-branch torch behaviors with no current invariant
 
 **P4 — record the warmup_pct==0 source-LR edge** (S13). torch short-circuits to full LR at step 0 (`warmup_steps=0`); JAX `max(floor(...),1)` yields LR=0 at step 0. Diverges for exactly one step only when `warmup_pct==0`; production uses 2.5%. One-line note or a JAX fix to match torch's short-circuit.
 
-**P5 — add a one-line S3 note** that `clean_logits` = suffix-only clean forward when residual-start is active (the on-branch torch single-pool reference is NOT residual-start; equivalent under sg/frozen prefix). Tightens the contract wording.
+**P5 — add a one-line S3 note** that `clean_output` = suffix-only clean forward when residual-start is active (the on-branch torch single-pool reference is NOT residual-start; equivalent under sg/frozen prefix). Tightens the contract wording.
 
 ## 2. (c) Genuine jax-vs-torch correctness risks surfaced
 

--- a/param_decomp_jax/jax_single_pool/TRANSITION.md
+++ b/param_decomp_jax/jax_single_pool/TRANSITION.md
@@ -10,7 +10,7 @@ dead.
 ## 1. The decision
 
 - **One framework: JAX.** Both training and analysis run in JAX. There is no permanent
-  torch consumption layer, no dual-backend seam, no `Arr`-generic protocol. `DecomposedLM`
+  torch consumption layer, no dual-backend seam, no `Arr`-generic protocol. `DecomposedModel`
   is simply THE model interface (no `Arr` TypeVar).
 - **Built on `feature/jax`, not `main`.** All work lands on `feature/jax`; the branch is
   squash-merged to `main` **once, at the very end** (phase 4). The cutover is
@@ -29,7 +29,7 @@ dead.
   torch code in HEAD.
 - **The JAX→torch export bridge is DEAD.** We do **not** make torch load JAX runs.
   `jsp-export`'s torch-`ComponentModel` shape goes away; JAX consumers read the **orbax
-  checkpoint + `DecomposedLM`** directly. The whole `#746`–`#752` export-bridge cluster is
+  checkpoint + `DecomposedModel`** directly. The whole `#746`–`#752` export-bridge cluster is
   closed as moot.
 - **Dropped features stay dropped for now** (revisit in JAX later, as backlog — not part
   of the numbered roadmap):
@@ -47,8 +47,8 @@ dead.
 Promote what already exists — pure-functional, state-injected. There is no torch
 counterpart to keep in sync.
 
-- **`DecomposedLM`** (`lm.py`): ordered `sites` + `clean_logits` / `site_inputs` /
-  `masked_logits` / `weight_deltas` over `(frozen, vu)` pytrees.
+- **`DecomposedModel`** (`lm.py`): ordered `sites` + `clean_output` / `site_inputs` /
+  `masked_output` / `weight_deltas` over `(frozen, vu)` pytrees.
 - **`CIFn`** (`ci_fn.py`): `site_inputs -> (ci_lower, ci_upper)`. (SRP: model and CI are
   separate concerns; a run is the pair + frozen target.)
 - **Dispatch lives only at the edges:** one `load(run) -> Decomposition` and one
@@ -84,7 +84,7 @@ A standalone, torch-free training runtime.
 
 ### Phase 2 — Analyze in JAX (*in progress*)
 
-Port the consumers to read JAX runs **natively** (orbax + `DecomposedLM`), in dependency
+Port the consumers to read JAX runs **natively** (orbax + `DecomposedModel`), in dependency
 order:
 
 1. **Harvest** — the keystone; component-statistics collection everything else reads.

--- a/param_decomp_jax/jax_single_pool/eval.py
+++ b/param_decomp_jax/jax_single_pool/eval.py
@@ -52,7 +52,7 @@ from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, Float, Int, PRNGKeyArray
 
-from jax_single_pool.lm import DecomposedLM
+from jax_single_pool.lm import DecomposedModel
 from jax_single_pool.losses import kl_per_position
 from jax_single_pool.train import COMPUTE_DT, cast_floating
 
@@ -70,7 +70,7 @@ def next_token_cross_entropy(
 
 
 def make_eval_step(
-    lm: DecomposedLM,
+    lm: DecomposedModel,
     rounding_threshold: float,
     ci_alive_threshold: float,
     l0_group_patterns: dict[str, tuple[str, ...]] | None,
@@ -109,7 +109,7 @@ def make_eval_step(
         delta_masks: dict[str, Array],
     ) -> Array:  # fmt: skip
         return batch_sharded(
-            lm.masked_logits(
+            lm.masked_output(
                 frozen, components_bf16, residual, masks, delta_masks, None, site_names, True
             )
         )
@@ -124,7 +124,7 @@ def make_eval_step(
         key: PRNGKeyArray,
     ) -> dict[str, Array]:
         residual = batch_sharded(residual)
-        clean_logits = batch_sharded(lm.clean_logits(frozen, residual))
+        clean_output = batch_sharded(lm.clean_output(frozen, residual))
         site_inputs = lm.site_inputs(frozen, residual)
 
         components_bf16 = cast_floating(components, COMPUTE_DT)
@@ -176,9 +176,9 @@ def make_eval_step(
         ce: dict[str, Array] = {}
         for variant, (masks, delta_masks) in variant_masks.items():
             variant_logits = masked_forward(frozen, components_bf16, residual, masks, delta_masks)
-            kl[variant] = kl_per_position(variant_logits, clean_logits)
+            kl[variant] = kl_per_position(variant_logits, clean_output)
             ce[variant] = next_token_cross_entropy(variant_logits, token_ids)
-        target_ce = next_token_cross_entropy(clean_logits, token_ids)
+        target_ce = next_token_cross_entropy(clean_output, token_ids)
 
         out: dict[str, Array] = {}
         for variant in variant_masks:
@@ -217,7 +217,7 @@ def make_eval_step(
                     masks[site] = ci_site + (1.0 - ci_site) * source[..., :-1]
                     delta_masks[site] = source[..., -1]
                 masked = masked_forward(frozen, components_bf16, residual, masks, delta_masks)
-                return kl_per_position(masked, clean_logits)
+                return kl_per_position(masked, clean_output)
 
             def ascend(
                 adversarial_sources: dict[str, Array], _: None

--- a/param_decomp_jax/jax_single_pool/llama8b.py
+++ b/param_decomp_jax/jax_single_pool/llama8b.py
@@ -1,4 +1,4 @@
-"""Llama-3.1-8B vendored target — the first `DecomposedLM` implementation.
+"""Llama-3.1-8B vendored target — the first `DecomposedModel` implementation.
 
 The decomposed sites are any per-layer weight matrices (SPEC §1/§3) named torch-style:
 `layers.{i}.self_attn.{q,k,v,o}_proj` and `layers.{i}.mlp.{gate,up,down}_proj`, each
@@ -34,7 +34,7 @@ from vendored_jax.llama import (
     rope_cos_sin,
 )
 
-from jax_single_pool.lm import DecomposedLM, SiteC, SiteSpec
+from jax_single_pool.lm import DecomposedModel, SiteC, SiteSpec
 
 DT = jnp.bfloat16
 
@@ -450,8 +450,8 @@ def weight_deltas_fp32(
     return out
 
 
-def llama_decomposed_lm(cfg: LlamaConfig, sites: tuple[SiteSpec, ...]) -> DecomposedLM:
-    """The `DecomposedLM` boundary for this target (SPEC §1; `lm.py` contract).
+def llama_decomposed_lm(cfg: LlamaConfig, sites: tuple[SiteSpec, ...]) -> DecomposedModel:
+    """The `DecomposedModel` boundary for this target (SPEC §1; `lm.py` contract).
     `sites` must be canonical-ordered with dims matching `cfg` (`llama_site_specs`)."""
     site_cs = tuple(SiteC(s.name, s.C) for s in sites)
     assert sites == llama_site_specs(cfg, canonical_site_cs(site_cs)), (
@@ -459,11 +459,11 @@ def llama_decomposed_lm(cfg: LlamaConfig, sites: tuple[SiteSpec, ...]) -> Decomp
     )
     site_names = tuple(s.name for s in sites)
     first_layer = first_decomposed_layer(site_names)
-    return DecomposedLM(
+    return DecomposedModel(
         sites=sites,
-        clean_logits=lambda frozen, resid: clean_suffix_logits(frozen, resid),
+        clean_output=lambda frozen, resid: clean_suffix_logits(frozen, resid),
         site_inputs=lambda frozen, resid: clean_site_inputs(frozen, first_layer, site_names, resid),
-        masked_logits=lambda frozen,
+        masked_output=lambda frozen,
         components,
         resid,
         masks,

--- a/param_decomp_jax/jax_single_pool/llama_simple_mlp.py
+++ b/param_decomp_jax/jax_single_pool/llama_simple_mlp.py
@@ -1,4 +1,4 @@
-"""`LlamaSimpleMLP` pile-pretrained target — the second `DecomposedLM` implementation.
+"""`LlamaSimpleMLP` pile-pretrained target — the second `DecomposedModel` implementation.
 
 Torch reference (read-only, ground truth):
 `param_decomp_lab/experiments/lm/pretrain/models/llama_simple_mlp.py`, weights from
@@ -43,7 +43,7 @@ from safetensors import safe_open
 from vendored_jax.llama import rms_norm
 
 from jax_single_pool.llama8b import DecompVU, FrozenAttn
-from jax_single_pool.lm import DecomposedLM, SiteC, SiteSpec
+from jax_single_pool.lm import DecomposedModel, SiteC, SiteSpec
 
 KIND_ORDER = ("q_proj", "k_proj", "v_proj", "o_proj", "c_fc", "down_proj")
 """Within-layer canonical site order = computation order. The canonical site order
@@ -444,8 +444,8 @@ def weight_deltas_fp32(
 
 def llama_simple_mlp_decomposed_lm(
     cfg: LlamaSimpleMLPConfig, sites: tuple[SiteSpec, ...]
-) -> DecomposedLM:
-    """The `DecomposedLM` boundary for this target (`lm.py` contract). `sites` must be
+) -> DecomposedModel:
+    """The `DecomposedModel` boundary for this target (`lm.py` contract). `sites` must be
     canonical-ordered with dims matching `cfg` (`site_specs`)."""
     site_cs = tuple(SiteC(s.name, s.C) for s in sites)
     assert sites == site_specs(cfg, canonical_site_cs(site_cs)), (
@@ -453,11 +453,11 @@ def llama_simple_mlp_decomposed_lm(
     )
     site_names = tuple(s.name for s in sites)
     first_layer = first_decomposed_layer(site_names)
-    return DecomposedLM(
+    return DecomposedModel(
         sites=sites,
-        clean_logits=lambda frozen, resid: clean_suffix_logits(frozen, resid),
+        clean_output=lambda frozen, resid: clean_suffix_logits(frozen, resid),
         site_inputs=lambda frozen, resid: clean_site_inputs(frozen, first_layer, site_names, resid),
-        masked_logits=lambda frozen,
+        masked_output=lambda frozen,
         components,
         resid,
         masks,

--- a/param_decomp_jax/jax_single_pool/lm.py
+++ b/param_decomp_jax/jax_single_pool/lm.py
@@ -1,4 +1,4 @@
-"""`DecomposedLM` — the interface a vendored target implements for the generic trainer.
+"""`DecomposedModel` — the interface a vendored target implements for the generic trainer.
 
 The trainer (`train.py`) is abstract over the target model: it sees an ordered set of
 decomposed **sites** (SPEC §1.2) and a handful of pure functions over `(frozen, vu)`
@@ -8,9 +8,9 @@ layer axis) is its own business.
 
 The `[B,T,d]` residual is the FIXED WAIST: masking, routing, source scopes, imp-min, the
 CI fn, and normalization all operate on `(B,T)` and stay LM-shaped. Only the three EDGES
-are generic — the model's INPUT (whatever `site_inputs`/`clean_logits`/`masked_logits`
+are generic — the model's INPUT (whatever `site_inputs`/`clean_output`/`masked_output`
 read upstream of the residual; tokens for an LM, a dict for a bio target), the model's
-OUTPUT (`clean_logits`/`masked_logits` return `Any` — logits, a tuple of heads, coords),
+OUTPUT (`clean_output`/`masked_output` return `Any` — logits, a tuple of heads, coords),
 and the recon comparison (`recon_loss_fn`, default `kl_per_position`).
 
 Every function takes the frozen-target pytree as a RUNTIME argument. Never close over
@@ -51,21 +51,21 @@ class SiteSpec:
 
 
 @dataclass(frozen=True)
-class DecomposedLM:
+class DecomposedModel:
     """Pure-function table over `(frozen, vu)` pytrees (see module docstring).
 
     `sites` fixes the canonical site order — chunking (SPEC S10) and the CI fn's
     input/output concatenation both follow it.
 
-    `masked_logits(frozen, vu, resid, masks, delta_masks, routes, live, has_delta)`:
+    `masked_output(frozen, vu, resid, masks, delta_masks, routes, live, has_delta)`:
     `live` (a tuple of site names, static under jit) lists the sites running their
     decomposed forward; all other sites MUST run the frozen `x @ W` path (SPEC S2).
     `masks`/`delta_masks` may broadcast over the batch dim (the PPGD source case).
     `has_delta` (static) False skips the `x @ Δ` matmul for constant-source entries
     whose delta mask is a constant 0 (LOSS_PARITY_DESIGN §4b).
 
-    `clean_logits` is the all-frozen forward — the recon target (SPEC S3); never the
-    `mask=1` decomposed identity. Its output (and `masked_logits`') is `Any`: an LM
+    `clean_output` is the all-frozen forward — the recon target (SPEC S3); never the
+    `mask=1` decomposed identity. Its output (and `masked_output`') is `Any`: an LM
     emits `[B,T,vocab]` logits, a bio target a tuple of heads or coordinates.
 
     `weight_deltas` returns fp32 `W − V@U` per site from fp32 master `vu` (SPEC N2).
@@ -77,9 +77,9 @@ class DecomposedLM:
     """
 
     sites: tuple[SiteSpec, ...]
-    clean_logits: Callable[[Any, Float[Array, "B T d"]], Any]
+    clean_output: Callable[[Any, Float[Array, "B T d"]], Any]
     site_inputs: Callable[[Any, Float[Array, "B T d"]], dict[str, Float[Array, "B T d_in"]]]
-    masked_logits: Callable[
+    masked_output: Callable[
         [
             Any,
             Any,

--- a/param_decomp_jax/jax_single_pool/load_run.py
+++ b/param_decomp_jax/jax_single_pool/load_run.py
@@ -3,7 +3,7 @@ consumers that follow it: clustering, autointerp, slow-eval, app).
 
 This is the reusable "load a JAX run" pattern. It reads a run dir
 (`runs/<p-id>/{config.yaml, experiment_config.yaml, ckpts/}`), rebuilds the frozen
-target + `DecomposedLM` from the pinned config, restores the orbax checkpoint onto a
+target + `DecomposedModel` from the pinned config, restores the orbax checkpoint onto a
 reference `TrainState`, and exposes the pure forward a consumer needs:
 
     run = open_jax_run(run_dir)                 # latest checkpoint
@@ -39,7 +39,7 @@ from jax_single_pool.config import (
     load_run_dir_config,
 )
 from jax_single_pool.llama8b import DecompVU
-from jax_single_pool.lm import DecomposedLM
+from jax_single_pool.lm import DecomposedModel
 from jax_single_pool.run_state import build_optimizers, init_train_state
 from jax_single_pool.sharding import dp_mesh
 from jax_single_pool.train import COMPUTE_DT, TrainState, cast_floating
@@ -103,7 +103,7 @@ class LoadedJaxRun:
 
     run_id: str
     step: int
-    lm: DecomposedLM
+    lm: DecomposedModel
     config: ExperimentConfig
     vocab_size: int
     _state: TrainState
@@ -157,7 +157,7 @@ def open_jax_run(run_dir: Path, step: int | None = None) -> LoadedJaxRun:
         components: DecompVU, ci_fn: Any, token_ids: Int[Array, "B T"]
     ) -> tuple[dict[str, Array], dict[str, Array], Array]:
         residual = prefix_residual_fn(prefix, token_ids)
-        clean_logits = lm.clean_logits(target, residual)
+        clean_output = lm.clean_output(target, residual)
         site_inputs = lm.site_inputs(target, residual)
 
         components_bf16 = cast_floating(components, COMPUTE_DT)
@@ -173,7 +173,7 @@ def open_jax_run(run_dir: Path, step: int | None = None) -> LoadedJaxRun:
         return (
             {site: lower_ci[site].astype(jnp.float32) for site in site_names},
             component_acts,
-            jax.nn.softmax(clean_logits.astype(jnp.float32), axis=-1),
+            jax.nn.softmax(clean_output.astype(jnp.float32), axis=-1),
         )
 
     return LoadedJaxRun(

--- a/param_decomp_jax/jax_single_pool/losses.py
+++ b/param_decomp_jax/jax_single_pool/losses.py
@@ -7,14 +7,14 @@ from jaxtyping import Array
 from param_decomp_config.losses import ImportanceMinimalityLossConfig
 
 
-def kl_per_position(masked_logits: Array, clean_logits: Array) -> Array:
+def kl_per_position(masked_output: Array, clean_output: Array) -> Array:
     """`Σ_{b,t} KL(softmax(clean) ‖ softmax(masked)) / (B·T)` in fp32 (SPEC §2.3, N3)."""
-    masked_logits = masked_logits.astype(jnp.float32)
-    clean_logits = clean_logits.astype(jnp.float32)
-    log_q = jax.nn.log_softmax(masked_logits, axis=-1)
-    log_p = jax.nn.log_softmax(clean_logits, axis=-1)
+    masked_output = masked_output.astype(jnp.float32)
+    clean_output = clean_output.astype(jnp.float32)
+    log_q = jax.nn.log_softmax(masked_output, axis=-1)
+    log_p = jax.nn.log_softmax(clean_output, axis=-1)
     p = jnp.exp(log_p)
-    n_positions = masked_logits.shape[0] * masked_logits.shape[1]
+    n_positions = masked_output.shape[0] * masked_output.shape[1]
     return jnp.sum(p * (log_p - log_q)) / n_positions
 
 

--- a/param_decomp_jax/jax_single_pool/run.py
+++ b/param_decomp_jax/jax_single_pool/run.py
@@ -56,7 +56,7 @@ from jax_single_pool.llama8b import (
     prefix_residual,
 )
 from jax_single_pool.llama8b_sharding import replicate_target
-from jax_single_pool.lm import DecomposedLM
+from jax_single_pool.lm import DecomposedModel
 from jax_single_pool.recon import build_recon_terms
 from jax_single_pool.run_state import build_optimizers, init_train_state
 from jax_single_pool.sharding import dp_mesh, init_distributed
@@ -175,7 +175,7 @@ class MetricsSink:
 def train(
     cfg: ExperimentConfig,
     raw_cfg: dict[str, object],
-    lm: DecomposedLM,
+    lm: DecomposedModel,
     frozen: Target | llama_simple_mlp.SimpleMLPTarget,
     prefix: Prefix | llama_simple_mlp.SimpleMLPPrefix,
     prefix_residual_fn: Callable[[Any, Any], jax.Array],

--- a/param_decomp_jax/jax_single_pool/run_state.py
+++ b/param_decomp_jax/jax_single_pool/run_state.py
@@ -21,7 +21,7 @@ from jax_single_pool.llama8b_sharding import (
     init_decomp_vu_sharded,
     init_sources_sharded,
 )
-from jax_single_pool.lm import DecomposedLM
+from jax_single_pool.lm import DecomposedModel
 from jax_single_pool.recon import build_recon_terms
 from jax_single_pool.train import TrainState
 
@@ -77,7 +77,7 @@ def build_optimizers(cfg: ExperimentConfig):
 
 def init_train_state(
     cfg: ExperimentConfig,
-    lm: DecomposedLM,
+    lm: DecomposedModel,
     opt_vu: optax.GradientTransformation,
     opt_ci: optax.GradientTransformation,
     init_key: PRNGKeyArray,

--- a/param_decomp_jax/jax_single_pool/slow_eval.py
+++ b/param_decomp_jax/jax_single_pool/slow_eval.py
@@ -46,7 +46,7 @@ from jax_single_pool.config import (
     load_run_dir_config,
 )
 from jax_single_pool.data import BatchSchedule, ShardServer, scan_shards
-from jax_single_pool.lm import DecomposedLM
+from jax_single_pool.lm import DecomposedModel
 from jax_single_pool.run_state import build_optimizers, init_train_state
 from jax_single_pool.sharding import dp_mesh
 
@@ -76,7 +76,7 @@ flat_logits)` — the per-batch reduction, pre-reduced over positions. The slow 
 metrics read only the CI arrays, so V/U (`components`) is not an input."""
 
 
-def make_slow_eval_step(lm: DecomposedLM, ci_alive_threshold: float) -> SlowEvalStep:
+def make_slow_eval_step(lm: DecomposedModel, ci_alive_threshold: float) -> SlowEvalStep:
     """Build the jit'd per-batch reduction `slow_eval_step(ci_fn, frozen, residual) ->
     ({site: density_counts}, {site: ci_sums}, n_positions, {site: flat lower},
     {site: flat logits})`. `lower`/`logits` are returned whole (the host caps the

--- a/param_decomp_jax/jax_single_pool/tests/equivalence/jax_equivalence.py
+++ b/param_decomp_jax/jax_single_pool/tests/equivalence/jax_equivalence.py
@@ -1,18 +1,18 @@
 """JAX equivalence check: the JAX single-pool PD loss terms vs the torch reference.
 
 Loads the SAME fixtures behind the frozen `torch_reference.json` golden, builds the
-Llama `DecomposedLM` with the identical (zeroed-attn) suffix weights, and computes each
+Llama `DecomposedModel` with the identical (zeroed-attn) suffix weights, and computes each
 loss term through the generic trainer's OWN helpers (`train.py`), feeding the FIXED
 masks / sources / routing from the fixtures (no RNG). Compares to
 `torch_reference.json` at fp32 tolerance.
 
-Term wiring (all `jax_single_pool.train` + the `DecomposedLM` boundary):
+Term wiring (all `jax_single_pool.train` + the `DecomposedModel` boundary):
   * faith — `faithfulness_loss(lm.weight_deltas(frozen, vu))`
   * imp   — `importance_minimality_terms(ci_upper, p, beta, eps)` (per-site dicts)
   * stoch — per chunk: `mask = ci+(1-ci)*u`, fixed delta mask, fixed route over the
-            chunk's 3 sites; `lm.masked_logits(..., live=chunk)`; `kl_per_position`
-            vs `lm.clean_logits` (the frozen path, SPEC S3). Mean over chunks.
-  * ppgd  — `source_masks` + `lm.masked_logits(..., live=all)`.
+            chunk's 3 sites; `lm.masked_output(..., live=chunk)`; `kl_per_position`
+            vs `lm.clean_output` (the frozen path, SPEC S3). Mean over chunks.
+  * ppgd  — `source_masks` + `lm.masked_output(..., live=all)`.
 
 Bit-identical is impossible across RNG/FP backends; we assert each term within
 `RTOL`/`ATOL` of the torch value.
@@ -143,7 +143,7 @@ def compute_jax_terms(f: dict[str, np.ndarray]) -> dict[str, float]:
     lm, tgt, vu, n_layers = _build(f)
     resid = jnp.asarray(f["resid"], dtype=FP)
 
-    clean = jax.lax.stop_gradient(lm.clean_logits(tgt, resid))
+    clean = jax.lax.stop_gradient(lm.clean_output(tgt, resid))
 
     # fixtures key CI per kind as (B, T, L, C); the trainer keys per site.
     def per_site(prefix: str) -> dict[str, jnp.ndarray]:
@@ -171,14 +171,14 @@ def compute_jax_terms(f: dict[str, np.ndarray]) -> dict[str, float]:
         masks = {s: ci_lower[s] + (1.0 - ci_lower[s]) * stoch_u[s] for s in chunk}
         delta_masks = {s: stoch_delta[s] for s in chunk}
         routes = {site_name(i, k): jnp.asarray(f[f"route_chunk{i}_{k}"]) for k in MLP_KINDS}
-        pred = lm.masked_logits(tgt, vu, resid, masks, delta_masks, routes, chunk, True)
+        pred = lm.masked_output(tgt, vu, resid, masks, delta_masks, routes, chunk, True)
         stoch_total += float(kl_per_position(pred, clean))
     stoch = stoch_total / n_layers
 
     # ---- ppgd (FIXED sources) ----
     source = per_site("ppgd_source")  # {site: (1, T, C+1)}
     masks, delta_masks = source_masks(ci_lower, source, lm.site_names)
-    pred = lm.masked_logits(tgt, vu, resid, masks, delta_masks, None, lm.site_names, True)
+    pred = lm.masked_output(tgt, vu, resid, masks, delta_masks, None, lm.site_names, True)
     ppgd = float(kl_per_position(pred, clean))
 
     return {"faith": faith, "imp": imp, "stoch": stoch, "ppgd": ppgd}
@@ -198,7 +198,7 @@ def _suffix_with_split_mlp(
     through the decomposed `_site_out` path and EVERY other MLP site (including this
     layer's NON-live sibling sites) through the frozen `x @ W` path. This is the
     explicit S2 realization the production `subset_chunk_plan` relies on when a chunk
-    boundary splits a layer's MLP — a reference for `masked_logits(..., live=...)`."""
+    boundary splits a layer's MLP — a reference for `masked_output(..., live=...)`."""
     x = resid
     for layer_offset, suffix_layer in enumerate(tgt.layers):
         layer = layer_offset  # first decomposed layer is 0 in this harness
@@ -225,7 +225,7 @@ def _suffix_with_split_mlp(
 
 
 def chunk_plan_static_gate_kl(f: dict[str, np.ndarray]) -> tuple[float, float]:
-    """SPEC S2 under a layer-SPLITTING chunk plan (issue #640): drive `lm.masked_logits`
+    """SPEC S2 under a layer-SPLITTING chunk plan (issue #640): drive `lm.masked_output`
     with `live = (l_i.gate, l_i.up)` so `l_i.down` is a fully-frozen site WITHIN an
     otherwise-decomposed layer's MLP — the static-live-gate path the production
     `subset_chunk_plan` exercises but the per-chunk `stoch` term (whole live chunks) and
@@ -233,7 +233,7 @@ def chunk_plan_static_gate_kl(f: dict[str, np.ndarray]) -> tuple[float, float]:
     KL); the test asserts they agree to fp32 tolerance."""
     lm, tgt, vu, n_layers = _build(f)
     resid = jnp.asarray(f["resid"], dtype=FP)
-    clean = jax.lax.stop_gradient(lm.clean_logits(tgt, resid))
+    clean = jax.lax.stop_gradient(lm.clean_output(tgt, resid))
 
     def per_site(prefix: str) -> dict[str, jnp.ndarray]:
         by_kind = {k: jnp.asarray(f[f"{prefix}_{k}"], dtype=FP) for k in MLP_KINDS}
@@ -249,7 +249,7 @@ def chunk_plan_static_gate_kl(f: dict[str, np.ndarray]) -> tuple[float, float]:
     masks = {s: ci_lower[s] + (1.0 - ci_lower[s]) * stoch_u[s] for s in live}
     delta_masks = {s: stoch_delta[s] for s in live}
 
-    gate_pred = lm.masked_logits(tgt, vu, resid, masks, delta_masks, None, live, True)
+    gate_pred = lm.masked_output(tgt, vu, resid, masks, delta_masks, None, live, True)
     ref_pred = _suffix_with_split_mlp(
         tgt, vu, resid, live_layer, live_kinds, masks, delta_masks, n_layers
     )

--- a/param_decomp_jax/jax_single_pool/tests/equivalence/test_equivalence.py
+++ b/param_decomp_jax/jax_single_pool/tests/equivalence/test_equivalence.py
@@ -18,7 +18,7 @@ Two kinds of check:
     forward, and a B/T-transposed source must break it (the fixtures keep `B != T`).
 
   * **Chunk-plan static-live gate (S2).** `test_chunk_plan_static_live_gate` drives
-    `masked_logits` with a live set that splits a layer's MLP (`live = (l0.gate, l0.up)`,
+    `masked_output` with a live set that splits a layer's MLP (`live = (l0.gate, l0.up)`,
     `l0.down` frozen) — the realization the production `subset_chunk_plan` hits when a
     chunk boundary cuts across a layer, which `stoch` (whole-layer chunks) and `ppgd`
     (all sites live) never exercise — and asserts it equals an explicit reference that
@@ -75,7 +75,7 @@ def test_chunk_plan_static_live_gate() -> None:
     `subset_chunk_plan` partitions sites into sequential groups that can cut across a
     layer's MLP, leaving whole sites frozen (`x @ W`) inside an otherwise-decomposed
     layer. The `stoch` term here uses whole-layer live chunks and `ppgd` decomposes
-    every site, so neither pins this static-live gate. Drive `masked_logits` with
+    every site, so neither pins this static-live gate. Drive `masked_output` with
     `live = (l0.gate, l0.up)` (so `l0.down` is the frozen sibling) and assert it equals
     an explicit reference forward that hard-codes `l0.down` to `x @ W`."""
     f = dict(np.load(HERE / "fixtures.npz"))
@@ -198,7 +198,7 @@ def test_sc_source_broadcasts_over_batch_in_masked_forward() -> None:
         assert masks[s].shape[0] == B and masks[s].shape[1] == T, masks[s].shape
         assert delta_masks[s].shape == (1, T), delta_masks[s].shape
 
-    pred = lm.masked_logits(tgt, vu, resid, masks, delta_masks, None, lm.site_names, True)
+    pred = lm.masked_output(tgt, vu, resid, masks, delta_masks, None, lm.site_names, True)
     assert pred.shape == (B, T, vocab), pred.shape
 
     # A source whose free axis is sized B (not T) — i.e. the B/T axes transposed — must NOT
@@ -208,4 +208,4 @@ def test_sc_source_broadcasts_over_batch_in_masked_forward() -> None:
         assert bt_transposed[s].shape == (1, B, source[s].shape[-1]), bt_transposed[s].shape
     with pytest.raises(Exception):  # noqa: B017 — broadcast error, framework-specific type
         bad_masks, bad_delta = source_masks(ci_lower, bt_transposed, lm.site_names)
-        lm.masked_logits(tgt, vu, resid, bad_masks, bad_delta, None, lm.site_names, True)
+        lm.masked_output(tgt, vu, resid, bad_masks, bad_delta, None, lm.site_names, True)

--- a/param_decomp_jax/jax_single_pool/tests/stacked_parity/gen_stacked_fixtures.py
+++ b/param_decomp_jax/jax_single_pool/tests/stacked_parity/gen_stacked_fixtures.py
@@ -120,7 +120,7 @@ def main() -> None:
     arrays["resid"] = np.asarray(resid)
 
     # ── direct forward pins (fp32, eager) ──
-    arrays["out::clean"] = np.asarray(lm.clean_logits(tgt, resid))
+    arrays["out::clean"] = np.asarray(lm.clean_output(tgt, resid))
     for name, site_input in lm.site_inputs(tgt, resid).items():
         arrays[f"out::site_input::{name}"] = np.asarray(site_input)
     for name, delta in lm.weight_deltas(tgt, vu).items():
@@ -144,10 +144,10 @@ def main() -> None:
     jm = {k: jax.numpy.asarray(v) for k, v in masks.items()}
     jdm = {k: jax.numpy.asarray(v) for k, v in delta_masks.items()}
     arrays["out::masked_all"] = np.asarray(
-        lm.masked_logits(tgt, vu, resid, jm, jdm, None, lm.site_names, True)
+        lm.masked_output(tgt, vu, resid, jm, jdm, None, lm.site_names, True)
     )
     arrays["out::masked_subset"] = np.asarray(
-        lm.masked_logits(
+        lm.masked_output(
             tgt,
             vu,
             resid,

--- a/param_decomp_jax/jax_single_pool/tests/stacked_parity/test_stacked_parity.py
+++ b/param_decomp_jax/jax_single_pool/tests/stacked_parity/test_stacked_parity.py
@@ -5,8 +5,8 @@ against the pre-restructure `feature/jax-single-pool-pd` code (stacked `DecompVU
 contiguous-MLP-only `llama_decomposed_lm`). This test rebuilds the identical model in
 the per-site representation and checks, for the same MLP-family site set:
 
-  * `clean_logits` — BIT-identical (same op sequence on the frozen path).
-  * `site_inputs` / `weight_deltas` / `masked_logits` — to fp32 reassociation
+  * `clean_output` — BIT-identical (same op sequence on the frozen path).
+  * `site_inputs` / `weight_deltas` / `masked_output` — to fp32 reassociation
     tolerance (SPEC D4: rel ~1e-5; observed essentially exact).
   * a 2-step training trajectory (metrics + final V/U + final adversary sources) —
     rel ~1e-5. The sources / train-step code is unchanged, so their RNG streams
@@ -42,7 +42,7 @@ from jax_single_pool.llama8b import (
     llama_site_specs,
     mlp_family_site_cs,
 )
-from jax_single_pool.lm import DecomposedLM
+from jax_single_pool.lm import DecomposedModel
 from jax_single_pool.recon import StochasticSources, build_recon_terms, subset_chunk_plan
 from jax_single_pool.tests.test_llama8b import _tiny_cfg
 from jax_single_pool.train import TrainState, make_train_step
@@ -74,7 +74,7 @@ old fixed names. The stored arrays themselves are untouched — only the lookup 
 the live metrics dict is remapped."""
 
 
-def _load() -> tuple[dict[str, np.ndarray], DecomposedLM, Target, DecompVU, jnp.ndarray]:
+def _load() -> tuple[dict[str, np.ndarray], DecomposedModel, Target, DecompVU, jnp.ndarray]:
     assert FIXTURES.exists(), "regenerate via gen_stacked_fixtures.py on the base branch"
     f = dict(np.load(FIXTURES))
     cfg = _tiny_cfg()
@@ -119,9 +119,9 @@ def _assert_close(got: jnp.ndarray, want: np.ndarray, what: str) -> None:
     np.testing.assert_allclose(np.asarray(got), want, rtol=RTOL, atol=ATOL, err_msg=what)
 
 
-def test_clean_logits_bit_identical():
+def test_clean_output_bit_identical():
     f, lm, tgt, _vu, resid = _load()
-    clean = lm.clean_logits(tgt, resid)
+    clean = lm.clean_output(tgt, resid)
     assert jnp.array_equal(clean, jnp.asarray(f["out::clean"])), (
         "clean logits diverged from the stacked implementation (must be bit-identical)"
     )
@@ -137,26 +137,26 @@ def test_site_inputs_and_weight_deltas_match():
         _assert_close(deltas[name], f[f"out::wd::{name}"], f"weight_delta {name}")
 
 
-def test_masked_logits_match():
+def test_masked_output_match():
     f, lm, tgt, vu, resid = _load()
     masks = {s: jnp.asarray(f[f"mask::{s}"]) for s in lm.site_names}
     delta_masks = {s: jnp.asarray(f[f"delta_mask::{s}"]) for s in lm.site_names}
-    masked_all = lm.masked_logits(tgt, vu, resid, masks, delta_masks, None, lm.site_names, True)
-    _assert_close(masked_all, f["out::masked_all"], "masked_logits (all live)")
+    masked_all = lm.masked_output(tgt, vu, resid, masks, delta_masks, None, lm.site_names, True)
+    _assert_close(masked_all, f["out::masked_all"], "masked_output (all live)")
 
     chunk0 = lm.site_names[:3]
     routes0 = {s: jnp.asarray(f[f"route0::{s}"]) for s in chunk0}
-    masked_subset = lm.masked_logits(
+    masked_subset = lm.masked_output(
         tgt, vu, resid,
         {s: masks[s] for s in chunk0}, {s: delta_masks[s] for s in chunk0}, routes0, chunk0, True,
     )  # fmt: skip
-    _assert_close(masked_subset, f["out::masked_subset"], "masked_logits (subset live)")
+    _assert_close(masked_subset, f["out::masked_subset"], "masked_output (subset live)")
 
 
 def test_chunk_plan_static_live_set_matches():
     """The production `subset_chunk_plan` (`ChunkwiseSubsetReconLoss`) is what reaches the
     static live-set realization of SPEC S2: each plan entry holds a STATIC `live_sites`
-    tuple, and `masked_logits` runs every absent site on the frozen `x @ W` path (no
+    tuple, and `masked_output` runs every absent site on the frozen `x @ W` path (no
     `(B,T,C)` acts) — distinct from the per-position routing fallback. This drives that
     plan directly and asserts its first chunk's frozen-site forward matches the torch
     golden (`out::masked_subset`), so the chunk-plan path is verified against the oracle.
@@ -173,7 +173,7 @@ def test_chunk_plan_static_live_set_matches():
     masks = {s: jnp.asarray(f[f"mask::{s}"]) for s in chunk0}
     delta_masks = {s: jnp.asarray(f[f"delta_mask::{s}"]) for s in chunk0}
     routes = {s: jnp.asarray(f[f"route0::{s}"]) for s in chunk0}
-    masked = lm.masked_logits(
+    masked = lm.masked_output(
         tgt, vu, resid, masks, delta_masks, routes, plan[0].live_sites, plan[0].has_delta
     )
     _assert_close(masked, f["out::masked_subset"], "chunk-plan static-live-set forward")

--- a/param_decomp_jax/jax_single_pool/tests/test_fresh_pgd_cscope_dp_invariance.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_fresh_pgd_cscope_dp_invariance.py
@@ -64,7 +64,7 @@ def _ascend_cscope_source(
     if mesh is not None:
         residual = shard_batch(residual, mesh, batch_axis=0)
 
-    clean_logits = jax.lax.stop_gradient(lm.clean_logits(frozen, residual))
+    clean_output = jax.lax.stop_gradient(lm.clean_output(frozen, residual))
     # ci_lower = 0 so the mask is just the c-scope source — the cleanest probe of the
     # sign-ascent. Shapes match the masked forward's per-site (B, T, C) expectation.
     ci_lower = {s.name: jnp.zeros((gbatch, seq, s.C), jnp.float32) for s in sites}
@@ -73,10 +73,10 @@ def _ascend_cscope_source(
 
     def ascent_loss(sources: dict[str, jax.Array]) -> jax.Array:
         masks, delta_masks = source_masks(ci_lower, sources, lm.site_names)
-        masked = lm.masked_logits(
+        masked = lm.masked_output(
             frozen, components, residual, masks, delta_masks, None, lm.site_names, True
         )
-        return kl_per_position(masked, clean_logits)
+        return kl_per_position(masked, clean_output)
 
     def sign_ascend_body(
         sources: dict[str, jax.Array], _: None

--- a/param_decomp_jax/jax_single_pool/tests/test_generic_model_io.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_generic_model_io.py
@@ -1,8 +1,8 @@
 """Forcing function for the generic model-I/O seam (issue #828).
 
 The trainer's `[B,T,d]` residual is the fixed waist; only three EDGES are generic — the
-model INPUT (`prefix_residual_fn` reads it), the model OUTPUT (`clean_logits` /
-`masked_logits` return `Any`), and the recon comparison (`DecomposedLM.recon_loss_fn`).
+model INPUT (`prefix_residual_fn` reads it), the model OUTPUT (`clean_output` /
+`masked_output` return `Any`), and the recon comparison (`DecomposedModel.recon_loss_fn`).
 This builds a tiny non-LM target that bends ALL THREE at once:
 
   * INPUT  — a dict `{"feat": [B,T,d], "gain": [B,T]}` rather than token ids.
@@ -27,7 +27,7 @@ from jax import random
 from jaxtyping import Array, Float
 
 from jax_single_pool.ci_fn import CIArch, init_ci_fn
-from jax_single_pool.lm import DecomposedLM, SiteSpec
+from jax_single_pool.lm import DecomposedModel, SiteSpec
 from jax_single_pool.recon import build_recon_terms
 from jax_single_pool.train import TrainState, make_train_step
 from param_decomp_config.losses import (
@@ -68,7 +68,7 @@ def _heads(frozen: SyntheticFrozen, hidden: Array) -> tuple[Array, Array]:
     return hidden @ frozen.read_coords.T, hidden @ frozen.read_aux.T
 
 
-def _synthetic_lm() -> DecomposedLM:
+def _synthetic_lm() -> DecomposedModel:
     site = SiteSpec(name=SITE, d_in=D, d_out=D, C=C)
 
     def clean_output(frozen: SyntheticFrozen, resid: Array) -> tuple[Array, Array]:
@@ -107,11 +107,11 @@ def _synthetic_lm() -> DecomposedLM:
         aux_err = (masked[1].astype(jnp.float32) - clean[1].astype(jnp.float32)) ** 2
         return (jnp.sum(coords_err) + jnp.sum(aux_err)) / (B * T)
 
-    return DecomposedLM(
+    return DecomposedModel(
         sites=(site,),
-        clean_logits=clean_output,
+        clean_output=clean_output,
         site_inputs=site_inputs,
-        masked_logits=masked_output,
+        masked_output=masked_output,
         weight_deltas=weight_deltas,
         recon_loss_fn=geometric_mse,
     )
@@ -127,11 +127,11 @@ def test_default_recon_loss_fn_is_kl_per_position():
     byte-for-byte the pre-seam behavior (proved at scale by the stacked-parity golden)."""
     from jax_single_pool.losses import kl_per_position
 
-    lm = DecomposedLM(
+    lm = DecomposedModel(
         sites=(SiteSpec(SITE, D, D, C),),
-        clean_logits=lambda f, r: r,
+        clean_output=lambda f, r: r,
         site_inputs=lambda f, r: {SITE: r},
-        masked_logits=lambda *a: a[2],
+        masked_output=lambda *a: a[2],
         weight_deltas=lambda f, c: {},
     )
     assert lm.recon_loss_fn is kl_per_position
@@ -150,7 +150,7 @@ def test_prefix_residual_consumes_dict_input():
 
 
 def test_tuple_output_and_geometric_loss_flow():
-    """`clean_logits`/`masked_logits` emit a tuple; `recon_loss_fn` (MSE) contracts it."""
+    """`clean_output`/`masked_output` emit a tuple; `recon_loss_fn` (MSE) contracts it."""
     lm = _synthetic_lm()
     key = random.PRNGKey(1)
     frozen = SyntheticFrozen(
@@ -164,20 +164,20 @@ def test_tuple_output_and_geometric_loss_flow():
     )
     resid = random.normal(random.fold_in(key, 5), (B, T, D))
 
-    clean = lm.clean_logits(frozen, resid)
+    clean = lm.clean_output(frozen, resid)
     assert isinstance(clean, tuple) and len(clean) == 2
     assert clean[0].shape == (B, T, K_COORDS) and clean[1].shape == (B, T, M_AUX)
 
     masks = {SITE: jnp.ones((B, T, C))}
     delta_masks = {SITE: jnp.zeros((B, T))}
-    masked = lm.masked_logits(frozen, components, resid, masks, delta_masks, None, (SITE,), False)
+    masked = lm.masked_output(frozen, components, resid, masks, delta_masks, None, (SITE,), False)
     assert isinstance(masked, tuple) and len(masked) == 2
 
     loss = lm.recon_loss_fn(masked, clean)
     assert loss.shape == () and jnp.isfinite(loss)
 
 
-def _initial_state(lm: DecomposedLM, components: SyntheticComponents, ci_arch: CIArch):
+def _initial_state(lm: DecomposedModel, components: SyntheticComponents, ci_arch: CIArch):
     opt_vu = optax.adamw(1e-2, weight_decay=0.0)
     opt_ci = optax.adamw(1e-2, weight_decay=0.0)
     ci_fn = init_ci_fn(ci_arch, lm.sites, random.PRNGKey(11))

--- a/param_decomp_jax/jax_single_pool/tests/test_llama8b.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_llama8b.py
@@ -1,6 +1,6 @@
 """CPU tests for the Llama target + generic trainer at a tiny config.
 
-Validates the `DecomposedLM` contract (clean == all-frozen masked forward, shapes) and
+Validates the `DecomposedModel` contract (clean == all-frozen masked forward, shapes) and
 the full SPEC step (trains, VPD loss signature, adversary state advances) — for the
 MLP site family AND for attention (q/k/v/o) sites with heterogeneous per-site C —
 without real weights or a GPU.
@@ -162,12 +162,12 @@ def test_clean_path_and_masked_identity(first: int, last: int):
     b, t = 2, 16
     resid = jax.random.normal(jax.random.PRNGKey(2), (b, t, cfg.n_embd)) * 0.5
 
-    clean = lm.clean_logits(tgt, resid)
+    clean = lm.clean_output(tgt, resid)
     assert clean.shape == (b, t, cfg.vocab_size)
 
     # SPEC S2: a masked forward with NO live sites is the frozen path — bit-identical
     # to the clean target.
-    none_masked = lm.masked_logits(tgt, vu, resid, {}, {}, None, (), True)
+    none_masked = lm.masked_output(tgt, vu, resid, {}, {}, None, (), True)
     assert jnp.array_equal(clean, none_masked), "live=() must be the exact frozen path"
 
     # All-live, masks=1, delta=1, route-everywhere reconstructs the frozen path up to
@@ -175,7 +175,7 @@ def test_clean_path_and_masked_identity(first: int, last: int):
     names = lm.site_names
     ones_masks = {s: jnp.ones((b, t, C)) for s in names}
     ones_delta = {s: jnp.ones((b, t)) for s in names}
-    full = lm.masked_logits(tgt, vu, resid, ones_masks, ones_delta, None, names, True)
+    full = lm.masked_output(tgt, vu, resid, ones_masks, ones_delta, None, names, True)
     assert jnp.allclose(clean, full, atol=1e-4), "mask=1 identity drifted"
 
     site_in = lm.site_inputs(tgt, resid)
@@ -203,14 +203,14 @@ def test_attention_sites_clean_and_masked_identity():
         V, U = vu.site(spec.name)
         assert V.shape == (spec.d_in, spec.C) and U.shape == (spec.C, spec.d_out)
 
-    clean = lm.clean_logits(tgt, resid)
-    none_masked = lm.masked_logits(tgt, vu, resid, {}, {}, None, (), True)
+    clean = lm.clean_output(tgt, resid)
+    none_masked = lm.masked_output(tgt, vu, resid, {}, {}, None, (), True)
     assert jnp.array_equal(clean, none_masked), "live=() must be the exact frozen path"
 
     names = lm.site_names
     ones_masks = {s.name: jnp.ones((b, t, s.C)) for s in lm.sites}
     ones_delta = {s: jnp.ones((b, t)) for s in names}
-    full = lm.masked_logits(tgt, vu, resid, ones_masks, ones_delta, None, names, True)
+    full = lm.masked_output(tgt, vu, resid, ones_masks, ones_delta, None, names, True)
     assert jnp.allclose(clean, full, atol=1e-4), "mask=1 identity drifted (attention sites)"
 
     # zero-mask + zero-delta on q alone must CHANGE the logits (the site is live on
@@ -218,7 +218,7 @@ def test_attention_sites_clean_and_masked_identity():
     q_site = "layers.4.self_attn.q_proj"
     zero_mask = {q_site: jnp.zeros((b, t, 8))}
     zero_delta = {q_site: jnp.zeros((b, t))}
-    ablated = lm.masked_logits(tgt, vu, resid, zero_mask, zero_delta, None, (q_site,), True)
+    ablated = lm.masked_output(tgt, vu, resid, zero_mask, zero_delta, None, (q_site,), True)
     assert not jnp.allclose(clean, ablated, atol=1e-4), "ablating q did nothing"
 
     site_in = lm.site_inputs(tgt, resid)
@@ -244,8 +244,8 @@ def test_o_site_masks_attention_output():
     b, t = 2, 16
     resid = jax.random.normal(jax.random.PRNGKey(2), (b, t, cfg.n_embd)) * 0.5
 
-    clean = lm.clean_logits(tgt, resid)
-    ones = lm.masked_logits(
+    clean = lm.clean_output(tgt, resid)
+    ones = lm.masked_output(
         tgt,
         vu,
         resid,

--- a/param_decomp_jax/jax_single_pool/tests/test_llama_simple_mlp.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_llama_simple_mlp.py
@@ -1,6 +1,6 @@
 """CPU tests for the LlamaSimpleMLP target + generic trainer at a tiny config.
 
-Mirrors `test_llama8b.py`: validates the `DecomposedLM` contract (clean == all-frozen
+Mirrors `test_llama8b.py`: validates the `DecomposedModel` contract (clean == all-frozen
 masked forward, shapes, site seams) and the full SPEC step — for mixed attention + MLP
 sites with heterogeneous per-site C — without real weights or a GPU.
 """
@@ -214,11 +214,11 @@ def test_clean_path_and_masked_identity():
         V, U = vu.site(spec.name)
         assert V.shape == (spec.d_in, spec.C) and U.shape == (spec.C, spec.d_out)
 
-    clean = lm.clean_logits(target, resid)
+    clean = lm.clean_output(target, resid)
     assert clean.shape == (b, t, cfg.vocab_size)
 
     # SPEC S2: a masked forward with NO live sites is the frozen path — bit-identical.
-    none_masked = lm.masked_logits(target, vu, resid, {}, {}, None, (), True)
+    none_masked = lm.masked_output(target, vu, resid, {}, {}, None, (), True)
     assert jnp.array_equal(clean, none_masked), "live=() must be the exact frozen path"
 
     # All-live, masks=1, delta=1, route-everywhere reconstructs the frozen path up to
@@ -226,7 +226,7 @@ def test_clean_path_and_masked_identity():
     names = lm.site_names
     ones_masks = {s.name: jnp.ones((b, t, s.C)) for s in lm.sites}
     ones_delta = {s: jnp.ones((b, t)) for s in names}
-    full = lm.masked_logits(target, vu, resid, ones_masks, ones_delta, None, names, True)
+    full = lm.masked_output(target, vu, resid, ones_masks, ones_delta, None, names, True)
     assert jnp.allclose(clean, full, atol=1e-4), "mask=1 identity drifted"
 
     site_in = lm.site_inputs(target, resid)
@@ -258,9 +258,9 @@ def test_zero_masking_one_site_changes_logits(ablated_site: str):
     b, t = 2, 16
     resid = jax.random.normal(jax.random.PRNGKey(2), (b, t, cfg.n_embd)) * 0.5
 
-    clean = lm.clean_logits(target, resid)
+    clean = lm.clean_output(target, resid)
     C = {s.name: s.C for s in _MIXED_SITE_CS}[ablated_site]
-    ablated = lm.masked_logits(
+    ablated = lm.masked_output(
         target, vu, resid,
         {ablated_site: jnp.zeros((b, t, C))}, {ablated_site: jnp.zeros((b, t))},
         None, (ablated_site,), True,
@@ -278,8 +278,8 @@ def test_o_site_masks_attention_output():
     b, t = 2, 16
     resid = jax.random.normal(jax.random.PRNGKey(2), (b, t, cfg.n_embd)) * 0.5
 
-    clean = lm.clean_logits(target, resid)
-    ones = lm.masked_logits(
+    clean = lm.clean_output(target, resid)
+    ones = lm.masked_output(
         target, vu, resid, {o_site: jnp.ones((b, t, 8))}, {o_site: jnp.ones((b, t))}, None,
         (o_site,), True,
     )  # fmt: skip

--- a/param_decomp_jax/jax_single_pool/tests/test_source_grad_mean.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_source_grad_mean.py
@@ -11,7 +11,7 @@ The contract this guards: the per-device gradient flowing into the replicated `s
 source is the GLOBAL mean. If GSPMD instead emitted a bare all-reduce(SUM) on the
 source cotangent (the bug), the N-device source grad would be N× the single-device grad.
 We compute the source-leaf grad of the adversarial ascent objective
-(`kl_per_position(masked_logits(...), clean_logits)`, the same loss the persistent
+(`kl_per_position(masked_output(...), clean_output)`, the same loss the persistent
 ascent backprops, SPEC S12'/S14') on the SAME fixed global batch + seed at 1 layout
 (`mesh=None`) and at N≥2 simulated devices, and assert they match to rel ≤ 1e-4.
 
@@ -78,14 +78,14 @@ def _source_grad(sharded: bool) -> dict[str, jax.Array]:
     ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
     site_inputs = lm.site_inputs(tgt, resid)
     ci_lower = ci_fn_bf16(site_inputs).lower
-    clean_logits = jax.lax.stop_gradient(lm.clean_logits(tgt, resid))
+    clean_output = jax.lax.stop_gradient(lm.clean_output(tgt, resid))
 
     def source_loss(sources: dict[str, jax.Array]) -> jax.Array:
         masks, delta_masks = source_masks(ci_lower, sources, lm.site_names)
-        masked = lm.masked_logits(
+        masked = lm.masked_output(
             tgt, components_bf16, resid, masks, delta_masks, None, lm.site_names, True
         )
-        return kl_per_position(masked, clean_logits)
+        return kl_per_position(masked, clean_output)
 
     grad_fn = jax.jit(jax.grad(source_loss))
     if mesh is not None:

--- a/param_decomp_jax/jax_single_pool/train.py
+++ b/param_decomp_jax/jax_single_pool/train.py
@@ -1,4 +1,4 @@
-"""The generic single-pool VPD training step over a `DecomposedLM` (SPEC §4).
+"""The generic single-pool VPD training step over a `DecomposedModel` (SPEC §4).
 
 One `jax.jit` step: clean target → CI envelope → per-persistent-term supplemental
 ascents + per-fresh-entry sign-PGD ascents (`adversary.py`) → faith + imp-min +
@@ -34,7 +34,7 @@ from jax_single_pool.adversary import (
     sources_adam_ascend_project,
 )
 from jax_single_pool.ci_fn import CIFn, CIValues
-from jax_single_pool.lm import DecomposedLM
+from jax_single_pool.lm import DecomposedModel
 from jax_single_pool.losses import (
     annealed_pnorm,
     faithfulness_loss,
@@ -109,7 +109,7 @@ def _grad_norm_metrics(components_grad: Any, ci_fn_grad: Any) -> dict[str, Array
 
 
 def make_train_step(
-    lm: DecomposedLM,
+    lm: DecomposedModel,
     *,
     loss_spec: LossSpec,
     components_optimizer: optax.GradientTransformation,
@@ -172,7 +172,7 @@ def make_train_step(
         has_delta: bool,
     ) -> Array:
         return batch_sharded(
-            lm.masked_logits(
+            lm.masked_output(
                 frozen, components_bf16, residual, masks, delta_masks, routes, live_sites, has_delta
             )
         )
@@ -232,7 +232,7 @@ def make_train_step(
         components_bf16: Any,
         ci_lower: dict[str, Array],
         residual: Array,
-        clean_logits: Array,
+        clean_output: Array,
         forward_fn: Any,
     ) -> Array:
         """Mean KL over the entry's draws with FIXED source values — the adversarial
@@ -250,7 +250,7 @@ def make_train_step(
                 entry.live_sites,
                 entry.has_delta,
             )
-            total = total + recon_loss_fn(masked, clean_logits)
+            total = total + recon_loss_fn(masked, clean_output)
         return total / len(routes_per_draw)
 
     @jax.jit
@@ -262,7 +262,7 @@ def make_train_step(
         batch, seq = residual.shape[0], residual.shape[1]
 
         residual = batch_sharded(residual)
-        clean_logits = jax.lax.stop_gradient(batch_sharded(lm.clean_logits(frozen, residual)))
+        clean_output = jax.lax.stop_gradient(batch_sharded(lm.clean_output(frozen, residual)))
         site_inputs = lm.site_inputs(frozen, residual)
 
         # ── adversary ascents: params + CI detached (SPEC §4.5) ──
@@ -306,7 +306,7 @@ def make_train_step(
                     site_names,
                     True,
                 )
-                return recon_loss_fn(masked, clean_logits)
+                return recon_loss_fn(masked, clean_output)
 
             def warmup_body(
                 carry: tuple[dict[str, Array], SourcesAdamState],
@@ -369,7 +369,7 @@ def make_train_step(
                         components_detached,
                         ci_lower_detached,
                         residual,
-                        clean_logits,
+                        clean_output,
                         masked_forward,
                     )
 
@@ -450,7 +450,7 @@ def make_train_step(
                             entry.live_sites,
                             entry.has_delta,
                         )
-                        total = total + recon_loss_fn(masked, clean_logits)
+                        total = total + recon_loss_fn(masked, clean_output)
                         n_forwards += 1
                 assert n_forwards > 0, f"term {term.name!r} produced no forwards"
                 term_loss = total / n_forwards
@@ -540,7 +540,7 @@ def make_train_step(
 
 
 def make_faith_warmup_step(
-    lm: DecomposedLM, opt: optax.GradientTransformation
+    lm: DecomposedModel, opt: optax.GradientTransformation
 ) -> Callable[[Any, optax.OptState, Any], tuple[Any, optax.OptState, Array]]:
     @jax.jit
     def warmup_step(

--- a/param_decomp_lab/harvest/CLAUDE.md
+++ b/param_decomp_lab/harvest/CLAUDE.md
@@ -41,7 +41,7 @@ dense component co-occurrence (`O(C²)` + `O(C·vocab)` per batch) dominates; pa
 
 `jax_single_pool.load_run.open_jax_run(run_dir, step=None) -> LoadedJaxRun` is the single
 entry point any consumer of a JAX run should use. It rebuilds the frozen target +
-`DecomposedLM` from the run's pinned config (`load_run_dir_config`), restores the orbax
+`DecomposedModel` from the run's pinned config (`load_run_dir_config`), restores the orbax
 checkpoint onto a reference `TrainState`, and exposes `run.forward(token_ids) ->
 HarvestForward` plus the metadata torch consumers key on (`layer_activation_sizes`,
 `vocab_size`, `site_names`). Pure JAX, torch-free, single-device-friendly. Add the


### PR DESCRIPTION
Deferred follow-up from #828, which made the model interface generic over input/output/recon-loss but left it wearing its LM-specific name.

- `DecomposedLM` → `DecomposedModel`
- `clean_logits` → `clean_output`, `masked_logits` → `masked_output` (the output fns now return `Any` — an LM emits logits, a non-LM target emits coords/heads)
- Genuinely-LM names kept: `LoadedJaxRun.lm`, `DecomposedModel.site_names`, the `llama_simple_mlp_decomposed_lm` / `llama_decomposed_lm` builders, `logits`/`vocab` locals inside LM target impls.

Pure identifier rename — semantically neutral. JAX suite **161 passed at both 1 and 4 simulated devices** (includes the equivalence + stacked-parity goldens, untouched → proof of neutrality).

🤖 Generated with [Claude Code](https://claude.com/claude-code)