### PR TITLE
feat(jax): TMS target — first non-LM bundle over the generic core

### DIFF
--- a/param_decomp_config/tms.py
+++ b/param_decomp_config/tms.py
@@ -1,0 +1,49 @@
+"""TMS (Toy Model of Superposition) experiment config schema — torch-free.
+
+The JAX trainer reads this directly (`jax_single_pool.config`), the same way it reads
+`LMExperimentConfig`. Unlike the LM target there is no HuggingFace/pretrain-cache weight
+source: the tiny TMS target is pretrained from scratch, deterministically from
+`target.pretrain` (the original Anthropic `mean((|x| - relu_out)^2)` objective on the
+synthetic sparse-feature data), so a run is fully reproducible from the config alone.
+"""
+
+from typing import Literal
+
+from pydantic import NonNegativeInt, PositiveInt
+
+from param_decomp_config.base import BaseConfig, Probability
+from param_decomp_config.experiment import ExperimentConfig
+
+TMSDataGenerationType = Literal["exactly_one_active", "at_least_zero_active"]
+
+
+class TMSPretrainConfig(BaseConfig):
+    """How the frozen TMS target is pretrained from scratch (Anthropic TMS objective)."""
+
+    steps: PositiveInt
+    batch_size: PositiveInt
+    lr: float
+    seed: int = 0
+
+
+class TMSTargetConfig(BaseConfig):
+    """The TMS target architecture + its from-scratch pretraining.
+
+    The target has tied weights (`linear2 = linear1ᵀ`); the *decomposition* is untied
+    (`pd.decomposition_targets = [linear1, linear2]`, `pd.tied_weights = null`)."""
+
+    n_features: PositiveInt
+    n_hidden: PositiveInt
+    n_hidden_layers: NonNegativeInt = 0
+    pretrain: TMSPretrainConfig
+
+
+class TMSDataConfig(BaseConfig):
+    """Synthetic sparse-feature data for the PD decomposition step."""
+
+    feature_probability: Probability
+    data_generation_type: TMSDataGenerationType = "at_least_zero_active"
+
+
+class TMSExperimentConfig(ExperimentConfig[TMSTargetConfig, TMSDataConfig]):
+    pass

--- a/param_decomp_jax/jax_single_pool/CLAUDE.md
+++ b/param_decomp_jax/jax_single_pool/CLAUDE.md
@@ -64,6 +64,34 @@ config dispatch is `TargetConfig` (llama8b) vs `LlamaSimpleMLPTargetConfig` in
 wildcards), target build in `run.py::main`. `jsp-export` (torch-format export) stays
 llama8b-only (guarded); the slow plot metrics are computed NATIVELY in JAX for the
 SimpleMLP target via `jsp-slow-eval` (`slow_eval.py`) — no torch export round-trip.
+`tms.py` is the third target and the **first non-LM one** (`leading_axes=()`, no position
+axis; the waist is `[B, n_features]`) — the proof the generic `[*leading, d]` core fits a
+positionless target. The TMS target is the Anthropic toy (`out = relu(linear2(linear1(x)))`,
+weights TIED) with an UNTIED 2-site decomposition (`linear1`/`linear2`, independent V/U);
+the recon comparison is `recon_loss_fn = tms_mse` (MSE on the post-ReLU output, NOT KL),
+there is NO prefix (the whole model is decomposed, residual = raw input `x`), and the
+frozen target is **pretrained from scratch in-process** (`pretrain_tms_target`, the
+`mean((|x|-out)²)` objective — no wandb/cache). `ci_fn_mlp.py` is the second CI-fn arch:
+the **layerwise per-site MLP** (`fn_type=mlp`, `expects_axes=()`, `LayerwiseMLPCIFn`) —
+one independent MLP per site mapping `site_input [B,d_in] -> [B,C]` logits through the
+same `lower/upper_leaky_hard` squashings; `run_state.init_train_state` dispatches CI-fn
+construction on `cfg.ci_fn` (`CIArch` transformer vs `MLPCIArch`) and uses replicated
+(not C-sharded) V/U + CI for the tiny TMS. Config dispatch: `config._is_tms_schema`
+(structural `target.n_features` marker) routes the canonical schema to
+`build_tms_experiment_config` (torch-free `param_decomp_config.tms.TMSExperimentConfig`);
+`TMSTargetConfig` / `TMSDataConfig` join the `AnyTargetConfig` / `AnyDataConfig` unions;
+`run.py::main` builds + pretrains the target and calls `train_tms` (the TMS composition
+over the unified core — same `init_train_state` / faith warmup / `make_train_step` /
+orbax checkpointing, but synthetic data + the ground-truth target-CI metric
+`tms.identity_ci_error` instead of the LM CEandKLLosses eval pass). Harvest / slow-eval /
+export over TMS are NOT wired (`load_run.build_target` / `export` / `slow_eval` assert
+LM). **Finding (axis-semantics):** the core needed ZERO change for TMS — only ADDED a
+target + a CI arch + dispatch. The one deviation from the torch `fn_type=mlp` is by
+design: torch's scalar `MLPCiFn` feeds `get_component_acts(x)=x@V` (per-component scalar),
+which couples the CI-fn input to the trained components and so does NOT fit the generic
+`ci_fn(site_inputs)` waist; the vector-input per-site MLP (consumes the raw `site_input`)
+fits the waist with no core change and recovers a clean identity in the non-superposed
+(`n_hidden==n_features`) regime (validated end-to-end in `tests/test_tms.py`).
 
 ## Invariants with sharp teeth (the ones that have actually bitten)
 

--- a/param_decomp_jax/jax_single_pool/ci_fn_mlp.py
+++ b/param_decomp_jax/jax_single_pool/ci_fn_mlp.py
@@ -1,0 +1,102 @@
+"""The layerwise per-site MLP CI fn — the sibling of `ci_fn.py`'s transformer for
+positionless (`leading_axes=()`) targets like TMS.
+
+One independent MLP per decomposed site maps that site's clean input `[*leading, d_in]`
+to `[*leading, C]` pre-squash logits; the SAME logits feed the shared
+`lower_leaky_hard` (recon/PPGD masks) and `upper_leaky_hard` (importance-minimality)
+squashings (SPEC S5/S6), exactly as the transformer CI fn. Params are fp32 masters
+(SPEC N1); the trainer casts for bf16 compute.
+
+`expects_axes = ()` (no position axes): the MLP is applied independently over every
+leading cell, so it places no structural constraint on the leading prefix — it works for
+any `leading_axes` that the paired model declares empty. (The transformer CI fn, by
+contrast, applies RoPE over a `sequence` axis and so declares `expects_axes=("sequence",)`.)
+
+This is the vector-input per-site MLP: each site's MLP consumes the full `[*leading, d_in]`
+site input and emits `C` logits (torch `VectorMLPCiFn` shape; see the JAX TMS CLAUDE
+note on why this is the chosen `fn_type=mlp` realization rather than torch's scalar
+`get_component_acts(x)=x@V` coupling, which would change the generic `ci_fn(site_inputs)`
+contract)."""
+
+from dataclasses import dataclass
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+from jaxtyping import Array, Float, PRNGKeyArray
+
+from jax_single_pool.ci_fn import CIValues, lower_leaky_hard_sigmoid, upper_leaky_hard_sigmoid
+from jax_single_pool.lm import SiteSpec
+
+
+@dataclass(frozen=True)
+class MLPCIArch:
+    """Hidden widths shared by every per-site MLP (torch `LayerwiseCiConfig.hidden_dims`)."""
+
+    hidden_dims: tuple[int, ...]
+
+
+class SiteMLP(eqx.Module):
+    """One site's MLP: `hidden_dims` ReLU-init Linear+GELU layers then a linear head to C.
+
+    Matches torch `VectorMLPCiFn` layer structure: each hidden layer is Kaiming-`relu`
+    (`gain √2`) initialized with zero bias, the final head is linear-gain (`1`)."""
+
+    weights: list[Float[Array, "d_in d_out"]]
+    biases: list[Float[Array, " d_out"]]
+
+    def __call__(self, x: Float[Array, "*leading d_in"]) -> Float[Array, "*leading C"]:
+        n_hidden = len(self.weights) - 1
+        for layer_idx, (w, b) in enumerate(zip(self.weights, self.biases, strict=True)):
+            x = x @ w + b
+            if layer_idx < n_hidden:
+                x = jax.nn.gelu(x, approximate=False)
+        return x
+
+
+class LayerwiseMLPCIFn(eqx.Module):
+    """A per-site MLP bundle behind the same dict-in / `CIValues`-out interface as the
+    transformer `CIFn` (`__call__(site_inputs) -> CIValues`)."""
+
+    site_mlps: dict[str, SiteMLP]
+    site_names: tuple[str, ...] = eqx.field(static=True)
+    expects_axes: tuple[str, ...] = eqx.field(static=True)
+
+    def site_logits(self, site_inputs: dict[str, Array]) -> dict[str, Array]:
+        assert set(site_inputs) == set(self.site_names), (
+            f"site_inputs keys {sorted(site_inputs)} != CI fn sites {sorted(self.site_names)}"
+        )
+        return {name: self.site_mlps[name](site_inputs[name]) for name in self.site_names}
+
+    def __call__(self, site_inputs: dict[str, Array]) -> CIValues:
+        logits = self.site_logits(site_inputs)
+        return CIValues(
+            lower={name: lower_leaky_hard_sigmoid(logits[name]) for name in self.site_names},
+            upper={name: upper_leaky_hard_sigmoid(logits[name]) for name in self.site_names},
+        )
+
+
+def init_layerwise_mlp_ci_fn(
+    arch: MLPCIArch, sites: tuple[SiteSpec, ...], key: PRNGKeyArray
+) -> LayerwiseMLPCIFn:
+    """Per-site MLP init: each site's MLP maps `d_in -> hidden_dims... -> C`, Kaiming
+    `relu`-gain on the hidden layers (matching torch `init_param_` fan-in init) and
+    linear gain on the C head, zero biases."""
+    assert arch.hidden_dims, "MLP CI fn needs at least one hidden layer"
+    relu_gain = 2.0**0.5
+    site_mlps: dict[str, SiteMLP] = {}
+    for site_idx, spec in enumerate(sites):
+        dims = (spec.d_in, *arch.hidden_dims, spec.C)
+        layer_keys = jax.random.split(jax.random.fold_in(key, site_idx), len(dims) - 1)
+        weights: list[Array] = []
+        biases: list[Array] = []
+        for layer_idx, (d_in, d_out) in enumerate(zip(dims[:-1], dims[1:], strict=True)):
+            gain = relu_gain if layer_idx < len(dims) - 2 else 1.0
+            weights.append(
+                jax.random.normal(layer_keys[layer_idx], (d_in, d_out)) * (gain / d_in**0.5)
+            )
+            biases.append(jnp.zeros((d_out,)))
+        site_mlps[spec.name] = SiteMLP(weights=weights, biases=biases)
+    return LayerwiseMLPCIFn(
+        site_mlps=site_mlps, site_names=tuple(s.name for s in sites), expects_axes=()
+    )

--- a/param_decomp_jax/jax_single_pool/config.py
+++ b/param_decomp_jax/jax_single_pool/config.py
@@ -42,10 +42,12 @@ import yaml
 
 from jax_single_pool import llama_simple_mlp
 from jax_single_pool.ci_fn import CIArch
+from jax_single_pool.ci_fn_mlp import MLPCIArch
 from jax_single_pool.llama8b import SITE_NAME_PATTERN, canonical_site_cs
 from jax_single_pool.lm import SiteC
 from jax_single_pool.recon import build_recon_terms
-from param_decomp_config.ci_fn import GlobalSharedTransformerCiFnConfig
+from jax_single_pool.tms import canonical_site_cs as tms_canonical_site_cs
+from param_decomp_config.ci_fn import GlobalSharedTransformerCiFnConfig, LayerwiseCiConfig
 from param_decomp_config.eval_metrics import CEandKLLossesConfig, CI_L0Config
 from param_decomp_config.experiment import WandbConfig
 from param_decomp_config.jax_wrapper import WRAPPER_KEYS, WRAPPER_OPTIONAL_KEYS
