### PR TITLE
fix(jax): tighten Anys + fail-fast asserts (review pass)

### DIFF
--- a/param_decomp_jax/jax_single_pool/config.py
+++ b/param_decomp_jax/jax_single_pool/config.py
@@ -230,7 +230,7 @@ def _site_cs(cfg: LMExperimentConfig) -> tuple[SiteC, ...]:
     return canonical_site_cs(tuple(site_cs))
 
 
-def _resolve_target(cfg: LMExperimentConfig) -> "TargetConfig | LlamaSimpleMLPTargetConfig":
+def _resolve_target(cfg: LMExperimentConfig) -> AnyTargetConfig:
     """Target spec + decomposition patterns -> the JAX target config.
 
     Vendored and raw-HF Llama specs load the SAME meta-llama weights (the export

--- a/param_decomp_jax/jax_single_pool/hidden_acts_eval.py
+++ b/param_decomp_jax/jax_single_pool/hidden_acts_eval.py
@@ -34,6 +34,7 @@ from jaxtyping import Array, Float, PRNGKeyArray
 
 from jax_single_pool.lm import DecomposedModel
 from jax_single_pool.train import COMPUTE_DT, cast_floating
+from param_decomp_config.routing import SamplingType
 
 
 @dataclass(frozen=True)
@@ -105,12 +106,11 @@ def make_ci_hidden_acts_step(lm: DecomposedModel) -> HiddenActsStep:
 
 
 def make_stochastic_hidden_acts_step(
-    lm: DecomposedModel, n_mask_samples: int, sampling: str
+    lm: DecomposedModel, n_mask_samples: int, sampling: SamplingType
 ) -> HiddenActsStep:
     """Stochastic-mask hidden-acts step: `n_mask_samples` draws of `mask = ci + (1−ci)·s`
     (with weight deltas), per-draw per-site MSE summed. RNG via per-draw / per-site
     `fold_in` (the eval-step discipline, mirrors `train.stochastic_entry_masks`)."""
-    assert sampling in ("continuous", "binomial"), sampling
     assert n_mask_samples >= 1, n_mask_samples
     site_names = lm.site_names
 

--- a/param_decomp_jax/jax_single_pool/load_run.py
+++ b/param_decomp_jax/jax_single_pool/load_run.py
@@ -35,6 +35,7 @@ from jaxtyping import Array, Float, Int
 
 from jax_single_pool import llama_simple_mlp
 from jax_single_pool.checkpoint import make_checkpoint_manager, restore_latest, restore_step
+from jax_single_pool.ci_fn import CIFn
 from jax_single_pool.config import (
     ExperimentConfig,
     LlamaSimpleMLPTargetConfig,
@@ -55,6 +56,7 @@ from jax_single_pool.llama8b_sharding import replicate_target
 from jax_single_pool.lm import DecomposedModel
 from jax_single_pool.run_state import build_optimizers, init_train_state
 from jax_single_pool.sharding import dp_mesh
+from jax_single_pool.target_aliases import AnyFrozenTarget, AnyPrefix
 from jax_single_pool.train import COMPUTE_DT, TrainState, cast_floating
 
 
@@ -70,7 +72,7 @@ class HarvestForward:
 
 def build_target(
     cfg: ExperimentConfig, mesh: jax.sharding.Mesh
-) -> tuple[DecomposedModel, Any, Any, Callable[[Any, Any], jax.Array], int]:
+) -> tuple[DecomposedModel, AnyFrozenTarget, AnyPrefix, Callable[[Any, Any], jax.Array], int]:
     """`(lm, frozen target, prefix, prefix_residual_fn, vocab_size)` for the run's target
     config. SimpleMLP reads its local pretrain cache (no network); llama8b reads the HF
     snapshot (frozen bf16 target + fp32-compute, matching `run.py::main`)."""
@@ -130,7 +132,10 @@ class LoadedJaxRun:
     config: ExperimentConfig
     vocab_size: int
     _state: TrainState
-    _forward: Any
+    _forward: Callable[
+        [DecompVU, CIFn, Int[Array, "B T"]],
+        tuple[dict[str, Array], dict[str, Array], Array],
+    ]
 
     @property
     def site_names(self) -> tuple[str, ...]:
@@ -177,7 +182,7 @@ def open_jax_run(run_dir: Path, step: int | None = None) -> LoadedJaxRun:
 
     @jax.jit
     def forward(
-        components: DecompVU, ci_fn: Any, token_ids: Int[Array, "B T"]
+        components: DecompVU, ci_fn: CIFn, token_ids: Int[Array, "B T"]
     ) -> tuple[dict[str, Array], dict[str, Array], Array]:
         residual = prefix_residual_fn(prefix, token_ids)
         clean_output = lm.clean_output(target, residual)

--- a/param_decomp_jax/jax_single_pool/recon.py
+++ b/param_decomp_jax/jax_single_pool/recon.py
@@ -42,6 +42,7 @@ from param_decomp_config.losses import (
 from param_decomp_config.pd import AnyLossMetricConfig
 from param_decomp_config.routing import (
     AllRoutingConfig,
+    SamplingType,
     StaticProbabilityRoutingConfig,
     SubsetRoutingType,
     UniformKSubsetRoutingConfig,
@@ -66,7 +67,7 @@ sampler identities, family sizes — is static; only the key varies per step."""
 class StochasticSources:
     """Fresh per-draw sources: components `U[0,1]` (or Bernoulli), delta `U[0,1]`."""
 
