### PR TITLE
fix(config): fail-fast validators + narrow types + discriminated GlobalCiConfig (review pass)

### DIFF
--- a/param_decomp/ci_fns.py
+++ b/param_decomp/ci_fns.py
@@ -15,6 +15,8 @@ from param_decomp.components import Components, EmbeddingComponents, get_module_
 from param_decomp_config.ci_fn import (
     CiConfig,
     GlobalCiConfig,
+    GlobalSharedMlpCiConfig,
+    GlobalSharedTransformerCiFnConfig,
     LayerwiseCiConfig,
     LayerwiseCiFnType,
 )
@@ -415,9 +417,6 @@ def _make_global_ci_fn(
     components: dict[str, Components],
     ci_config: GlobalCiConfig,
 ) -> GlobalSharedMLPCiFn | GlobalSharedTransformerCiFn:
-    ci_fn_type = ci_config.fn_type
-    ci_fn_hidden_dims = ci_config.hidden_dims
-
     layer_configs: dict[str, tuple[int, int]] = {}
     for path, module_c in module_to_c.items():
         target_module = target_model.get_submodule(path)
@@ -429,13 +428,13 @@ def _make_global_ci_fn(
             input_dim = get_module_input_dim(target_module)
         layer_configs[path] = (input_dim, module_c)
 
-    match ci_fn_type:
-        case "global_shared_mlp":
-            assert ci_fn_hidden_dims is not None
-            return GlobalSharedMLPCiFn(layer_configs=layer_configs, hidden_dims=ci_fn_hidden_dims)
-        case "global_shared_transformer":
+    match ci_config:
+        case GlobalSharedMlpCiConfig():
+            return GlobalSharedMLPCiFn(
+                layer_configs=layer_configs, hidden_dims=ci_config.hidden_dims
+            )
+        case GlobalSharedTransformerCiFnConfig():
             transformer_cfg = ci_config.simple_transformer_ci_cfg
-            assert transformer_cfg is not None
             return GlobalSharedTransformerCiFn(
                 target_model_layer_configs={
                     path: TargetLayerConfig(input_dim=input_dim, C=C)
@@ -486,7 +485,7 @@ def make_ci_fn_wrapper(
                 components=components,
                 ci_fn_type=ci_config.fn_type,
             )
-        case GlobalCiConfig():
+        case GlobalSharedMlpCiConfig() | GlobalSharedTransformerCiFnConfig():
             raw_global = _make_global_ci_fn(
                 target_model=target_model,
                 module_to_c=module_to_c,

--- a/param_decomp/tests/test_component_model.py
+++ b/param_decomp/tests/test_component_model.py
@@ -32,7 +32,7 @@ from param_decomp.decomposition_targets import (
     resolve_decomposition_targets,
 )
 from param_decomp.masks import ComponentsMaskInfo, make_mask_infos
-from param_decomp_config.ci_fn import GlobalCiConfig, LayerwiseCiConfig
+from param_decomp_config.ci_fn import GlobalSharedMlpCiConfig, LayerwiseCiConfig
 from param_decomp_config.decomposition_target import DecompositionTargetConfig
 from param_decomp_config.losses import ImportanceMinimalityLossConfig
 from param_decomp_config.pd import OptimizerConfig, PDConfig
@@ -531,7 +531,7 @@ def test_checkpoint_ci_config_mismatch_global_to_layerwise():
                 DecompositionTargetConfig(module_pattern="linear1", C=4),
                 DecompositionTargetConfig(module_pattern="linear2", C=4),
             ],
-            ci_config=GlobalCiConfig(fn_type="global_shared_mlp", hidden_dims=[4]),
+            ci_config=GlobalSharedMlpCiConfig(hidden_dims=[4]),
             batch_size=1,
             steps=1,
             components_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
@@ -636,7 +636,7 @@ def test_checkpoint_ci_config_mismatch_layerwise_to_global():
                 DecompositionTargetConfig(module_pattern="linear1", C=4),
                 DecompositionTargetConfig(module_pattern="linear2", C=4),
             ],
-            ci_config=GlobalCiConfig(fn_type="global_shared_mlp", hidden_dims=[4]),
+            ci_config=GlobalSharedMlpCiConfig(hidden_dims=[4]),
             batch_size=1,
             steps=1,
             components_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),
@@ -874,7 +874,7 @@ def test_component_model_with_global_ci():
         decomposition_targets=[
             DecompositionTarget(module_path=p, C=C) for p in target_module_paths
         ],
-        ci_config=GlobalCiConfig(fn_type="global_shared_mlp", hidden_dims=[16]),
+        ci_config=GlobalSharedMlpCiConfig(hidden_dims=[16]),
         sigmoid_type="leaky_hard",
     )
 