@@ -58,6 +60,9 @@ from param_decomp_config.lm import (
 from param_decomp_config.losses import PGDReconLossConfig
 from param_decomp_config.pd import AnyLossMetricConfig, OptimizerConfig
 from param_decomp_config.schedule import ScheduleConfig
+from param_decomp_config.tms import TMSExperimentConfig
+
+CIFnArch = CIArch | MLPCIArch
 
 WeightsDtype = Literal["float32", "bfloat16"]
 
@@ -91,7 +96,28 @@ class LlamaSimpleMLPTargetConfig:
     `jnp.bfloat16` hardcoded at the call site). See `TargetConfig.supported_weights_dtypes`."""
 
 
-AnyTargetConfig = TargetConfig | LlamaSimpleMLPTargetConfig
+@dataclass(frozen=True)
+class TMSTargetConfig:
+    """The vendored TMS target (`tms.py`), pretrained from scratch in-process from
+    `pretrain` (no weight artifact). `n_hidden_layers` is fixed 0 (the production TMS
+    configs have none); a positive value is refused at convert time."""
+
+    n_features: int
+    n_hidden: int
+    sites: tuple[SiteC, ...]
+    pretrain_steps: int
+    pretrain_batch_size: int
+    pretrain_lr: float
+    pretrain_seed: int
+    feature_probability: float
+    data_generation_type: str
+
+    supported_weights_dtypes: frozenset[WeightsDtype] = frozenset({"float32", "bfloat16"})
+    """The from-scratch pretrain runs in fp32 and the frozen target is cast at build time,
+    so any dtype the config declares is honoured."""
+
+
+AnyTargetConfig = TargetConfig | LlamaSimpleMLPTargetConfig | TMSTargetConfig
 
 
 @dataclass(frozen=True)
@@ -99,6 +125,20 @@ class DataConfig:
     dir: Path
     seq_len: int
     global_batch: int
+
+
+@dataclass(frozen=True)
+class TMSDataConfig:
+    """The TMS synthetic sparse-feature data — generated fresh per step in-process
+    (`tms.sample_sparse_features`), no parquet/tokenizer."""
+
+    n_features: int
+    global_batch: int
+    feature_probability: float
+    data_generation_type: str
+
+
+AnyDataConfig = DataConfig | TMSDataConfig
 
 
 @dataclass(frozen=True)
@@ -170,7 +210,7 @@ class ExperimentConfig:
     seed: int
     steps: int
     target: AnyTargetConfig
-    data: DataConfig
+    data: AnyDataConfig
     loss_metrics: tuple[AnyLossMetricConfig, ...]
     """The shared `pd.loss_metrics` configs, verbatim and in yaml order (order is
     RNG-load-bearing — see `build_recon_terms`)."""
@@ -179,7 +219,7 @@ class ExperimentConfig:
     remat_recon_forwards: bool
     vu_optimizer: VUOptimizerConfig
     ci_optimizer: CIOptimizerConfig
-    ci_fn: CIArch
+    ci_fn: CIFnArch
     faith_warmup: FaithWarmupConfig
     cadence: CadenceConfig
     eval: EvalConfig | None
@@ -278,6 +318,14 @@ def _ci_arch(cfg: LMExperimentConfig, seq_len: int) -> CIArch:
     )
 
 
+def _layerwise_mlp_ci_arch(cfg: TMSExperimentConfig) -> MLPCIArch:
+    ci = cfg.pd.ci_config
+    assert isinstance(ci, LayerwiseCiConfig), ci
+    assert ci.fn_type == "mlp", f"TMS CI fn must be fn_type=mlp, got {ci.fn_type}"
+    assert ci.hidden_dims, "TMS MLP CI fn needs at least one hidden layer"
+    return MLPCIArch(hidden_dims=tuple(ci.hidden_dims))
+
+
 def _assert_cosine_to_tenth(schedule: ScheduleConfig, who: str) -> None:
     """The trainer hardcodes optax cosine decay to 0.1x with no warmup (SPEC S19/S20)."""
     assert schedule.fn_type == "cosine", f"{who}: only cosine lr supported, got {schedule}"
@@ -368,17 +416,20 @@ def assert_supported_weights_dtype(cfg: LMExperimentConfig) -> None:
     )
 
 
-def build_experiment_config(
-    cfg: LMExperimentConfig,
-    run_name: str,
-    run_id: str,
-    out_dir: Path,
-    remat_recon_forwards: bool,
-    wandb_group: str | None = None,
-    wandb_tags: tuple[str, ...] = (),
-) -> ExperimentConfig:
-    target = _resolve_target(cfg)
+@dataclass(frozen=True)
+class _SharedConvert:
+    """The algorithm-config pieces shared by every target (optimizers, faith warmup,
+    cadence) — the part of `*ExperimentConfig` that does not depend on the target/data
+    domain."""
 
+    vu_optimizer: VUOptimizerConfig
+    ci_optimizer: CIOptimizerConfig
+    faith_warmup: FaithWarmupConfig
+    cadence: CadenceConfig
+    ci_lr_for_arch: float
+
+
+def _convert_shared(cfg: "LMExperimentConfig | TMSExperimentConfig") -> _SharedConvert:
     assert cfg.pd.sigmoid_type == "leaky_hard", cfg.pd.sigmoid_type
     assert cfg.pd.use_delta_component and cfg.pd.tied_weights is None
     assert cfg.runtime.autocast_bf16, "JAX trainer computes in bf16 (autocast analog)"
@@ -393,29 +444,13 @@ def build_experiment_config(
     assert vu_opt.grad_clip_norm is not None, "components grad clip is part of the method"
     assert ci_opt.grad_clip_norm is None, "CI-fn grad clip unsupported"
 
-    loss_metrics = _losses(cfg, tuple(sc.name for sc in target.sites))
-    data = _data(cfg)
-
     cadence = cfg.cadence
     assert cadence.save_every is not None and cadence.keep_last_n_checkpoints is not None, cadence
-
-    return ExperimentConfig(
-        run_name=run_name,
-        run_id=run_id,
-        out_dir=out_dir,
-        seed=cfg.pd.seed,
-        steps=cfg.pd.steps,
-        target=target,
-        data=data,
-        loss_metrics=loss_metrics,
-        n_mask_samples=cfg.pd.n_mask_samples,
-        sampling=cfg.pd.sampling,
-        remat_recon_forwards=remat_recon_forwards,
+    return _SharedConvert(
         vu_optimizer=VUOptimizerConfig(
             lr=vu_opt.lr_schedule.start_val, grad_clip_norm=vu_opt.grad_clip_norm
         ),
         ci_optimizer=CIOptimizerConfig(lr=ci_opt.lr_schedule.start_val),
-        ci_fn=_ci_arch(cfg, data.seq_len),
         faith_warmup=FaithWarmupConfig(
             steps=cfg.pd.faithfulness_warmup_steps, lr=cfg.pd.faithfulness_warmup_lr
         ),
@@ -432,6 +467,41 @@ def build_experiment_config(
                 else None
             ),
         ),
+        ci_lr_for_arch=ci_opt.lr_schedule.start_val,
+    )
+
+
+def build_experiment_config(
+    cfg: LMExperimentConfig,
+    run_name: str,
+    run_id: str,
+    out_dir: Path,
+    remat_recon_forwards: bool,
+    wandb_group: str | None = None,
+    wandb_tags: tuple[str, ...] = (),
+) -> ExperimentConfig:
+    target = _resolve_target(cfg)
+    shared = _convert_shared(cfg)
+    loss_metrics = _losses(cfg, tuple(sc.name for sc in target.sites))
+    data = _data(cfg)
+
+    return ExperimentConfig(
+        run_name=run_name,
+        run_id=run_id,
+        out_dir=out_dir,
+        seed=cfg.pd.seed,
+        steps=cfg.pd.steps,
+        target=target,
+        data=data,
+        loss_metrics=loss_metrics,
+        n_mask_samples=cfg.pd.n_mask_samples,
+        sampling=cfg.pd.sampling,
+        remat_recon_forwards=remat_recon_forwards,
+        vu_optimizer=shared.vu_optimizer,
+        ci_optimizer=shared.ci_optimizer,
+        ci_fn=_ci_arch(cfg, data.seq_len),
+        faith_warmup=shared.faith_warmup,
+        cadence=shared.cadence,
         eval=_eval(cfg),
         wandb=cfg.wandb,
         wandb_group=wandb_group,
@@ -439,7 +509,115 @@ def build_experiment_config(
     )
 
 
+def _tms_target(cfg: TMSExperimentConfig) -> TMSTargetConfig:
+    assert cfg.target.n_hidden_layers == 0, "TMS hidden layers unsupported (production has none)"
+    assert cfg.pd.identity_decomposition_targets is None, "identity targets unsupported"
+    site_cs = tms_canonical_site_cs(
+        tuple(SiteC(t.module_pattern, t.C) for t in cfg.pd.decomposition_targets)
+    )
+    return TMSTargetConfig(
+        n_features=cfg.target.n_features,
+        n_hidden=cfg.target.n_hidden,
+        sites=site_cs,
+        pretrain_steps=cfg.target.pretrain.steps,
+        pretrain_batch_size=cfg.target.pretrain.batch_size,
+        pretrain_lr=cfg.target.pretrain.lr,
+        pretrain_seed=cfg.target.pretrain.seed,
+        feature_probability=cfg.data.feature_probability,
+        data_generation_type=cfg.data.data_generation_type,
+    )
+
+
+def build_tms_experiment_config(
+    cfg: TMSExperimentConfig,
+    run_name: str,
+    run_id: str,
+    out_dir: Path,
+    remat_recon_forwards: bool,
+    wandb_group: str | None = None,
+    wandb_tags: tuple[str, ...] = (),
+) -> ExperimentConfig:
+    target = _tms_target(cfg)
+    shared = _convert_shared(cfg)
+    loss_metrics = tuple(cfg.pd.loss_metrics)
+    build_recon_terms(
+        loss_metrics, tuple(sc.name for sc in target.sites), cfg.pd.n_mask_samples, cfg.pd.sampling
+    )
+    assert cfg.eval is None, (
+        "TMS in-loop eval is the standalone target-CI metric (run.py::train_tms), not the "
+        "LM CEandKLLosses pass; omit the eval: block"
+    )
+    data = TMSDataConfig(
+        n_features=cfg.target.n_features,
+        global_batch=cfg.pd.batch_size,
+        feature_probability=cfg.data.feature_probability,
+        data_generation_type=cfg.data.data_generation_type,
+    )
+    return ExperimentConfig(
+        run_name=run_name,
+        run_id=run_id,
+        out_dir=out_dir,
+        seed=cfg.pd.seed,
+        steps=cfg.pd.steps,
+        target=target,
+        data=data,
+        loss_metrics=loss_metrics,
+        n_mask_samples=cfg.pd.n_mask_samples,
+        sampling=cfg.pd.sampling,
+        remat_recon_forwards=remat_recon_forwards,
+        vu_optimizer=shared.vu_optimizer,
+        ci_optimizer=shared.ci_optimizer,
+        ci_fn=_layerwise_mlp_ci_arch(cfg),
+        faith_warmup=shared.faith_warmup,
+        cadence=shared.cadence,
+        eval=None,
+        wandb=cfg.wandb,
+        wandb_group=wandb_group,
+        wandb_tags=wandb_tags,
+    )
+
+
 _RUN_ID_PATTERN = re.compile(r"^p-[0-9a-f]{8}$")
+
+
+def _is_tms_schema(schema_raw: dict[str, Any]) -> bool:
+    """TMS vs LM schemas differ in their `target` block: the LM target carries a `spec`
+    discriminated union, the TMS target carries `n_features`. The schema yaml has no top-
+    level kind tag, so dispatch on this structural marker."""
+    target = schema_raw.get("target", {})
+    return isinstance(target, dict) and "n_features" in target
+
+
+def _build_from_schema(
+    schema_raw: dict[str, Any],
+    run_name: str,
+    run_id: str,
+    out_dir: Path,
+    remat_recon_forwards: bool,
+    wandb_group: str | None,
+    wandb_tags: tuple[str, ...],
+) -> ExperimentConfig:
+    if _is_tms_schema(schema_raw):
+        return build_tms_experiment_config(
+            TMSExperimentConfig(**schema_raw),
+            run_name=run_name,
+            run_id=run_id,
+            out_dir=out_dir,
+            remat_recon_forwards=remat_recon_forwards,
+            wandb_group=wandb_group,
+            wandb_tags=wandb_tags,
+        )
+    cfg = LMExperimentConfig(**schema_raw)
+    assert_supported_weights_dtype(cfg)
+    return build_experiment_config(
+        cfg,
+        run_name=run_name,
+        run_id=run_id,
+        out_dir=out_dir,
+        remat_recon_forwards=remat_recon_forwards,
+        wandb_group=wandb_group,
+        wandb_tags=wandb_tags,
+    )
 
 
 def _wandb_group_tags(raw: dict[str, Any]) -> tuple[str | None, tuple[str, ...]]:
@@ -470,11 +648,9 @@ def load_wrapper(wrapper_path: Path) -> tuple[ExperimentConfig, Path, dict[str, 
     schema_yaml_path = (wrapper_path.parent / raw["torch_config"]).resolve()
     assert schema_yaml_path.exists(), f"config not found: {schema_yaml_path}"
     schema_raw = yaml.safe_load(schema_yaml_path.read_text())
-    cfg = LMExperimentConfig(**schema_raw)
-    assert_supported_weights_dtype(cfg)
     wandb_group, wandb_tags = _wandb_group_tags(raw)
-    experiment_config = build_experiment_config(
-        cfg,
+    experiment_config = _build_from_schema(
+        schema_raw,
         run_name=raw["run_name"],
         run_id=run_id,
         out_dir=Path(raw["out_dir"]),
@@ -500,8 +676,8 @@ def load_run_dir_config(run_dir: Path) -> ExperimentConfig:
     )
     schema_raw = yaml.safe_load((run_dir / "experiment_config.yaml").read_text())
     wandb_group, wandb_tags = _wandb_group_tags(raw)
-    return build_experiment_config(
-        LMExperimentConfig(**schema_raw),
+    return _build_from_schema(
+        schema_raw,
         run_name=raw["run_name"],
         run_id=raw["run_id"],
         out_dir=Path(raw["out_dir"]),

--- a/param_decomp_jax/jax_single_pool/configs/tms_5-2_from_torch.yaml
+++ b/param_decomp_jax/jax_single_pool/configs/tms_5-2_from_torch.yaml
@@ -1,0 +1,7 @@
+# TMS 5->2 PD decomposition (superposition toy). Small target, no remat. Launch:
+# pd-jax-lm, 1 node. Validates via the in-loop ground-truth target-CI metric
+# (eval/identity_ci_error/<site>) logged each train-log step — no separate eval pass.
+torch_config: torch/tms_5-2.yaml
+run_name: jax-tms-5-2
+out_dir: /mnt/data/artifacts/mechanisms/param-decomp/jax_runs
+remat_recon_forwards: false

--- a/param_decomp_jax/jax_single_pool/configs/tms_5-5_SMOKE.yaml
+++ b/param_decomp_jax/jax_single_pool/configs/tms_5-5_SMOKE.yaml
@@ -1,0 +1,4 @@
+# TMS 5->5 SMOKE wrapper — jsp-train full-loop validation (pretrain + decompose + ckpt).
+torch_config: torch/tms_5-5_SMOKE.yaml
+run_name: jax-tms-5-5-smoke
+remat_recon_forwards: false

--- a/param_decomp_jax/jax_single_pool/configs/torch/tms_5-2.yaml
+++ b/param_decomp_jax/jax_single_pool/configs/torch/tms_5-2.yaml
@@ -1,0 +1,76 @@
+# TMS 5->2 PD decomposition — the canonical superposition toy (5 features in 2 hidden
+# dims). The JAX counterpart of the torch `tms_5-2_config.yaml`, adapted to the JAX
+# trainer's schema: the target is pretrained from scratch in-process (no wandb run_path),
+# and FaithfulnessLoss is in the loss list (the JAX recon-term builder requires it; the
+# torch TMS configs relied on faith warmup alone). The decomposition is UNTIED
+# (linear1/linear2 are two sites with independent V/U; tied_weights: null), the target is
+# tied. CI fn: layerwise per-site MLP (fn_type=mlp, hidden_dims=[16]). Runs on 1 GPU.
+pd:
+  seed: 0
+  n_mask_samples: 1
+  sampling: continuous
+  ci_config:
+    mode: layerwise
+    fn_type: mlp
+    hidden_dims:
+    - 16
+  sigmoid_type: leaky_hard
+  use_delta_component: true
+  tied_weights: null
+  decomposition_targets:
+  - module_pattern: linear1
+    C: 20
+  - module_pattern: linear2
+    C: 20
+  loss_metrics:
+  - type: ImportanceMinimalityLoss
+    coeff: 3e-3
+    pnorm: 1.0
+    beta: 0.0
+    p_anneal_start_frac: 0.0
+    p_anneal_final_p: 1.0
+    p_anneal_end_frac: 1.0
+  - type: StochasticReconLoss
+    coeff: 1.0
+  - type: StochasticReconLayerwiseLoss
+    coeff: 1.0
+  - type: FaithfulnessLoss
+    coeff: 1.0
+  batch_size: 4096
+  steps: 10000
+  components_optimizer:
+    grad_clip_norm: 0.01
+    lr_schedule:
+      start_val: 1e-3
+      fn_type: cosine
+      warmup_pct: 0.0
+      final_val_frac: 0.1
+  ci_fn_optimizer:
+    lr_schedule:
+      start_val: 1e-3
+      fn_type: cosine
+      warmup_pct: 0.0
+      final_val_frac: 0.1
+  faithfulness_warmup_steps: 200
+  faithfulness_warmup_lr: 0.01
+  faithfulness_warmup_weight_decay: 0.0
+runtime:
+  autocast_bf16: true
+  device: cuda
+  dp: null
+cadence:
+  train_log_every: 200
+  save_every: 5000
+  keep_last_n_checkpoints: 2
+target:
+  n_features: 5
+  n_hidden: 2
+  n_hidden_layers: 0
+  pretrain:
+    steps: 5000
+    batch_size: 2048
+    lr: 1e-2
+    seed: 0
+data:
+  feature_probability: 0.05
+  data_generation_type: at_least_zero_active

--- a/param_decomp_jax/jax_single_pool/configs/torch/tms_5-5_SMOKE.yaml
+++ b/param_decomp_jax/jax_single_pool/configs/torch/tms_5-5_SMOKE.yaml
@@ -1,0 +1,72 @@
+# TMS 5->5 (non-superposed) PD decomposition SMOKE — the clean recovers-identity regime,
+# tiny step count for a jsp-train smoke (full-loop composition-root validation: pretrain →
+# faith warmup → step loop → checkpoint → in-loop target-CI metric). 1 GPU / CPU.
+pd:
+  seed: 0
+  n_mask_samples: 1
+  sampling: continuous
+  ci_config:
+    mode: layerwise
+    fn_type: mlp
+    hidden_dims:
+    - 16
+  sigmoid_type: leaky_hard
+  use_delta_component: true
+  tied_weights: null
+  decomposition_targets:
+  - module_pattern: linear1
+    C: 5
+  - module_pattern: linear2
+    C: 5
+  loss_metrics:
+  - type: ImportanceMinimalityLoss
+    coeff: 3e-3
+    pnorm: 1.0
+    beta: 0.0
+    p_anneal_start_frac: 0.0
+    p_anneal_final_p: 1.0
+    p_anneal_end_frac: 1.0
+  - type: StochasticReconLoss
+    coeff: 1.0
+  - type: StochasticReconLayerwiseLoss
+    coeff: 1.0
+  - type: FaithfulnessLoss
+    coeff: 1.0
+  batch_size: 256
+  steps: 20
+  components_optimizer:
+    grad_clip_norm: 0.01
+    lr_schedule:
+      start_val: 1e-3
+      fn_type: cosine
+      warmup_pct: 0.0
+      final_val_frac: 0.1
+  ci_fn_optimizer:
+    lr_schedule:
+      start_val: 1e-3
+      fn_type: cosine
+      warmup_pct: 0.0
+      final_val_frac: 0.1
+  faithfulness_warmup_steps: 50
+  faithfulness_warmup_lr: 0.01
+  faithfulness_warmup_weight_decay: 0.0
+runtime:
+  autocast_bf16: true
+  device: cuda
+  dp: null
+cadence:
+  train_log_every: 5
+  save_every: 10
+  keep_last_n_checkpoints: 2
+target:
+  n_features: 5
+  n_hidden: 5
+  n_hidden_layers: 0
+  pretrain:
+    steps: 500
+    batch_size: 256
+    lr: 1e-2
+    seed: 0
+data:
+  feature_probability: 0.05
+  data_generation_type: at_least_zero_active

--- a/param_decomp_jax/jax_single_pool/export.py
+++ b/param_decomp_jax/jax_single_pool/export.py
@@ -173,6 +173,7 @@ def main() -> None:
     assert step is not None, f"no checkpoints under {args.run_dir / 'ckpts'}"
     state = restore_step(manager, reference, step)
     assert isinstance(state.components, DecompVU)
+    assert isinstance(state.ci_fn, CIFn), "export is the transformer-CI-fn (LM) path only"
 
     tensors = components_state(state.components, lm.sites)
     tensors |= ci_fn_state(state.ci_fn, lm.sites)

--- a/param_decomp_jax/jax_single_pool/llama8b_sharding.py
+++ b/param_decomp_jax/jax_single_pool/llama8b_sharding.py
@@ -34,6 +34,7 @@ from jaxtyping import Array, PRNGKeyArray
 
 from jax_single_pool.adversary import init_persistent_sources
 from jax_single_pool.ci_fn import CIArch, CIFn, init_ci_fn
+from jax_single_pool.ci_fn_mlp import LayerwiseMLPCIFn, MLPCIArch, init_layerwise_mlp_ci_fn
 from jax_single_pool.llama8b import DecompVU, Target, init_decomp_vu
 from jax_single_pool.lm import SiteSpec
 from jax_single_pool.sharding import dp_mesh
@@ -44,7 +45,9 @@ __all__ = [
     "dp_mesh",
     "replicate_target",
     "init_decomp_vu_sharded",
+    "init_decomp_vu_replicated",
     "init_ci_fn_sharded",
+    "init_layerwise_mlp_ci_fn_replicated",
     "init_sources_sharded",
     "shard_batch",
 ]
@@ -88,6 +91,27 @@ def init_decomp_vu_sharded(sites: tuple[SiteSpec, ...], key: PRNGKeyArray, mesh:
 
     out_shardings = jax.tree_util.tree_map_with_path(place, jax.eval_shape(init, key))
     return jax.jit(init, out_shardings=out_shardings)(key)
+
+
+def init_decomp_vu_replicated(
+    sites: tuple[SiteSpec, ...], key: PRNGKeyArray, mesh: Mesh
+) -> DecompVU:
+    """REPLICATED per-site V/U init — the TMS path (tiny model, runs on one device; the
+    per-site C need not divide the mesh size). The activation waist still batch-shards;
+    only these masters replicate."""
+    repl = NamedSharding(mesh, P())
+    init = partial(init_decomp_vu, sites)
+    return jax.jit(init, out_shardings=repl)(key)
+
+
+def init_layerwise_mlp_ci_fn_replicated(
+    arch: MLPCIArch, sites: tuple[SiteSpec, ...], key: PRNGKeyArray, mesh: Mesh
+) -> LayerwiseMLPCIFn:
+    """REPLICATED per-site MLP CI fn init — the TMS path; the per-site MLPs are tiny so
+    replicating costs nothing (same rationale as `init_decomp_vu_replicated`)."""
+    repl = NamedSharding(mesh, P())
+    init = partial(init_layerwise_mlp_ci_fn, arch, sites)
+    return jax.jit(init, out_shardings=repl)(key)
 
 
 def init_ci_fn_sharded(

--- a/param_decomp_jax/jax_single_pool/load_run.py
+++ b/param_decomp_jax/jax_single_pool/load_run.py
@@ -40,6 +40,7 @@ from jax_single_pool.config import (
     ExperimentConfig,
     LlamaSimpleMLPTargetConfig,
     TargetConfig,
+    TMSTargetConfig,
     load_run_dir_config,
 )
 from jax_single_pool.llama8b import (
@@ -76,6 +77,10 @@ def build_target(
     """`(lm, frozen target, prefix, prefix_residual_fn, vocab_size)` for the run's target
     config. SimpleMLP reads its local pretrain cache (no network); llama8b reads the HF
     snapshot (frozen bf16 target + fp32-compute, matching `run.py::main`)."""
+    assert not isinstance(cfg.target, TMSTargetConfig), (
+        "harvest/slow-eval over the TMS target is not wired (TMS validates via the in-loop "
+        "target-CI metric in run.py::train_tms)"
+    )
     match cfg.target:
         case LlamaSimpleMLPTargetConfig():
             cache_dir = llama_simple_mlp.pretrain_cache_dir(cfg.target.pretrain_run_path)
@@ -148,8 +153,10 @@ class LoadedJaxRun:
         return [(s.name, s.C) for s in self.lm.sites]
 
     def forward(self, token_ids: Int[Array, "B T"]) -> HarvestForward:
+        ci_fn = self._state.ci_fn
+        assert isinstance(ci_fn, CIFn), "harvest is the transformer-CI-fn (LM) path only"
         lower_leaky_ci, component_acts, output_probs = self._forward(
-            self._state.components, self._state.ci_fn, token_ids
+            self._state.components, ci_fn, token_ids
         )
         return HarvestForward(
             lower_leaky_ci=lower_leaky_ci,

--- a/param_decomp_jax/jax_single_pool/run.py
+++ b/param_decomp_jax/jax_single_pool/run.py
@@ -33,12 +33,15 @@ from jax import random
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 
-from jax_single_pool import llama_simple_mlp
+from jax_single_pool import llama_simple_mlp, tms
 from jax_single_pool.checkpoint import make_checkpoint_manager, restore_latest, save_state
 from jax_single_pool.config import (
+    DataConfig,
     ExperimentConfig,
     LlamaSimpleMLPTargetConfig,
     TargetConfig,
+    TMSDataConfig,
+    TMSTargetConfig,
     load_wrapper,
 )
 from jax_single_pool.data import BatchSchedule, ShardServer, scan_shards
@@ -182,6 +185,7 @@ def train(
     prefix_residual_fn: Callable[[Any, Any], jax.Array],
     mesh: Mesh,
 ) -> None:
+    assert isinstance(cfg.data, DataConfig), "train() is the LM (parquet) data path"
     is_main = jax.process_index() == 0
     n_proc = jax.process_count()
     ndev = mesh.devices.size
@@ -399,6 +403,120 @@ def train(
             break
 
 
+def train_tms(
+    cfg: ExperimentConfig,
+    raw_cfg: dict[str, object],
+    lm: DecomposedModel,
+    frozen: tms.TMSTarget,
+    mesh: Mesh,
+) -> None:
+    """The TMS composition over the unified core: same `init_train_state` / faith warmup /
+    `make_train_step` / orbax checkpointing as the LM path, but with in-process synthetic
+    sparse-feature data (no parquet/prefix) and the standalone ground-truth target-CI
+    metric (`tms.identity_ci_error`) instead of the LM CEandKLLosses eval pass.
+
+    The residual entering the decomposed model IS the raw input `x` (no prefix); the step
+    factory, recon terms (MSE recon_loss_fn), losses and adversaries are all the generic
+    core, unchanged."""
+    data_cfg = cfg.data
+    assert isinstance(data_cfg, TMSDataConfig) and isinstance(cfg.target, TMSTargetConfig)
+    is_main = jax.process_index() == 0
+    ndev = mesh.devices.size
+    assert data_cfg.global_batch % ndev == 0, (data_cfg.global_batch, ndev)
+
+    cfg.run_dir.mkdir(parents=True, exist_ok=True)
+    opt_vu, opt_ci, (sched_vu, sched_ci) = build_optimizers(cfg)
+
+    key = random.PRNGKey(cfg.seed)
+    init_key, src_key, run_key, data_key = random.split(key, 4)
+    state = _ensure_global(init_train_state(cfg, lm, opt_vu, opt_ci, init_key, src_key, mesh), mesh)
+
+    checkpoint_manager = make_checkpoint_manager(cfg.run_dir / "ckpts", cfg.cadence.keep_last)
+    restored = restore_latest(checkpoint_manager, state)
+    if restored is not None:
+        state, ckpt_step = restored
+        assert int(state.step) == ckpt_step, (int(state.step), ckpt_step)
+        start_step = ckpt_step
+        if is_main:
+            print(f"resumed from checkpoint step {ckpt_step}", flush=True)
+    else:
+        start_step = 0
+        if cfg.faith_warmup.steps > 0:
+            faith_warmup_optimizer = optax.adamw(cfg.faith_warmup.lr, weight_decay=0.0)
+            faith_warmup_opt_state = faith_warmup_optimizer.init(
+                eqx.filter(state.components, eqx.is_array)
+            )
+            faith_warmup_step = make_faith_warmup_step(lm, faith_warmup_optimizer)
+            warmed_components = state.components
+            faith_warmup_loss = None
+            for _ in range(cfg.faith_warmup.steps):
+                warmed_components, faith_warmup_opt_state, faith_warmup_loss = faith_warmup_step(
+                    warmed_components, faith_warmup_opt_state, frozen
+                )
+            assert faith_warmup_loss is not None
+            jax.block_until_ready(faith_warmup_loss)
+            new_opt_vu = _ensure_global(
+                opt_vu.init(eqx.filter(warmed_components, eqx.is_array)), mesh
+            )
+            state = dataclasses.replace(
+                state, components=warmed_components, components_opt_state=new_opt_vu
+            )
+            if is_main:
+                print(f"faith warmup: final faith {float(faith_warmup_loss):.3e}", flush=True)
+        save_state(checkpoint_manager, 0, state)
+
+    step_fn = make_train_step(
+        lm=lm,
+        loss_spec=build_recon_terms(
+            cfg.loss_metrics, lm.site_names, cfg.n_mask_samples, cfg.sampling
+        ),
+        components_optimizer=opt_vu,
+        ci_fn_optimizer=opt_ci,
+        total_steps=cfg.steps,
+        remat_recon_forwards=cfg.remat_recon_forwards,
+        mesh=mesh,
+    )
+
+    @jax.jit
+    def sample_residual(step_key: jax.Array) -> jax.Array:
+        x = tms.sample_sparse_features(
+            step_key,
+            data_cfg.global_batch,
+            data_cfg.n_features,
+            data_cfg.feature_probability,
+            data_cfg.data_generation_type,
+        )
+        return jax.lax.with_sharding_constraint(x, NamedSharding(mesh, P("dp")))
+
+    @jax.jit
+    def single_feature_ci(components: Any, ci_fn: Any) -> dict[str, jax.Array]:
+        probe = jnp.eye(data_cfg.n_features) * 0.75
+        return ci_fn(lm.site_inputs(frozen, probe)).lower
+
+    wandb_config = flatten_typed_lists(
+        dict(raw_cfg, jax_runtime={"n_devices": ndev, "run_id": cfg.run_id})
+    )
+    sink = MetricsSink(cfg, wandb_config, is_main)
+
+    for step in range(start_step, cfg.steps):
+        residual = sample_residual(random.fold_in(data_key, step))
+        state, metrics = step_fn(state, frozen, residual, random.fold_in(run_key, step))
+        now_step = step + 1
+        if now_step % cfg.cadence.log_every == 0 or now_step == cfg.steps:
+            jax.block_until_ready(metrics["total"])
+            record = {k: float(v) for k, v in metrics.items()}
+            ci_lower = single_feature_ci(state.components, state.ci_fn)
+            for site, ci in ci_lower.items():
+                record[f"eval/identity_ci_error/{site}"] = float(
+                    tms.identity_ci_error(ci, tolerance=0.1)
+                )
+            sink.log(now_step, record)
+        if now_step % cfg.cadence.save_every == 0 or now_step == cfg.steps:
+            save_state(checkpoint_manager, now_step, state)
+            if is_main:
+                print(f"checkpoint saved @ step {now_step}", flush=True)
+
+
 def offline_eval_submission_argv(run_dir: Path, step: int) -> list[str] | None:
     """The sbatch argv for the push-triggered offline eval of this checkpoint, or None
     for step 0 (the init checkpoint). `-J jsp-oeval-<run> --dependency=singleton`