-    sampling: Literal["continuous", "binomial"]
+    sampling: SamplingType
 
 
 @dataclass(frozen=True)
@@ -297,10 +298,10 @@ def _assert_supported_persistent(cfg: PersistentPGDReconLossConfig) -> None:
 
 
 def build_recon_terms(
-    loss_metrics: tuple[AnyLossMetricConfig, ...] | list[AnyLossMetricConfig],
+    loss_metrics: tuple[AnyLossMetricConfig, ...],
     site_names: tuple[str, ...],
     n_mask_samples: int,
-    sampling: Literal["continuous", "binomial"],
+    sampling: SamplingType,
 ) -> LossSpec:
     """Map the shared torch loss configs onto recon terms (LOSS_PARITY_DESIGN §3).
 
@@ -312,7 +313,7 @@ def build_recon_terms(
     terms: list[ReconLossTerm] = []
     persistent: dict[str, PersistentPGDReconLossConfig] = {}
 
-    def instance_key(cfg: AnyLossMetricConfig) -> str:
+    def assert_unique_instance_key(cfg: AnyLossMetricConfig) -> str:
         name = cfg.name if cfg.name is not None else cfg.type
         assert all(t.name != name for t in terms), f"duplicate loss instance_key {name!r}"
         return name
@@ -332,17 +333,17 @@ def build_recon_terms(
                 plan = make_plan(
                     one_chunk(site_names), AllRoutingConfig(), ConstantSources(value), n_samples=1
                 )
-                terms.append(ReconLossTerm(instance_key(cfg), cfg.coeff, plan))
+                terms.append(ReconLossTerm(assert_unique_instance_key(cfg), cfg.coeff, plan))
             case CIMaskedReconSubsetLossConfig():
                 plan = make_plan(
                     one_chunk(site_names), cfg.routing, ConstantSources(0.0), n_samples=1
                 )
-                terms.append(ReconLossTerm(instance_key(cfg), cfg.coeff, plan))
+                terms.append(ReconLossTerm(assert_unique_instance_key(cfg), cfg.coeff, plan))
             case CIMaskedReconLayerwiseLossConfig():
                 plan = make_plan(
                     per_site(site_names), AllRoutingConfig(), ConstantSources(0.0), n_samples=1
                 )
-                terms.append(ReconLossTerm(instance_key(cfg), cfg.coeff, plan))
+                terms.append(ReconLossTerm(assert_unique_instance_key(cfg), cfg.coeff, plan))
             case StochasticReconLossConfig():
                 plan = make_plan(
                     one_chunk(site_names),
@@ -350,12 +351,12 @@ def build_recon_terms(
                     StochasticSources(sampling),
                     n_mask_samples,
                 )
-                terms.append(ReconLossTerm(instance_key(cfg), cfg.coeff, plan))
+                terms.append(ReconLossTerm(assert_unique_instance_key(cfg), cfg.coeff, plan))
             case StochasticReconSubsetLossConfig():
                 plan = make_plan(
                     one_chunk(site_names), cfg.routing, StochasticSources(sampling), n_mask_samples
                 )
-                terms.append(ReconLossTerm(instance_key(cfg), cfg.coeff, plan))
+                terms.append(ReconLossTerm(assert_unique_instance_key(cfg), cfg.coeff, plan))
             case StochasticReconLayerwiseLossConfig():
                 plan = make_plan(
                     per_site(site_names),
@@ -363,7 +364,7 @@ def build_recon_terms(
                     StochasticSources(sampling),
                     n_mask_samples,
                 )
-                terms.append(ReconLossTerm(instance_key(cfg), cfg.coeff, plan))
+                terms.append(ReconLossTerm(assert_unique_instance_key(cfg), cfg.coeff, plan))
             case ChunkwiseSubsetReconLossConfig():
                 assert isinstance(cfg.routing, UniformKSubsetRoutingConfig), cfg.routing
                 plan = make_plan(
@@ -372,21 +373,21 @@ def build_recon_terms(
                     StochasticSources(sampling),
                     cfg.n_samples,
                 )
-                terms.append(ReconLossTerm(instance_key(cfg), cfg.coeff, plan))
+                terms.append(ReconLossTerm(assert_unique_instance_key(cfg), cfg.coeff, plan))
             case PGDReconLossConfig() | PGDReconSubsetLossConfig():
                 fresh = FreshPGDSources(cfg.init, cfg.n_steps, cfg.step_size, cfg.mask_scope)
                 routing = (
                     cfg.routing if isinstance(cfg, PGDReconSubsetLossConfig) else AllRoutingConfig()
                 )
                 plan = make_plan(one_chunk(site_names), routing, fresh, n_samples=1)
-                terms.append(ReconLossTerm(instance_key(cfg), cfg.coeff, plan))
+                terms.append(ReconLossTerm(assert_unique_instance_key(cfg), cfg.coeff, plan))
             case PGDReconLayerwiseLossConfig():
                 fresh = FreshPGDSources(cfg.init, cfg.n_steps, cfg.step_size, cfg.mask_scope)
                 plan = make_plan(per_site(site_names), AllRoutingConfig(), fresh, n_samples=1)
-                terms.append(ReconLossTerm(instance_key(cfg), cfg.coeff, plan))
+                terms.append(ReconLossTerm(assert_unique_instance_key(cfg), cfg.coeff, plan))
             case PersistentPGDReconLossConfig():
                 _assert_supported_persistent(cfg)
-                key = instance_key(cfg)
+                key = assert_unique_instance_key(cfg)
                 assert key not in persistent
                 persistent[key] = cfg
                 plan = make_plan(

--- a/param_decomp_jax/jax_single_pool/run.py
+++ b/param_decomp_jax/jax_single_pool/run.py
@@ -45,8 +45,6 @@ from jax_single_pool.data import BatchSchedule, ShardServer, scan_shards
 from jax_single_pool.eval import make_eval_step
 from jax_single_pool.hf_http import configure_hf_http_retries
 from jax_single_pool.llama8b import (
-    Prefix,
-    Target,
     first_decomposed_layer,
     llama31_8b_config,
     llama_decomposed_lm,
@@ -60,7 +58,8 @@ from jax_single_pool.lm import DecomposedModel
 from jax_single_pool.recon import build_recon_terms
 from jax_single_pool.run_state import build_optimizers, init_train_state
 from jax_single_pool.sharding import dp_mesh, init_distributed
-from jax_single_pool.train import TrainState, make_faith_warmup_step, make_train_step
+from jax_single_pool.target_aliases import AnyFrozenTarget, AnyPrefix
+from jax_single_pool.train import make_faith_warmup_step, make_train_step
 from param_decomp_config.wandb_config import flatten_typed_lists
 
 _sigterm_received = False
@@ -74,7 +73,7 @@ def _install_sigterm_flag() -> None:
     signal.signal(signal.SIGTERM, handler)
 
 
-def _ensure_global(tree: object, mesh: Mesh) -> object:
+def _ensure_global[T](tree: T, mesh: Mesh) -> T:
     """Re-materialize the NON-mesh array leaves (eagerly created scalars: step
     counters, Adam counts) as well-formed GLOBAL replicated arrays via an identity
     jit. Multi-controller orbax can only save global arrays — and an eager