@@ -901,7 +901,7 @@ def test_component_model_global_ci_calc_causal_importances():
         decomposition_targets=[
             DecompositionTarget(module_path=p, C=C) for p in target_module_paths
         ],
-        ci_config=GlobalCiConfig(fn_type="global_shared_mlp", hidden_dims=[16]),
+        ci_config=GlobalSharedMlpCiConfig(hidden_dims=[16]),
         sigmoid_type="leaky_hard",
     )
 
@@ -947,7 +947,7 @@ def test_component_model_global_ci_different_inputs_different_ci():
         decomposition_targets=[
             DecompositionTarget(module_path=p, C=C) for p in target_module_paths
         ],
-        ci_config=GlobalCiConfig(fn_type="global_shared_mlp", hidden_dims=[16]),
+        ci_config=GlobalSharedMlpCiConfig(hidden_dims=[16]),
         sigmoid_type="leaky_hard",
     )
 
@@ -980,7 +980,7 @@ def test_component_model_global_ci_binomial_sampling():
         decomposition_targets=[
             DecompositionTarget(module_path=p, C=C) for p in target_module_paths
         ],
-        ci_config=GlobalCiConfig(fn_type="global_shared_mlp", hidden_dims=[16]),
+        ci_config=GlobalSharedMlpCiConfig(hidden_dims=[16]),
         sigmoid_type="leaky_hard",
     )
 
@@ -1007,7 +1007,7 @@ def test_component_model_global_ci_with_embeddings():
         decomposition_targets=[
             DecompositionTarget(module_path=p, C=C) for p in target_module_paths
         ],
-        ci_config=GlobalCiConfig(fn_type="global_shared_mlp", hidden_dims=[16]),
+        ci_config=GlobalSharedMlpCiConfig(hidden_dims=[16]),
         sigmoid_type="leaky_hard",
     )
 
@@ -1049,7 +1049,7 @@ def test_component_model_global_ci_gradient_flow():
         decomposition_targets=[
             DecompositionTarget(module_path=p, C=C) for p in target_module_paths
         ],
-        ci_config=GlobalCiConfig(fn_type="global_shared_mlp", hidden_dims=[16]),
+        ci_config=GlobalSharedMlpCiConfig(hidden_dims=[16]),
         sigmoid_type="leaky_hard",
     )
 
@@ -1088,7 +1088,7 @@ def test_component_model_global_ci_detach_inputs_blocks_gradients():
         decomposition_targets=[
             DecompositionTarget(module_path=p, C=C) for p in target_module_paths
         ],
-        ci_config=GlobalCiConfig(fn_type="global_shared_mlp", hidden_dims=[16]),
+        ci_config=GlobalSharedMlpCiConfig(hidden_dims=[16]),
         sigmoid_type="leaky_hard",
     )
 
@@ -1127,7 +1127,7 @@ def test_component_model_global_ci_masking_zeros():
         decomposition_targets=[
             DecompositionTarget(module_path=p, C=C) for p in target_module_paths
         ],
-        ci_config=GlobalCiConfig(fn_type="global_shared_mlp", hidden_dims=[16]),
+        ci_config=GlobalSharedMlpCiConfig(hidden_dims=[16]),
         sigmoid_type="leaky_hard",
     )
 
@@ -1175,7 +1175,7 @@ def test_component_model_global_ci_partial_masking():
         decomposition_targets=[
             DecompositionTarget(module_path=p, C=C) for p in target_module_paths
         ],
-        ci_config=GlobalCiConfig(fn_type="global_shared_mlp", hidden_dims=[16]),
+        ci_config=GlobalSharedMlpCiConfig(hidden_dims=[16]),
         sigmoid_type="leaky_hard",
     )
 
@@ -1209,7 +1209,7 @@ def test_component_model_global_ci_weight_deltas_all_ones_matches_target():
         decomposition_targets=[
             DecompositionTarget(module_path=p, C=C) for p in target_module_paths
         ],
-        ci_config=GlobalCiConfig(fn_type="global_shared_mlp", hidden_dims=[16]),
+        ci_config=GlobalSharedMlpCiConfig(hidden_dims=[16]),
         sigmoid_type="leaky_hard",
     )
 
@@ -1249,7 +1249,7 @@ def test_global_ci_save_and_load():
                 DecompositionTargetConfig(module_pattern="linear1", C=4),
                 DecompositionTargetConfig(module_pattern="linear2", C=4),
             ],
-            ci_config=GlobalCiConfig(fn_type="global_shared_mlp", hidden_dims=[8]),
+            ci_config=GlobalSharedMlpCiConfig(hidden_dims=[8]),
             batch_size=1,
             steps=1,
             components_optimizer=OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3)),

