### PR TITLE
feat(jax): generic [*leading,d] waist + axis names + jaxtyping/beartype shape contract

### DIFF
--- a/param_decomp_jax/jax_single_pool/AXIS_SEMANTICS_DESIGN.md
+++ b/param_decomp_jax/jax_single_pool/AXIS_SEMANTICS_DESIGN.md
@@ -1,0 +1,113 @@
+# Axis semantics: the generic `[*leading, d]` waist
+
+This documents the activation-waist contract after generalizing the trainer core from a
+fixed `(B, T)` (batch, sequence) waist to a generic `[*leading, d]` waist. It is the
+companion to `SPEC.md` (which is normative on the algorithm) — this doc is normative on
+the *shape contract* the generic loop and the per-domain targets agree on.
+
+## The waist
+
+Per decomposed **site**, the trainer threads two shape families through the step:
+
+- **activations** `[*leading, d]` — the residual entering the suffix, per-site inputs
+  (`[*leading, d_in]`), per-site outputs (`[*leading, d_out]`), final model output
+  (`[*leading, vocab]` for an LM).
+- **masks / CI** `[*leading, C]`, **delta masks / routes** `[*leading]`.
+
+`leading = (batch,) + named position axes`. The **batch axis is ever-present and
+semantics-free**: it is the data/shard axis (GSPMD pins it to `P('dp', …)`), nothing in
+the method treats one batch element differently from another. The named position axes are
+domain-specific: an LM has one (`sequence`); a TMS-style target has none.
+
+### CI is independent over every leading axis
+
+A single team decision underpins the whole simplification: **CI is always independent
+over every leading axis** (the old `broadcast_ci` knob is dropped). The CI fn emits one
+logit per `(*leading, component)` cell; there is no axis over which CI is shared or
+pooled. Consequently there is **no per-axis CI semantics** — only axis *names*. The core
+never needs to know what a leading axis *means*; it only needs its *extent* (for sampling
+shapes) and the invariant that every per-site tensor in a forward shares the same
+`*leading` prefix.
+
+This is why the generic loop can stay free of domain branches: it reads
+`leading = residual.shape[:-1]` once and uses it uniformly for routing-draw shapes,
+stochastic source shapes, delta-mask shapes, and the imp-min / KL reductions
+(`math.prod(shape[:-1])`, `axis=tuple(range(ndim-1))`).
+
+## Axis names live on the model and the CI fn
+
+- **`DecomposedModel.leading_axes: tuple[str, ...]`** names the position axes (batch is
+  implicit): `("sequence",)` for an LM, `()` for TMS.
+- **`CIFn.expects_axes: tuple[str, ...]`** names the position axes the CI fn is built for.
+  The LM CI fn applies RoPE over a single `sequence` axis, so it declares
+  `("sequence",)`.
+
+At trainer construction (`run_state.init_train_state`) we **assert
+`ci_fn.expects_axes == model.leading_axes`** and fail early. This lets the CI fn stay
+per-domain (it can encode position structure however it likes — RoPE here) without the
+generic core ever adapting: the core only ever sees the opaque `*leading` prefix, and the
+construction-time check guarantees the two halves agree on how many position axes there
+are and what they are.
+
+## What changed in the core (all per-domain branches stay out of the loop)
+
+The generalization is mechanical — every site that assumed exactly two leading axes now
+reads an opaque `leading`:
+
+- `train.py` (keystone): `batch, seq = residual.shape[0], residual.shape[1]` →
+  `leading = residual.shape[:-1]`, threaded to the routing samplers, fresh-PGD source
+  init, and stochastic delta-mask shapes (the `(batch, seq)` tuple param is now
+  `leading_shape: tuple[int, ...]`).
+- `losses.py`: imp-min and `kl_per_position` reductions — `shape[0]*shape[1]` →
+  `math.prod(shape[:-1])`, `axis=(0,1)` → `axis=tuple(range(ndim-1))`.
+- `recon.py`: `RoutingSampler` and the three sampler bodies — `tuple[int, int]` →
+  `tuple[int, ...]` (bodies were already generic over the shape tuple).
+- `adversary.py`: `init_persistent_sources` takes a `leading_shape` directly;
+  `init_fresh_pgd_sources` takes the model's `leading` and spells `scope` (`c`/`bc`/`bsc`)
+  over it. `source_masks` already broadcast via `…[..., :-1]` ellipsis.
+- `llama8b_sharding.py`: `init_sources_sharded` builds the per-scope `leading_shape`
+  (`sc` → `(1, T)`, `bsc` → `(B, T)`) for the LM before placing.
+- `eval.py` / `slow_eval.py` / `hidden_acts_eval.py`: the same `shape[:-1]` / `prod`
+  generalizations for delta-mask shapes and position counts.
+- `lm.py` type aliases: `Float[Array, "B T C"]` → `Float[Array, "*leading C"]`, etc.
+
+The LM `CIFn` internals (`b, t, d = x.shape`, RoPE over `t`) are **per-domain and stay
+exactly as written** — they are the concrete realization of `expects_axes=("sequence",)`,
+not core. Likewise the concrete Llama target forwards keep their honest `"b t d"`
+annotations.
+
+## The shape contract is enforced (jaxtyping + beartype)
+
+The waist invariant — *all per-site tensors in one forward share one `*leading` prefix* —
+is enforced at trace time, not just documented. `@jaxtyped(typechecker=beartype)`
+decorates the generic `masked_forward` (residual `[*leading d]`, masks `[*leading _]`,
+delta masks `[*leading]`, routes `[*leading]` — `*leading` is bound consistently across
+all of them by jaxtyping), the core `step` (residual `[*leading d]`), and the pure loss
+fns (`kl_per_position`, `faithfulness_loss`, `importance_minimality_terms`). The check
+runs on shaped JAX tracers under `jit`, so a target that emits a ragged leading prefix
+fails at trace time with a shape error rather than silently miscomputing a reduction.
+
+Per-site `C` / `d_in` / `d_out` are deliberately **anonymous** (`_`) inside the per-site
+dict annotations — they vary across sites, so they must not be bound across dict entries;
+only the `*leading` prefix is shared and bound.
+
+## Designed extensions (no current consumer — NOT implemented here)
+
+These fall out of the same axis-name machinery and are recorded so the next change has a
+target, but nothing consumes them today:
+
+- **PPGD source scope as "the subset of leading axes the source spans."** Today's
+  `c`/`sc`/`bsc` are LM-specific spellings (collapse batch, collapse nothing, etc.).
+  Generalized, a scope is a subset of `leading_axes` (plus the implicit batch axis) that
+  the adversarial source is *independent over*; the complementary axes are singleton and
+  broadcast. The current LM code keeps the `c`/`sc`/`bsc` literals; generalizing scope to
+  arbitrary axis subsets is out of scope for this change.
+- **Tying as a shared `vu` leaf.** Tied decomposed weights would be expressed as a single
+  shared leaf in the `vu` pytree referenced by multiple sites, rather than a separate
+  tying mechanism. No current consumer.
+
+## Out of scope for this change
+
+- **TMS** is not ported here (separate task). `leading_axes=()` is the contract a TMS
+  target would declare, but no TMS `DecomposedModel` exists in this distribution yet.
+- **Source-scope over arbitrary axes** (above) — `c`/`sc`/`bsc` stay LM-shaped.