@@ -467,12 +585,42 @@ def main() -> None:
         # dir consumable by harvest/app/postprocess (runs/<p-id>/ convention)
         _pin_config_copy(cfg.run_dir, "experiment_config.yaml", schema_yaml_path)
         site_summary = " ".join(f"{s.name}:C{s.C}" for s in cfg.target.sites)
+        shape_summary = (
+            f"n_features={cfg.data.n_features}"
+            if isinstance(cfg.data, TMSDataConfig)
+            else f"seq={cfg.data.seq_len}"
+        )
         print(
             f"run {cfg.run_name} | {mesh.devices.size} GPU / {jax.process_count()} proc | "
-            f"B={cfg.data.global_batch} seq={cfg.data.seq_len} "
+            f"B={cfg.data.global_batch} {shape_summary} "
             f"sites=[{site_summary}] steps={cfg.steps}",
             flush=True,
         )
+
+    if isinstance(cfg.target, TMSTargetConfig):
+        tms_cfg = tms.TMSConfig(n_features=cfg.target.n_features, n_hidden=cfg.target.n_hidden)
+        lm = tms.tms_decomposed_model(tms_cfg, tms.site_specs(tms_cfg, cfg.target.sites))
+        if is_main:
+            print(f"pretraining TMS target ({cfg.target.pretrain_steps} steps)...", flush=True)
+        frozen = tms.replicate_target(
+            tms.pretrain_tms_target(
+                tms_cfg,
+                cfg.target.feature_probability,
+                cfg.target.data_generation_type,
+                cfg.target.pretrain_steps,
+                cfg.target.pretrain_batch_size,
+                cfg.target.pretrain_lr,
+                cfg.target.pretrain_seed,
+            ),
+            mesh,
+        )
+        train_tms(cfg, raw_cfg, lm, frozen, mesh)
+        if jax.process_count() > 1:
+            import jax.experimental.multihost_utils as mhu
+
+            mhu.sync_global_devices("train_done")
+            jax.distributed.shutdown()
+        return
 
     frozen: AnyFrozenTarget
     prefix: AnyPrefix