@@ -178,8 +177,8 @@ def train(
     cfg: ExperimentConfig,
     raw_cfg: dict[str, object],
     lm: DecomposedModel,
-    frozen: Target | llama_simple_mlp.SimpleMLPTarget,
-    prefix: Prefix | llama_simple_mlp.SimpleMLPPrefix,
+    frozen: AnyFrozenTarget,
+    prefix: AnyPrefix,
     prefix_residual_fn: Callable[[Any, Any], jax.Array],
     mesh: Mesh,
 ) -> None:
@@ -194,12 +193,12 @@ def train(
     key = random.PRNGKey(cfg.seed)
     init_key, src_key, run_key = random.split(key, 3)
     state = _ensure_global(init_train_state(cfg, lm, opt_vu, opt_ci, init_key, src_key, mesh), mesh)
-    assert isinstance(state, TrainState)
 
     checkpoint_manager = make_checkpoint_manager(cfg.run_dir / "ckpts", cfg.cadence.keep_last)
     restored = restore_latest(checkpoint_manager, state)
     if restored is not None:
         state, ckpt_step = restored
+        assert int(state.step) == ckpt_step, (int(state.step), ckpt_step)
         start_step = ckpt_step
         if is_main:
             print(f"resumed from checkpoint step {ckpt_step}", flush=True)
@@ -475,8 +474,8 @@ def main() -> None:
             flush=True,
         )
 
