### PR TITLE
Smooth-L0 (Geman-McClure) importance-minimality loss

### DIFF
--- a/docs/smooth_l0_importance_minimality.md
+++ b/docs/smooth_l0_importance_minimality.md
@@ -1,0 +1,53 @@
+# Smooth-L0 importance-minimality — configs to run
+
+New CI-sparsity penalty `φ(c) = c²/(c²+γ²)` (Geman–McClure), an alternative to the `L_p`
+`ImportanceMinimalityLoss`. Flat gradient at 0, bounded `~0.65/γ` near `c≈γ` — no cliff as
+the threshold tightens (`L_p`'s `p·c^(p-1)` blows up as `c→0` for `p<1`). `SmoothL0ImportanceMinimalityLoss`
+in `param_decomp/metrics/smooth_l0_importance_minimality.py`.
+
+## Configs
+
+Both decompose `pile_llama_simple_mlp-4L` (target `t-9d2b8f02`), 400k-step schedule, and
+cross-log the *other* penalty's sparsity proxy at eval (`eval/loss/{ImportanceMinimalityLoss,
+SmoothL0ImportanceMinimalityLoss}_no_beta`) so the two are directly comparable on one run.
+
+- `param_decomp_lab/experiments/lm/pile_llama_simple_mlp-4L_impmin_lp.yaml` — L_p control
+  (`pnorm 2.0→0.4`) + smooth-L0 eval probe.
+- `param_decomp_lab/experiments/lm/pile_llama_simple_mlp-4L_impmin_smoothl0.yaml` — smooth-L0
+  driver (`γ 1.0→0.1`) + L_p eval probe.
+
+Both use `coeff: 2e-4`, `beta: 0.5`. The smooth-L0 loss scale (≈ active-count) differs from
+`L_p`'s, so sweep `coeff` (e.g. ×{0.3, 1, 3}) on each to trace the sparsity/faithfulness curve.
+
+## Run
+
+```bash
+source .venv/bin/activate
+pd-lm param_decomp_lab/experiments/lm/pile_llama_simple_mlp-4L_impmin_smoothl0.yaml \
+  --dp 8 --group smoothl0-vs-lp --tags smoothl0,c2e-4
+pd-lm param_decomp_lab/experiments/lm/pile_llama_simple_mlp-4L_impmin_lp.yaml \
+  --dp 8 --group smoothl0-vs-lp --tags lp,c2e-4
+```
+
+`batch_size` is global (split across ranks), so `--dp 8` and `--dp 16` give the same
+trajectory. Compare at 5k / 10k: `eval/.../CI_L0` total (sparsity, lower=sparser) vs
+`eval/ce_kl/kl_ci_masked` (faithfulness, lower=better) and `eval/loss/PGDReconLoss` (20-step
+adversarial). Parity = smooth-L0 matches/beats L_p's CI_L0-vs-KL frontier.
+
+## Another cluster / data
+
+Configs stream `danbraunai/pile-uncopyrighted-tok-shuffled` from HF (portable). If HF
+streaming is unavailable, point at a local snapshot instead:
+
+```yaml
+data:
+  dataset_name: parquet
+  data_files: {train: "<snapshot>/data/train-*.parquet", val: "<snapshot>/data/val-*.parquet"}
+```
+
+## Prior result
+
+A 10-run sweep on the sibling `feature/jax` branch (same loss math) found smooth-L0 **dominates
+the L_p trade-off** at 5k/10k — ~0.1–0.15 lower KL at matched CI_L0 and lower 20-step PGD
+recon, including a fast-anneal (γ→0.05 / p→0.4 by step 8k) cliff-regime pair. Re-running on
+`main` is the point of this PR.

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -33,6 +33,9 @@ from param_decomp.metrics.persistent_pgd_recon import (
 from param_decomp.metrics.pgd_masked_recon import PGDReconLossConfig
 from param_decomp.metrics.pgd_masked_recon_layerwise import PGDReconLayerwiseLossConfig
 from param_decomp.metrics.pgd_masked_recon_subset import PGDReconSubsetLossConfig
+from param_decomp.metrics.smooth_l0_importance_minimality import (
+    SmoothL0ImportanceMinimalityLossConfig,
+)
 from param_decomp.metrics.stochastic_hidden_acts_recon import StochasticHiddenActsReconLossConfig
 from param_decomp.metrics.stochastic_recon import StochasticReconLossConfig
 from param_decomp.metrics.stochastic_recon_layerwise import StochasticReconLayerwiseLossConfig
@@ -64,6 +67,7 @@ AnyLossMetricConfig = Annotated[
     | PGDReconLayerwiseLossConfig
     | PGDReconLossConfig
     | PGDReconSubsetLossConfig
+    | SmoothL0ImportanceMinimalityLossConfig
     | StochasticHiddenActsReconLossConfig
     | StochasticReconLayerwiseLossConfig
     | StochasticReconLossConfig

--- a/param_decomp/metrics/CLAUDE.md
+++ b/param_decomp/metrics/CLAUDE.md
@@ -33,6 +33,20 @@ entry. Duplicate `type` literals in a single config are rejected.
 A metric that wants to manipulate state coupled to backward overrides `before_backward`
 and/or `after_backward` (see PPGD for the canonical example).
 
+## Importance-minimality variants
+
+Two interchangeable CI-sparsity penalties, same `sum + beta·entropy` shape:
+
+- `ImportanceMinimalityLoss` (`importance_minimality.py`) — `L_p`: `(c + eps)^p`, `p`
+  annealed toward 0. Gradient `p·c^(p-1)` blows up as `c→0` for `p<1`.
+- `SmoothL0ImportanceMinimalityLoss` (`smooth_l0_importance_minimality.py`) — bounded
+  Geman–McClure `c²/(c²+γ²)`: flat at 0, saturating to 1, bounded gradient `~0.65/γ` near
+  `c≈γ`. Drop-in alternative avoiding the `L_p` cliff; `γ` anneals like `p`. Self-contained.
+
+Both are registered eval-side (`EVAL_METRIC_CLASSES` + `AnyEvalMetricConfig`), so a run driven
+by one can log the other as an eval-only sparsity proxy. The directly comparable cross-run
+sparsity number is `CI_L0`; each penalty's own `_no_beta` proxy is on its own scale.
+
 ## Metric identity (`instance_key`) and same-class loss + eval
 
 Metric instances are keyed everywhere — instance dicts, state-dict, and log-key

--- a/param_decomp/metrics/dispatch.py
+++ b/param_decomp/metrics/dispatch.py
@@ -20,6 +20,7 @@ from param_decomp.metrics.persistent_pgd_recon import (
 from param_decomp.metrics.pgd_masked_recon import PGDReconLoss
 from param_decomp.metrics.pgd_masked_recon_layerwise import PGDReconLayerwiseLoss
 from param_decomp.metrics.pgd_masked_recon_subset import PGDReconSubsetLoss
+from param_decomp.metrics.smooth_l0_importance_minimality import SmoothL0ImportanceMinimalityLoss
 from param_decomp.metrics.stochastic_hidden_acts_recon import StochasticHiddenActsReconLoss
 from param_decomp.metrics.stochastic_recon import StochasticReconLoss
 from param_decomp.metrics.stochastic_recon_layerwise import StochasticReconLayerwiseLoss
@@ -39,6 +40,7 @@ LOSS_METRIC_CLASSES: dict[str, type[Metric[Any]]] = {
         PGDReconLayerwiseLoss,
         PGDReconLoss,
         PGDReconSubsetLoss,
+        SmoothL0ImportanceMinimalityLoss,
         StochasticHiddenActsReconLoss,
         StochasticReconLayerwiseLoss,
         StochasticReconLoss,

--- a/param_decomp/metrics/smooth_l0_importance_minimality.py
+++ b/param_decomp/metrics/smooth_l0_importance_minimality.py
@@ -1,0 +1,197 @@
+"""Bounded smooth-L0 (Geman–McClure) importance-minimality penalty on CI values.
+
+A drop-in alternative to the `L_p` `ImportanceMinimalityLoss`: the per-CI-value penalty is
+`φ(c) = c² / (c² + γ²)` instead of `(c + eps)^p`. It is flat at 0 (`φ'(0)=0`) and has a
+bounded gradient (`~0.65/γ` near the threshold `c≈γ`), so there is no gradient cliff at the
+accumulation point where most components live (the `L_p` gradient `p·c^(p-1)` blows up as
+`c→0` for `p<1`). The per-component sum saturates to ≈ the active-component count. Self-
+contained (the entropy term and DDP-`world_size` handling mirror the `L_p` variant) so it adds
+no coupling to `importance_minimality.py`.
+"""
+
+from typing import Literal, override
+
+import torch
+from jaxtyping import Float
+from pydantic import NonNegativeFloat, PositiveFloat
+from torch import Tensor
+from torch.distributed import ReduceOp
+
+from param_decomp.base_config import Probability
+from param_decomp.distributed import all_reduce, get_distributed_state
+from param_decomp.metrics.base import LossMetricConfig, Metric, MetricResult
+from param_decomp.metrics.context import MetricContext
+
+
+class SmoothL0ImportanceMinimalityLossConfig(LossMetricConfig):
+    """Config for the bounded smooth-L0 (Geman–McClure) importance-minimality penalty.
+
+    `gamma` is the initial threshold `γ` in `φ(c) = c² / (c² + γ²)`; `beta` weights the same
+    entropy-like `mean * log2(1 + sum)` term used by the `L_p` variant, now over `φ`. `gamma`
+    is linearly annealed toward `gamma_final` between `gamma_anneal_start_frac` and
+    `gamma_anneal_end_frac` of training (no-op when `gamma_final is None` or
+    `gamma_anneal_start_frac == 1.0`).
+    """
+
+    type: Literal["SmoothL0ImportanceMinimalityLoss"] = "SmoothL0ImportanceMinimalityLoss"
+    gamma: PositiveFloat
+    beta: NonNegativeFloat
+    gamma_anneal_start_frac: Probability = 1.0
+    gamma_final: PositiveFloat | None = None
+    gamma_anneal_end_frac: Probability = 1.0
+
+
+def _get_linear_annealed_gamma(
+    current_frac_of_training: float,
+    initial_gamma: float,
+    gamma_anneal_start_frac: float,
+    gamma_final: float | None,
+    gamma_anneal_end_frac: float,
+) -> float:
+    if gamma_final is None or gamma_anneal_start_frac >= 1.0:
+        return initial_gamma
+    assert gamma_anneal_end_frac >= gamma_anneal_start_frac, (
+        f"gamma_anneal_end_frac ({gamma_anneal_end_frac}) must be >= "
+        f"gamma_anneal_start_frac ({gamma_anneal_start_frac})"
+    )
+    if current_frac_of_training < gamma_anneal_start_frac:
+        return initial_gamma
+    elif current_frac_of_training >= gamma_anneal_end_frac:
+        return gamma_final
+    progress = (current_frac_of_training - gamma_anneal_start_frac) / (
+        gamma_anneal_end_frac - gamma_anneal_start_frac
+    )
+    return initial_gamma + (gamma_final - initial_gamma) * progress
+
+
+def _per_component_sums(
+    ci_upper_leaky: dict[str, Float[Tensor, "... C"]],
+    gamma: float,
+) -> tuple[dict[str, Float[Tensor, " C"]], int]:
+    assert ci_upper_leaky, "Empty ci_upper_leaky"
+    assert gamma > 0.0, f"gamma must be positive, got {gamma}"
+    gamma_sq = gamma * gamma
+    out: dict[str, Float[Tensor, " C"]] = {}
+    for layer_name, layer_ci in ci_upper_leaky.items():
+        ci_sq = layer_ci * layer_ci
+        phi = ci_sq / (ci_sq + gamma_sq)
+        out[layer_name] = phi.sum(dim=tuple(range(phi.dim() - 1)))
+    n_examples = next(iter(ci_upper_leaky.values())).shape[:-1].numel()
+    return out, n_examples
+
+
+def _smooth_l0_and_entropy_terms(
+    per_component_sums: dict[str, Float[Tensor, " C"]],
+    n_examples: int,
+    world_size: int,
+) -> tuple[Float[Tensor, ""], Float[Tensor, ""]]:
+    """The two additive parts of the loss, summed over components: `(smooth_l0, entropy)`.
+
+    Full loss is `smooth_l0 + beta * entropy`; `smooth_l0` alone (≈ the active-component
+    count) is the beta-independent sparsity proxy.
+    """
+    device = next(iter(per_component_sums.values())).device
+    smooth_l0 = torch.zeros((), device=device)
+    entropy = torch.zeros((), device=device)
+    for layer_sums in per_component_sums.values():
+        per_component_mean = layer_sums / n_examples
+        smooth_l0 = smooth_l0 + per_component_mean.sum()
+        entropy = entropy + (per_component_mean * torch.log2(1 + layer_sums * world_size)).sum()
+    return smooth_l0, entropy
+
+
+def _finalize(
+    per_component_sums: dict[str, Float[Tensor, " C"]],
+    n_examples: int,
+    beta: float,
+    world_size: int,
+) -> Float[Tensor, ""]:
+    smooth_l0, entropy = _smooth_l0_and_entropy_terms(per_component_sums, n_examples, world_size)
+    return smooth_l0 + beta * entropy
+
+
+def smooth_l0_importance_minimality_loss(
+    ci_upper_leaky: dict[str, Float[Tensor, "... C"]],
+    current_frac_of_training: float,
+    gamma: float,
+    beta: float,
+    gamma_anneal_start_frac: float,
+    gamma_final: float | None,
+    gamma_anneal_end_frac: float,
+) -> Float[Tensor, ""]:
+    """Compute the smooth-L0 importance-minimality loss directly (helper for external callers)."""
+    annealed_gamma = _get_linear_annealed_gamma(
+        current_frac_of_training=current_frac_of_training,
+        initial_gamma=gamma,
+        gamma_anneal_start_frac=gamma_anneal_start_frac,
+        gamma_final=gamma_final,
+        gamma_anneal_end_frac=gamma_anneal_end_frac,
+    )
+    per_component_sums, n_examples = _per_component_sums(
+        ci_upper_leaky=ci_upper_leaky, gamma=annealed_gamma
+    )
+    dist_state = get_distributed_state()
+    world_size = dist_state.world_size if dist_state is not None else 1
+    return _finalize(
+        per_component_sums=per_component_sums,
+        n_examples=n_examples,
+        beta=beta,
+        world_size=world_size,
+    )
+
+
+class SmoothL0ImportanceMinimalityLoss(Metric[SmoothL0ImportanceMinimalityLossConfig]):
+    """Bounded smooth-L0 (Geman–McClure) penalty driving CI sparsity.
+
+    `c² / (c² + γ²)` summed across components plus a `beta`-weighted
+    `mean * log2(1 + sum)` term.
+    """
+
+    log_namespace = "loss"
+    short_name = "SmoothL0ImpMin"
+
+    @override
+    def reset(self) -> None:
+        self.per_component_sums: dict[str, Float[Tensor, " C"]] = {}
+        self.n_examples = torch.zeros((), device=self.device, dtype=torch.long)
+
+    @override
+    def update(self, ctx: MetricContext) -> Tensor:
+        gamma = _get_linear_annealed_gamma(
+            current_frac_of_training=ctx.current_frac_of_training,
+            initial_gamma=self.cfg.gamma,
+            gamma_anneal_start_frac=self.cfg.gamma_anneal_start_frac,
+            gamma_final=self.cfg.gamma_final,
+            gamma_anneal_end_frac=self.cfg.gamma_anneal_end_frac,
+        )
+        per_component_sums, n = _per_component_sums(
+            ci_upper_leaky=ctx.ci.upper_leaky,
+            gamma=gamma,
+        )
+        for layer_name, layer_sums in per_component_sums.items():
+            if layer_name not in self.per_component_sums:
+                self.per_component_sums[layer_name] = torch.zeros_like(layer_sums)
+            self.per_component_sums[layer_name] += layer_sums.detach()
+        self.n_examples += n
+
+        dist_state = get_distributed_state()
+        world_size = dist_state.world_size if dist_state is not None else 1
+        return _finalize(
+            per_component_sums=per_component_sums,
+            n_examples=n,
+            beta=self.cfg.beta,
+            world_size=world_size,
+        )
+
+    @override
+    def compute(self) -> MetricResult:
+        reduced_sums = {
+            k: all_reduce(v, op=ReduceOp.SUM) for k, v in self.per_component_sums.items()
+        }
+        n_examples = int(all_reduce(self.n_examples, op=ReduceOp.SUM))
+        smooth_l0, entropy = _smooth_l0_and_entropy_terms(reduced_sums, n_examples, world_size=1)
+        name = type(self).__name__
+        return {
+            name: smooth_l0 + self.cfg.beta * entropy,
+            f"{name}_no_beta": smooth_l0,
+        }

--- a/param_decomp/tests/metrics/test_smooth_l0_importance_minimality_loss.py
+++ b/param_decomp/tests/metrics/test_smooth_l0_importance_minimality_loss.py
@@ -1,0 +1,201 @@
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+from param_decomp.metrics.smooth_l0_importance_minimality import (
+    SmoothL0ImportanceMinimalityLoss,
+    SmoothL0ImportanceMinimalityLossConfig,
+    _get_linear_annealed_gamma,
+    smooth_l0_importance_minimality_loss,
+)
+
+
+def _loss(
+    ci_upper_leaky: dict[str, torch.Tensor],
+    *,
+    gamma: float,
+    beta: float = 0.0,
+    current_frac_of_training: float = 0.0,
+    gamma_anneal_start_frac: float = 1.0,
+    gamma_final: float | None = None,
+    gamma_anneal_end_frac: float = 1.0,
+) -> torch.Tensor:
+    return smooth_l0_importance_minimality_loss(
+        ci_upper_leaky=ci_upper_leaky,
+        current_frac_of_training=current_frac_of_training,
+        gamma=gamma,
+        beta=beta,
+        gamma_anneal_start_frac=gamma_anneal_start_frac,
+        gamma_final=gamma_final,
+        gamma_anneal_end_frac=gamma_anneal_end_frac,
+    )
+
+
+class TestSmoothL0Penalty:
+    def test_phi_values(self: object) -> None:
+        # phi(c) = c^2 / (c^2 + gamma^2): phi(0)=0, phi(gamma)=0.5, phi(c>>gamma)~1.
+        ci = {"layer1": torch.tensor([[0.0, 1.0, 1e6]], dtype=torch.float32)}
+        # gamma=1: [0, 1/2, ~1] -> sum 1.5
+        result = _loss(ci, gamma=1.0)
+        assert torch.allclose(result, torch.tensor(1.5), atol=1e-5)
+
+    def test_saturates_to_active_count(self: object) -> None:
+        # Large activations saturate phi to ~1, so the sum counts active components.
+        ci = {"layer1": torch.tensor([[5.0, 5.0, 5.0, 5.0]], dtype=torch.float32)}
+        result = _loss(ci, gamma=0.1)
+        assert torch.allclose(result, torch.tensor(4.0), atol=1e-2)
+
+    def test_flat_finite_gradient_at_zero(self: object) -> None:
+        """The defining property: gradient is finite and ~0 at c=0 (no L_p cliff)."""
+        ci = torch.zeros((1, 4), dtype=torch.float32, requires_grad=True)
+        result = _loss({"layer1": ci}, gamma=0.5)
+        result.backward()
+        assert ci.grad is not None
+        assert torch.isfinite(ci.grad).all()
+        assert torch.allclose(ci.grad, torch.zeros_like(ci.grad))
+
+    def test_gradient_bounded_and_peaks_near_gamma(self: object) -> None:
+        # dphi/dc = 2 c gamma^2 / (c^2+gamma^2)^2, max 0.65/gamma at c=gamma/sqrt(3).
+        gamma = 0.1
+        # one position, 200 components, so finalize divides by n_examples=1 and each
+        # component's grad is the raw dphi/dc.
+        cs = torch.linspace(0.0, 1.0, 200, dtype=torch.float64).reshape(1, -1)
+        cs.requires_grad_(True)
+        out = _loss({"layer1": cs}, gamma=gamma)
+        out.backward()
+        grad = cs.grad
+        assert grad is not None
+        max_grad = grad.abs().max().item()
+        expected_max = (3.0**1.5) / (8.0 * gamma)  # ~0.6495/gamma
+        assert max_grad <= expected_max + 1e-3
+        assert math.isclose(max_grad, expected_max, rel_tol=2e-2)
+        argmax_c = cs.flatten()[grad.abs().argmax()].item()
+        assert math.isclose(argmax_c, gamma / math.sqrt(3.0), abs_tol=0.01)
+
+    def test_multiple_layers_aggregation(self: object) -> None:
+        ci = {
+            "layer1": torch.tensor([[1.0, 1.0]], dtype=torch.float32),
+            "layer2": torch.tensor([[1.0]], dtype=torch.float32),
+        }
+        # gamma=1: every phi=0.5 -> 0.5+0.5 + 0.5 = 1.5
+        result = _loss(ci, gamma=1.0)
+        assert torch.allclose(result, torch.tensor(1.5))
+
+    def test_beta_logarithmic_penalty(self: object) -> None:
+        ci = {"layer1": torch.tensor([[1.0, 1.0], [1.0, 1.0]], dtype=torch.float32)}
+        # gamma=1: phi=0.5 everywhere. per_component_sums=[1,1], n=2, mean=[0.5,0.5].
+        # no_beta = sum(mean) = 1.0
+        # beta term per comp = mean * log2(1 + sum) = 0.5 * log2(2) = 0.5 -> total 1.0
+        loss_b0 = _loss(ci, gamma=1.0, beta=0.0)
+        loss_b1 = _loss(ci, gamma=1.0, beta=1.0)
+        assert torch.allclose(loss_b0, torch.tensor(1.0))
+        assert torch.allclose(loss_b1, torch.tensor(1.0 + 1.0))
+        assert loss_b1 > loss_b0
+
+    def test_finite_for_extreme_values(self: object) -> None:
+        for vals in ([[1e-12, 1e-12]], [[1e8, 1e8]]):
+            ci = {"layer1": torch.tensor(vals, dtype=torch.float32)}
+            result = _loss(ci, gamma=0.3, beta=1.0)
+            assert torch.isfinite(result)
+            assert result >= 0
+
+
+class TestAnnealedGamma:
+    def test_no_anneal_when_final_none(self: object) -> None:
+        assert _get_linear_annealed_gamma(0.9, 1.0, 0.0, None, 1.0) == 1.0
+
+    def test_before_start(self: object) -> None:
+        assert _get_linear_annealed_gamma(0.1, 1.0, 0.5, 0.1, 1.0) == 1.0
+
+    def test_during(self: object) -> None:
+        # halfway through [0.0, 1.0]: 1.0 + (0.1 - 1.0) * 0.5 = 0.55
+        assert math.isclose(_get_linear_annealed_gamma(0.5, 1.0, 0.0, 0.1, 1.0), 0.55)
+
+    def test_after_end(self: object) -> None:
+        assert _get_linear_annealed_gamma(0.9, 1.0, 0.0, 0.1, 0.5) == 0.1
+
+
+@dataclass
+class _FakeCI:
+    upper_leaky: dict[str, torch.Tensor]
+    lower_leaky: dict[str, torch.Tensor]
+    pre_sigmoid: dict[str, torch.Tensor]
+
+
+@dataclass
+class _FakeCtx:
+    ci: _FakeCI
+    current_frac_of_training: float
+
+
+def _make_bound_metric(
+    *, gamma: float, beta: float, device: str = "cpu"
+) -> SmoothL0ImportanceMinimalityLoss:
+    cfg = SmoothL0ImportanceMinimalityLossConfig(coeff=1.0, gamma=gamma, beta=beta)
+    m = SmoothL0ImportanceMinimalityLoss(cfg)
+    m.model = None  # pyright: ignore[reportAttributeAccessIssue]
+    m.device = device
+    m._bound = True
+    m.reset()
+    return m
+
+
+class TestSmoothL0Update:
+    def test_update_matches_closed_form(self: object) -> None:
+        ci = {"layer1": torch.tensor([[1.0, 1.0], [1.0, 1.0]], dtype=torch.float32)}
+        m = _make_bound_metric(gamma=1.0, beta=1.0)
+        ctx: Any = _FakeCtx(
+            ci=_FakeCI(upper_leaky=ci, lower_leaky={}, pre_sigmoid={}),
+            current_frac_of_training=0.0,
+        )
+        live = m.update(ctx)
+        assert torch.allclose(live, torch.tensor(2.0, dtype=torch.float32))
+
+    def test_update_matches_compute_single_rank(self: object) -> None:
+        ci = {"layer1": torch.tensor([[0.5, 1.5], [2.5, 3.5]], dtype=torch.float32)}
+        m = _make_bound_metric(gamma=0.7, beta=0.3)
+        ctx: Any = _FakeCtx(
+            ci=_FakeCI(upper_leaky=ci, lower_leaky={}, pre_sigmoid={}),
+            current_frac_of_training=0.0,
+        )
+        live = m.update(ctx)
+        evaluated = m.compute()
+        assert isinstance(evaluated, dict)
+        assert torch.allclose(live, evaluated["SmoothL0ImportanceMinimalityLoss"])
+
+    def test_update_returns_grad_tracking_scalar(self: object) -> None:
+        ci = torch.tensor([[0.2, 0.4]], dtype=torch.float32, requires_grad=True)
+        m = _make_bound_metric(gamma=0.5, beta=0.0)
+        ctx: Any = _FakeCtx(
+            ci=_FakeCI(upper_leaky={"layer1": ci}, lower_leaky={}, pre_sigmoid={}),
+            current_frac_of_training=0.0,
+        )
+        live = m.update(ctx)
+        live.backward()
+        assert ci.grad is not None
+        # beta=0, n=1: grad wrt c = dphi/dc = 2 c gamma^2 / (c^2 + gamma^2)^2
+        g2 = 0.5**2
+        expected = 2.0 * ci.detach() * g2 / (ci.detach() ** 2 + g2) ** 2
+        assert torch.allclose(ci.grad, expected, atol=1e-6)
+
+    def test_compute_logs_beta_and_no_beta(self: object) -> None:
+        m = _make_bound_metric(gamma=1.0, beta=1.0)
+        # phi=0.5 sums: per_component_sums=[1,1], n=2 -> mean=[0.5,0.5]
+        m.per_component_sums = {"layer1": torch.tensor([1.0, 1.0])}
+        m.n_examples = torch.tensor(2, dtype=torch.long)
+        out = m.compute()
+        assert isinstance(out, dict)
+        assert set(out) == {
+            "SmoothL0ImportanceMinimalityLoss",
+            "SmoothL0ImportanceMinimalityLoss_no_beta",
+        }
+        expected_no_beta = 1.0
+        expected_with_beta = 1.0 + (0.5 * math.log2(2) + 0.5 * math.log2(2))
+        assert torch.allclose(
+            out["SmoothL0ImportanceMinimalityLoss_no_beta"], torch.tensor(expected_no_beta)
+        )
+        assert torch.allclose(
+            out["SmoothL0ImportanceMinimalityLoss"], torch.tensor(expected_with_beta)
+        )

--- a/param_decomp_lab/eval_metrics/__init__.py
+++ b/param_decomp_lab/eval_metrics/__init__.py
@@ -10,7 +10,15 @@ from typing import Annotated, Any
 from pydantic import Discriminator
 
 from param_decomp.metrics.base import Metric
+from param_decomp.metrics.importance_minimality import (
+    ImportanceMinimalityLoss,
+    ImportanceMinimalityLossConfig,
+)
 from param_decomp.metrics.pgd_masked_recon import PGDReconLoss, PGDReconLossConfig
+from param_decomp.metrics.smooth_l0_importance_minimality import (
+    SmoothL0ImportanceMinimalityLoss,
+    SmoothL0ImportanceMinimalityLossConfig,
+)
 from param_decomp.metrics.stochastic_hidden_acts_recon import (
     StochasticHiddenActsReconLoss,
     StochasticHiddenActsReconLossConfig,
@@ -49,8 +57,10 @@ AnyEvalMetricConfig = Annotated[
     | CIMeanPerComponentConfig
     | ComponentActivationDensityConfig
     | IdentityCIErrorConfig
+    | ImportanceMinimalityLossConfig
     | PermutedCIPlotsConfig
     | PGDReconLossConfig
+    | SmoothL0ImportanceMinimalityLossConfig
     | StochasticAttnPatternsReconLossConfig
     | StochasticHiddenActsReconLossConfig
     | UVPlotsConfig,
@@ -68,8 +78,10 @@ EVAL_METRIC_CLASSES: dict[str, type[Metric[Any]]] = {
         CIMeanPerComponent,
         ComponentActivationDensity,
         IdentityCIError,
+        ImportanceMinimalityLoss,
         PermutedCIPlots,
         PGDReconLoss,
+        SmoothL0ImportanceMinimalityLoss,
         StochasticAttnPatternsReconLoss,
         StochasticHiddenActsReconLoss,
         UVPlots,

--- a/param_decomp_lab/experiments/lm/pile_llama_simple_mlp-4L_impmin_lp.yaml
+++ b/param_decomp_lab/experiments/lm/pile_llama_simple_mlp-4L_impmin_lp.yaml
@@ -1,0 +1,147 @@
+pd:
+  seed: 0
+  n_mask_samples: 1
+  ci_config:
+    mode: global
+    fn_type: global_shared_transformer
+    hidden_dims: null
+    simple_transformer_ci_cfg:
+      d_model: 2048
+      n_blocks: 8
+      mlp_hidden_dim:
+      - 8192
+      attn_config:
+        n_heads: 16
+        max_len: 512
+        rope_base: 10000.0
+  sampling: continuous
+  sigmoid_type: leaky_hard
+  decomposition_targets:
+  - module_pattern: h.*.mlp.c_fc
+    C: 3072
+  - module_pattern: h.*.mlp.down_proj
+    C: 3584
+  - module_pattern: h.*.attn.q_proj
+    C: 512
+  - module_pattern: h.*.attn.k_proj
+    C: 512
+  - module_pattern: h.*.attn.v_proj
+    C: 1024
+  - module_pattern: h.*.attn.o_proj
+    C: 1024
+  identity_decomposition_targets: null
+  use_delta_component: true
+  components_optimizer:
+    lr_schedule:
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+      final_val_frac: 0.1
+      fn_type: cosine
+    grad_clip_norm: 0.01
+  ci_fn_optimizer:
+    lr_schedule:
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+      final_val_frac: 0.1
+      fn_type: cosine
+  steps: 400000
+  batch_size: 64
+  faithfulness_warmup_steps: 400
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_weight_decay: 0.0
+  loss_metrics:
+    - type: ImportanceMinimalityLoss
+      coeff: 0.0002
+      pnorm: 2.0
+      beta: 0.5
+      p_anneal_start_frac: 0.0
+      p_anneal_final_p: 0.4
+      p_anneal_end_frac: 1.0
+      eps: 1.0e-12
+    - type: StochasticReconSubsetLoss
+      coeff: 0.5
+      routing:
+        type: uniform_k_subset
+    - type: PersistentPGDReconLoss
+      coeff: 0.5
+      optimizer:
+        type: adam
+        beta1: 0.5
+        beta2: 0.99
+        eps: 1.0e-08
+        lr_schedule:
+          start_val: 0.01
+          warmup_pct: 0.025
+          final_val_frac: 1.0
+          fn_type: constant
+      scope:
+        type: per_batch_per_position
+      use_sigmoid_parameterization: false
+      n_warmup_steps: 2
+    - type: FaithfulnessLoss
+      coeff: 10000000.0
+cadence:
+  train_log_every: 200
+eval:
+  n_steps: 1
+  batch_size: 128
+  every: 1000
+  slow_every: 10000
+  slow_on_first_step: true
+  metrics:
+    - type: CIHistograms
+      n_batches_accum: 1
+    - type: ComponentActivationDensity
+    - type: CI_L0
+      groups:
+        layer_0:
+        - h.0.*
+        layer_1:
+        - h.1.*
+        layer_2:
+        - h.2.*
+        layer_3:
+        - h.3.*
+        total:
+        - '*'
+    - type: CEandKLLosses
+      rounding_threshold: 0.0
+    - type: CIMeanPerComponent
+    - type: StochasticHiddenActsReconLoss
+    - type: CIHiddenActsReconLoss
+    - type: PGDReconLoss
+      init: random
+      step_size: 0.1
+      n_steps: 20
+      mask_scope: shared_across_batch
+    # Cross-logged sparsity proxy: smooth-L0 measured on the L_p-driven trajectory.
+    # Eval-only (no coeff); gamma anneal mirrors the L_p pnorm anneal schedule.
+    - type: SmoothL0ImportanceMinimalityLoss
+      gamma: 1.0
+      beta: 0.5
+      gamma_anneal_start_frac: 0.0
+      gamma_final: 0.1
+      gamma_anneal_end_frac: 1.0
+target:
+  spec:
+    kind: pretrained
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
+    run_path: goodfire/spd/runs/t-9d2b8f02
+  output_extract: 0
+data:
+  tokenizer_name: EleutherAI/gpt-neox-20b
+  max_seq_len: 512
+  buffer_size: 1000
+  dataset_name: danbraunai/pile-uncopyrighted-tok-shuffled
+  column_name: input_ids
+  train_split: train
+  eval_split: val
+  shuffle_each_epoch: true
+  is_tokenized: true
+  streaming: true
+runtime:
+  autocast_bf16: true
+  device: cuda
+  dp: null
+wandb:
+  project: param-decomp

--- a/param_decomp_lab/experiments/lm/pile_llama_simple_mlp-4L_impmin_smoothl0.yaml
+++ b/param_decomp_lab/experiments/lm/pile_llama_simple_mlp-4L_impmin_smoothl0.yaml
@@ -1,0 +1,149 @@
+pd:
+  seed: 0
+  n_mask_samples: 1
+  ci_config:
+    mode: global
+    fn_type: global_shared_transformer
+    hidden_dims: null
+    simple_transformer_ci_cfg:
+      d_model: 2048
+      n_blocks: 8
+      mlp_hidden_dim:
+      - 8192
+      attn_config:
+        n_heads: 16
+        max_len: 512
+        rope_base: 10000.0
+  sampling: continuous
+  sigmoid_type: leaky_hard
+  decomposition_targets:
+  - module_pattern: h.*.mlp.c_fc
+    C: 3072
+  - module_pattern: h.*.mlp.down_proj
+    C: 3584
+  - module_pattern: h.*.attn.q_proj
+    C: 512
+  - module_pattern: h.*.attn.k_proj
+    C: 512
+  - module_pattern: h.*.attn.v_proj
+    C: 1024
+  - module_pattern: h.*.attn.o_proj
+    C: 1024
+  identity_decomposition_targets: null
+  use_delta_component: true
+  components_optimizer:
+    lr_schedule:
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+      final_val_frac: 0.1
+      fn_type: cosine
+    grad_clip_norm: 0.01
+  ci_fn_optimizer:
+    lr_schedule:
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+      final_val_frac: 0.1
+      fn_type: cosine
+  steps: 400000
+  batch_size: 64
+  faithfulness_warmup_steps: 400
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_weight_decay: 0.0
+  loss_metrics:
+    # Smooth-L0 (Geman-McClure) importance-minimality driver, replacing the L_p penalty.
+    # gamma anneal 1.0 -> 0.1 mirrors the baseline's pnorm 2.0 -> 0.4 anneal structure.
+    - type: SmoothL0ImportanceMinimalityLoss
+      coeff: 0.0002
+      gamma: 1.0
+      beta: 0.5
+      gamma_anneal_start_frac: 0.0
+      gamma_final: 0.1
+      gamma_anneal_end_frac: 1.0
+    - type: StochasticReconSubsetLoss
+      coeff: 0.5
+      routing:
+        type: uniform_k_subset
+    - type: PersistentPGDReconLoss
+      coeff: 0.5
+      optimizer:
+        type: adam
+        beta1: 0.5
+        beta2: 0.99
+        eps: 1.0e-08
+        lr_schedule:
+          start_val: 0.01
+          warmup_pct: 0.025
+          final_val_frac: 1.0
+          fn_type: constant
+      scope:
+        type: per_batch_per_position
+      use_sigmoid_parameterization: false
+      n_warmup_steps: 2
+    - type: FaithfulnessLoss
+      coeff: 10000000.0
+cadence:
+  train_log_every: 200
+eval:
+  n_steps: 1
+  batch_size: 128
+  every: 1000
+  slow_every: 10000
+  slow_on_first_step: true
+  metrics:
+    - type: CIHistograms
+      n_batches_accum: 1
+    - type: ComponentActivationDensity
+    - type: CI_L0
+      groups:
+        layer_0:
+        - h.0.*
+        layer_1:
+        - h.1.*
+        layer_2:
+        - h.2.*
+        layer_3:
+        - h.3.*
+        total:
+        - '*'
+    - type: CEandKLLosses
+      rounding_threshold: 0.0
+    - type: CIMeanPerComponent
+    - type: StochasticHiddenActsReconLoss
+    - type: CIHiddenActsReconLoss
+    - type: PGDReconLoss
+      init: random
+      step_size: 0.1
+      n_steps: 20
+      mask_scope: shared_across_batch
+    # Cross-logged sparsity proxy: the baseline L_p penalty measured on the
+    # smooth-L0-driven trajectory. Eval-only (no coeff); params match the baseline.
+    - type: ImportanceMinimalityLoss
+      pnorm: 2.0
+      beta: 0.5
+      p_anneal_start_frac: 0.0
+      p_anneal_final_p: 0.4
+      p_anneal_end_frac: 1.0
+      eps: 1.0e-12
+target:
+  spec:
+    kind: pretrained
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
+    run_path: goodfire/spd/runs/t-9d2b8f02
+  output_extract: 0
+data:
+  tokenizer_name: EleutherAI/gpt-neox-20b
+  max_seq_len: 512
+  buffer_size: 1000
+  dataset_name: danbraunai/pile-uncopyrighted-tok-shuffled
+  column_name: input_ids
+  train_split: train
+  eval_split: val
+  shuffle_each_epoch: true
+  is_tokenized: true
+  streaming: true
+runtime:
+  autocast_bf16: true
+  device: cuda
+  dp: null
+wandb:
+  project: param-decomp


### PR DESCRIPTION
## What

Adds **`SmoothL0ImportanceMinimalityLoss`** — a bounded smooth-L0 CI-sparsity penalty
`φ(c) = c²/(c²+γ²)` (Geman–McClure) as an alternative to the existing `L_p`
`ImportanceMinimalityLoss`. The `L_p` penalty's gradient `p·c^(p-1)` blows up as `c→0` for
`p<1` (an infinite cliff at the accumulation point where most components sit). Smooth-L0 is:

- **flat at 0** (`φ'(0)=0`) — no cliff,
- **saturating to 1** (so the per-component sum ≈ the active-component count),
- **bounded gradient** (`~0.65/γ` at the meaningful threshold `c≈γ`).

`γ` anneals like `p`. The implementation is **self-contained** — it does not modify
`importance_minimality.py`.

## Changes

- `param_decomp/metrics/smooth_l0_importance_minimality.py` — loss + config (`gamma`, `beta`,
  `gamma_final`, anneal fracs), mirroring the `L_p` structure (entropy term, DDP `world_size`
  handling, un-namespaced `{name}`/`{name}_no_beta` compute keys).
- Registered loss-side (`configs.py` `AnyLossMetricConfig`, `dispatch.py`) and **both**
  imp-min metrics eval-side (`param_decomp_lab/eval_metrics/__init__.py`) so a run driven by
  one logs the other's sparsity proxy as an eval-only metric.
- `param_decomp/tests/metrics/test_smooth_l0_importance_minimality_loss.py` — 15 tests incl.
  the defining flat-finite-gradient-at-0 and bounded-gradient-peaks-at-γ checks.
- Two cross-logging comparison configs off `pile_llama_simple_mlp-4L.yaml`:
  `..._impmin_lp.yaml` (L_p control + smooth-L0 eval probe) and `..._impmin_smoothl0.yaml`
  (smooth-L0 driver + L_p eval probe).
- `docs/smooth_l0_importance_minimality.md` — short note: the configs, run commands, the
  metrics to compare, and a local-data fallback for clusters where HF streaming is down.
- `param_decomp/metrics/CLAUDE.md` — variants note.

## How to compare

```bash
pd-lm param_decomp_lab/experiments/lm/pile_llama_simple_mlp-4L_impmin_smoothl0.yaml --dp 8 --group smoothl0-vs-lp
pd-lm param_decomp_lab/experiments/lm/pile_llama_simple_mlp-4L_impmin_lp.yaml       --dp 8 --group smoothl0-vs-lp
```

Compare at 5k/10k: `eval/.../CI_L0` total (sparsity) vs `eval/ce_kl/kl_ci_masked` and
`eval/loss/PGDReconLoss` (faithfulness). `batch_size` is global, so `--dp 8` ≡ `--dp 16`
trajectory. Sweep `coeff` on each to trace the full sparsity/faithfulness frontier (smooth-L0's
loss scale ≈ active-count, so its `coeff` is not 1:1 with `L_p`'s).

## Prior validation (sibling `feature/jax` branch, same loss math)

A 10-run sweep found smooth-L0 **dominates the `L_p` sparsity/faithfulness trade-off** at 5k/10k
— ~0.1–0.15 lower KL at matched CI_L0 and lower 20-step adversarial PGD recon, including a
fast-anneal cliff-regime (γ→0.05 / p→0.4 by step 8k) pair, training stably. Re-running this on
`main` is the purpose of this PR.

Caveat: only early training (5k/10k) was tested; the long-horizon collapse-robustness story is
not yet evaluated.

## Test

`pytest param_decomp/tests/metrics/test_smooth_l0_importance_minimality_loss.py` (15 passed);
basedpyright + ruff clean (pre-commit).