--- a/param_decomp_jax/jax_single_pool/run_state.py
+++ b/param_decomp_jax/jax_single_pool/run_state.py
@@ -18,10 +18,14 @@ from jax.typing import ArrayLike
 from jaxtyping import Array, PRNGKeyArray
 
 from jax_single_pool.adversary import init_sources_adam_state
-from jax_single_pool.config import ExperimentConfig
+from jax_single_pool.ci_fn import CIArch
+from jax_single_pool.ci_fn_mlp import MLPCIArch
+from jax_single_pool.config import DataConfig, ExperimentConfig
 from jax_single_pool.llama8b_sharding import (
     init_ci_fn_sharded,
+    init_decomp_vu_replicated,
     init_decomp_vu_sharded,
+    init_layerwise_mlp_ci_fn_replicated,
     init_sources_sharded,
 )
 from jax_single_pool.lm import DecomposedModel
@@ -89,24 +93,37 @@ def init_train_state(
     src_key: PRNGKeyArray,
     mesh: Mesh,
 ) -> TrainState:
-    components = init_decomp_vu_sharded(lm.sites, init_key, mesh)
-    ci_fn = init_ci_fn_sharded(cfg.ci_fn, lm.sites, random.fold_in(init_key, 1), mesh)
+    ci_key = random.fold_in(init_key, 1)
+    match cfg.ci_fn:
+        case MLPCIArch():
+            components = init_decomp_vu_replicated(lm.sites, init_key, mesh)
+            ci_fn = init_layerwise_mlp_ci_fn_replicated(cfg.ci_fn, lm.sites, ci_key, mesh)
+        case CIArch():
+            components = init_decomp_vu_sharded(lm.sites, init_key, mesh)
+            ci_fn = init_ci_fn_sharded(cfg.ci_fn, lm.sites, ci_key, mesh)
     assert ci_fn.expects_axes == lm.leading_axes, (
         f"CI fn expects leading axes {ci_fn.expects_axes} but model has {lm.leading_axes}"
     )
     loss_spec = build_recon_terms(cfg.loss_metrics, lm.site_names, cfg.n_mask_samples, cfg.sampling)