-    frozen: Target | llama_simple_mlp.SimpleMLPTarget
-    prefix: Prefix | llama_simple_mlp.SimpleMLPPrefix
+    frozen: AnyFrozenTarget
+    prefix: AnyPrefix
     prefix_residual_fn: Callable[[Any, Any], jax.Array]
     match cfg.target:
         case TargetConfig():

--- a/param_decomp_jax/jax_single_pool/slow_eval.py
+++ b/param_decomp_jax/jax_single_pool/slow_eval.py
@@ -62,6 +62,7 @@ from jax_single_pool.lm import DecomposedModel
 from jax_single_pool.load_run import build_target
 from jax_single_pool.run_state import build_optimizers, init_train_state
 from jax_single_pool.sharding import dp_mesh
+from param_decomp_config.routing import SamplingType
 
 
 @dataclass(frozen=True)
@@ -246,8 +247,9 @@ def render_slow_eval_figures(
     logs them under `slow_eval/` (`figures/<key>` from each metric's `compute()`)."""
     lower_hist = plot_ci_value_histograms({s: r.lower_sample for s, r in reductions.items()})
     logits_hist = plot_ci_value_histograms({s: r.logits_sample for s, r in reductions.items()})
-    densities = {s: r.density_counts / max(r.n_positions, 1) for s, r in reductions.items()}
-    mean_cis = {s: r.ci_sums / max(r.n_positions, 1) for s, r in reductions.items()}
+    assert all(r.n_positions > 0 for r in reductions.values())
+    densities = {s: r.density_counts / r.n_positions for s, r in reductions.items()}
+    mean_cis = {s: r.ci_sums / r.n_positions for s, r in reductions.items()}
     density_fig = plot_component_activation_density(densities)
     mean_linear, mean_log = plot_mean_component_cis_both_scales(mean_cis)
     return {
@@ -279,7 +281,7 @@ def compute_hidden_acts_metrics(
     frozen: Any,
     residual_batches: list[Float[Array, "B T d"]],
     n_mask_samples: int,
-    sampling: str,
+    sampling: SamplingType,
     base_key: Array,
 ) -> dict[str, float]:
     """Both hidden-acts recon eval metrics over the eval batches, keyed by the torch

--- a/param_decomp_jax/jax_single_pool/target_aliases.py
+++ b/param_decomp_jax/jax_single_pool/target_aliases.py
@@ -1,0 +1,8 @@
+"""Frozen-target / prefix unions shared by the two call sites that dispatch on
+`cfg.target` (`run.py::main` and `load_run.py::build_target`)."""
+
+from jax_single_pool.llama8b import Prefix, Target
+from jax_single_pool.llama_simple_mlp import SimpleMLPPrefix, SimpleMLPTarget
+
+AnyFrozenTarget = Target | SimpleMLPTarget
+AnyPrefix = Prefix | SimpleMLPPrefix


### PR DESCRIPTION
Behavior-preserving review-pass cleanups over the JAX trainer core (`param_decomp_jax/jax_single_pool/`). The equivalence + stacked-parity goldens are untouched and pass unmodified; full suite green at both device counts; `make check-jax` clean.

## Tighten `Any`s (kept the documented generic-boundary `Any`s)
- `load_run.py` `build_target`: the two return `Any`s -> `AnyFrozenTarget` / `AnyPrefix`. New shared `target_aliases.py` defines these unions, imported by both `build_target` and `run.py::main` (which dispatch on the identical `match cfg.target`). `prefix_residual_fn: Callable[[Any, Any], Array]` kept (legit generic input edge).
- `load_run.py`: inner `forward`'s `ci_fn: Any` -> `CIFn`; `LoadedJaxRun._forward: Any` -> the honest `Callable[...]`.
- `hidden_acts_eval.py` / `slow_eval.py`: `sampling: str` -> `SamplingType` (the existing `Literal["continuous","binomial"]`), threaded through `compute_hidden_acts_metrics`; dropped the now-redundant runtime `assert sampling in (...)`. `recon.py` `StochasticSources.sampling` + `build_recon_terms` also use `SamplingType`; `build_recon_terms` `loss_metrics` narrowed `tuple|list` -> `tuple` (no caller passes a list).
- `config.py`: `_resolve_target` uses the existing `AnyTargetConfig` alias (was a quoted forward-ref).

## Fail-fast / clarity
- `slow_eval.py`: `max(n_positions, 1)` -> `assert n_positions > 0`.
- `recon.py`: `instance_key` -> `assert_unique_instance_key` (reflects that it asserts uniqueness as a side effect).
- `run.py`: `assert int(state.step) == ckpt_step` after restore (codifies the dual-step resume invariant, S22); `_ensure_global` made PEP-695 generic `[T](tree, mesh) -> T`, dropping the call-site `isinstance(state, TrainState)` assert.

## Skipped (behavior-affecting / non-trivial — noted, not applied)
- `losses.py` `annealed_pnorm` span assert: `assert end_frac > start_frac` would break the documented `start_frac == end_frac == 1.0` no-op config (default when `final_p` is set but annealing is off). The `max(..., 1e-9)` soft-fail is load-bearing there. Left as-is.
- `build_experiment_config` `wandb_group`/`wandb_tags` default drop: both production call sites supply them, but ~8 test call sites rely on the defaults; dropping them is non-trivial and the defaults represent a real "ungrouped, no tags" base case.

## Verification
- `pytest jax_single_pool/tests/`: 166 passed (default device count).
- `XLA_FLAGS="--xla_force_host_platform_device_count=4" pytest jax_single_pool/tests/`: 166 passed.
- `make check-jax`: 0 errors. No new `# type: ignore` / `Any` / `cast`. Goldens untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)