### PR TITLE
feat(jax): open_jax_run loads llama8b targets (+ slow_eval shares the builder)

### DIFF
--- a/param_decomp_jax/jax_single_pool/load_run.py
+++ b/param_decomp_jax/jax_single_pool/load_run.py
@@ -22,12 +22,15 @@ compute on the components / CI fn (training's `COMPUTE_DT`) so consumed CI match
 trained model's; output probs are fp32 from the fp32-upcast frozen forward.
 """
 
+from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import jax
 import jax.numpy as jnp
+from jax.sharding import NamedSharding
+from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, Float, Int
 
 from jax_single_pool import llama_simple_mlp
@@ -38,7 +41,17 @@ from jax_single_pool.config import (
     TargetConfig,
     load_run_dir_config,
 )
-from jax_single_pool.llama8b import DecompVU
+from jax_single_pool.llama8b import (
+    DecompVU,
+    first_decomposed_layer,
+    llama31_8b_config,
+    llama_decomposed_lm,
+    llama_site_specs,
+    load_prefix_from_hf,
+    load_target_from_hf,
+    prefix_residual,
+)
+from jax_single_pool.llama8b_sharding import replicate_target
 from jax_single_pool.lm import DecomposedModel
 from jax_single_pool.run_state import build_optimizers, init_train_state
 from jax_single_pool.sharding import dp_mesh
@@ -55,9 +68,12 @@ class HarvestForward:
     output_probs: Float[Array, "B T vocab"]
 
 
-def _build_target(cfg: ExperimentConfig, mesh: jax.sharding.Mesh):
-    """Frozen target + prefix-residual fn for the run's target config. SimpleMLP reads
-    its local pretrain cache (no network); llama8b reads the HF snapshot."""
+def build_target(
+    cfg: ExperimentConfig, mesh: jax.sharding.Mesh
+) -> tuple[DecomposedModel, Any, Any, Callable[[Any, Any], jax.Array], int]:
+    """`(lm, frozen target, prefix, prefix_residual_fn, vocab_size)` for the run's target
+    config. SimpleMLP reads its local pretrain cache (no network); llama8b reads the HF
+    snapshot (frozen bf16 target + fp32-compute, matching `run.py::main`)."""
     match cfg.target:
         case LlamaSimpleMLPTargetConfig():
             cache_dir = llama_simple_mlp.pretrain_cache_dir(cfg.target.pretrain_run_path)
@@ -80,10 +96,17 @@ def _build_target(cfg: ExperimentConfig, mesh: jax.sharding.Mesh):
             )
             return lm, target, prefix, llama_simple_mlp.prefix_residual, simple_cfg.vocab_size
         case TargetConfig():
-            raise NotImplementedError(
-                "open_jax_run currently builds the LlamaSimpleMLP target only; the "
-                "llama8b target needs HF weight loading + sharding (see run.py main)."
+            llama_cfg = llama31_8b_config()
+            lm = llama_decomposed_lm(llama_cfg, llama_site_specs(llama_cfg, cfg.target.sites))
+            first_layer = first_decomposed_layer(lm.site_names)
+            target = replicate_target(
+                load_target_from_hf(cfg.target.model_name, llama_cfg, first_layer), mesh
             )
+            prefix = jax.device_put(
+                load_prefix_from_hf(cfg.target.model_name, llama_cfg, first_layer),
+                NamedSharding(mesh, P()),
+            )
+            return lm, target, prefix, prefix_residual, llama_cfg.vocab_size
 
 
 def _u_norms(components: DecompVU, site_names: tuple[str, ...]) -> dict[str, Float[Array, " C"]]:
@@ -134,7 +157,7 @@ def open_jax_run(run_dir: Path, step: int | None = None) -> LoadedJaxRun:
     """Open the run at `run_dir`; restore checkpoint `step` (latest if None)."""
     cfg = load_run_dir_config(run_dir)
     mesh = dp_mesh()
-    lm, target, prefix, prefix_residual_fn, vocab_size = _build_target(cfg, mesh)
+    lm, target, prefix, prefix_residual_fn, vocab_size = build_target(cfg, mesh)
 
     opt_vu, opt_ci, _ = build_optimizers(cfg)
     init_key, src_key = jax.random.split(jax.random.PRNGKey(cfg.seed))

--- a/param_decomp_jax/jax_single_pool/slow_eval.py
+++ b/param_decomp_jax/jax_single_pool/slow_eval.py
@@ -36,17 +36,16 @@ from jaxtyping import Array, Float
 from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
 
-from jax_single_pool import llama_simple_mlp
 from jax_single_pool.checkpoint import make_checkpoint_manager, restore_step
 from jax_single_pool.ci_fn import lower_leaky_hard_sigmoid
 from jax_single_pool.config import (
     EvalConfig,
     ExperimentConfig,
-    LlamaSimpleMLPTargetConfig,
     load_run_dir_config,
 )
 from jax_single_pool.data import BatchSchedule, ShardServer, scan_shards
 from jax_single_pool.lm import DecomposedModel
+from jax_single_pool.load_run import build_target
 from jax_single_pool.run_state import build_optimizers, init_train_state
 from jax_single_pool.sharding import dp_mesh
 
@@ -251,38 +250,13 @@ def _eval_config(cfg: ExperimentConfig) -> EvalConfig:
     return cfg.eval
 
 
-def _build_simple_mlp(cfg: ExperimentConfig, mesh: Any):
-    assert isinstance(cfg.target, LlamaSimpleMLPTargetConfig), (
-        f"JAX slow-eval implements the SimpleMLP target; got {type(cfg.target).__name__}"
-    )
-    cache_dir = llama_simple_mlp.pretrain_cache_dir(cfg.target.pretrain_run_path)
-    simple_cfg = llama_simple_mlp.load_model_config(cache_dir)
-    lm = llama_simple_mlp.llama_simple_mlp_decomposed_lm(
-        simple_cfg, llama_simple_mlp.site_specs(simple_cfg, cfg.target.sites)
-    )
-    first_layer = llama_simple_mlp.first_decomposed_layer(lm.site_names)
-    frozen = llama_simple_mlp.replicate_frozen(
-        llama_simple_mlp.load_target_from_pretrain_cache(
-            cache_dir, simple_cfg, first_layer, jnp.bfloat16
-        ),
-        mesh,
-    )
-    prefix = llama_simple_mlp.replicate_frozen(
-        llama_simple_mlp.load_prefix_from_pretrain_cache(
-            cache_dir, simple_cfg, first_layer, jnp.bfloat16
-        ),
-        mesh,
-    )
-    return lm, frozen, prefix
-
-
 def run_offline_slow_eval(run_dir: Path, cfg: ExperimentConfig, step: int) -> dict[str, bytes]:
     """Restore checkpoint `step` from `run_dir`'s ckpts and render the slow figures.
     `run_dir` is the on-disk dir (the exporter takes it the same way); `cfg.run_dir`
     can differ when a run dir is read from a relocated copy. CPU-OK."""
     eval_cfg = _eval_config(cfg)
     mesh = dp_mesh()
-    lm, frozen, prefix = _build_simple_mlp(cfg, mesh)
+    lm, frozen, prefix, prefix_residual_fn, _vocab_size = build_target(cfg, mesh)
 
     opt_vu, opt_ci, _schedules = build_optimizers(cfg)
     init_key, src_key, _run_key = random.split(random.PRNGKey(cfg.seed), 3)
@@ -292,9 +266,9 @@ def run_offline_slow_eval(run_dir: Path, cfg: ExperimentConfig, step: int) -> di
 
     schedule = BatchSchedule(scan_shards(cfg.data.dir), eval_cfg.batch_size, cfg.seed + 1)
     server = ShardServer(schedule, cfg.data.seq_len, jax.process_index(), jax.process_count())
-    harvest = jax.jit(llama_simple_mlp.prefix_residual)
+    to_residual = jax.jit(prefix_residual_fn)
     residual_batches = [
-        harvest(prefix, jnp.asarray(server.local_batch(j))) for j in range(eval_cfg.n_steps)
+        to_residual(prefix, jnp.asarray(server.local_batch(j))) for j in range(eval_cfg.n_steps)
     ]
 
     slow_eval_step = make_slow_eval_step(lm, eval_cfg.ci_alive_threshold)


### PR DESCRIPTION
## What

`open_jax_run` (`load_run.py`) raised `NotImplementedError` for non-SimpleMLP targets, leaving `jsp-slow-eval` and the app blocked on llama8b runs. This wires the llama8b build into the shared loader and routes `slow_eval.py` through it, so one loader covers both targets.

## Changes

- **`load_run.py`** — replace the `NotImplementedError` `TargetConfig` branch in the target builder with the llama8b build mirroring `run.py::main`: `llama_decomposed_lm` over `llama_site_specs`, `replicate_target(load_target_from_hf(...))` for the frozen suffix, `device_put(load_prefix_from_hf(...), P())` for the prefix, `prefix_residual` as the residual fn, `vocab_size` from `llama31_8b_config()`. Returns the same `(lm, target, prefix, prefix_residual_fn, vocab_size)` tuple the SimpleMLP branch returns, so `open_jax_run` / `LoadedJaxRun.forward` stay target-agnostic. Promoted `_build_target` → public `build_target`.
- **`slow_eval.py`** — delete the private SimpleMLP-only `_build_simple_mlp`; `run_offline_slow_eval` now builds its target through the shared `build_target` (and uses the returned `prefix_residual_fn` instead of hardcoding `llama_simple_mlp.prefix_residual`). SimpleMLP restore/forward behavior unchanged.

## Validation

- **SimpleMLP regression**: `jsp-slow-eval` on `p-761bc061` (4L SimpleMLP) produced all 5 figure PNGs unchanged (3 plot types; mean-CI emits linear + log).
- **llama8b loader**: no on-disk JAX llama8b run has a `config.yaml` wrapper or a checkpoint (all predate the consumable-run-dir convention; their schema yamls no longer validate against the current `LMExperimentConfig`), so a full `open_jax_run(run_dir)` restore couldn't be exercised on a real run. Instead exercised the new `build_target` branch directly on CPU with the real L18-MLP sites (`layers.18.mlp.{gate,up,down}_proj`, model `meta-llama/Llama-3.1-8B` from the local HF snapshot): HF suffix load + sharding, prefix forward → `(1,4,4096)` bf16 residual, full suffix `clean_output` → `(1,4,128256)` bf16 logits. The `NotImplementedError` is gone and the pieces wire together end-to-end.
- Full JAX suite green at both device counts (`pytest jax_single_pool/tests/`: 161 passed, default + `--xla_force_host_platform_device_count=4`); `make check-jax` clean; `make type` clean. Equivalence / stacked-parity goldens untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)