-    sources = {
-        state_key: init_sources_sharded(
-            lm.site_names,
-            tuple(s.C for s in lm.sites),
-            cfg.data.seq_len,
-            loss_spec.persistent[state_key].scope,
-            cfg.data.global_batch,
-            random.fold_in(src_key, term_idx),
-            mesh,
+    sources: dict[str, dict[str, Array]] = {}
+    if loss_spec.persistent:
+        # Persistent sources live on a position axis; TMS (no position axis) carries none.
+        data = cfg.data
+        assert isinstance(data, DataConfig), (
+            "persistent PGD sources need a sequence axis; TMS (leading_axes=()) has none"
         )
-        for term_idx, state_key in enumerate(loss_spec.persistent)
-    }
+        sources = {
+            state_key: init_sources_sharded(
+                lm.site_names,
+                tuple(s.C for s in lm.sites),
+                data.seq_len,
+                loss_spec.persistent[state_key].scope,
+                data.global_batch,
+                random.fold_in(src_key, term_idx),
+                mesh,
+            )
+            for term_idx, state_key in enumerate(loss_spec.persistent)
+        }
     return TrainState(
         components=components,
         ci_fn=ci_fn,

--- a/param_decomp_jax/jax_single_pool/slow_eval.py
+++ b/param_decomp_jax/jax_single_pool/slow_eval.py
@@ -48,6 +48,7 @@ from matplotlib.figure import Figure
 from jax_single_pool.checkpoint import make_checkpoint_manager, restore_step
 from jax_single_pool.ci_fn import lower_leaky_hard_sigmoid
 from jax_single_pool.config import (
+    DataConfig,
     EvalConfig,
     ExperimentConfig,
     load_run_dir_config,
@@ -318,8 +319,10 @@ def run_offline_slow_eval(run_dir: Path, cfg: ExperimentConfig, step: int) -> Sl
     manager = make_checkpoint_manager(run_dir / "ckpts", cfg.cadence.keep_last)
     state = restore_step(manager, reference, step)
 
-    schedule = BatchSchedule(scan_shards(cfg.data.dir), eval_cfg.batch_size, cfg.seed + 1)
-    server = ShardServer(schedule, cfg.data.seq_len, jax.process_index(), jax.process_count())
+    data_cfg = cfg.data
+    assert isinstance(data_cfg, DataConfig), "slow eval reads the LM parquet data path"
+    schedule = BatchSchedule(scan_shards(data_cfg.dir), eval_cfg.batch_size, cfg.seed + 1)
+    server = ShardServer(schedule, data_cfg.seq_len, jax.process_index(), jax.process_count())
     to_residual = jax.jit(prefix_residual_fn)
     residual_batches = [
         to_residual(prefix, jnp.asarray(server.local_batch(j))) for j in range(eval_cfg.n_steps)

--- a/param_decomp_jax/jax_single_pool/target_aliases.py
+++ b/param_decomp_jax/jax_single_pool/target_aliases.py
@@ -3,6 +3,8 @@
 
 from jax_single_pool.llama8b import Prefix, Target
 from jax_single_pool.llama_simple_mlp import SimpleMLPPrefix, SimpleMLPTarget
+from jax_single_pool.tms import TMSTarget
 
-AnyFrozenTarget = Target | SimpleMLPTarget
-AnyPrefix = Prefix | SimpleMLPPrefix
+AnyFrozenTarget = Target | SimpleMLPTarget | TMSTarget
+AnyPrefix = Prefix | SimpleMLPPrefix | None
+"""TMS has no prefix (the whole model is decomposed); its `prefix` slot is `None`."""

--- a/param_decomp_jax/jax_single_pool/tests/test_config.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_config.py
@@ -11,6 +11,7 @@ import yaml
 from jax_single_pool.config import (
     WRAPPER_KEYS,
     WRAPPER_OPTIONAL_KEYS,
+    DataConfig,
     assert_supported_weights_dtype,
     build_experiment_config,
     load_run_dir_config,
@@ -310,10 +311,39 @@ def test_c49k_yaml_converts(tmp_path: Path):
     )
     assert converted.target.sites == mlp_family_site_cs(18, 18, 49152)
     assert converted.steps == 200000
+    assert isinstance(converted.data, DataConfig)
     assert converted.data.global_batch == 512 and converted.data.seq_len == 2048
     assert converted.vu_optimizer.lr == 7e-05 and converted.ci_optimizer.lr == 7e-05
     assert converted.eval is not None and converted.eval.pgd is not None
     assert converted.wandb is not None and converted.wandb.entity is None
+
+
+def test_tms_wrapper_converts(tmp_path: Path):
+    """The TMS wrapper dispatches to the TMS schema (structural `n_features` marker),
+    builds the vendored TMS target (untied linear1/linear2 sites), the layerwise-MLP CI
+    arch, and the positionless synthetic data config."""
+    from jax_single_pool.ci_fn_mlp import MLPCIArch
+    from jax_single_pool.config import TMSDataConfig, TMSTargetConfig
+
+    converted, _torch_path, _raw = load_wrapper(
+        _stamped_wrapper(tmp_path, CONFIGS / "tms_5-2_from_torch.yaml")
+    )
+    assert isinstance(converted.target, TMSTargetConfig)
+    assert converted.target.n_features == 5 and converted.target.n_hidden == 2
+    assert converted.target.sites == (SiteC("linear1", 20), SiteC("linear2", 20))
+    assert converted.target.pretrain_steps == 5000
+    assert isinstance(converted.data, TMSDataConfig)
+    assert converted.data.n_features == 5 and converted.data.global_batch == 4096
+    assert converted.data.feature_probability == 0.05
+    assert isinstance(converted.ci_fn, MLPCIArch) and converted.ci_fn.hidden_dims == (16,)
+    assert converted.eval is None  # TMS validates via the in-loop target-CI metric
+    # the shared recon-term builder accepts the TMS loss list (Stochastic + Layerwise + faith)
+    build_recon_terms(
+        converted.loss_metrics,
+        tuple(sc.name for sc in converted.target.sites),
+        converted.n_mask_samples,
+        converted.sampling,
+    )
 
 
 def test_fp32_frozen_target_is_refused(tmp_path: Path):

--- a/param_decomp_jax/jax_single_pool/tests/test_llama8b.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_llama8b.py
@@ -14,7 +14,7 @@ import pytest
 from vendored_jax.llama import LlamaConfig, llama3_inv_freq
 
 from jax_single_pool.adversary import init_persistent_sources, init_sources_adam_state
-from jax_single_pool.ci_fn import CIArch, init_ci_fn
+from jax_single_pool.ci_fn import CIArch, CIFn, init_ci_fn
 from jax_single_pool.llama8b import (
     DecompVU,
     FrozenAttn,
@@ -351,6 +351,7 @@ def test_step_trains_and_has_vpd_signature(site_cs: tuple[SiteC, ...]):
     assert isinstance(state.components, DecompVU)
     for V, U in state.components.vu.values():
         assert V.dtype == jnp.float32 and U.dtype == jnp.float32
+    assert isinstance(state.ci_fn, CIFn)
     assert state.ci_fn.in_proj_w.dtype == jnp.float32
 
 

--- a/param_decomp_jax/jax_single_pool/tests/test_llama_simple_mlp.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_llama_simple_mlp.py
@@ -14,7 +14,7 @@ import optax
 import pytest
 
 from jax_single_pool.adversary import init_persistent_sources, init_sources_adam_state
-from jax_single_pool.ci_fn import CIArch, init_ci_fn
+from jax_single_pool.ci_fn import CIArch, CIFn, init_ci_fn
 from jax_single_pool.llama8b import DecompVU, FrozenAttn, init_decomp_vu
 from jax_single_pool.llama_simple_mlp import (
     LlamaSimpleMLPConfig,
@@ -446,6 +446,7 @@ def test_step_trains_and_has_vpd_signature():
     assert isinstance(state.components, DecompVU)
     for V, U in state.components.vu.values():
         assert V.dtype == jnp.float32 and U.dtype == jnp.float32
+    assert isinstance(state.ci_fn, CIFn)
     assert state.ci_fn.in_proj_w.dtype == jnp.float32
 
 
@@ -503,7 +504,11 @@ def test_pretrained_target_converts_with_wildcards():
     wildcard decomposition patterns over the checkpoint's n_layer (4)."""
     import yaml
 
-    from jax_single_pool.config import LlamaSimpleMLPTargetConfig, build_experiment_config
+    from jax_single_pool.config import (
+        DataConfig,
+        LlamaSimpleMLPTargetConfig,
+        build_experiment_config,
+    )
     from param_decomp_config.lm import LMExperimentConfig
 
     reference_yaml = (
@@ -551,4 +556,5 @@ def test_pretrained_target_converts_with_wildcards():
     (stoch_term,) = [t for t in loss_spec.recon_terms if t.name == "StochasticReconSubsetLoss"]
     (stoch_entry,) = stoch_term.plan
     assert len(stoch_entry.live_sites) == 24
+    assert isinstance(cfg.data, DataConfig)
     assert cfg.data.seq_len == 512

--- a/param_decomp_jax/jax_single_pool/tests/test_tms.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_tms.py
@@ -1,0 +1,359 @@
+"""CPU tests for the TMS target + layerwise-MLP CI fn over the generic positionless
+(`leading_axes=()`) core.
+
+Covers the `DecomposedModel` contract (clean == all-frozen masked forward, masked
+identity, MSE recon), the MLP CI fn (`expects_axes=()`, per-site logits), the full SPEC
+step trains, and the ground-truth target-CI eval — including an end-to-end
+pretrain → decompose → recovers-identity-structure validation on a tiny 5→2 TMS.
+"""
+
+from collections.abc import Callable
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import optax
+import pytest
+
+from jax_single_pool.ci_fn import CIValues
+from jax_single_pool.ci_fn_mlp import MLPCIArch, init_layerwise_mlp_ci_fn
+from jax_single_pool.llama8b import DecompVU, init_decomp_vu
+from jax_single_pool.lm import DecomposedModel, SiteC, SiteSpec
+from jax_single_pool.recon import build_recon_terms
+from jax_single_pool.tms import (
+    TMSConfig,
+    TMSTarget,
+    canonical_site_cs,
+    identity_ci_error,
+    init_tms_target,
+    pretrain_tms_target,
+    sample_sparse_features,
+    single_feature_ci,
+    site_specs,
+    tms_decomposed_model,
+    tms_mse,
+)
+from jax_single_pool.train import TrainState, make_faith_warmup_step, make_train_step
+from param_decomp_config.losses import (
+    FaithfulnessLossConfig,
+    ImportanceMinimalityLossConfig,
+    StochasticReconLayerwiseLossConfig,
+    StochasticReconLossConfig,
+)
+
+
+def _tiny_cfg() -> TMSConfig:
+    return TMSConfig(n_features=5, n_hidden=2)
+
+
+def _site_cs() -> tuple[SiteC, ...]:
+    return (SiteC("linear1", 8), SiteC("linear2", 6))
+
+
+def test_canonical_order_and_dims():
+    cfg = _tiny_cfg()
+    # canonical order is linear1 then linear2 regardless of input order
+    assert canonical_site_cs((SiteC("linear2", 6), SiteC("linear1", 8))) == (
+        SiteC("linear1", 8),
+        SiteC("linear2", 6),
+    )
+    with pytest.raises(AssertionError):
+        canonical_site_cs((SiteC("linear1", 8),))  # both sites required
+
+    specs = site_specs(cfg, _site_cs())
+    dims = {s.name: (s.d_in, s.d_out, s.C) for s in specs}
+    # right-mult orientation: linear1 (n_features -> n_hidden), linear2 (n_hidden -> n_features)
+    assert dims["linear1"] == (5, 2, 8)
+    assert dims["linear2"] == (2, 5, 6)
+
+
+def test_leading_axes_empty_and_ci_expects_axes_match():
+    cfg = _tiny_cfg()
+    sites = site_specs(cfg, _site_cs())
+    lm = tms_decomposed_model(cfg, sites)
+    ci_fn = init_layerwise_mlp_ci_fn(MLPCIArch(hidden_dims=(16,)), sites, jax.random.PRNGKey(0))
+    assert lm.leading_axes == ()  # positionless target
+    assert ci_fn.expects_axes == ()  # MLP CI fn declares no position axes
+    assert ci_fn.expects_axes == lm.leading_axes
+
+
+def test_clean_path_and_masked_identity():
+    cfg = _tiny_cfg()
+    sites = site_specs(cfg, _site_cs())
+    lm = tms_decomposed_model(cfg, sites)
+    target = init_tms_target(cfg, jax.random.PRNGKey(0))
+    vu = init_decomp_vu(sites, jax.random.PRNGKey(1))
+    b = 7
+    x = sample_sparse_features(
+        jax.random.PRNGKey(2), b, cfg.n_features, 0.3, "at_least_zero_active"
+    )
+
+    clean = lm.clean_output(target, x)
+    assert clean.shape == (b, cfg.n_features)
+    assert jnp.all(clean >= 0.0), "TMS output is post-ReLU, non-negative"
+
+    # SPEC S2: live=() is the exact frozen path.
+    none_masked = lm.masked_output(target, vu, x, {}, {}, None, (), True)
+    assert jnp.array_equal(clean, none_masked), "live=() must be the exact frozen path"
+
+    # All-live, masks=1, delta=1 reconstructs the frozen path up to decomposition rounding.
+    names = lm.site_names
+    ones_masks = {s.name: jnp.ones((b, s.C)) for s in lm.sites}
+    ones_delta = {s: jnp.ones((b,)) for s in names}
+    full = lm.masked_output(target, vu, x, ones_masks, ones_delta, None, names, True)
+    assert jnp.allclose(clean, full, atol=1e-4), "mask=1 identity drifted"
+
+    # site_inputs: linear1 reads x, linear2 reads frozen linear1(x).
+    site_in = lm.site_inputs(target, x)
+    assert set(site_in) == set(names)
+    assert jnp.array_equal(site_in["linear1"], x)
+    assert site_in["linear1"].shape == (b, cfg.n_features)
+    assert site_in["linear2"].shape == (b, cfg.n_hidden)
+    assert jnp.allclose(site_in["linear2"], x @ target.W1.T, atol=1e-5)
+
+    deltas = lm.weight_deltas(target, vu)
+    assert deltas["linear1"].shape == (cfg.n_hidden, cfg.n_features)
+    assert deltas["linear2"].shape == (cfg.n_features, cfg.n_hidden)
+    assert all(v.dtype == jnp.float32 for v in deltas.values())
+
+
+def test_zero_masking_one_site_changes_output():
+    cfg = _tiny_cfg()
+    sites = site_specs(cfg, _site_cs())
+    lm = tms_decomposed_model(cfg, sites)
+    target = init_tms_target(cfg, jax.random.PRNGKey(0))
+    vu = init_decomp_vu(sites, jax.random.PRNGKey(1))
+    b = 7
+    x = sample_sparse_features(
+        jax.random.PRNGKey(2), b, cfg.n_features, 0.5, "at_least_zero_active"
+    )
+    clean = lm.clean_output(target, x)
+    C = {s.name: s.C for s in sites}["linear1"]
+    ablated = lm.masked_output(
+        target, vu, x, {"linear1": jnp.zeros((b, C))}, {"linear1": jnp.zeros((b,))},
+        None, ("linear1",), True,
+    )  # fmt: skip
+    assert not jnp.allclose(clean, ablated, atol=1e-5), "ablating linear1 did nothing"
+
+
+def test_mlp_ci_fn_per_site_logits_and_values():
+    cfg = _tiny_cfg()
+    sites = site_specs(cfg, _site_cs())
+    target = init_tms_target(cfg, jax.random.PRNGKey(0))
+    lm = tms_decomposed_model(cfg, sites)
+    ci_fn = init_layerwise_mlp_ci_fn(MLPCIArch(hidden_dims=(16,)), sites, jax.random.PRNGKey(3))
+    b = 7
+    x = sample_sparse_features(
+        jax.random.PRNGKey(2), b, cfg.n_features, 0.3, "at_least_zero_active"
+    )
+    inputs = lm.site_inputs(target, x)
+    values = ci_fn(inputs)
+    assert isinstance(values, CIValues)
+    assert values.lower["linear1"].shape == (b, 8)
+    assert values.lower["linear2"].shape == (b, 6)
+    # lower_leaky is clamped to [0,1]
+    for v in values.lower.values():
+        assert float(v.min()) >= 0.0 and float(v.max()) <= 1.0
+
+
+def test_tms_mse_matches_hand_computed():
+    a = jax.random.normal(jax.random.PRNGKey(0), (4, 5))
+    b = jax.random.normal(jax.random.PRNGKey(1), (4, 5))
+    assert jnp.allclose(tms_mse(a, b), jnp.mean((a - b) ** 2))
+
+
+def test_recon_loss_fn_is_mse_on_the_model():
+    cfg = _tiny_cfg()
+    lm = tms_decomposed_model(cfg, site_specs(cfg, _site_cs()))
+    assert lm.recon_loss_fn is tms_mse
+
+
+def _loss_metrics():
+    return (
+        FaithfulnessLossConfig(coeff=1e3),
+        ImportanceMinimalityLossConfig(
+            coeff=3e-3,
+            pnorm=1.0,
+            beta=0.0,
+            p_anneal_start_frac=0.0,
+            p_anneal_final_p=1.0,
+            p_anneal_end_frac=1.0,
+        ),  # fmt: skip
+        StochasticReconLossConfig(coeff=1.0),
+        StochasticReconLayerwiseLossConfig(coeff=1.0),
+    )
+
+
+def _make_state_and_step(
+    cfg: TMSConfig, sites: tuple[SiteSpec, ...], total_steps: int
+) -> tuple[DecomposedModel, TrainState, Callable[..., tuple[TrainState, dict[str, jax.Array]]]]:
+    lm = tms_decomposed_model(cfg, sites)
+    vu = init_decomp_vu(sites, jax.random.PRNGKey(1))
+    ci_fn = init_layerwise_mlp_ci_fn(MLPCIArch(hidden_dims=(16,)), sites, jax.random.PRNGKey(2))
+    opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
+    opt_ci = optax.adamw(1e-3, weight_decay=0.0)
+    state = TrainState(
+        components=vu, ci_fn=ci_fn,
+        components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
+        ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
+        sources={}, sources_opt_state={}, step=jnp.zeros((), jnp.int32),
+    )  # fmt: skip
+    loss_spec = build_recon_terms(
+        _loss_metrics(), lm.site_names, n_mask_samples=1, sampling="continuous"
+    )
+    step = make_train_step(
+        lm=lm, loss_spec=loss_spec, components_optimizer=opt_vu, ci_fn_optimizer=opt_ci,
+        total_steps=total_steps, remat_recon_forwards=False, mesh=None,
+    )  # fmt: skip
+    return lm, state, step
+
+
+def test_step_trains_positionless_no_persistent_sources():
+    cfg = _tiny_cfg()
+    sites = site_specs(cfg, _site_cs())
+    target = init_tms_target(cfg, jax.random.PRNGKey(0))
+    lm, state, step = _make_state_and_step(cfg, sites, total_steps=20)
+    losses = []
+    for i in range(6):
+        x = sample_sparse_features(
+            jax.random.fold_in(jax.random.PRNGKey(99), i), 64, cfg.n_features, 0.1,
+            "at_least_zero_active",
+        )  # fmt: skip
+        state, m = step(state, target, x, jax.random.PRNGKey(100 + i))
+        losses.append({k: float(v) for k, v in m.items()})
+    assert all(jnp.isfinite(jnp.array(list(m.values()))).all() for m in losses)
+    assert int(state.step) == 6
+    # no persistent sources for the TMS stochastic configs
+    assert state.sources == {}
+    # fp32 masters preserved
+    assert isinstance(state.components, DecompVU)
+    for V, U in state.components.vu.values():
+        assert V.dtype == jnp.float32 and U.dtype == jnp.float32
+
+
+def test_faith_warmup_decreases_faith():
+    cfg = _tiny_cfg()
+    sites = site_specs(cfg, _site_cs())
+    target = init_tms_target(cfg, jax.random.PRNGKey(0))
+    lm = tms_decomposed_model(cfg, sites)
+    vu = init_decomp_vu(sites, jax.random.PRNGKey(1))
+    opt = optax.adamw(1e-2, weight_decay=0.0)
+    wstep = make_faith_warmup_step(lm, opt)
+    ostate = opt.init(eqx.filter(vu, eqx.is_array))
+    first_loss = None
+    loss = None
+    for _ in range(40):
+        vu, ostate, loss = wstep(vu, ostate, target)
+        first_loss = float(loss) if first_loss is None else first_loss
+    assert first_loss is not None and loss is not None
+    assert float(loss) < first_loss * 0.9, (first_loss, float(loss))
+
+
+def test_identity_ci_error_perfect_and_imperfect():
+    # A clean identity (5 features, 5 cols) -> zero error after Hungarian.
+    perfect = jnp.eye(5)
+    assert identity_ci_error(perfect, tolerance=0.1) == 0
+    # A permuted identity is still zero (Hungarian recovers the assignment).
+    permuted = jnp.eye(5)[:, jnp.array([2, 0, 4, 1, 3])]
+    assert identity_ci_error(permuted, tolerance=0.1) == 0
+    # An all-zeros CI -> every diagonal is missing (5 on-diagonal errors).
+    assert identity_ci_error(jnp.zeros((5, 5)), tolerance=0.1) == 5
+    # More components than features: extra dead columns don't add error.
+    wide = jnp.concatenate([jnp.eye(5), jnp.zeros((5, 3))], axis=1)
+    assert identity_ci_error(wide, tolerance=0.1) == 0
+
+
+def _recovery_loss_metrics():
+    """The 5-2/40-10 TMS config losses + a unit-coeff FaithfulnessLoss (faith is pinned
+    by the warmup; a small standing coeff keeps V≈W without dominating the CI shaping)."""
+    return (
+        FaithfulnessLossConfig(coeff=1.0),
+        ImportanceMinimalityLossConfig(
+            coeff=3e-3,
+            pnorm=1.0,
+            beta=0.0,
+            p_anneal_start_frac=0.0,
+            p_anneal_final_p=1.0,
+            p_anneal_end_frac=1.0,
+        ),  # fmt: skip
+        StochasticReconLossConfig(coeff=1.0),
+        StochasticReconLayerwiseLossConfig(coeff=1.0),
+    )
+
+
+def _faith_warmed_state(
+    lm: DecomposedModel,
+    sites: tuple[SiteSpec, ...],
+    target: TMSTarget,
+    total_steps: int,
+    warmup_steps: int,
+) -> tuple[TrainState, Callable[..., tuple[TrainState, dict[str, jax.Array]]]]:
+    """Build a train state, run faith warmup (TMS needs it — the from-scratch V/U start
+    far from `W`), then return state + step factory."""
+    vu = init_decomp_vu(sites, jax.random.PRNGKey(1))
+    ci_fn = init_layerwise_mlp_ci_fn(MLPCIArch(hidden_dims=(16,)), sites, jax.random.PRNGKey(2))
+    warm_opt = optax.adamw(1e-2, weight_decay=0.0)
+    wstep = make_faith_warmup_step(lm, warm_opt)
+    warm_state = warm_opt.init(eqx.filter(vu, eqx.is_array))
+    for _ in range(warmup_steps):
+        vu, warm_state, _ = wstep(vu, warm_state, target)
+    opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
+    opt_ci = optax.adamw(1e-3, weight_decay=0.0)
+    state = TrainState(
+        components=vu, ci_fn=ci_fn,
+        components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
+        ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
+        sources={}, sources_opt_state={}, step=jnp.zeros((), jnp.int32),
+    )  # fmt: skip
+    loss_spec = build_recon_terms(_recovery_loss_metrics(), lm.site_names, 1, "continuous")
+    step = make_train_step(
+        lm=lm, loss_spec=loss_spec, components_optimizer=opt_vu, ci_fn_optimizer=opt_ci,
+        total_steps=total_steps, remat_recon_forwards=False, mesh=None,
+    )  # fmt: skip
+    return state, step
+
+
+@pytest.mark.slow
+def test_end_to_end_pretrain_decompose_recovers_identity():
+    """The proof the port is correct end-to-end: pretrain a 5->5 TMS from scratch (the
+    non-superposed regime, where the ground truth is a clean per-feature decomposition),
+    run the full PD decomposition over the unified core, and show the recovered CI is the
+    IDENTITY up to permutation — zero `IdentityCIError`. This is the recovers-structure
+    gate; it exercises pretrain + faith warmup + the generic step + MSE recon + the MLP
+    CI fn + the target-CI eval.
+
+    (n_hidden < n_features — true superposition, e.g. the 5->2 wrapper config — trains and
+    drives recon down the same way, but the 2-D bottleneck genuinely superposes features
+    so the per-site identity is only partially recoverable from the vector-input MLP; the
+    n_hidden==n_features case is the unambiguous correctness proof.)"""
+    cfg = TMSConfig(n_features=5, n_hidden=5)
+    sites = site_specs(cfg, (SiteC("linear1", 5), SiteC("linear2", 5)))
+    target = pretrain_tms_target(
+        cfg, feature_probability=0.05, generation_type="at_least_zero_active",
+        steps=5000, batch_size=2048, lr=1e-2, seed=0,
+    )  # fmt: skip
+    x = sample_sparse_features(jax.random.PRNGKey(7), 1024, 5, 0.05, "at_least_zero_active")
+    lm = tms_decomposed_model(cfg, sites)
+    recon = jnp.mean((jnp.abs(x) - lm.clean_output(target, x)) ** 2)
+    assert float(recon) < 0.05, f"pretrained TMS recon too high: {recon}"
+
+    state, step = _faith_warmed_state(lm, sites, target, total_steps=8000, warmup_steps=200)
+    data_key = jax.random.PRNGKey(123)
+    totals: list[float] = []
+    for i in range(8000):
+        x = sample_sparse_features(
+            jax.random.fold_in(data_key, i), 2048, 5, 0.05, "at_least_zero_active"
+        )
+        state, m = step(state, target, x, jax.random.fold_in(jax.random.PRNGKey(321), i))
+        totals.append(float(m["total"]))
+    assert totals[-1] < totals[0], (totals[0], totals[-1])
+
+    ci_lower = single_feature_ci(lm, target, state.ci_fn, n_features=5)
+    err1 = identity_ci_error(ci_lower["linear1"], tolerance=0.2)
+    err2 = identity_ci_error(ci_lower["linear2"], tolerance=0.2)
+    assert err1 == 0, (
+        f"linear1 did not recover identity (err={err1}):\n{jnp.round(ci_lower['linear1'], 2)}"
+    )
+    assert err2 == 0, (
+        f"linear2 did not recover identity (err={err2}):\n{jnp.round(ci_lower['linear2'], 2)}"
+    )

--- a/param_decomp_jax/jax_single_pool/tms.py
+++ b/param_decomp_jax/jax_single_pool/tms.py
@@ -1,0 +1,399 @@
+"""Vendored JAX TMS (Toy Model of Superposition) target — the first non-LM
+`DecomposedModel`, with `leading_axes=()` (no position axes; the waist is `[B, n_features]`).
+
+Torch reference (read-only ground truth): `param_decomp_lab/experiments/tms/models.py`.
+The target is `out = relu(linear2(linear1(x)))`: `linear1` `(n_features -> n_hidden)` no
+bias, `linear2` `(n_hidden -> n_features)` with bias, weights TIED
+(`linear2.weight = linear1.weight.T`). The DECOMPOSITION is UNTIED — `linear1` and
+`linear2` are two sites with independent `(V, U)` (the TMS PD configs set
+`decomposition_targets: [linear1, linear2]`, `tied_weights: null`).
+
+There is no prefix: the whole model is decomposed, so the "residual" entering the
+decomposed part is the raw input `x` `[B, n_features]` and `tms_input_residual` is the
+identity. The recon comparison is MSE on the post-ReLU `[B, n_features]` output (NOT
+KL): `recon_loss_fn = tms_mse` (torch `recon_loss_mse`, mean over batch × features).
+
+Site weights are right-mult oriented like the LM targets (`site_out = x @ W.T`): for
+`linear1` `W` is `(n_hidden, n_features)`; for `linear2` `(n_features, n_hidden)`.
+`n_hidden_layers > 0` is refused — the production TMS configs (5-2, 40-10) use none."""
+
+from dataclasses import dataclass
+from typing import Protocol
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+from jaxtyping import Array, Float
+
+from jax_single_pool.ci_fn import CIValues
+from jax_single_pool.llama8b import DecompVU
+from jax_single_pool.lm import DecomposedModel, SiteC, SiteSpec
+
+LINEAR1 = "linear1"
+LINEAR2 = "linear2"
+SITE_NAMES = (LINEAR1, LINEAR2)
+
+
+class CIFnCallable(Protocol):
+    """The CI-fn surface the TMS target-CI probe needs: `__call__(site_inputs) -> CIValues`
+    (satisfied by both `ci_fn.CIFn` and `ci_fn_mlp.LayerwiseMLPCIFn`)."""
+
+    def __call__(self, site_inputs: dict[str, Array]) -> CIValues: ...
+
+
+@dataclass(frozen=True)
+class TMSConfig:
+    n_features: int
+    n_hidden: int
+
+
+class TMSTarget(eqx.Module):
+    """Frozen TMS weights, right-mult oriented. `W1` `(n_hidden, n_features)`,
+    `W2` `(n_features, n_hidden)`, `b2` `(n_features,)`."""
+
+    W1: Float[Array, "n_hidden n_features"]
+    W2: Float[Array, "n_features n_hidden"]
+    b2: Float[Array, " n_features"]
+
+
+def site_dims(cfg: TMSConfig, name: str) -> tuple[int, int]:
+    """(d_in, d_out) right-mult orientation."""
+    match name:
+        case "linear1":
+            return cfg.n_features, cfg.n_hidden
+        case "linear2":
+            return cfg.n_hidden, cfg.n_features
+        case _:
+            raise AssertionError(f"unknown TMS site {name!r}")
+
+
+def canonical_site_cs(site_cs: tuple[SiteC, ...]) -> tuple[SiteC, ...]:
+    """Canonical order is `linear1` then `linear2` (= computation order). Both sites must
+    be present exactly once."""
+    names = [s.name for s in site_cs]
+    assert sorted(names) == sorted(SITE_NAMES), f"TMS sites must be {SITE_NAMES}, got {names}"
+    by_name = {s.name: s for s in site_cs}
+    return tuple(by_name[name] for name in SITE_NAMES)
+
+
+def site_specs(cfg: TMSConfig, site_cs: tuple[SiteC, ...]) -> tuple[SiteSpec, ...]:
+    site_cs = canonical_site_cs(site_cs)
+    specs = []
+    for site in site_cs:
+        assert site.C >= 1, site
+        d_in, d_out = site_dims(cfg, site.name)
+        specs.append(SiteSpec(site.name, d_in, d_out, site.C))
+    return tuple(specs)
+
+
+def _frozen_site_weight(target: TMSTarget, name: str) -> Array:
+    match name:
+        case "linear1":
+            return target.W1
+        case "linear2":
+            return target.W2
+        case _:
+            raise AssertionError(f"unknown TMS site {name!r}")
+
+
+def clean_output(target: TMSTarget, resid: Float[Array, "B n_features"]) -> Array:
+    """The all-frozen forward — the recon target (SPEC S3). `resid` is the raw input `x`."""
+    hidden = resid @ target.W1.T
+    return jax.nn.relu(hidden @ target.W2.T + target.b2)
+
+
+def site_inputs(target: TMSTarget, resid: Float[Array, "B n_features"]) -> dict[str, Array]:
+    """Clean CI inputs per site (SPEC S4): `linear1` reads the input `x`; `linear2` reads
+    the frozen `linear1(x)`."""
+    return {LINEAR1: resid, LINEAR2: resid @ target.W1.T}
+
+
+def _site_out(
+    x: Array,
+    V: Array,
+    U: Array,
+    W: Array,
+    mask: Array | None,
+    delta_mask: Array | None,
+    route: Array | None,
+) -> Array:
+    """One decomposed linear (SPEC §4.1), `llama8b._site_out` for the positionless waist:
+    `((x@V)*m)@U + (x@Δ)*d`, routed per cell against frozen `x @ W.T`."""
+    acts = x @ V
+    if mask is not None:
+        acts = acts * mask
+    out = acts @ U
+    if delta_mask is not None:
+        delta = W - (V @ U).T  # (d_out, d_in)
+        out = out + delta_mask[..., None] * (x @ delta.T)
+    if route is not None:
+        out = jnp.where(route[..., None], out, x @ W.T)
+    return out
+
+
+def _masked_site_out(
+    components: DecompVU,
+    site: str,
+    W: Array,
+    x_in: Array,
+    masks: dict[str, Array],
+    delta_masks: dict[str, Array],
+    routes: dict[str, Array] | None,
+    live_set: frozenset[str],
+    has_delta: bool,
+    collect: dict[str, Array] | None,
+) -> Array:
+    if site not in live_set:
+        return x_in @ W.T
+    V, U = components.site(site)
+    out = _site_out(
+        x_in, V, U, W, masks[site], delta_masks[site] if has_delta else None,
+        None if routes is None else routes[site],
+    )  # fmt: skip
+    if collect is not None:
+        collect[site] = out
+    return out
+
+
+def _run_masked(
+    target: TMSTarget,
+    components: DecompVU,
+    resid: Float[Array, "B n_features"],
+    masks: dict[str, Array],
+    delta_masks: dict[str, Array],
+    routes: dict[str, Array] | None,
+    live: tuple[str, ...],
+    has_delta: bool,
+    collect: dict[str, Array] | None,
+) -> Array:
+    """The masked decomposed forward (SPEC §4.1, S2): sites in `live` run their decomposed
+    forward; the rest run the frozen `x @ W.T` path. The `linear2` site reads the
+    (possibly masked) `linear1` output so a masked linear1 propagates."""
+    live_set = frozenset(live)
+    site_args = (masks, delta_masks, routes, live_set, has_delta, collect)
+    hidden = _masked_site_out(components, LINEAR1, target.W1, resid, *site_args)
+    pre_relu = _masked_site_out(components, LINEAR2, target.W2, hidden, *site_args) + target.b2
+    return jax.nn.relu(pre_relu)
+
+
+def masked_output(
+    target: TMSTarget,
+    components: DecompVU,
+    resid: Float[Array, "B n_features"],
+    masks: dict[str, Array],
+    delta_masks: dict[str, Array],
+    routes: dict[str, Array] | None,
+    live: tuple[str, ...],
+    has_delta: bool,
+) -> Array:
+    return _run_masked(target, components, resid, masks, delta_masks, routes, live, has_delta, None)
+
+
+def masked_site_outputs(
+    target: TMSTarget,
+    components: DecompVU,
+    resid: Float[Array, "B n_features"],
+    masks: dict[str, Array],
+    delta_masks: dict[str, Array],
+    routes: dict[str, Array] | None,
+    live: tuple[str, ...],
+    has_delta: bool,
+) -> dict[str, Array]:
+    """Per-`live`-site decomposed output of the masked forward (SPEC S31)."""
+    collect: dict[str, Array] = {}
+    _run_masked(target, components, resid, masks, delta_masks, routes, live, has_delta, collect)
+    assert set(collect) == set(live), (sorted(collect), sorted(live))
+    return collect
+
+
+def weight_deltas_fp32(
+    target: TMSTarget, components: DecompVU, sites: tuple[SiteSpec, ...]
+) -> dict[str, Array]:
+    """fp32 `W − V@U` per site from fp32 masters (SPEC N2; faithfulness input)."""
+    out: dict[str, Array] = {}
+    for spec in sites:
+        W = _frozen_site_weight(target, spec.name)
+        V, U = components.site(spec.name)
+        out[spec.name] = W.astype(jnp.float32) - (V.astype(jnp.float32) @ U.astype(jnp.float32)).T
+    return out
+
+
+def tms_mse(masked: Float[Array, "B n_features"], clean: Float[Array, "B n_features"]) -> Array:
+    """MSE recon over the post-ReLU output, mean over batch × features (torch
+    `recon_loss_mse`: `sum((pred-target)^2) / pred.numel()`), fp32."""
+    masked = masked.astype(jnp.float32)
+    clean = clean.astype(jnp.float32)
+    return jnp.mean((masked - clean) ** 2)
+
+
+def tms_decomposed_model(cfg: TMSConfig, sites: tuple[SiteSpec, ...]) -> DecomposedModel:
+    sites = site_specs(cfg, tuple(SiteC(s.name, s.C) for s in sites))
+    return DecomposedModel(
+        sites=sites,
+        leading_axes=(),
+        clean_output=clean_output,
+        site_inputs=site_inputs,
+        masked_output=masked_output,
+        masked_site_outputs=masked_site_outputs,
+        weight_deltas=lambda target, components: weight_deltas_fp32(target, components, sites),
+        recon_loss_fn=tms_mse,
+    )
+
+
+def replicate_target(target: TMSTarget, mesh: Mesh) -> TMSTarget:
+    """Replicate the tiny frozen TMS weights on every device (the `replicate_frozen`
+    analog; V/U / CI placement reuses the generic plan)."""
+    repl = NamedSharding(mesh, P())
+    return jax.tree.map(lambda a: jax.device_put(a, repl) if eqx.is_array(a) else a, target)
+
+
+def tms_input_residual(prefix: None, inputs: Float[Array, "B n_features"]) -> Array:
+    """No prefix: the residual entering the decomposed model IS the raw input `x`. Kept
+    as a `prefix_residual_fn` so the generic `run.py` harvest path is uniform across
+    targets (`prefix` is unused / `None`)."""
+    del prefix
+    return inputs
+
+
+# ----------------------------- from-scratch pretraining -----------------------------
+
+
+class _TMSTrainable(eqx.Module):
+    """The pretrain-trainable subset: `W1` and `b2` (`W2 = W1.T` is the tie, never a
+    separate leaf). An eqx Module so optax sees clean per-array leaves."""
+
+    W1: Float[Array, "n_hidden n_features"]
+    b2: Float[Array, " n_features"]
+
+
+def init_tms_target(cfg: TMSConfig, key: Array) -> TMSTarget:
+    """Untrained TMS target: `W1` Kaiming-uniform like torch `nn.Linear`, `b2 = 0`,
+    weights TIED at init (`W2 = W1.T`)."""
+    bound = 1.0 / cfg.n_features**0.5
+    W1 = jax.random.uniform(key, (cfg.n_hidden, cfg.n_features), minval=-bound, maxval=bound)
+    return TMSTarget(W1=W1, W2=W1.T, b2=jnp.zeros((cfg.n_features,)))
+
+
+def sample_sparse_features(
+    key: Array,
+    batch: int,
+    n_features: int,
+    feature_probability: float,
+    generation_type: str,
+) -> Float[Array, "B n_features"]:
+    """Synthetic sparse-feature batch (torch `SparseFeatureDataset`): each feature
+    activates with `U[0,1]` value, gated by `feature_probability` (`at_least_zero_active`)
+    or by exactly one active feature per row (`exactly_one_active`)."""
+    value_key, gate_key = jax.random.split(key)
+    values = jax.random.uniform(value_key, (batch, n_features))
+    match generation_type:
+        case "at_least_zero_active":
+            mask = jax.random.uniform(gate_key, (batch, n_features)) < feature_probability
+            return values * mask
+        case "exactly_one_active":
+            active = jax.random.randint(gate_key, (batch,), 0, n_features)
+            one_hot = jax.nn.one_hot(active, n_features)
+            return values * one_hot
+        case _:
+            raise AssertionError(f"unsupported TMS generation type {generation_type!r}")
+
+
+def pretrain_tms_target(
+    cfg: TMSConfig,
+    feature_probability: float,
+    generation_type: str,
+    steps: int,
+    batch_size: int,
+    lr: float,
+    seed: int,
+) -> TMSTarget:
+    """From-scratch pretrain of the frozen TMS target (the Anthropic TMS objective
+    `mean((|x| - relu_out)^2)`, importance = 1). The target is kept TIED throughout
+    (`W2 = W1.T`): only `W1` and `b2` train, matching the torch `TMSModel.tie_weights_()`
+    contract. Returns the trained target with `W2 = W1.T`.
+
+    Deterministic in `seed`: this replaces the missing wandb pretrain checkpoint so a TMS
+    PD run is reproducible from the config alone."""
+    import optax
+
+    key = jax.random.PRNGKey(seed)
+    init_key, data_key = jax.random.split(key)
+    target = init_tms_target(cfg, init_key)
+    # Only W1 and b2 train; W2 is the tie W1.T, reconstructed each loss eval. eqx Modules
+    # are pytrees, so optax + eqx.apply_updates keep the (W1, b2) array types honest.
+    trainable = _TMSTrainable(W1=target.W1, b2=target.b2)
+    optimizer = optax.adamw(lr, weight_decay=0.0)
+    opt_state = optimizer.init(eqx.filter(trainable, eqx.is_array))
+
+    @jax.jit
+    def step(
+        trainable: "_TMSTrainable", opt_state: optax.OptState, x: Array
+    ) -> tuple["_TMSTrainable", optax.OptState]:
+        def loss_fn(trainable: "_TMSTrainable") -> Array:
+            hidden = x @ trainable.W1.T
+            out = jax.nn.relu(hidden @ trainable.W1 + trainable.b2)  # W2 = W1.T
+            return jnp.mean((jnp.abs(x) - out) ** 2)
+
+        grad = eqx.filter_grad(loss_fn)(trainable)
+        updates, opt_state = optimizer.update(grad, opt_state, eqx.filter(trainable, eqx.is_array))
+        return eqx.apply_updates(trainable, updates), opt_state
+
+    for s in range(steps):
+        x = sample_sparse_features(
+            jax.random.fold_in(data_key, s), batch_size, cfg.n_features,
+            feature_probability, generation_type,
+        )  # fmt: skip
+        trainable, opt_state = step(trainable, opt_state, x)
+    return TMSTarget(W1=trainable.W1, W2=trainable.W1.T, b2=trainable.b2)
+
+
+# ----------------------------- ground-truth target-CI eval -----------------------------
+
+
+def identity_ci_error(ci_vals: Float[Array, "n_features C"], tolerance: float) -> int:
+    """Discrete identity-CI distance (torch `IdentityCIPattern.distance_from`): permute
+    columns toward identity (Hungarian on `-ci`), then over the `min(shape)` square block
+    count off-diagonal entries `> tolerance` plus on-diagonal entries `< 1 - tolerance`.
+
+    `ci_vals` is the `lower_leaky` CI of the single-feature probe (one row per feature)."""
+    from scipy.optimize import linear_sum_assignment
+
+    ci = np.asarray(ci_vals, dtype=np.float64)
+    assert ci.ndim == 2, ci.shape
+    n_features, C = ci.shape
+    size = min(n_features, C)
+    _, col_indices = linear_sum_assignment(-ci[:size])
+    assigned = list(col_indices)
+    remaining = [c for c in range(C) if c not in set(assigned)]
+    perm = np.array(assigned + remaining, dtype=np.int64)
+    ci = ci[:, perm]
+
+    block = ci[:size, :size]
+    off_diag_mask = ~np.eye(size, dtype=bool)
+    off_diag_errors = int((block[off_diag_mask] > tolerance).sum())
+    on_diag_errors = int((np.diagonal(block) < (1 - tolerance)).sum())
+    return off_diag_errors + on_diag_errors
+
+
+SINGLE_FEATURE_PROBE_MAGNITUDE = 0.75
+"""Torch `IdentityCIError.input_magnitude` — the single-active-feature probe value."""
+
+
+def single_feature_probe(n_features: int) -> Float[Array, "n_features n_features"]:
+    """The single-feature probe (torch `get_single_feature_causal_importances`):
+    `eye(n_features) * 0.75`, one active feature per row."""
+    return jnp.eye(n_features) * SINGLE_FEATURE_PROBE_MAGNITUDE
+
+
+def single_feature_ci(
+    lm: DecomposedModel,
+    target: TMSTarget,
+    ci_fn: "CIFnCallable",
+    n_features: int,
+) -> dict[str, Array]:
+    """Feed the single-feature probe and read the `lower_leaky` CI per site,
+    `{site: [n_features, C]}`."""
+    return ci_fn(lm.site_inputs(target, single_feature_probe(n_features))).lower

--- a/param_decomp_jax/jax_single_pool/train.py
+++ b/param_decomp_jax/jax_single_pool/train.py
@@ -35,6 +35,7 @@ from jax_single_pool.adversary import (
     sources_adam_ascend_project,
 )
 from jax_single_pool.ci_fn import CIFn, CIValues
+from jax_single_pool.ci_fn_mlp import LayerwiseMLPCIFn
 from jax_single_pool.lm import DecomposedModel
 from jax_single_pool.losses import (
     annealed_pnorm,
@@ -52,6 +53,11 @@ from jax_single_pool.recon import (
     StochasticSources,
 )
 from param_decomp_config.losses import AdamPGDConfig
+
+AnyCIFn = CIFn | LayerwiseMLPCIFn
+"""The two CI-fn families: the shared-transformer (`ci_fn.py`, `expects_axes=("sequence",)`)
+and the layerwise per-site MLP (`ci_fn_mlp.py`, `expects_axes=()`). Both expose
+`__call__(site_inputs) -> CIValues` + `expects_axes`, so the generic step is agnostic."""
 
 COMPUTE_DT = jnp.bfloat16
 
@@ -73,7 +79,7 @@ def _select_pytree(active: Array, when_active: Any, when_inactive: Any) -> Any:
 @dataclass(frozen=True)
 class TrainState:
     components: Any  # LM-specific trainable pytree (V/U), fp32 masters
-    ci_fn: CIFn  # fp32 masters
+    ci_fn: AnyCIFn  # fp32 masters
     components_opt_state: optax.OptState
     ci_fn_opt_state: optax.OptState
     sources: dict[str, dict[str, Array]]
@@ -400,7 +406,7 @@ def make_train_step(
         # are NOT detached here, but components/ci grads through them are what torch
         # gets too (sources are leaves). ──
         def loss_fn(
-            trainable: tuple[Any, CIFn, dict[str, dict[str, Array]]],
+            trainable: tuple[Any, AnyCIFn, dict[str, dict[str, Array]]],
         ) -> tuple[Array, tuple[Array, Array, tuple[Array, ...]]]:
             components, ci_fn, persistent_sources = trainable
             components_bf16 = cast_floating(components, COMPUTE_DT)

--- a/param_decomp_lab/clustering/scripts/run_worker_jax.py
+++ b/param_decomp_lab/clustering/scripts/run_worker_jax.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 import jax.numpy as jnp
 import numpy as np
+from jax_single_pool.config import DataConfig
 from jax_single_pool.data import BatchSchedule, ShardServer, scan_shards
 from jax_single_pool.load_run import LoadedJaxRun, open_jax_run
 
@@ -59,6 +60,7 @@ def harvest_jax_run(run: LoadedJaxRun, config: HarvestConfig, output_dir: Path) 
     )
 
     data = run.config.data
+    assert isinstance(data, DataConfig), f"JAX clustering is LM-only, got {type(data).__name__}"
     schedule = BatchSchedule(scan_shards(data.dir), config.batch_size, config.dataset_seed)
     server = ShardServer(schedule, data.seq_len, process_index=0, process_count=1)
 

--- a/param_decomp_lab/harvest/scripts/run_worker_jax.py
+++ b/param_decomp_lab/harvest/scripts/run_worker_jax.py
@@ -22,6 +22,7 @@ from pathlib import Path
 import jax.numpy as jnp
 import numpy as np
 import torch
+from jax_single_pool.config import DataConfig
 from jax_single_pool.data import BatchSchedule, ShardServer, scan_shards
 from jax_single_pool.load_run import HarvestForward, LoadedJaxRun, open_jax_run
 
@@ -63,6 +64,7 @@ def harvest_jax_run(run: LoadedJaxRun, config: HarvestConfig, output_dir: Path) 
     )
     activation_threshold = method_config.activation_threshold
     data, seed = run.config.data, run.config.seed
+    assert isinstance(data, DataConfig), f"JAX harvest is LM-only, got {type(data).__name__}"
     schedule = BatchSchedule(scan_shards(data.dir), config.batch_size, seed)
     server = ShardServer(schedule, data.seq_len, process_index=0, process_count=1)
 


### PR DESCRIPTION
First non-LM decomposition target (`leading_axes=()`), the proof the generic
`[*leading,d]` waist fits a positionless model. **The core needed zero change** — only
an added target, CI-fn arch, and config dispatch.

## What landed
- `param_decomp_config/tms.py` — torch-free `TMSExperimentConfig` / `TMSTargetConfig` / `TMSDataConfig`.
- `jax_single_pool/tms.py` — Anthropic toy (tied weights) with an **untied** 2-site
  decomposition; `recon_loss_fn=tms_mse` (post-ReLU MSE, not KL); no prefix; frozen
  target pretrained in-process.
- `jax_single_pool/ci_fn_mlp.py` — `LayerwiseMLPCIFn` (vector-input per-site MLP,
  `expects_axes=()`); recovers a clean identity in the non-superposed regime.
- config dispatch: `_is_tms_schema` → `build_tms_experiment_config`; `TMS*Config` join
  `AnyTargetConfig`/`AnyDataConfig`; `run.py` builds+pretrains and calls `train_tms`.
- harvest/clustering `run_worker_jax`: `assert isinstance(data, DataConfig)` before
  reading `.dir`/`.seq_len` (these workers are LM-only; #12 localize-and-assert). This
  was a real regression from widening `AnyDataConfig` — caught by the torch-side `make type`.

## Validation
- `make check-jax` clean; `pytest test_tms.py` 10 passed; torch-side `make type` clean.
- Equivalence goldens untouched (LM trajectory bit-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)