### PR TITLE
fix(jax): drive make check-jax toward zero + gate it in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,3 +24,15 @@ repos:
         types: [python]
         stages:
           - pre-commit
+
+      # The `type` hook above runs the torch venv's basedpyright, which excludes the JAX
+      # distribution. This runs the JAX venv's basedpyright over `jax_single_pool/` so the
+      # JAX side can't regress (`make check-jax`).
+      - id: type-jax
+        name: "Type check JAX with BasedPyright"
+        entry: make check-jax
+        language: system
+        files: ^param_decomp_jax/
+        pass_filenames: false
+        stages:
+          - pre-commit

--- a/param_decomp_config/losses.py
+++ b/param_decomp_config/losses.py
@@ -62,9 +62,9 @@ class CIMaskedReconLayerwiseLossConfig(LossMetricConfig):
 
 class CIMaskedReconSubsetLossConfig(LossMetricConfig):
     type: Literal["CIMaskedReconSubsetLoss"] = "CIMaskedReconSubsetLoss"
-    routing: Annotated[
-        SubsetRoutingType, Field(discriminator="type", default=UniformKSubsetRoutingConfig())
-    ]
+    routing: Annotated[SubsetRoutingType, Field(discriminator="type")] = (
+        UniformKSubsetRoutingConfig()
+    )
 
 
 class StochasticReconLossConfig(LossMetricConfig):
@@ -77,9 +77,9 @@ class StochasticReconLayerwiseLossConfig(LossMetricConfig):
 
 class StochasticReconSubsetLossConfig(LossMetricConfig):
     type: Literal["StochasticReconSubsetLoss"] = "StochasticReconSubsetLoss"
-    routing: Annotated[
-        SubsetRoutingType, Field(discriminator="type", default=UniformKSubsetRoutingConfig())
-    ]
+    routing: Annotated[SubsetRoutingType, Field(discriminator="type")] = (
+        UniformKSubsetRoutingConfig()
+    )
 
 
 class StochasticHiddenActsReconLossConfig(LossMetricConfig):
@@ -108,9 +108,9 @@ class ChunkwiseSubsetReconLossConfig(LossMetricConfig):
 
     type: Literal["ChunkwiseSubsetReconLoss"] = "ChunkwiseSubsetReconLoss"
     sites_per_chunk: PositiveInt
-    routing: Annotated[
-        SubsetRoutingType, Field(discriminator="type", default=UniformKSubsetRoutingConfig())
-    ]
+    routing: Annotated[SubsetRoutingType, Field(discriminator="type")] = (
+        UniformKSubsetRoutingConfig()
+    )
     n_samples: PositiveInt = 1
     use_fused_kl: bool = True
 
@@ -156,9 +156,9 @@ class PGDReconLayerwiseLossConfig(PGDConfig):
 
 class PGDReconSubsetLossConfig(PGDConfig):
     type: Literal["PGDReconSubsetLoss"] = "PGDReconSubsetLoss"
-    routing: Annotated[
-        SubsetRoutingType, Field(discriminator="type", default=UniformKSubsetRoutingConfig())
-    ]
+    routing: Annotated[SubsetRoutingType, Field(discriminator="type")] = (
+        UniformKSubsetRoutingConfig()
+    )
 
 
 class SignPGDConfig(BaseConfig):

--- a/param_decomp_jax/jax_single_pool/run.py
+++ b/param_decomp_jax/jax_single_pool/run.py
@@ -164,11 +164,13 @@ class MetricsSink:
             flush=True,
         )
         if self._wandb is not None:
+            import wandb.errors
+
             # CommError catches wandb-server hiccups (a transient outage must not kill a
             # multi-day run) while letting genuine misuse (e.g. a non-dict record) raise.
             try:
                 self._wandb.log(record, step=step)
-            except self._wandb.errors.CommError as e:
+            except wandb.errors.CommError as e:
                 print(f"wandb communication error, skipping log: {e}", flush=True)
 
 