--- a/param_decomp_config/autointerp.py
+++ b/param_decomp_config/autointerp.py
@@ -7,7 +7,7 @@ Provider runtime classes (HTTP clients, dispatch) live in
 
 from typing import Annotated, Literal
 
-from pydantic import Field
+from pydantic import Field, PositiveInt
 
 from param_decomp_config.base import BaseConfig
 
@@ -128,9 +128,9 @@ class CompactSkepticalConfig(BaseConfig):
     """Current default strategy: compact prompt, skeptical tone, structured JSON output."""
 
     type: Literal["compact_skeptical"] = "compact_skeptical"
-    max_examples: int = 30
+    max_examples: PositiveInt = 30
     include_pmi: bool = True
-    label_max_words: int = 8
+    label_max_words: PositiveInt = 8
     forbidden_words: list[str] | None = None
     example_rendering: ExampleRenderingConfig = Field(default_factory=default_example_rendering)
 
@@ -145,9 +145,9 @@ class DualViewConfig(BaseConfig):
     """
 
     type: Literal["dual_view"] = "dual_view"
-    max_examples: int = 30
+    max_examples: PositiveInt = 30
     include_pmi: bool = True
-    label_max_words: int = 8
+    label_max_words: PositiveInt = 8
     forbidden_words: list[str] | None = None
     example_rendering: ExampleRenderingConfig = Field(default_factory=default_example_rendering)
 
@@ -160,8 +160,8 @@ class RichExamplesConfig(BaseConfig):
     """
 
     type: Literal["rich_examples"] = "rich_examples"
