### PR TITLE
fix(tests): repair two pre-existing red tests (jax-launch validation, wandb short-name table)

### DIFF
--- a/param_decomp_config/wandb_config.py
+++ b/param_decomp_config/wandb_config.py
@@ -18,7 +18,6 @@ METRIC_SHORT_NAMES: dict[str, str] = {
     "FaithfulnessLoss": "Faith",
     "ImportanceMinimalityLoss": "ImpMin",
     "PersistentPGDReconLoss": "PersistPGDRecon",
-    "PersistentPGDReconSubsetLoss": "PersistPGDReconSub",
     "PGDReconLayerwiseLoss": "PGDReconLayer",
     "PGDReconLoss": "PGDRecon",
     "PGDReconSubsetLoss": "PGDReconSub",

--- a/param_decomp_lab/tests/test_jax_launch.py
+++ b/param_decomp_lab/tests/test_jax_launch.py
@@ -27,5 +27,5 @@ def test_validate_wrapper_rejects_unexpected_key(tmp_path: Path):
     wrapper = tmp_path / "wrapper.yaml"
     raw = {key: "x" for key in WRAPPER_KEYS_BEFORE_SUBMIT} | {"bogus_key": "x"}
     wrapper.write_text(yaml.safe_dump(raw))
-    with pytest.raises(AssertionError, match="keys must be"):
+    with pytest.raises(AssertionError, match="keys must include"):
         _validate_wrapper(wrapper)


### PR DESCRIPTION
## Summary

Repairs two pre-existing red tests on `feature/jax`. Both failures are *drift*: code moved, the guardrails didn't follow.

### 1. `test_jax_launch.py::test_validate_wrapper_rejects_unexpected_key` — stale test
`_validate_wrapper`'s assertion message was reworded to `"keys must include ... and may add ..."`, but the test's `pytest.raises(match=...)` still expected the old `"keys must be"`. The validation correctly rejects the unexpected key — only the regex was stale. Fixed the test regex.

### 2. `test_wandb_config_short_names.py::test_config_short_name_table_matches_metric_registry` — real drift in the table
The torch-free `METRIC_SHORT_NAMES` carried a stale `PersistentPGDReconSubsetLoss` entry whose metric class was removed in #824 (PPGD+subset removal). The registry-derived names no longer contain it. Dropped the dead table entry so the two stay in lockstep.

## Verification
- Both target tests pass
- `make test` (excl. slow): 415 passed, 4 skipped
- `make type`: 0 errors
- pre-commit (ruff + main-venv basedpyright): pass. The `type-jax` hook needs the separate `param_decomp_jax/.venv`, which is out of scope for this worktree; no JAX files were touched.

No `# type: ignore` / `Any` / `cast` introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)