--- a/param_decomp_jax/jax_single_pool/run_state.py
+++ b/param_decomp_jax/jax_single_pool/run_state.py
@@ -6,12 +6,15 @@ rebuild the state exactly as the run did — same init fns, same key derivation,
 optimizer-state structure.
 """
 
+from collections.abc import Callable
+
 import equinox as eqx
 import jax
 import jax.numpy as jnp
 import optax
 from jax import random
 from jax.sharding import Mesh
+from jax.typing import ArrayLike
 from jaxtyping import Array, PRNGKeyArray
 
 from jax_single_pool.adversary import init_sources_adam_state
@@ -26,14 +29,16 @@ from jax_single_pool.recon import build_recon_terms
 from jax_single_pool.train import TrainState
 
 
-def torch_cosine_schedule(peak_lr: float, total_steps: int, alpha: float) -> optax.Schedule:
+def torch_cosine_schedule(
+    peak_lr: float, total_steps: int, alpha: float
+) -> Callable[[ArrayLike], Array]:
     """Cosine decay matching torch's `get_scheduled_value` denominator: `progress =
     step / (total_steps - 1)` (no warmup), so `0.1×` is reached at `step = total_steps - 1`.
     optax's `cosine_decay_schedule` divides by `total_steps`, reaching it one step later
     (SPEC S20). `total_steps == 1` collapses to a constant `peak_lr`."""
     denom = max(total_steps - 1, 1)
 
-    def schedule(count: Array) -> Array:
+    def schedule(count: ArrayLike) -> Array:
         progress = jnp.asarray(count, jnp.float32) / denom
         return peak_lr * (alpha + (1 - alpha) * 0.5 * (1 + jnp.cos(jnp.pi * progress)))
 
@@ -51,8 +56,8 @@ def clip_by_global_norm_with_eps(max_norm: float, eps: float) -> optax.GradientT
         return optax.EmptyState()
 
     def update(
-        updates: optax.Updates, state: optax.EmptyState, params: optax.Params | None = None
-    ) -> tuple[optax.Updates, optax.EmptyState]:
+        updates: optax.Updates, state: optax.OptState, params: optax.Params | None = None
+    ) -> tuple[optax.Updates, optax.OptState]:
         del params
         global_norm = optax.global_norm(updates)
         scale = jnp.minimum(max_norm / (global_norm + eps), 1.0)

--- a/param_decomp_jax/jax_single_pool/tests/test_checkpoint.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_checkpoint.py
@@ -8,6 +8,7 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import optax
+from jax.sharding import Mesh
 
 from jax_single_pool.adversary import (
     init_persistent_sources,
@@ -191,7 +192,7 @@ def test_no_checkpoint_returns_none(tmp_path: Path):
     assert restore_latest(mgr, fresh) is None
 
 
-def _build_sharded(seed: int, mesh):
+def _build_sharded(seed: int, mesh: Mesh):
     """A `TrainState` placed exactly as the production trainer places it
     (`run_state.init_train_state`): C-sharded V/U + ci_fn, replicated sources, over the
     `dp` mesh. Built directly from the `*_sharded` init fns so the saved/restored

--- a/param_decomp_jax/jax_single_pool/tests/test_config.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_config.py
@@ -179,7 +179,7 @@ def test_unsupported_model_family_refuses_and_supported_families_dispatch():
 
     torch_cfg, raw = _reference_torch_cfg()
 
-    def _converted_target(spec: dict):
+    def _converted_target(spec: dict[str, str]):
         cfg = build_experiment_config(
             type(torch_cfg)(**dict(raw, target=dict(raw["target"], spec=spec))),
             run_name="t", run_id=RUN_ID, out_dir=Path("/tmp"), remat_recon_forwards=True,

--- a/param_decomp_jax/jax_single_pool/tests/test_optim_torch_parity.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_optim_torch_parity.py
@@ -6,11 +6,29 @@
   optax's eps-free `clip_by_global_norm`.
 """
 
+import jax
 import jax.numpy as jnp
 import optax
 import pytest
+from jax.typing import ArrayLike
+from jaxtyping import Array
 
 from jax_single_pool.run_state import clip_by_global_norm_with_eps, torch_cosine_schedule
+
+
+def _scalar(value: ArrayLike) -> float:
+    """`optax.Schedule` returns the wide `ArrayLike` union; narrow a scalar schedule
+    output to a Python float for comparison."""
+    return float(jnp.asarray(value))
+
+
+def _clip(transform: optax.GradientTransformation, grads: dict[str, Array]) -> dict[str, Array]:
+    """Run a `GradientTransformation` over a concrete grad dict and recover the result
+    with that same `dict[str, Array]` structure — `optax.Updates` is a wide pytree union
+    the type-checker can't index, but the transform preserves the input tree."""
+    out, _ = transform.update(grads, transform.init(grads))
+    _, treedef = jax.tree.flatten(grads)
+    return jax.tree.unflatten(treedef, jax.tree.leaves(out))
 
 
 def torch_cosine_reference(peak_lr: float, total_steps: int, alpha: float, step: int) -> float:
@@ -26,10 +44,10 @@ def test_cosine_schedule_matches_torch_denominator():
     alpha = 0.1
     sched = torch_cosine_schedule(peak_lr, total_steps, alpha)
     for step in (0, total_steps // 2, total_steps - 1):
-        jax_value = float(sched(jnp.int32(step)))
+        jax_value = _scalar(sched(jnp.int32(step)))
         torch_value = torch_cosine_reference(peak_lr, total_steps, alpha, step)
         assert jax_value == pytest.approx(torch_value, rel=1e-7), f"step {step}"
-    assert float(sched(jnp.int32(total_steps - 1))) == pytest.approx(alpha * peak_lr, rel=1e-6)
+    assert _scalar(sched(jnp.int32(total_steps - 1))) == pytest.approx(alpha * peak_lr, rel=1e-6)
 
 
 def test_cosine_schedule_differs_from_optax():
@@ -42,9 +60,9 @@ def test_cosine_schedule_differs_from_optax():
     optax_sched = optax.cosine_decay_schedule(peak_lr, total_steps, alpha=0.1)
     ours = torch_cosine_schedule(peak_lr, total_steps, alpha=0.1)
     endpoint = total_steps - 1
-    assert float(ours(jnp.int32(endpoint))) == pytest.approx(0.1 * peak_lr, rel=1e-6)
-    assert float(optax_sched(jnp.int32(endpoint))) != pytest.approx(0.1 * peak_lr, rel=1e-6)
-    assert float(optax_sched(jnp.int32(total_steps))) == pytest.approx(0.1 * peak_lr, rel=1e-6)
+    assert _scalar(ours(jnp.int32(endpoint))) == pytest.approx(0.1 * peak_lr, rel=1e-6)
+    assert _scalar(optax_sched(jnp.int32(endpoint))) != pytest.approx(0.1 * peak_lr, rel=1e-6)
+    assert _scalar(optax_sched(jnp.int32(total_steps))) == pytest.approx(0.1 * peak_lr, rel=1e-6)
 
 
 def test_grad_clip_matches_torch_eps():
@@ -53,8 +71,7 @@ def test_grad_clip_matches_torch_eps():
     clip = clip_by_global_norm_with_eps(max_norm, eps)
     grads = {"a": jnp.array([3.0, 4.0]), "b": jnp.array([0.0])}
     global_norm = 5.0
-    state = clip.init(grads)
-    out, _ = clip.update(grads, state)
+    out = _clip(clip, grads)
     torch_coef = min(max_norm / (global_norm + eps), 1.0)
     assert float(out["a"][0]) == pytest.approx(3.0 * torch_coef, rel=1e-7)
     assert float(out["a"][1]) == pytest.approx(4.0 * torch_coef, rel=1e-7)
@@ -63,10 +80,8 @@ def test_grad_clip_matches_torch_eps():
 def test_grad_clip_differs_from_optax_when_clipping():
     max_norm = 0.01
     grads = {"a": jnp.array([3.0, 4.0])}
-    ours = clip_by_global_norm_with_eps(max_norm, eps=1e-6)
-    out_ours, _ = ours.update(grads, ours.init(grads))
-    optax_clip = optax.clip_by_global_norm(max_norm)
-    out_optax, _ = optax_clip.update(grads, optax_clip.init(grads))
+    out_ours = _clip(clip_by_global_norm_with_eps(max_norm, eps=1e-6), grads)
+    out_optax = _clip(optax.clip_by_global_norm(max_norm), grads)
     assert float(out_ours["a"][0]) != pytest.approx(float(out_optax["a"][0]), rel=1e-9)
 
 
@@ -74,6 +89,6 @@ def test_grad_clip_noop_below_threshold():
     max_norm = 100.0
     clip = clip_by_global_norm_with_eps(max_norm, eps=1e-6)
     grads = {"a": jnp.array([3.0, 4.0])}
-    out, _ = clip.update(grads, clip.init(grads))
+    out = _clip(clip, grads)
     assert float(out["a"][0]) == pytest.approx(3.0)
     assert float(out["a"][1]) == pytest.approx(4.0)

--- a/param_decomp_jax/pyproject.toml
+++ b/param_decomp_jax/pyproject.toml
@@ -24,7 +24,11 @@ dependencies = [
 
 [project.optional-dependencies]
 cuda = ["jax[cuda12]==0.10.1"]
-dev = ["pytest", "basedpyright"]
+# huggingface-hub is a typecheck-/dev-time dep only: `hf_http.configure_hf_http_retries`
+# imports it behind a runtime `find_spec` guard (no-op when absent), so it is never a
+# runtime dependency — but the type-checker needs its (`py.typed`) stubs to resolve those
+# guarded imports. Pinned to the torch side's version.
+dev = ["pytest", "basedpyright", "huggingface-hub==0.36.0"]
 
 [project.scripts]
 jsp-train = "jax_single_pool.run:main"


### PR DESCRIPTION
## What

Drives `make check-jax` (basedpyright over `param_decomp_jax/jax_single_pool/`) from **117 errors → 0**, using proper types only — **no `# type: ignore`, no `Any`, no `cast`** — and adds a `type-jax` pre-commit hook so the JAX side can't regress (the existing `type` hook runs the torch venv's basedpyright and skips the JAX distribution entirely).