-    max_examples: int = 30
-    label_max_words: int = 8
+    max_examples: PositiveInt = 30
+    label_max_words: PositiveInt = 8
     output_pmi_min_count: float = 2.0
     example_rendering: RichExampleRenderingConfig = Field(
         default_factory=default_rich_example_rendering
@@ -176,8 +176,8 @@ class CanonConfig(BaseConfig):
     """
 
     type: Literal["canon"] = "canon"
-    max_examples: int = 30
-    label_max_words: int = 8
+    max_examples: PositiveInt = 30
+    label_max_words: PositiveInt = 8
 
 
 StrategyConfig = CompactSkepticalConfig | DualViewConfig | RichExamplesConfig | CanonConfig

--- a/param_decomp_config/ci_fn.py
+++ b/param_decomp_config/ci_fn.py
@@ -1,13 +1,12 @@
 """Causal-importance function configs."""
 
-from typing import Literal, Self
+from typing import Annotated, Literal, Self
 
-from pydantic import Field, PositiveInt, model_validator
+from pydantic import BeforeValidator, Field, PositiveInt, model_validator
 
 from param_decomp_config.base import BaseConfig
 
 LayerwiseCiFnType = Literal["mlp", "vector_mlp", "shared_mlp"]
-GlobalCiFnType = Literal["global_shared_mlp", "global_shared_transformer"]
 
 
 class LayerwiseCiConfig(BaseConfig):
@@ -76,36 +75,53 @@ class GlobalSharedTransformerCiConfig(BaseConfig):
         return self
 
 
-class GlobalCiConfig(BaseConfig):
-    """A single global CI fn that maps all layers jointly."""
+class GlobalSharedMlpCiConfig(BaseConfig):
+    """A single global MLP CI fn that maps all layers jointly."""
 
     mode: Literal["global"] = "global"
-    fn_type: GlobalCiFnType = Field(
-        ...,
-        description="Type of global CI function: global_shared_mlp or global_shared_transformer",
+    fn_type: Literal["global_shared_mlp"] = "global_shared_mlp"
+    hidden_dims: list[PositiveInt] = Field(
+        ..., description="Hidden dimensions for the global_shared_mlp CI function."
     )
-    hidden_dims: list[PositiveInt] | None = Field(
-        default=None,
-        description="Hidden dimensions for global_shared_mlp CI function.",
-    )
-    simple_transformer_ci_cfg: GlobalSharedTransformerCiConfig | None = None
-
-    @model_validator(mode="after")
-    def validate_ci_config(self) -> Self:
-        if self.fn_type == "global_shared_mlp":
-            assert self.hidden_dims is not None, (
-                "hidden_dims must be specified when fn_type='global_shared_mlp'"
-            )
-        elif self.fn_type == "global_shared_transformer":
-            assert self.simple_transformer_ci_cfg is not None, (
-                "simple_transformer_ci_cfg must be specified when fn_type='global_shared_transformer'"
-            )
-            assert self.hidden_dims is None, (
-                "hidden_dims is only used for fn_type='global_shared_mlp'"
-            )
-        return self
 
 
-# Discriminated union (by `mode`) of every CI-fn config the trainer accepts. Pydantic
-# picks the right branch from the YAML `pd.ci_config.mode` literal.
-CiConfig = LayerwiseCiConfig | GlobalCiConfig
+class GlobalSharedTransformerCiFnConfig(BaseConfig):
+    """A single global transformer CI fn that maps all layers jointly."""
+
+    mode: Literal["global"] = "global"
+    fn_type: Literal["global_shared_transformer"] = "global_shared_transformer"
+    simple_transformer_ci_cfg: GlobalSharedTransformerCiConfig
+
+
+# Stored global CI configs predate the split into per-fn_type classes: they wrote a
+# single class with both `hidden_dims` and `simple_transformer_ci_cfg`, the inactive one
+# left as `None`. Drop the inactive null so the now-`extra=forbid` per-fn_type classes
+# accept old files. Delete once stored runs are migrated.
+_NULLABLE_LEGACY_GLOBAL_CI_KEYS = frozenset({"hidden_dims", "simple_transformer_ci_cfg"})
+
+
+def _drop_null_inactive_global_ci_field(value: object) -> object:
+    if isinstance(value, dict):
+        return {
+            k: v
+            for k, v in value.items()
+            if not (k in _NULLABLE_LEGACY_GLOBAL_CI_KEYS and v is None)
+        }
+    return value
+
+
+# Discriminated (by `fn_type`) union of the global CI-fn configs. Both share
+# `mode="global"`; the `fn_type` literal selects MLP vs transformer.
+GlobalCiConfig = Annotated[
+    GlobalSharedMlpCiConfig | GlobalSharedTransformerCiFnConfig,
+    Field(discriminator="fn_type"),
+    BeforeValidator(_drop_null_inactive_global_ci_field),
+]
+
+
+# Nested discriminated union: the outer `mode` literal picks layerwise vs global, and
+# the global branch's inner `fn_type` literal selects MLP vs transformer.
+CiConfig = Annotated[
+    LayerwiseCiConfig | GlobalCiConfig,
+    Field(discriminator="mode"),
+]

--- a/param_decomp_config/eval_metrics.py
+++ b/param_decomp_config/eval_metrics.py
@@ -7,7 +7,7 @@ subclass via `EVAL_METRIC_CLASSES` (lab-side).
 
 from typing import Annotated, Literal, Self
 
-from pydantic import Discriminator, Field, model_validator
+from pydantic import Discriminator, Field, PositiveInt, model_validator
 
 from param_decomp_config.autointerp import LLMConfig, StrategyConfig
 from param_decomp_config.base import BaseConfig
@@ -19,13 +19,13 @@ from param_decomp_config.losses import (
 
 class AutointerpLabelsConfig(BaseConfig):
     type: Literal["AutointerpLabels"] = "AutointerpLabels"
-    k: int
+    k: PositiveInt
     """Number of components to sample uniformly over the concatenated component space."""
     seed: int
     activation_threshold: float
-    max_examples: int
+    max_examples: PositiveInt
     """Reservoir capacity (activation examples kept per sampled component)."""
-    context_tokens_per_side: int
+    context_tokens_per_side: PositiveInt
     llm: LLMConfig
     template_strategy: Annotated[StrategyConfig, Field(discriminator="type")]
     # Run/data facts the prompt needs that a bare ComponentModel doesn't carry. They
@@ -33,7 +33,7 @@ class AutointerpLabelsConfig(BaseConfig):
     # is self-contained (plain config dispatch). `n_blocks` / `layer_descriptions` are
     # derived from the model at `bind`.
     dataset_name: str
-    seq_len: int
+    seq_len: PositiveInt
     tokenizer_name: str
 
 
@@ -52,7 +52,7 @@ class CIHistogramsConfig(BaseConfig):
     """`n_batches_accum=None` accumulates every batch in the eval pass."""
 
     type: Literal["CIHistograms"] = "CIHistograms"
-    n_batches_accum: int | None
+    n_batches_accum: PositiveInt | None
 
 
 class CI_L0Config(BaseConfig):
@@ -76,7 +76,7 @@ class _AttnPatternsBaseConfig(BaseConfig):
     output split as `[Q | K | V]` along the last dim) — not both, not neither.
     """
 
-    n_heads: int
+    n_heads: PositiveInt
     q_proj_path: str | None = None
     k_proj_path: str | None = None
     c_attn_path: str | None = None
@@ -108,34 +108,44 @@ class ComponentActivationDensityConfig(BaseConfig):
     ci_alive_threshold: float = 0.0
 
 
+class IdentityCITargetSpec(BaseConfig):
+    """A layer expected to produce an Identity CI pattern over `n_features` features."""
+
+    layer_pattern: str
+    n_features: PositiveInt
+
+
+class DenseCITargetSpec(BaseConfig):
+    """A layer expected to produce a Dense CI pattern with `k` active components."""
+
+    layer_pattern: str
+    k: PositiveInt
+
+
 class IdentityCIErrorConfig(BaseConfig):
     """`identity_ci` / `dense_ci` list layers expected to produce Identity / Dense patterns."""
 
     type: Literal["IdentityCIError"] = "IdentityCIError"
-    identity_ci: list[dict[str, str | int]] | None
-    dense_ci: list[dict[str, str | int]] | None
+    identity_ci: list[IdentityCITargetSpec] | None
+    dense_ci: list[DenseCITargetSpec] | None
 
 
-class PermutedCIPlotsConfig(BaseConfig):
+class _PermutationPlotsBaseConfig(BaseConfig):
     """fnmatch patterns for layers permuted to align with the corresponding target solution.
 
     `identity_patterns` and `dense_patterns` are matched separately against the model.
     """
 
+    identity_patterns: list[str] | None
+    dense_patterns: list[str] | None
+
+
+class PermutedCIPlotsConfig(_PermutationPlotsBaseConfig):
     type: Literal["PermutedCIPlots"] = "PermutedCIPlots"
-    identity_patterns: list[str] | None
-    dense_patterns: list[str] | None
 
 
-class UVPlotsConfig(BaseConfig):
-    """fnmatch patterns for layers permuted to align with the corresponding target solution.
-
-    `identity_patterns` and `dense_patterns` are matched separately against the model.
-    """
-
+class UVPlotsConfig(_PermutationPlotsBaseConfig):
     type: Literal["UVPlots"] = "UVPlots"
-    identity_patterns: list[str] | None
-    dense_patterns: list[str] | None
 
 
 AnyEvalMetricConfig = Annotated[

--- a/param_decomp_config/experiment.py
+++ b/param_decomp_config/experiment.py
@@ -5,8 +5,9 @@ types.
 """
 
 from pathlib import Path
+from typing import Self
 
-from pydantic import Field, PositiveInt
+from pydantic import Field, PositiveInt, model_validator
 
 from param_decomp_config.base import BaseConfig
 from param_decomp_config.eval_metrics import AnyEvalMetricConfig
@@ -30,6 +31,13 @@ class EvalConfig(BaseConfig):
     slow_on_first_step: bool = True
     metrics: list[AnyEvalMetricConfig] = Field(default_factory=list)
 
+    @model_validator(mode="after")
+    def validate_slow_every_multiple_of_every(self) -> Self:
+        assert self.slow_every % self.every == 0, (
+            f"slow_every ({self.slow_every}) must be a multiple of every ({self.every})"
+        )
+        return self
+
 
 class ResumeProvenance(BaseConfig):
     """Records where a resumed run came from. Lives on `ExperimentConfig`.
@@ -46,8 +54,8 @@ class ResumeProvenance(BaseConfig):
     """Path to the parent run's directory."""
 
     parent_step: int
-    """The step at which we resumed (i.e. the step number in the parent's
-    `training_<step>.pth` snapshot we loaded from)."""
+    """The step at which we resumed (i.e. the step number of the parent's orbax
+    `ckpts/<step>/` checkpoint we loaded from)."""
 
 
 class ExperimentConfig[T: BaseConfig, D: BaseConfig](BaseConfig):

--- a/param_decomp_config/losses.py
+++ b/param_decomp_config/losses.py
@@ -7,7 +7,14 @@ subset recon). Each carries a unique `type: Literal["<ClassName>"]` discriminato
 
 from typing import Annotated, Any, Literal
 
-from pydantic import BeforeValidator, Field, NonNegativeFloat, NonNegativeInt, PositiveInt
+from pydantic import (
+    BeforeValidator,
+    Field,
+    NonNegativeFloat,
+    NonNegativeInt,
+    PositiveFloat,
+    PositiveInt,
+)
 
 from param_decomp_config.base import BaseConfig, Probability
 from param_decomp_config.routing import SubsetRoutingType, UniformKSubsetRoutingConfig
@@ -134,6 +141,12 @@ def _alias_legacy_mask_scope(value: Any) -> Any:
 # Scope literals spell the adversarial-source shape in tensor order (batch, seq, C).
 # `c` is one shared vector, rank-polymorphic and DP-synced; `bc` (no seq axis) and
 # `bsc` (LM) are independent per batch element, and must match the batch rank.
+#
+# Deliberately NOT unified with `PersistentPGDSourceScope` below: per-step PGD encodes
+# its scope as a bare YAML string (this `Literal`), while persistent PGD encodes it as a
+# nested config object (the `CScope | ... | BSCScope` discriminated union). The value
+# spaces also differ — `bc` is per-step-only; `sc`/`nsc` are persistent-only. Converging
+# them would change the stored YAML shape of one side and break old-run parsing.
 MaskScope = Annotated[Literal["c", "bc", "bsc"], BeforeValidator(_alias_legacy_mask_scope)]
 
 
@@ -141,8 +154,8 @@ class PGDConfig(LossMetricConfig):
     """Shared base for per-step PGD loss configs."""
 
     init: PGDInitStrategy
-    step_size: float
-    n_steps: int
+    step_size: PositiveFloat
+    n_steps: NonNegativeInt
     mask_scope: MaskScope
 
 

--- a/param_decomp_config/pd.py
+++ b/param_decomp_config/pd.py
@@ -113,7 +113,7 @@ class PDConfig(BaseConfig):
 
     Flipping any field here changes what algorithm runs. Pair with `RuntimeConfig`
     (substrate), `Cadence` (when to emit) and `RunSink` (where output goes) when
-    calling `optimize`.
+    running `jsp-train`.
     """
 
     # --- General ---
@@ -231,8 +231,8 @@ class Cadence(BaseConfig):
 
     Held separately from `RunSink` so the sink only owns *where* output goes; `Cadence`
     owns *when* train logs and checkpoints fire. Eval timing lives on `EvalLoop`,
-    alongside the runtime objects it depends on. `Trainer.run` always checkpoints at the
-    final step regardless of `save_every`.
+    alongside the runtime objects it depends on. The `jsp-train` loop always checkpoints
+    at the final step regardless of `save_every`.
     """
 
     train_log_every: PositiveInt
@@ -240,12 +240,11 @@ class Cadence(BaseConfig):
     """Optional denser logging for early training; `None` means a flat `train_log_every`."""
     save_every: PositiveInt | None = None
     keep_last_n_checkpoints: PositiveInt | None = None
-    """How many of the most-recent ``training_<step>.pth`` / ``model_<step>.pth`` pairs
-    to keep on disk after each checkpoint write. ``None`` (the default) keeps all
-    checkpoints — the conservative choice for research where prior steps may matter.
-    Opt in to e.g. ``3`` for long jobs where disk pressure outweighs the value of
-    intermediate checkpoints; the final-step checkpoint is always included in the
-    retained set."""
+    """How many of the most-recent orbax `ckpts/<step>/` checkpoints to keep on disk
+    after each checkpoint write. `None` (the default) keeps all checkpoints — the
+    conservative choice for research where prior steps may matter. Opt in to e.g. `3`
+    for long jobs where disk pressure outweighs the value of intermediate checkpoints;
+    the final-step checkpoint is always included in the retained set."""
 
     def should_log_train(self, step: int) -> bool:
         if self.dense_log_phase is not None and step < self.dense_log_phase.until_step:

--- a/param_decomp_config/schedule.py
+++ b/param_decomp_config/schedule.py
@@ -1,4 +1,4 @@
-"""Schedule config and value lookup used by `Trainer.run` and PGD metrics."""
+"""Schedule config and value lookup used by the `jsp-train` loop and PGD metrics."""
 
 from typing import Literal, Self
 

--- a/param_decomp_jax/jax_single_pool/config.py
+++ b/param_decomp_jax/jax_single_pool/config.py
@@ -45,6 +45,7 @@ from jax_single_pool.ci_fn import CIArch
 from jax_single_pool.llama8b import SITE_NAME_PATTERN, canonical_site_cs
 from jax_single_pool.lm import SiteC
 from jax_single_pool.recon import build_recon_terms
+from param_decomp_config.ci_fn import GlobalSharedTransformerCiFnConfig
 from param_decomp_config.eval_metrics import CEandKLLossesConfig, CI_L0Config
 from param_decomp_config.experiment import WandbConfig
 from param_decomp_config.jax_wrapper import WRAPPER_KEYS, WRAPPER_OPTIONAL_KEYS
@@ -262,9 +263,8 @@ def _resolve_target(cfg: LMExperimentConfig) -> "TargetConfig | LlamaSimpleMLPTa
 
 def _ci_arch(cfg: LMExperimentConfig, seq_len: int) -> CIArch:
     ci = cfg.pd.ci_config
-    assert ci.mode == "global" and ci.fn_type == "global_shared_transformer", ci
+    assert isinstance(ci, GlobalSharedTransformerCiFnConfig), ci
     transformer = ci.simple_transformer_ci_cfg
-    assert transformer is not None
     assert transformer.mlp_hidden_dim is not None and len(transformer.mlp_hidden_dim) == 1, (
         f"CI MLP must be single-hidden-layer, got {transformer.mlp_hidden_dim}"
     )

--- a/param_decomp_lab/component_model_io.py
+++ b/param_decomp_lab/component_model_io.py
@@ -21,7 +21,12 @@ from param_decomp.decomposition_targets import (
     insert_identity_operations_,
     resolve_decomposition_targets,
 )
-from param_decomp_config.ci_fn import CiConfig, GlobalCiConfig, LayerwiseCiConfig
+from param_decomp_config.ci_fn import (
+    CiConfig,
+    GlobalSharedMlpCiConfig,
+    GlobalSharedTransformerCiFnConfig,
+    LayerwiseCiConfig,
+)
 from param_decomp_config.decomposition_target import DecompositionTargetConfig
 from param_decomp_config.pd import PDConfig
 from param_decomp_config.routing import SamplingType
@@ -79,7 +84,7 @@ def _validate_checkpoint_ci_config_compatibility(
                 f"Config specifies layerwise CI but checkpoint has no ci_fn._ci_fns keys "
                 f"(has ci_fn._global_ci_fn: {has_global_ci_fn})"
             )
-        case GlobalCiConfig():
+        case GlobalSharedMlpCiConfig() | GlobalSharedTransformerCiFnConfig():
             assert has_global_ci_fn, (
                 f"Config specifies global CI but checkpoint has no ci_fn._global_ci_fn keys "
                 f"(has ci_fn._ci_fns: {has_layerwise_ci_fns})"

--- a/param_decomp_lab/tests/test_target_ci_solutions.py
+++ b/param_decomp_lab/tests/test_target_ci_solutions.py
@@ -1,11 +1,32 @@
 import torch
 
+from param_decomp_config.eval_metrics import DenseCITargetSpec, IdentityCITargetSpec
 from param_decomp_lab.toy_models.target_ci import (
     DenseCIPattern,
     IdentityCIPattern,
     TargetCISolution,
     compute_target_metrics,
+    make_target_ci_solution,
 )
+
+
+class TestMakeTargetCISolution:
+    def test_none_when_both_empty(self):
+        assert make_target_ci_solution(identity_ci=None, dense_ci=None) is None
+        assert make_target_ci_solution(identity_ci=[], dense_ci=[]) is None
+
+    def test_builds_from_typed_specs(self):
+        solution = make_target_ci_solution(
+            identity_ci=[IdentityCITargetSpec(layer_pattern="layers.*.mlp_in", n_features=100)],
+            dense_ci=[DenseCITargetSpec(layer_pattern="layers.*.mlp_out", k=3)],
+        )
+        assert solution is not None
+        identity = solution.module_targets["layers.*.mlp_in"]
+        dense = solution.module_targets["layers.*.mlp_out"]
+        assert isinstance(identity, IdentityCIPattern)
+        assert identity.n_features == 100
+        assert isinstance(dense, DenseCIPattern)
+        assert dense.k == 3
 
 
 class TestIdentityCIPattern:

--- a/param_decomp_lab/toy_models/target_ci.py
+++ b/param_decomp_lab/toy_models/target_ci.py
@@ -17,6 +17,7 @@ import torch
 from jaxtyping import Float, Int
 from torch import Tensor
 
+from param_decomp_config.eval_metrics import DenseCITargetSpec, IdentityCITargetSpec
 from param_decomp_lab.toy_models._linear_sum_assignment import linear_sum_assignment
 
 
@@ -265,27 +266,21 @@ def compute_target_metrics(
 
 
 def make_target_ci_solution(
-    identity_ci: list[dict[str, str | int]] | None = None,
-    dense_ci: list[dict[str, str | int]] | None = None,
+    identity_ci: list[IdentityCITargetSpec] | None,
+    dense_ci: list[DenseCITargetSpec] | None,
 ) -> TargetCISolution | None:
-    """Build a `TargetCISolution` from config-style specs.
-
-    Each `identity_ci` entry needs `{layer_pattern, n_features}`; each `dense_ci` entry
-    needs `{layer_pattern, k}`. Returns `None` when both lists are empty.
-    """
+    """Build a `TargetCISolution` from config specs. Returns `None` when both are empty."""
     if not identity_ci and not dense_ci:
         return None
 
-    module_targets = {}
+    module_targets: dict[str, TargetCIPattern] = {}
 
     if identity_ci:
         for spec in identity_ci:
-            module_targets[spec["layer_pattern"]] = IdentityCIPattern(
-                n_features=int(spec["n_features"])
-            )
+            module_targets[spec.layer_pattern] = IdentityCIPattern(n_features=spec.n_features)
 
     if dense_ci:
         for spec in dense_ci:
-            module_targets[spec["layer_pattern"]] = DenseCIPattern(k=int(spec["k"]))
+            module_targets[spec.layer_pattern] = DenseCIPattern(k=spec.k)
 
     return TargetCISolution(module_targets)


### PR DESCRIPTION
## What

Code-review pass over the `param_decomp_config/` schema package (plus the consumer updates each change requires). All behavior-preserving for valid configs; new validators reject only genuinely-invalid ones.

### Fail-fast
- **`EvalConfig`**: `@model_validator` enforcing the documented invariant `slow_every % every == 0`.
- **`PGDConfig`**: `step_size: float → PositiveFloat`; `n_steps: int → NonNegativeInt`. (Kept `n_steps` non-negative rather than positive because `n_steps=0` is the meaningful no-ascent fresh-sample baseline — exercised by `test_fresh_pgd_adversary_step`.)

### Narrow bare types → Positive*
- `eval_metrics.py`: `n_heads`, `AutointerpLabels.{k,max_examples,context_tokens_per_side,seq_len}` → `PositiveInt`; `CIHistograms.n_batches_accum` → `PositiveInt | None`. (`seed: int` left as-is.)
- `autointerp.py`: strategy `max_examples` / `label_max_words` → `PositiveInt`.

### Encode invariants in types
- **`GlobalCiConfig`**: was one class with two independently-optional fields (`hidden_dims | None`, `simple_transformer_ci_cfg | None`) gated by a `model_validator`. Now a `fn_type`-discriminated union of `GlobalSharedMlpCiConfig` (has `hidden_dims`) vs `GlobalSharedTransformerCiFnConfig` (has the transformer cfg), nested under the existing `mode` discriminator. Impossible states are now unrepresentable and the validator is deleted. Readers updated: `param_decomp/ci_fns.py`, `param_decomp_lab/component_model_io.py`, `param_decomp_jax/jax_single_pool/config.py`, and test fixtures.
- **`IdentityCIErrorConfig.identity_ci/dense_ci`**: `list[dict[str, str|int]] | None` → typed `IdentityCITargetSpec` / `DenseCITargetSpec`; `make_target_ci_solution` + its single caller updated (and a focused test added).
- **`PermutedCIPlotsConfig` / `UVPlotsConfig`**: were byte-identical configs → shared `_PermutationPlotsBaseConfig` (impls remain distinct; only the configs were dupes).

### Honesty (docstrings)
Retired-torch-`Trainer`/`.pth` references → orbax `ckpts/<step>/` + `jsp-train` (`pd.py` `Cadence` / `keep_last_n_checkpoints` / `PDConfig`, `schedule.py`, `experiment.py` `ResumeProvenance`).

## Stored-run compatibility
Old single-class global CI configs wrote `hidden_dims: None` (transformer branch) / `simple_transformer_ci_cfg: None` (mlp branch). A `BeforeValidator` on the new union drops those inactive nulls so stored runs still parse — the sanctioned legacy-shim-for-shared-storage exception. Verified by parsing a representative stored transformer run (`p-07b86ca3`) and confirming both PGD-scope legacy aliases (`shared_across_batch`/`unique_per_datapoint`, `broadcast_across_batch`/`per_batch_per_position`) still resolve. The legacy ci/scope shims survive across all 202 stored configs (the other parse failures predate this PR — `pd.losses`, `runtime.topology`, `runtime.compile_*` are earlier JAX-schema migrations).

## Surfaced, not forced
The two PGD scope vocabularies — `MaskScope` (bare-string `Literal`, per-step) vs `PersistentPGDSourceScope` (object discriminated-union, persistent) — were **not** converged: their value spaces differ (`bc` per-step-only; `sc`/`nsc` persistent-only) and their YAML shapes differ (string vs nested object), so unifying would change stored YAML and break old-run parsing. Added a cross-reference comment documenting the deliberate split.

## One historical config flagged
`p-8409845f` has `every: 100000, slow_every: 10000` (violates the now-enforced `slow_every % every == 0`). It was **already** unloadable on `feature/jax` (fails on `pd.losses` / `runtime.topology` from prior schema drift); the new validator just adds a third error to an already-broken file. No loadable run regresses.

## Verification
- `make test` (full non-slow): 580 passed, 4 deselected.
- `make test-jax`: 165 passed.
- `make type` + `make check-jax`: 0 errors.
- `pre-commit` on all changed files: pass.
- No new `# type: ignore` / `Any` / `cast`; `param_decomp_config` stays torch-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)