--- a/param_decomp_jax/jax_single_pool/CLAUDE.md
+++ b/param_decomp_jax/jax_single_pool/CLAUDE.md
@@ -25,18 +25,27 @@ never silently diverge. Cite IDs (`S14`, `N1`, …) in commit messages and revie
 
 ## Architecture in one breath
 
-`lm.py` defines `DecomposedModel` — ordered `sites` + five pure fns (`clean_output`,
-`site_inputs`, `masked_output`, `weight_deltas`) plus a pluggable `recon_loss_fn`
-(default `kl_per_position`), flat site-name-keyed dicts at the boundary, frozen pytree
-always a runtime arg (never a jit closure constant — an 8B target becomes a multi-GB
-HLO constant). The `[B,T,d]` residual is the FIXED WAIST: masking / routing / sources /
-imp-min / the CI fn all stay `(B,T)`-shaped. Only three EDGES are generic so non-LM
-(bio-style) targets fit (#828): the model INPUT (`prefix_residual_fn(prefix, inputs)`
-in `run.py` takes `Any` — tokens for an LM, a dict for bio), the model OUTPUT
-(`clean_output`/`masked_output` return `Any` — logits, a tuple of heads, coords; field
-NAMES stay `*_logits` pending a deferred rename), and the recon comparison
-(`recon_loss_fn(clean_output, masked_output) -> scalar`, default
-`kl_per_position` so the LM path is byte-identical). `train.py` is the generic step factory
+`lm.py` defines `DecomposedModel` — ordered `sites` + `leading_axes` + five pure fns
+(`clean_output`, `site_inputs`, `masked_output`, `weight_deltas`) plus a pluggable
+`recon_loss_fn` (default `kl_per_position`), flat site-name-keyed dicts at the boundary,
+frozen pytree always a runtime arg (never a jit closure constant — an 8B target becomes a
+multi-GB HLO constant). The activation waist is GENERIC `[*leading, d]` (masks/CI
+`[*leading, C]`), `leading = (batch,) + named position axes`: masking / routing / sources
+/ imp-min all read an opaque `leading = residual.shape[:-1]`; reductions are
+`math.prod(shape[:-1])` / `axis=tuple(range(ndim-1))`. CI is independent over every leading
+axis (no per-axis CI semantics, only axis NAMES — see AXIS_SEMANTICS_DESIGN.md).
+`DecomposedModel.leading_axes` names the position axes (`("sequence",)` for LM, `()` for
+TMS); `CIFn.expects_axes` mirrors it, and `init_train_state` asserts they're equal (early
+fail) so the CI fn stays per-domain (RoPE over `sequence`) without the core adapting. The
+three EDGES are generic so non-LM (bio-style) targets fit (#828): the model INPUT
+(`prefix_residual_fn(prefix, inputs)` in `run.py` takes `Any` — tokens for an LM, a dict
+for bio), the model OUTPUT (`clean_output`/`masked_output` return `Any` — logits, a tuple
+of heads, coords; field NAMES stay `*_logits` pending a deferred rename), and the recon
+comparison (`recon_loss_fn(clean_output, masked_output) -> scalar`, default
+`kl_per_position` so the LM path is byte-identical). The waist shape contract (all per-site
+tensors in one forward share one `*leading` prefix) is enforced at trace time by
+`@jaxtyped(typechecker=beartype)` on the core `step`, `masked_forward`, and the loss fns.
+`train.py` is the generic step factory
 (fp32 masters / bf16 compute) over a static tuple of recon loss TERMS (S10′ — the
 torch loss-class cartesian product factored as chunking × routing × mask-source
 strategy: a chunking helper (`one_chunk`/`per_site`/`into_groups`) feeds the single

--- a/param_decomp_jax/jax_single_pool/adversary.py
+++ b/param_decomp_jax/jax_single_pool/adversary.py
@@ -37,17 +37,17 @@ class SourcesAdamState:
 def init_persistent_sources(
     site_names: tuple[str, ...],
     site_component_counts: tuple[int, ...],
-    seq_len: int,
-    batch_dim: int,
+    leading_shape: tuple[int, ...],
     key: PRNGKeyArray,
 ) -> dict[str, Array]:
-    """Per-site PPGD sources `(batch_dim, T, C+1)`, init U[0,1] (SPEC S15; clamp
-    parameterization); trailing channel = the weight-delta source. `batch_dim` spells the
-    scope's leading axis (SPEC §1.6): 1 for `sc` (shared across batch, free per position),
-    B for `bsc` (independent per batch element and position)."""
+    """Per-site PPGD sources `(*leading_shape, C+1)`, init U[0,1] (SPEC S15; clamp
+    parameterization); trailing channel = the weight-delta source. `leading_shape` spells
+    the scope over the model's leading axes (SPEC §1.6): for an LM `(1, T)` for `sc`
+    (batch axis collapsed -> shared across batch, free per position) and `(B, T)` for `bsc`
+    (independent per batch element and position)."""
     keys = random.split(key, len(site_names))
     return {
-        name: random.uniform(k, (batch_dim, seq_len, c + 1), jnp.float32)
+        name: random.uniform(k, (*leading_shape, c + 1), jnp.float32)
         for name, c, k in zip(site_names, site_component_counts, keys, strict=True)
     }
 
@@ -56,24 +56,26 @@ def init_fresh_pgd_sources(
     sites: tuple[SiteSpec, ...],
     init: Literal["random", "ones", "zeroes"],
     scope: Literal["c", "bc", "bsc"],
-    batch: int,
-    seq: int,
+    leading: tuple[int, ...],
     key: PRNGKeyArray,
 ) -> dict[str, Array]:
     """Per-site fresh adversarial sources (torch `_init_adv_sources`): trailing channel
-    is the weight-delta source; shape per `scope` (shape-spelled: `bsc` ->
-    `(B, T, C+1)`, `bc` -> `(B, 1, C+1)`, `c` -> `(1, 1, C+1)`)."""
+    is the weight-delta source; `leading = (B,) + position axes`. The source's leading
+    shape spells `scope` over those axes (LM `(B, T)`): `bsc` keeps the full leading,
+    `bc` collapses every position axis to 1 (`(B, 1)`), `c` collapses every axis to 1
+    (`(1, 1)`)."""
+    batch, *positions = leading
     match scope:
         case "bsc":
-            leading = (batch, seq)
+            source_leading = leading
         case "bc":
-            leading = (batch, 1)
+            source_leading = (batch, *(1 for _ in positions))
         case "c":
-            leading = (1, 1)
+            source_leading = tuple(1 for _ in leading)
     keys = random.split(key, len(sites))
     sources = {}
     for site, site_key in zip(sites, keys, strict=True):
-        shape = (*leading, site.C + 1)
+        shape = (*source_leading, site.C + 1)
         match init:
             case "random":
                 sources[site.name] = random.uniform(site_key, shape, jnp.float32)

--- a/param_decomp_jax/jax_single_pool/ci_fn.py
+++ b/param_decomp_jax/jax_single_pool/ci_fn.py
@@ -107,6 +107,10 @@ class CIFn(eqx.Module):
     site_names: tuple[str, ...] = eqx.field(static=True)
     split_sizes: tuple[int, ...] = eqx.field(static=True)
     eps: float = eqx.field(static=True)
+    expects_axes: tuple[str, ...] = eqx.field(static=True)
+    """The leading position-axis names this CI fn expects; must equal the
+    `DecomposedModel.leading_axes` it pairs with (asserted at trainer construction). This
+    LM CI fn applies RoPE over a single `sequence` axis, so it expects `("sequence",)`."""
 
     def _site_slices(self) -> dict[str, slice]:
         offsets = [0]
@@ -192,4 +196,5 @@ def init_ci_fn(arch: CIArch, sites: tuple[SiteSpec, ...], key: PRNGKeyArray) -> 
         site_names=tuple(s.name for s in sites),
         split_sizes=tuple(s.C for s in sites),
         eps=CI_FN_RMS_EPS,
+        expects_axes=("sequence",),
     )

--- a/param_decomp_jax/jax_single_pool/eval.py
+++ b/param_decomp_jax/jax_single_pool/eval.py
@@ -120,7 +120,7 @@ def make_eval_step(
         ci_fn: Any,
         frozen: Any,
         token_ids: Int[Array, "B T"],
-        residual: Float[Array, "B T d"],
+        residual: Float[Array, "*leading d"],
         key: PRNGKeyArray,
     ) -> dict[str, Array]:
         residual = batch_sharded(residual)
@@ -132,8 +132,8 @@ def make_eval_step(
         # one explicit C-shard -> batch-shard reshard; see train.py batch_sharded_ci
         ci_lower = {site: batch_sharded(v) for site, v in ci_fn_bf16(site_inputs).lower.items()}
 
-        batch, seq = token_ids.shape
-        zeros_delta = {site: jnp.zeros((batch, seq), COMPUTE_DT) for site in site_names}
+        leading = token_ids.shape
+        zeros_delta = {site: jnp.zeros(leading, COMPUTE_DT) for site in site_names}
 
         stoch_key, random_key, pgd_key = random.split(key, 3)
         variant_masks: dict[str, tuple[dict[str, Array], dict[str, Array]]] = {}
@@ -151,7 +151,7 @@ def make_eval_step(
             )
             stoch_masks[site] = ci_site + (1.0 - ci_site) * stochastic_source
             stoch_deltas[site] = random.uniform(
-                random.fold_in(stoch_key, len(site_names) + site_idx), (batch, seq), COMPUTE_DT
+                random.fold_in(stoch_key, len(site_names) + site_idx), leading, COMPUTE_DT
             )
         variant_masks["stoch_masked"] = (stoch_masks, stoch_deltas)
         variant_masks["random_masked"] = (

--- a/param_decomp_jax/jax_single_pool/experiments/invariance_check.py
+++ b/param_decomp_jax/jax_single_pool/experiments/invariance_check.py
@@ -60,7 +60,7 @@ def _run(steps: int, sharded: bool) -> list[dict[str, float]]:
     opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)
     src = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, 1, random.PRNGKey(3)
+        lm.site_names, tuple(s.C for s in lm.sites), (1, seq), random.PRNGKey(3)
     )
     resid = random.normal(random.PRNGKey(4), (gbatch, seq, cfg.n_embd)) * 0.5
 

--- a/param_decomp_jax/jax_single_pool/experiments/llama8b_real.py
+++ b/param_decomp_jax/jax_single_pool/experiments/llama8b_real.py
@@ -187,7 +187,7 @@ def main():
         src = {
             k: jax.device_put(v, repl)
             for k, v in init_persistent_sources(
-                lm.site_names, site_Cs, args.seq, 1, random.PRNGKey(3)
+                lm.site_names, site_Cs, (1, args.seq), random.PRNGKey(3)
             ).items()
         }
     resid = shard_batch(resid_global, mesh)

--- a/param_decomp_jax/jax_single_pool/hidden_acts_eval.py
+++ b/param_decomp_jax/jax_single_pool/hidden_acts_eval.py
@@ -46,10 +46,10 @@ class SiteMSEReduction:
     n_elements: int
 
 
-def _all_false_routes(site_names: tuple[str, ...], batch: int, seq: int) -> dict[str, Array]:
+def _all_false_routes(site_names: tuple[str, ...], leading: tuple[int, ...]) -> dict[str, Array]:
     """Route every position to the frozen path so `masked_site_outputs` returns the
     target `x @ W` per site (the clean recon target)."""
-    return {s: jnp.zeros((batch, seq), bool) for s in site_names}
+    return {s: jnp.zeros(leading, bool) for s in site_names}
 
 
 def _per_site_sum_mse(
@@ -63,7 +63,7 @@ def _per_site_sum_mse(
 
 
 HiddenActsStep = Callable[
-    [Any, Any, Any, Float[Array, "B T d"], PRNGKeyArray],
+    [Any, Any, Any, Float[Array, "*leading d"], PRNGKeyArray],
     tuple[dict[str, Array], dict[str, int]],
 ]
 """`(components, ci_fn, frozen, residual, key) -> ({site: sum_mse}, {site: n_elements})`
@@ -80,7 +80,7 @@ def make_ci_hidden_acts_step(lm: DecomposedModel) -> HiddenActsStep:
         components: Any,
         ci_fn: Any,
         frozen: Any,
-        residual: Float[Array, "B T d"],
+        residual: Float[Array, "*leading d"],
         _key: PRNGKeyArray,
     ) -> tuple[dict[str, Array], dict[str, int]]:
         site_inputs = lm.site_inputs(frozen, residual)
@@ -88,12 +88,12 @@ def make_ci_hidden_acts_step(lm: DecomposedModel) -> HiddenActsStep:
         ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
         ci_lower = ci_fn_bf16(site_inputs).lower
 
-        batch, seq = residual.shape[0], residual.shape[1]
-        zeros_delta = {s: jnp.zeros((batch, seq), COMPUTE_DT) for s in site_names}
+        leading = residual.shape[:-1]
+        zeros_delta = {s: jnp.zeros(leading, COMPUTE_DT) for s in site_names}
         clean = lm.masked_site_outputs(
             frozen, components_bf16, residual,
             {s: jnp.ones_like(ci_lower[s]) for s in site_names}, zeros_delta,
-            _all_false_routes(site_names, batch, seq), site_names, False,
+            _all_false_routes(site_names, leading), site_names, False,
         )  # fmt: skip
         masked = lm.masked_site_outputs(
             frozen, components_bf16, residual, ci_lower, zeros_delta, None, site_names, False
@@ -116,19 +116,23 @@ def make_stochastic_hidden_acts_step(
 
     @jax.jit
     def step(
-        components: Any, ci_fn: Any, frozen: Any, residual: Float[Array, "B T d"], key: PRNGKeyArray
+        components: Any,
+        ci_fn: Any,
+        frozen: Any,
+        residual: Float[Array, "*leading d"],
+        key: PRNGKeyArray,
     ) -> tuple[dict[str, Array], dict[str, int]]:
         site_inputs = lm.site_inputs(frozen, residual)
         components_bf16 = cast_floating(components, COMPUTE_DT)
         ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
         ci_lower = ci_fn_bf16(site_inputs).lower
 
-        batch, seq = residual.shape[0], residual.shape[1]
+        leading = residual.shape[:-1]
         clean = lm.masked_site_outputs(
             frozen, components_bf16, residual,
             {s: jnp.ones_like(ci_lower[s]) for s in site_names},
-            {s: jnp.zeros((batch, seq), COMPUTE_DT) for s in site_names},
-            _all_false_routes(site_names, batch, seq), site_names, False,
+            {s: jnp.zeros(leading, COMPUTE_DT) for s in site_names},
+            _all_false_routes(site_names, leading), site_names, False,
         )  # fmt: skip
 
         sum_mse = {s: jnp.zeros((), jnp.float32) for s in site_names}
@@ -146,7 +150,7 @@ def make_stochastic_hidden_acts_step(
                         source = random.bernoulli(source_key, 0.5, ci_site.shape).astype(COMPUTE_DT)
                 masks[site] = ci_site + (1.0 - ci_site) * source
                 delta_masks[site] = random.uniform(
-                    random.fold_in(delta_key, site_idx), (batch, seq), COMPUTE_DT
+                    random.fold_in(delta_key, site_idx), leading, COMPUTE_DT
                 )
             masked = lm.masked_site_outputs(
                 frozen, components_bf16, residual, masks, delta_masks, None, site_names, True
@@ -165,7 +169,7 @@ def accumulate_hidden_acts(
     components: Any,
     ci_fn: Any,
     frozen: Any,
-    residual_batches: list[Float[Array, "B T d"]],
+    residual_batches: list[Float[Array, "*leading d"]],
     base_key: PRNGKeyArray,
 ) -> dict[str, SiteMSEReduction]:
     """Drive `step` over the eval batches, host-accumulating `(Σ sum_mse, Σ n)` per site

--- a/param_decomp_jax/jax_single_pool/llama8b.py
+++ b/param_decomp_jax/jax_single_pool/llama8b.py
@@ -507,6 +507,7 @@ def llama_decomposed_lm(cfg: LlamaConfig, sites: tuple[SiteSpec, ...]) -> Decomp
     first_layer = first_decomposed_layer(site_names)
     return DecomposedModel(
         sites=sites,
+        leading_axes=("sequence",),
         clean_output=lambda frozen, resid: clean_suffix_logits(frozen, resid),
         site_inputs=lambda frozen, resid: clean_site_inputs(frozen, first_layer, site_names, resid),
         masked_output=lambda frozen,

--- a/param_decomp_jax/jax_single_pool/llama8b_sharding.py
+++ b/param_decomp_jax/jax_single_pool/llama8b_sharding.py
@@ -139,12 +139,13 @@ def init_sources_sharded(
     batch-sharded elementwise combine."""
     match scope:
         case SCScope():
-            batch_dim, placement = 1, NamedSharding(mesh, P())
+            leading_shape, placement = (1, seq_len), NamedSharding(mesh, P())
         case BSCScope():
-            batch_dim, placement = global_batch, NamedSharding(mesh, P("dp", None, None))
+            leading_shape = (global_batch, seq_len)
+            placement = NamedSharding(mesh, P("dp", None, None))
         case _:
             raise AssertionError(f"unsupported persistent scope {scope}")
-    init = partial(init_persistent_sources, site_names, site_component_counts, seq_len, batch_dim)
+    init = partial(init_persistent_sources, site_names, site_component_counts, leading_shape)
     return jax.jit(init, out_shardings=placement)(key)
 
 

--- a/param_decomp_jax/jax_single_pool/llama_simple_mlp.py
+++ b/param_decomp_jax/jax_single_pool/llama_simple_mlp.py
@@ -501,6 +501,7 @@ def llama_simple_mlp_decomposed_lm(
     first_layer = first_decomposed_layer(site_names)
     return DecomposedModel(
         sites=sites,
+        leading_axes=("sequence",),
         clean_output=lambda frozen, resid: clean_suffix_logits(frozen, resid),
         site_inputs=lambda frozen, resid: clean_site_inputs(frozen, first_layer, site_names, resid),
         masked_output=lambda frozen,

--- a/param_decomp_jax/jax_single_pool/lm.py
+++ b/param_decomp_jax/jax_single_pool/lm.py
@@ -6,12 +6,16 @@ pytrees. Everything at the boundary is keyed by site name (flat dicts, torch-mod
 style); how a target lays its parameters out internally (e.g. the Llama target's stacked
 layer axis) is its own business.
 
-The `[B,T,d]` residual is the FIXED WAIST: masking, routing, source scopes, imp-min, the
-CI fn, and normalization all operate on `(B,T)` and stay LM-shaped. Only the three EDGES
-are generic — the model's INPUT (whatever `site_inputs`/`clean_output`/`masked_output`
-read upstream of the residual; tokens for an LM, a dict for a bio target), the model's
-OUTPUT (`clean_output`/`masked_output` return `Any` — logits, a tuple of heads, coords),
-and the recon comparison (`recon_loss_fn`, default `kl_per_position`).
+The activation WAIST is generic: per decomposed site activations are `[*leading, d]`
+and masks/CI are `[*leading, C]`, where `leading = (batch,) + named position axes`
+(`leading_axes` names the position axes; `("sequence",)` for an LM, `()` for TMS). Batch
+is ever-present and semantics-free (the data/shard axis); CI is always independent over
+every leading axis. Masking, routing, source scopes, imp-min, and normalization all
+operate over the opaque `*leading` prefix. The three EDGES are generic too — the model's
+INPUT (whatever `site_inputs`/`clean_output`/`masked_output` read upstream of the
+residual; tokens for an LM, a dict for a bio target), the model's OUTPUT
+(`clean_output`/`masked_output` return `Any` — logits, a tuple of heads, coords), and the
+recon comparison (`recon_loss_fn`, default `kl_per_position`).
 
 Every function takes the frozen-target pytree as a RUNTIME argument. Never close over
 it: a frozen 8B target captured as a jit constant bakes multi-GB weights into the HLO.
@@ -25,9 +29,9 @@ from jaxtyping import Array, Bool, Float
 
 from jax_single_pool.losses import kl_per_position
 
-SiteMasks = dict[str, Float[Array, "B T C"]]
-SiteDeltaMasks = dict[str, Float[Array, "B T"]]
-SiteRoutes = dict[str, Bool[Array, "B T"]] | None
+SiteMasks = dict[str, Float[Array, "*leading C"]]
+SiteDeltaMasks = dict[str, Float[Array, "*leading"]]
+SiteRoutes = dict[str, Bool[Array, "*leading"]] | None
 """Per-site per-position routing; `None` routes every position to the decomposition
 (SPEC §1.3). Positions routing False take the frozen `x @ W` path."""
 
@@ -64,9 +68,14 @@ class DecomposedModel:
     `has_delta` (static) False skips the `x @ Δ` matmul for constant-source entries
     whose delta mask is a constant 0 (LOSS_PARITY_DESIGN §4b).
 
+    `leading_axes` names the position axes of the activation waist (batch is implicit and
+    always present): `("sequence",)` for an LM, `()` for a TMS-style target. At trainer
+    construction it must equal the CI fn's `expects_axes` (early fail) so the CI fn stays
+    per-domain without the generic loop adapting.
+
     `clean_output` is the all-frozen forward — the recon target (SPEC S3); never the
     `mask=1` decomposed identity. Its output (and `masked_output`') is `Any`: an LM
-    emits `[B,T,vocab]` logits, a bio target a tuple of heads or coordinates.
+    emits `[*leading, vocab]` logits, a bio target a tuple of heads or coordinates.
 
     `weight_deltas` returns fp32 `W − V@U` per site from fp32 master `vu` (SPEC N2).
 
@@ -84,13 +93,16 @@ class DecomposedModel:
     """
 
     sites: tuple[SiteSpec, ...]
-    clean_output: Callable[[Any, Float[Array, "B T d"]], Any]
-    site_inputs: Callable[[Any, Float[Array, "B T d"]], dict[str, Float[Array, "B T d_in"]]]
+    leading_axes: tuple[str, ...]
+    clean_output: Callable[[Any, Float[Array, "*leading d"]], Any]
+    site_inputs: Callable[
+        [Any, Float[Array, "*leading d"]], dict[str, Float[Array, "*leading d_in"]]
+    ]
     masked_output: Callable[
         [
             Any,
             Any,
-            Float[Array, "B T d"],
+            Float[Array, "*leading d"],
             SiteMasks,
             SiteDeltaMasks,
             SiteRoutes,
@@ -103,14 +115,14 @@ class DecomposedModel:
         [
             Any,
             Any,
-            Float[Array, "B T d"],
+            Float[Array, "*leading d"],
             SiteMasks,
             SiteDeltaMasks,
             SiteRoutes,
             tuple[str, ...],
             bool,
         ],
-        dict[str, Float[Array, "B T d_out"]],
+        dict[str, Float[Array, "*leading d_out"]],
     ]
     weight_deltas: Callable[[Any, Any], dict[str, Float[Array, "d_out d_in"]]]
     recon_loss_fn: Callable[[Any, Any], Float[Array, ""]] = field(default=kl_per_position)

--- a/param_decomp_jax/jax_single_pool/losses.py
+++ b/param_decomp_jax/jax_single_pool/losses.py
@@ -1,25 +1,34 @@
 """The pure loss terms (SPEC §2) and their schedules — fp32 reductions, no state."""
 
+import math
+
 import jax
 import jax.numpy as jnp
-from jaxtyping import Array
+from beartype import beartype
+from jaxtyping import Array, Float, jaxtyped
 
 from param_decomp_config.losses import ImportanceMinimalityLossConfig
 
 
-def kl_per_position(masked_output: Array, clean_output: Array) -> Array:
-    """`Σ_{b,t} KL(softmax(clean) ‖ softmax(masked)) / (B·T)` in fp32 (SPEC §2.3, N3)."""
+@jaxtyped(typechecker=beartype)
+def kl_per_position(
+    masked_output: Float[Array, "*leading vocab"], clean_output: Float[Array, "*leading vocab"]
+) -> Float[Array, ""]:
+    """`Σ_{*leading} KL(softmax(clean) ‖ softmax(masked)) / Π(*leading)` in fp32
+    (SPEC §2.3, N3); `*leading` is every axis but the final logit axis."""
     masked_output = masked_output.astype(jnp.float32)
     clean_output = clean_output.astype(jnp.float32)
     log_q = jax.nn.log_softmax(masked_output, axis=-1)
     log_p = jax.nn.log_softmax(clean_output, axis=-1)
     p = jnp.exp(log_p)
-    n_positions = masked_output.shape[0] * masked_output.shape[1]
+    n_positions = math.prod(masked_output.shape[:-1])
     return jnp.sum(p * (log_p - log_q)) / n_positions
 
 
-def faithfulness_loss(weight_deltas: dict[str, Array]) -> Array:
-    """`Σ_s ‖Δ_s‖² / Σ_s numel` over fp32 deltas (SPEC S17)."""
+@jaxtyped(typechecker=beartype)
+def faithfulness_loss(weight_deltas: dict[str, Float[Array, "_ _"]]) -> Float[Array, ""]:
+    """`Σ_s ‖Δ_s‖² / Σ_s numel` over fp32 deltas (SPEC S17). Each `Δ_s` is `(d_out, d_in)`;
+    dims are per-site (anonymous, not bound across sites)."""
     numerator = sum(
         ((delta.astype(jnp.float32) ** 2).sum() for delta in weight_deltas.values()),
         start=jnp.zeros((), jnp.float32),
@@ -28,22 +37,24 @@ def faithfulness_loss(weight_deltas: dict[str, Array]) -> Array:
     return numerator / denominator
 
 
+@jaxtyped(typechecker=beartype)
 def importance_minimality_terms(
-    ci_upper: dict[str, Array], pnorm: Array, eps: float
-) -> tuple[Array, Array]:
+    ci_upper: dict[str, Float[Array, "*leading _"]], pnorm: Float[Array, ""], eps: float
+) -> tuple[Float[Array, ""], Float[Array, ""]]:
     """`(lp, entropy)` with per-site grouping and the global-batch sum inside the log2
     (SPEC S7/S8); the loss is `lp + beta * entropy`. Torch's `_no_beta` diagnostic (`lp`
     alone) is emitted only on the eval path (`Metric.compute`), never from the train
     step, so this trainer does not log a `train/loss/*_no_beta` key.
 
-    Under GSPMD the `(b, t)` axes are the global batch, so `jnp.sum` IS the exact
+    Under GSPMD the `*leading` axes are the global batch, so `jnp.sum` IS the exact
     global per-component sum — XLA reduces across shards inside the graph."""
     lp = jnp.zeros((), jnp.float32)
     entropy = jnp.zeros((), jnp.float32)
     for ci in ci_upper.values():
-        ci = ci.astype(jnp.float32)  # (B, T, C)
-        n_positions = ci.shape[0] * ci.shape[1]
-        per_component_sums = jnp.sum((ci + eps) ** pnorm, axis=(0, 1))  # (C,)
+        ci = ci.astype(jnp.float32)  # (*leading, C)
+        leading_axes = tuple(range(ci.ndim - 1))
+        n_positions = math.prod(ci.shape[:-1])
+        per_component_sums = jnp.sum((ci + eps) ** pnorm, axis=leading_axes)  # (C,)
         per_component_means = per_component_sums / n_positions
         lp = lp + jnp.sum(per_component_means)
         entropy = entropy + jnp.sum(per_component_means * jnp.log2(1.0 + per_component_sums))

--- a/param_decomp_jax/jax_single_pool/recon.py
+++ b/param_decomp_jax/jax_single_pool/recon.py
@@ -49,9 +49,9 @@ from param_decomp_config.routing import (
 )
 
 Routes = dict[str, Array] | None
-RoutingSampler = Callable[[PRNGKeyArray, tuple[int, int]], tuple[Routes, ...]]
-"""`(key, (B, T)) -> (routes, ...)` — a STATICALLY-sized family of routing draws, each
-`{site: bool[B, T]}` (or None = route everywhere) becoming ONE forward. The torch
+RoutingSampler = Callable[[PRNGKeyArray, tuple[int, ...]], tuple[Routes, ...]]
+"""`(key, leading_shape) -> (routes, ...)` — a STATICALLY-sized family of routing draws,
+each `{site: bool[*leading]}` (or None = route everywhere) becoming ONE forward. The torch
 `Router.get_masks` made pure: fresh draws per step require the key threaded in —
 samplers run INSIDE the jitted step, so they must be traceable (SPEC R1). Returning
 several draws from one invocation enables JOINTLY-sampled families (independent
@@ -150,14 +150,14 @@ ReconLossTerms = tuple[ReconLossTerm, ...]
 
 
 def uniform_k_subset_routes(
-    key: PRNGKeyArray, live_sites: tuple[str, ...], batch_seq_shape: tuple[int, ...]
+    key: PRNGKeyArray, live_sites: tuple[str, ...], leading_shape: tuple[int, ...]
 ) -> dict[str, Array]:
     """Per position: `k ~ U{1..|live|}`, then a uniform k-subset of the live sites
     routes True (SPEC S11). Distributionally identical to torch's double-argsort ranks."""
     n_sites = len(live_sites)
     k_key, perm_key = random.split(key)
-    k = random.randint(k_key, batch_seq_shape, 1, n_sites + 1)
-    perms = random.uniform(perm_key, (n_sites, *batch_seq_shape)).argsort(axis=0)
+    k = random.randint(k_key, leading_shape, 1, n_sites + 1)
+    perms = random.uniform(perm_key, (n_sites, *leading_shape)).argsort(axis=0)
     routed = perms < k
     return {name: routed[j] for j, name in enumerate(live_sites)}
 
@@ -165,9 +165,9 @@ def uniform_k_subset_routes(
 def uniform_k_routing(live_sites: tuple[str, ...], n_draws: int) -> RoutingSampler:
     """`n_draws` independent per-position uniform-k-subset draws over `live_sites`."""
 
-    def sample(key: PRNGKeyArray, batch_seq_shape: tuple[int, int]) -> tuple[Routes, ...]:
+    def sample(key: PRNGKeyArray, leading_shape: tuple[int, ...]) -> tuple[Routes, ...]:
         return tuple(
-            uniform_k_subset_routes(draw_key, live_sites, batch_seq_shape)
+            uniform_k_subset_routes(draw_key, live_sites, leading_shape)
             for draw_key in random.split(key, n_draws)
         )
 
@@ -180,10 +180,10 @@ def static_probability_routing(
     """`n_draws` independent draws routing each position to each live site with
     probability `p` (torch `StaticProbabilityRouter`)."""
 
-    def sample(key: PRNGKeyArray, batch_seq_shape: tuple[int, int]) -> tuple[Routes, ...]:
+    def sample(key: PRNGKeyArray, leading_shape: tuple[int, ...]) -> tuple[Routes, ...]:
         return tuple(
             {
-                name: random.bernoulli(random.fold_in(draw_key, j), p, batch_seq_shape)
+                name: random.bernoulli(random.fold_in(draw_key, j), p, leading_shape)
                 for j, name in enumerate(live_sites)
             }
             for draw_key in random.split(key, n_draws)
@@ -195,7 +195,7 @@ def static_probability_routing(
 def route_all_n(n_draws: int) -> RoutingSampler:
     """`n_draws` forwards, each routing every position to every live site (`AllRoutingConfig`)."""
 
-    def sample(_key: PRNGKeyArray, _batch_seq_shape: tuple[int, int]) -> tuple[Routes, ...]:
+    def sample(_key: PRNGKeyArray, _leading_shape: tuple[int, ...]) -> tuple[Routes, ...]:
         return (None,) * n_draws
 
     return sample

--- a/param_decomp_jax/jax_single_pool/run_state.py
+++ b/param_decomp_jax/jax_single_pool/run_state.py
@@ -91,6 +91,9 @@ def init_train_state(
 ) -> TrainState:
     components = init_decomp_vu_sharded(lm.sites, init_key, mesh)
     ci_fn = init_ci_fn_sharded(cfg.ci_fn, lm.sites, random.fold_in(init_key, 1), mesh)
+    assert ci_fn.expects_axes == lm.leading_axes, (
+        f"CI fn expects leading axes {ci_fn.expects_axes} but model has {lm.leading_axes}"
+    )
     loss_spec = build_recon_terms(cfg.loss_metrics, lm.site_names, cfg.n_mask_samples, cfg.sampling)
     sources = {
         state_key: init_sources_sharded(

--- a/param_decomp_jax/jax_single_pool/slow_eval.py
+++ b/param_decomp_jax/jax_single_pool/slow_eval.py
@@ -31,6 +31,7 @@ keys (`<ClassName>/<site>` + a combined `<ClassName>`).
 import argparse
 import io
 import json
+import math
 from collections.abc import Callable
 from dataclasses import dataclass
 from pathlib import Path
@@ -82,7 +83,7 @@ class SiteReduction:
 
 
 SlowEvalStep = Callable[
-    [Any, Any, Float[Array, "B T d"]],
+    [Any, Any, Float[Array, "*leading d"]],
     tuple[dict[str, Array], dict[str, Array], Array, dict[str, Array], dict[str, Array]],
 ]
 """`(ci_fn, frozen, residual) -> (density_counts, ci_sums, n_positions, flat_lower,
@@ -99,7 +100,7 @@ def make_slow_eval_step(lm: DecomposedModel, ci_alive_threshold: float) -> SlowE
 
     @jax.jit
     def slow_eval_step(
-        ci_fn: Any, frozen: Any, residual: Float[Array, "B T d"]
+        ci_fn: Any, frozen: Any, residual: Float[Array, "*leading d"]
     ) -> tuple[dict[str, Array], dict[str, Array], Array, dict[str, Array], dict[str, Array]]:
         # CI fn stays fp32 (its master dtype): torch offline-eval keeps V/U + CI fn fp32,
         # casting only the frozen target to bf16. The slow plot metrics are a
@@ -119,7 +120,7 @@ def make_slow_eval_step(lm: DecomposedModel, ci_alive_threshold: float) -> SlowE
         }
         ci_sums = {s: lower[s].reshape(-1, lower[s].shape[-1]).sum(0) for s in site_names}
         first = lower[site_names[0]]
-        n_positions = jnp.asarray(first.shape[0] * first.shape[1], jnp.int32)
+        n_positions = jnp.asarray(math.prod(first.shape[:-1]), jnp.int32)
         flat_lower = {s: lower[s].reshape(-1) for s in site_names}
         flat_logits = {s: logits[s].reshape(-1) for s in site_names}
         return density_counts, ci_sums, n_positions, flat_lower, flat_logits
@@ -131,7 +132,7 @@ def accumulate_site_reductions(
     slow_eval_step: SlowEvalStep,
     ci_fn: Any,
     frozen: Any,
-    residual_batches: list[Float[Array, "B T d"]],
+    residual_batches: list[Float[Array, "*leading d"]],
     n_batches_accum: int | None,
 ) -> dict[str, SiteReduction]:
     """Drive `slow_eval_step` over the eval batches and fold the per-batch reductions
@@ -279,7 +280,7 @@ def compute_hidden_acts_metrics(
     lm: DecomposedModel,
     state: Any,
     frozen: Any,
-    residual_batches: list[Float[Array, "B T d"]],
+    residual_batches: list[Float[Array, "*leading d"]],
     n_mask_samples: int,
     sampling: SamplingType,
     base_key: Array,

--- a/param_decomp_jax/jax_single_pool/tests/stacked_parity/gen_stacked_fixtures.py
+++ b/param_decomp_jax/jax_single_pool/tests/stacked_parity/gen_stacked_fixtures.py
@@ -103,7 +103,7 @@ def main() -> None:
     vu = init_decomp_vu(cfg, C, layer_range.n_layers, random.PRNGKey(1))
     ci_fn = init_ci_fn(CI_ARCH, lm.sites, random.PRNGKey(2))
     sources = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), T, 1, random.PRNGKey(3)
+        lm.site_names, tuple(s.C for s in lm.sites), (1, T), random.PRNGKey(3)
     )
     resid = random.normal(random.PRNGKey(4), (B, T, cfg.n_embd)) * 0.5
 

--- a/param_decomp_jax/jax_single_pool/tests/stacked_parity/test_stacked_parity.py
+++ b/param_decomp_jax/jax_single_pool/tests/stacked_parity/test_stacked_parity.py
@@ -191,7 +191,7 @@ def test_train_trajectory_matches():
     for leaf_idx, leaf in enumerate(jax.tree.leaves(eqx.filter(ci_fn, eqx.is_array))):
         np.testing.assert_array_equal(np.asarray(leaf), f[f"ci_leaf::{leaf_idx}"])
     sources = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), T, 1, random.PRNGKey(3)
+        lm.site_names, tuple(s.C for s in lm.sites), (1, T), random.PRNGKey(3)
     )
     for name, source in sources.items():
         np.testing.assert_array_equal(np.asarray(source), f[f"src::{name}"])

--- a/param_decomp_jax/jax_single_pool/tests/test_checkpoint.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_checkpoint.py
@@ -60,7 +60,7 @@ def _build(seed: int):
     opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)
     src = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, 1, jax.random.PRNGKey(seed + 2)
+        lm.site_names, tuple(s.C for s in lm.sites), (1, seq), jax.random.PRNGKey(seed + 2)
     )
     state = TrainState(
         components=vu, ci_fn=ci_fn,

--- a/param_decomp_jax/jax_single_pool/tests/test_fresh_pgd_cscope_dp_invariance.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_fresh_pgd_cscope_dp_invariance.py
@@ -69,7 +69,7 @@ def _ascend_cscope_source(
     # sign-ascent. Shapes match the masked forward's per-site (B, T, C) expectation.
     ci_lower = {s.name: jnp.zeros((gbatch, seq, s.C), jnp.float32) for s in sites}
 
-    init = init_fresh_pgd_sources(sites, "random", "c", gbatch, seq, random.PRNGKey(5))
+    init = init_fresh_pgd_sources(sites, "random", "c", (gbatch, seq), random.PRNGKey(5))
 
     def ascent_loss(sources: dict[str, jax.Array]) -> jax.Array:
         masks, delta_masks = source_masks(ci_lower, sources, lm.site_names)

--- a/param_decomp_jax/jax_single_pool/tests/test_generic_model_io.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_generic_model_io.py
@@ -127,6 +127,7 @@ def _synthetic_lm() -> DecomposedModel:
 
     return DecomposedModel(
         sites=(site,),
+        leading_axes=("sequence",),
         clean_output=clean_output,
         site_inputs=site_inputs,
         masked_output=masked_output,
@@ -148,6 +149,7 @@ def test_default_recon_loss_fn_is_kl_per_position():
 
     lm = DecomposedModel(
         sites=(SiteSpec(SITE, D, D, C),),
+        leading_axes=("sequence",),
         clean_output=lambda f, r: r,
         site_inputs=lambda f, r: {SITE: r},
         masked_output=lambda *a: a[2],

--- a/param_decomp_jax/jax_single_pool/tests/test_llama8b.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_llama8b.py
@@ -281,7 +281,7 @@ def test_step_trains_and_has_vpd_signature(site_cs: tuple[SiteC, ...]):
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)
 
     src = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, 1, jax.random.PRNGKey(3)
+        lm.site_names, tuple(s.C for s in lm.sites), (1, seq), jax.random.PRNGKey(3)
     )
     state = TrainState(
         components=vu, ci_fn=ci_fn,

--- a/param_decomp_jax/jax_single_pool/tests/test_llama_simple_mlp.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_llama_simple_mlp.py
@@ -376,7 +376,7 @@ def test_step_trains_and_has_vpd_signature():
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)
 
     src = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, 1, jax.random.PRNGKey(3)
+        lm.site_names, tuple(s.C for s in lm.sites), (1, seq), jax.random.PRNGKey(3)
     )
     state = TrainState(
         components=vu, ci_fn=ci_fn,

--- a/param_decomp_jax/jax_single_pool/tests/test_sharding.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_sharding.py
@@ -104,7 +104,7 @@ def test_jitted_sharded_inits_match_eager_values():
     src_sharded = init_sources_sharded(
         site_names, site_Cs, 16, SCScope(), 1, jax.random.PRNGKey(3), mesh
     )
-    src_eager = init_persistent_sources(site_names, site_Cs, 16, 1, jax.random.PRNGKey(3))
+    src_eager = init_persistent_sources(site_names, site_Cs, (1, 16), jax.random.PRNGKey(3))
     for name in site_names:
         src_sharding = src_sharded[name].sharding
         assert isinstance(src_sharding, NamedSharding)
@@ -153,8 +153,8 @@ def test_fresh_pgd_c_bc_sources_are_replica_identical():
 
     for scope in ("c", "bc"):
         key = jax.random.PRNGKey(660)
-        eager = init_fresh_pgd_sources(sites, "random", scope, batch, seq, key)
-        init = partial(init_fresh_pgd_sources, sites, "random", scope, batch, seq)
+        eager = init_fresh_pgd_sources(sites, "random", scope, (batch, seq), key)
+        init = partial(init_fresh_pgd_sources, sites, "random", scope, (batch, seq))
         repl = NamedSharding(mesh, P())
         sharded = jax.jit(init, out_shardings=repl)(key)
         for site in sites:

--- a/param_decomp_jax/jax_single_pool/tests/test_source_grad_mean.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_source_grad_mean.py
@@ -63,7 +63,7 @@ def _source_grad(sharded: bool) -> dict[str, jax.Array]:
     vu = init_decomp_vu(sites, random.PRNGKey(1))
     ci_fn = init_ci_fn(CIArch(16, 2, 2, 32), lm.sites, random.PRNGKey(2))
     src = init_persistent_sources(
-        lm.site_names, tuple(s.C for s in lm.sites), seq, 1, random.PRNGKey(3)
+        lm.site_names, tuple(s.C for s in lm.sites), (1, seq), random.PRNGKey(3)
     )
     resid = random.normal(random.PRNGKey(4), (gbatch, seq, cfg.n_embd)) * 0.5
 

--- a/param_decomp_jax/jax_single_pool/train.py
+++ b/param_decomp_jax/jax_single_pool/train.py
@@ -22,10 +22,11 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import optax
+from beartype import beartype
 from jax import random
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
-from jaxtyping import Array, Float, PRNGKeyArray
+from jaxtyping import Array, Bool, Float, PRNGKeyArray, jaxtyped
 
 from jax_single_pool.adversary import (
     SourcesAdamState,
@@ -161,16 +162,17 @@ def make_train_step(
             upper={site: batch_sharded(v) for site, v in ci_values.upper.items()},
         )
 
+    @jaxtyped(typechecker=beartype)
     def masked_forward(
         frozen: Any,
         components_bf16: Any,
-        residual: Array,
-        masks: dict[str, Array],
-        delta_masks: dict[str, Array],
-        routes: dict[str, Array] | None,
+        residual: Float[Array, "*leading d"],
+        masks: dict[str, Float[Array, "*leading _"]],
+        delta_masks: dict[str, Float[Array, "..."]],
+        routes: dict[str, Bool[Array, "*leading"]] | None,
         live_sites: tuple[str, ...],
         has_delta: bool,
-    ) -> Array:
+    ) -> Any:
         return batch_sharded(
             lm.masked_output(
                 frozen, components_bf16, residual, masks, delta_masks, routes, live_sites, has_delta
@@ -190,7 +192,7 @@ def make_train_step(
         strategy: StochasticSources,
         ci_lower: dict[str, Array],
         live_sites: tuple[str, ...],
-        batch_seq: tuple[int, int],
+        leading_shape: tuple[int, ...],
         draw_key: PRNGKeyArray,
     ) -> tuple[dict[str, Array], dict[str, Array]]:
         mask_source_key, delta_mask_key = random.split(draw_key)
@@ -208,7 +210,7 @@ def make_train_step(
                     )
             masks[site] = ci_site + (1.0 - ci_site) * stochastic_source
             delta_masks[site] = random.uniform(
-                random.fold_in(delta_mask_key, site_idx), batch_seq, COMPUTE_DT
+                random.fold_in(delta_mask_key, site_idx), leading_shape, COMPUTE_DT
             )
         return masks, delta_masks
 
@@ -254,12 +256,13 @@ def make_train_step(
         return total / len(routes_per_draw)
 
     @jax.jit
+    @jaxtyped(typechecker=beartype)
     def step(
-        state: TrainState, frozen: Any, residual: Float[Array, "b t d"], key: PRNGKeyArray
+        state: TrainState, frozen: Any, residual: Float[Array, "*leading d"], key: PRNGKeyArray
     ) -> tuple[TrainState, dict[str, Array]]:
         step_f32 = state.step.astype(jnp.float32)
         pnorm = annealed_pnorm(step_f32, total_steps, imp_min)
-        batch, seq = residual.shape[0], residual.shape[1]
+        leading = residual.shape[:-1]
 
         residual = batch_sharded(residual)
         clean_output = jax.lax.stop_gradient(batch_sharded(lm.clean_output(frozen, residual)))
@@ -349,11 +352,11 @@ def make_train_step(
                     continue
                 fresh_cfg = entry.sources
                 routing_key, init_key = random.split(random.fold_in(term_key, entry_idx))
-                routes_per_draw = entry.sample_routing(routing_key, (batch, seq))
+                routes_per_draw = entry.sample_routing(routing_key, leading)
                 fixed_routes[(term_idx, entry_idx)] = routes_per_draw
                 live_specs = tuple(s for s in lm.sites if s.name in entry.live_sites)
                 init = init_fresh_pgd_sources(
-                    live_specs, fresh_cfg.init, fresh_cfg.scope, batch, seq, init_key
+                    live_specs, fresh_cfg.init, fresh_cfg.scope, leading, init_key
                 )
 
                 def ascent_loss(
@@ -418,13 +421,13 @@ def make_train_step(
                         case FreshPGDSources():
                             routes_per_draw = fixed_routes[(term_idx, entry_idx)]
                         case _:
-                            routes_per_draw = entry.sample_routing(routing_key, (batch, seq))
+                            routes_per_draw = entry.sample_routing(routing_key, leading)
                     for draw_idx, routes in enumerate(routes_per_draw):
                         draw_key = random.fold_in(entry_key, draw_idx)
                         match entry.sources:
                             case StochasticSources() as strategy:
                                 masks, delta_masks = stochastic_entry_masks(
-                                    strategy, ci.lower, entry.live_sites, (batch, seq), draw_key
+                                    strategy, ci.lower, entry.live_sites, leading, draw_key
                                 )
                             case ConstantSources() as strategy:
                                 masks, delta_masks = constant_entry_masks(

--- a/param_decomp_jax/pyproject.toml
+++ b/param_decomp_jax/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
     "equinox==0.13.8",
     "optax==0.2.8",
     "jaxtyping==0.3.10",
+    "beartype==0.22.2",
     "einops==0.8.2",
     "numpy==2.4.6",
     "safetensors==0.7.0",


### PR DESCRIPTION
## What

Generalizes the JAX single-pool trainer core from the fixed `(B,T)` activation waist to a generic **`[*leading, d]`** waist (masks/CI `[*leading, C]`), where `leading = (batch,) + named position axes`. Batch is ever-present and semantics-free; **CI is independent over every leading axis** (`broadcast_ci` dropped, team consensus) — so there is no per-axis CI semantics, only axis *names*.

The LM path is **byte-identical**: the equivalence + stacked-parity goldens are unmodified and pass. This was the honesty gate.

## The shape contract

- `DecomposedModel` gains `leading_axes: tuple[str, ...]` (`("sequence",)` for LM, `()` for TMS).
- `CIFn` gains `expects_axes`; `init_train_state` **asserts `ci_fn.expects_axes == model.leading_axes`** (early fail) so the CI fn stays per-domain (RoPE over `sequence`) without the generic loop adapting.
- `@jaxtyped(typechecker=beartype)` on the core `step`, `masked_forward` (residual/masks/routes bind one shared `*leading`), and the pure loss fns — enforced at trace time, not cosmetic. New dep `beartype==0.22.2`.

## What changed

- **train.py** (keystone): `leading = residual.shape[:-1]`, threaded to routing samplers / fresh-PGD source init / stochastic delta-mask shapes (`leading_shape: tuple[int, ...]`).
- **losses.py**: imp-min + `kl_per_position` — `shape[0]*shape[1]` → `math.prod(shape[:-1])`, `axis=(0,1)` → `axis=tuple(range(ndim-1))`.
- **recon.py**: `RoutingSampler` + bodies `tuple[int,int]` → `tuple[int,...]`.
- **adversary.py / llama8b_sharding.py**: `init_persistent_sources` takes `leading_shape`; `init_fresh_pgd_sources` spells `c/bc/bsc` over the model's `leading`; sharding builds the per-scope leading (`sc`→`(1,T)`, `bsc`→`(B,T)`).
- **eval / slow_eval / hidden_acts_eval**: same `shape[:-1]` / `prod` generalizations.
- **lm.py** type aliases → `*leading`.
- **AXIS_SEMANTICS_DESIGN.md** documents the contract + designed (unimplemented, no consumer) extensions: PPGD scope as a leading-axis subset; tying as a shared `vu` leaf.

## Honesty gate

- Equivalence + stacked-parity golden **data** untouched (only test call-sites adapt to the renamed source-init signature → byte-identical source arrays, validated against the unmodified `src::` fixtures).
- Full JAX suite green: **166 passed** at 1 device and **166 passed** at 4 simulated devices (`XLA_FLAGS=--xla_force_host_platform_device_count=4`).
- `make check-jax` clean. No `# type: ignore` / `cast` introduced (beartype/jaxtyped is the typing mechanism).

## Out of scope (deliberate)

- TMS not ported (separate task).
- Source-scope stays LM's `c`/`sc`/`bsc` (generalizing scope to arbitrary axis subsets is documented as a designed extension only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)