## Root cause per category

- **106 in `tests/test_optim_torch_parity.py`** (`reportIndexIssue` + `reportArgumentType`) — `optax.Updates` and `optax.Schedule` are wide unions (incl. `complex`, `Iterable[ArrayTree]`, `Mapping`) that the checker can't index (`out["a"]`) or pass to `float()`. Added two typed test helpers: `_clip` runs a `GradientTransformation` over a concrete grad dict and recovers the result with that same `dict[str, Array]` structure via tree flatten/unflatten; `_scalar` narrows a scalar schedule output to `float` via `jnp.asarray`.
- **3 in `tests/test_recon_log_keys.py`** (`routing` missing) — **real config bug, not a stale test.** The `routing` field declared its default *inside* `Annotated[..., Field(default=…)]`, which pyright's pydantic synthesizer does not read, so the field was typed **required** while pydantic defaulted it at runtime. Moved the default to the assignment position (canonical pydantic v2: `Annotated[T, Field(discriminator=…)] = default`) across all 5 subset configs. Runtime is byte-identical (verified); the field is now correctly optional at the type level.
- **2 in `hf_http.py`** (`reportMissingImports` for `huggingface_hub`) — optional-at-runtime import, `find_spec`-guarded, with no stubs in the JAX venv. Added `huggingface-hub==0.36.0` (pinned to the torch side) to the **`dev` extra only**, so the checker resolves its `py.typed` stubs; runtime stays optional (the `cuda`/production extra is unchanged and still no-ops when absent).
- **2 in `run_state.py`** — schedule return narrowed to `Callable[[ArrayLike], Array]` (a valid subtype of `optax.Schedule`/`ScalarOrSchedule`); the clip `update` fn typed against the `TransformUpdateFn` protocol (`state: OptState`, not the narrower `EmptyState`).
- **1 in `run.py`** — `import wandb.errors` so the submodule is a known attribute (wandb ships `py.typed` but doesn't re-export `errors`).
- **2 in `tests/test_config.py` / 1 in `tests/test_checkpoint.py`** — missing parameter annotations (`dict[str, str]`, `Mesh`).

## Verification

- `make check-jax`: **117 → 0 errors**.
- JAX suite: **161 passed** at the default device count **and** `XLA_FLAGS=--xla_force_host_platform_device_count=4` (161×2). Equivalence + stacked-parity goldens untouched.
- New `type-jax` pre-commit hook fires + passes (`pre-commit run type-jax --all-files`), and genuinely fails on an injected type error.

## Not done

- **pytest-xdist**: dropped. JAX CPU tests with simulated multi-device risk device contention/flakiness across forked workers; the ~2.5 min saved doesn't justify the CI-flake risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)