### PR TITLE
fix(infra): retry HF Xet CDN 408s on dataset-shard streaming

### DIFF
--- a/param_decomp_lab/infra/ddp_launch.py
+++ b/param_decomp_lab/infra/ddp_launch.py
@@ -23,6 +23,9 @@ DDP_ENV = {
     "TORCH_NCCL_ASYNC_ERROR_HANDLING": "1",
     "HF_HUB_ETAG_TIMEOUT": "30",
     "HF_HUB_DOWNLOAD_TIMEOUT": "30",
+    # Avoid the flaky Xet CDN (see hf_http.py); not sufficient alone — the plain-GET
+    # fallback can still 408, so this leans on that 408 retry rather than replacing it.
+    "HF_HUB_DISABLE_XET": "1",
 }
 
 

--- a/param_decomp_lab/infra/hf_http.py
+++ b/param_decomp_lab/infra/hf_http.py
@@ -18,12 +18,15 @@ from param_decomp.log import logger
 _configured = False
 
 
-def configure_hf_http_retries(*, total_retries: int = 5, backoff_factor: float = 1.5) -> None:
+def configure_hf_http_retries(*, total_retries: int = 8, backoff_factor: float = 1.5) -> None:
     """Install a retrying HTTP backend on huggingface_hub (idempotent, process-global).
 
     `backoff_factor` with full jitter spaces retries at roughly 0, 1.5, 3, 6, 12s; the
     jitter de-synchronizes the simultaneous retries of many DDP ranks. Only idempotent
     methods (GET/HEAD) are retried, so non-idempotent writes are untouched.
+
+    `408` covers the HF Xet CDN (us.aws.cdn.hf.co/xet-bridge-us), which intermittently
+    times out dataset-shard GETs and would otherwise kill long streaming runs.
     """
     global _configured
     if _configured:
@@ -36,7 +39,7 @@ def configure_hf_http_retries(*, total_retries: int = 5, backoff_factor: float =
         status=total_retries,
         backoff_factor=backoff_factor,
         backoff_jitter=1.0,
-        status_forcelist=(429, 500, 502, 503, 504),
+        status_forcelist=(408, 429, 500, 502, 503, 504),
         allowed_methods=frozenset({"GET", "HEAD", "OPTIONS"}),
         respect_retry_after_header=True,
         raise_on_status=False,


### PR DESCRIPTION
## Description
Harden HuggingFace Hub dataset streaming against transient **408 Request-Timeout** responses from the HF Xet CDN (`us.aws.cdn.hf.co/xet-bridge-us`).

- `hf_http.py`: add `408` to the retry `status_forcelist` (it was the one transient status class not being retried) and bump `total_retries` 5→8 to better absorb the simultaneous startup burst from many DDP ranks.
- `ddp_launch.py`: set `HF_HUB_DISABLE_XET=1` in `DDP_ENV` so shard resolves fall back to the classic LFS download path instead of the xet client. The fallback is a plain `requests` GET that can itself 408 — which is exactly what the forcelist change now retries.

## Motivation and Context
The Xet CDN intermittently returns non-retryable 408s on dataset-shard GETs, killing long DDP streaming runs. Observed killing the `smoothl0-impmin-sweep` runs both at the simultaneous 8-rank **startup** resolve (step-0 eval val-shard fetch) and on **mid-stream** re-fetches (~step 60k of a 400k run). `configure_hf_http_retries()` is already wired into the LM data path (`experiments/lm/data.py`), but its forcelist omitted 408, so these transient timeouts crashed the job instead of being retried with backoff.

## Related Issue
N/A

## How Has This Been Tested?
- `ruff` + `basedpyright` pre-commit hooks pass.
- The same two changes are running live on the relaunched `smoothl0-impmin-sweep` (3× 8-GPU runs) to confirm they clear the step-0 eval fetch that previously crashed; will confirm steady-state.

## Does this PR introduce a breaking change?
No. `HF_HUB_DISABLE_XET=1` only affects DDP-launched jobs (trades xet-protocol dedup for the classic LFS path); the retry change is strictly additive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)