### PR TITLE
feat(jax): add ResidualMLP decomposition target (#4)

### DIFF
--- a/param_decomp_config/resid_mlp.py
+++ b/param_decomp_config/resid_mlp.py
@@ -1,0 +1,75 @@
+"""ResidualMLP experiment config schema — torch-free.
+
+The JAX trainer reads this directly (`jax_single_pool.config`), the same way it reads
+`TMSExperimentConfig`. Like TMS there is no HuggingFace/pretrain-cache weight source:
+the toy ResidualMLP target is pretrained from scratch, deterministically from
+`target.pretrain` (the `act_fn(coeffs·x) + x` read-off objective on the synthetic
+sparse-feature data), so a run is fully reproducible from the config alone.
+
+The target is the SPD/APD residual-stream toy: a fixed input embedding `W_E`
+(`n_features → d_embed`), a stack of `n_layers` MLP blocks each reading from and writing
+to the `d_embed` residual stream, and a fixed unembed `W_U` (`d_embed → n_features`). The
+*decomposition* targets the per-layer MLP matrices (`layers.{i}.mlp_in` /
+`layers.{i}.mlp_out`).
+"""
+
+from typing import Literal
+
+from pydantic import PositiveInt, model_validator
+
+from param_decomp_config.base import BaseConfig, Probability
+from param_decomp_config.experiment import ExperimentConfig
+
+ResidMLPDataGenerationType = Literal["exactly_one_active", "at_least_zero_active"]
+ResidMLPActFn = Literal["gelu", "relu"]
+
+
+class ResidMLPPretrainConfig(BaseConfig):
+    """How the frozen ResidualMLP target is pretrained from scratch.
+
+    The objective is the read-off MSE `mean((out − (act_fn(coeffs·x) + x))²)` with the
+    embedding held fixed (`fixed_random_embedding`: unit-norm random rows, `W_U = W_Eᵀ`)
+    and trivial unit label coeffs — the canonical clean-recovery regime."""
+
+    steps: PositiveInt
+    batch_size: PositiveInt
+    lr: float
+    seed: int = 0
+
+
+class ResidMLPTargetConfig(BaseConfig):
+    """The ResidualMLP target architecture + its from-scratch pretraining.
+
+    `d_mlp ≥ n_features` (no MLP-width superposition) and an identity/random fixed
+    embedding give the clean per-feature ground truth the identity-CI metric checks."""
+
+    n_features: PositiveInt
+    d_embed: PositiveInt
+    d_mlp: PositiveInt
+    n_layers: PositiveInt
+    act_fn_name: ResidMLPActFn
+    in_bias: bool = False
+    out_bias: bool = False
+    fixed_identity_embedding: bool = False
+    """`W_E = I` (requires `n_features == d_embed`); else a fixed random unit-norm
+    embedding (torch `fixed_random_embedding`)."""
+    pretrain: ResidMLPPretrainConfig
+
+    @model_validator(mode="after")
+    def validate_identity_embedding(self) -> "ResidMLPTargetConfig":
+        if self.fixed_identity_embedding:
+            assert self.n_features == self.d_embed, (
+                "n_features must equal d_embed for fixed_identity_embedding"
+            )
+        return self
+
+
+class ResidMLPDataConfig(BaseConfig):
+    """Synthetic sparse-feature data for the PD decomposition step (values in [-1, 1])."""
+
+    feature_probability: Probability
+    data_generation_type: ResidMLPDataGenerationType = "at_least_zero_active"
+
+
+class ResidMLPExperimentConfig(ExperimentConfig[ResidMLPTargetConfig, ResidMLPDataConfig]):
+    pass

--- a/param_decomp_jax/jax_single_pool/CLAUDE.md
+++ b/param_decomp_jax/jax_single_pool/CLAUDE.md
@@ -77,7 +77,7 @@ one independent MLP per site mapping `site_input [B,d_in] -> [B,C]` logits throu
 same `lower/upper_leaky_hard` squashings; `run_state.init_train_state` dispatches CI-fn
 construction on `cfg.ci_fn` (`CIArch` transformer vs `MLPCIArch`) and uses replicated
 (not C-sharded) V/U + CI for the tiny TMS. Config dispatch: `config._is_tms_schema`
-(structural `target.n_features` marker) routes the canonical schema to
+(structural `target.n_hidden` marker) routes the canonical schema to
 `build_tms_experiment_config` (torch-free `param_decomp_config.tms.TMSExperimentConfig`);
 `TMSTargetConfig` / `TMSDataConfig` join the `AnyTargetConfig` / `AnyDataConfig` unions;
 `run.py::main` builds + pretrains the target and calls `train_tms` (the TMS composition
@@ -92,6 +92,32 @@ which couples the CI-fn input to the trained components and so does NOT fit the 
 `ci_fn(site_inputs)` waist; the vector-input per-site MLP (consumes the raw `site_input`)
 fits the waist with no core change and recovers a clean identity in the non-superposed
 (`n_hidden==n_features`) regime (validated end-to-end in `tests/test_tms.py`).
+`resid_mlp.py` is the fourth target and the **second non-LM one** — the SPD/APD
+residual-stream toy (`leading_axes=()`, no position axis; the waist is the residual
+stream `[B, d_embed]`). A FIXED input embedding `W_E` (`n_features→d_embed`), `n_layers`
+MLP blocks each reading/writing the `d_embed` residual stream, a FIXED unembed `W_U =
+W_Eᵀ`; the DECOMPOSITION targets the per-layer MLP matrices (sites `layers.{i}.mlp_in` /
+`layers.{i}.mlp_out`, UNTIED V/U). Unlike TMS it HAS a prefix (`W_E`, so
+`resid_mlp_input_residual(frozen, x) = x @ W_E` — the prefix `W_E` is carried inside the
+frozen target itself, no separate `prefix` slot), and unlike LM the recon comparison is
+`recon_loss_fn = resid_mlp_mse` (MSE on the model output `[B, n_features]`, NOT KL). The
+frozen target is **pretrained from scratch in-process** (`pretrain_resid_mlp_target`, the
+read-off `mean((out − (act_fn(x)+x))²)` objective with trivial unit label coeffs — no
+wandb/cache). It REUSES `LayerwiseMLPCIFn` (`fn_type=mlp`, no new CI arch) and the same
+ground-truth identity-CI metric (`resid_mlp.identity_ci_error`, the single-feature probe
+through `W_E`). Config dispatch: `config._is_resid_mlp_schema` (structural `target.d_embed`
+marker, disjoint from TMS's `n_hidden` and the LM's `spec`) routes the canonical schema to
+`build_resid_mlp_experiment_config` (torch-free
+`param_decomp_config.resid_mlp.ResidMLPExperimentConfig`); `ResidMLPTargetConfig` /
+`ResidMLPDataConfig` join the `AnyTargetConfig` / `AnyDataConfig` unions and `ResidMLPTarget`
+joins `AnyFrozenTarget`; `run.py::main` builds + pretrains the target and calls
+`train_resid_mlp` (mirroring `train_tms`). Harvest / slow-eval / export over ResidMLP are
+NOT wired (`load_run.build_target` asserts against it; `export` is llama8b-only). **Finding:**
+again ZERO core change — only ADDED a target + dispatch (the CI arch was reused). The
+identity-embedding regime sets `W_U = W_Eᵀ = I` (the salvaged design choice; torch leaves
+`W_U` at its discarded random init there since only `mlp_in` CI structure is asserted), the
+unambiguous clean per-feature ground truth (validated end-to-end pretrain→decompose→identity
+recovery in `tests/test_resid_mlp.py`).
 
 ## Invariants with sharp teeth (the ones that have actually bitten)
 

--- a/param_decomp_jax/jax_single_pool/config.py
+++ b/param_decomp_jax/jax_single_pool/config.py
@@ -46,6 +46,7 @@ from jax_single_pool.ci_fn_mlp import MLPCIArch
 from jax_single_pool.llama8b import SITE_NAME_PATTERN, canonical_site_cs
 from jax_single_pool.lm import SiteC
 from jax_single_pool.recon import build_recon_terms
+from jax_single_pool.resid_mlp import canonical_site_cs as resid_mlp_canonical_site_cs
 from jax_single_pool.tms import canonical_site_cs as tms_canonical_site_cs
 from param_decomp_config.ci_fn import GlobalSharedTransformerCiFnConfig, LayerwiseCiConfig
 from param_decomp_config.eval_metrics import (
@@ -64,6 +65,7 @@ from param_decomp_config.lm import (
 )
 from param_decomp_config.losses import PGDReconLossConfig
 from param_decomp_config.pd import AnyLossMetricConfig, OptimizerConfig
+from param_decomp_config.resid_mlp import ResidMLPExperimentConfig
 from param_decomp_config.schedule import ScheduleConfig
 from param_decomp_config.tms import TMSExperimentConfig
 
@@ -122,7 +124,34 @@ class TMSTargetConfig:
     so any dtype the config declares is honoured."""
 
 
-AnyTargetConfig = TargetConfig | LlamaSimpleMLPTargetConfig | TMSTargetConfig
+@dataclass(frozen=True)
+class ResidMLPTargetConfig:
+    """The vendored ResidualMLP target (`resid_mlp.py`), pretrained from scratch in-process
+    from `pretrain` (no weight artifact); a fixed embedding (`W_U = W_Eᵀ`) with trainable
+    per-layer MLP blocks."""
+
+    n_features: int
+    d_embed: int
+    d_mlp: int
+    n_layers: int
+    act_fn_name: str
+    in_bias: bool
+    out_bias: bool
+    fixed_identity_embedding: bool
+    sites: tuple[SiteC, ...]
+    pretrain_steps: int
+    pretrain_batch_size: int
+    pretrain_lr: float
+    pretrain_seed: int
+    feature_probability: float
+    data_generation_type: str
+
+    supported_weights_dtypes: frozenset[WeightsDtype] = frozenset({"float32", "bfloat16"})
+    """The from-scratch pretrain runs in fp32 and the frozen target is cast at build time,
+    so any dtype the config declares is honoured."""
+
+
+AnyTargetConfig = TargetConfig | LlamaSimpleMLPTargetConfig | TMSTargetConfig | ResidMLPTargetConfig
 
 
 @dataclass(frozen=True)
@@ -143,7 +172,18 @@ class TMSDataConfig:
     data_generation_type: str
 
 
-AnyDataConfig = DataConfig | TMSDataConfig
+@dataclass(frozen=True)
+class ResidMLPDataConfig:
+    """The ResidMLP synthetic sparse-feature data — generated fresh per step in-process
+    (`resid_mlp.sample_sparse_features`, values in [-1, 1]), no parquet/tokenizer."""
+
+    n_features: int
+    global_batch: int
+    feature_probability: float
+    data_generation_type: str
+
+
+AnyDataConfig = DataConfig | TMSDataConfig | ResidMLPDataConfig
 
 
 @dataclass(frozen=True)
@@ -333,11 +373,11 @@ def _ci_arch(cfg: LMExperimentConfig, seq_len: int) -> CIArch:
     )
 
 
-def _layerwise_mlp_ci_arch(cfg: TMSExperimentConfig) -> MLPCIArch:
+def _layerwise_mlp_ci_arch(cfg: "TMSExperimentConfig | ResidMLPExperimentConfig") -> MLPCIArch:
     ci = cfg.pd.ci_config
     assert isinstance(ci, LayerwiseCiConfig), ci
-    assert ci.fn_type == "mlp", f"TMS CI fn must be fn_type=mlp, got {ci.fn_type}"
-    assert ci.hidden_dims, "TMS MLP CI fn needs at least one hidden layer"
+    assert ci.fn_type == "mlp", f"layerwise CI fn must be fn_type=mlp, got {ci.fn_type}"
+    assert ci.hidden_dims, "layerwise MLP CI fn needs at least one hidden layer"
     return MLPCIArch(hidden_dims=tuple(ci.hidden_dims))
 
 
@@ -468,7 +508,9 @@ class _SharedConvert:
     ci_lr_for_arch: float
 
 
-def _convert_shared(cfg: "LMExperimentConfig | TMSExperimentConfig") -> _SharedConvert:
+def _convert_shared(
+    cfg: "LMExperimentConfig | TMSExperimentConfig | ResidMLPExperimentConfig",
+) -> _SharedConvert:
     assert cfg.pd.sigmoid_type == "leaky_hard", cfg.pd.sigmoid_type
     assert cfg.pd.use_delta_component and cfg.pd.tied_weights is None
     assert cfg.runtime.autocast_bf16, "JAX trainer computes in bf16 (autocast analog)"
@@ -616,15 +658,97 @@ def build_tms_experiment_config(
     )
 
 
+def _resid_mlp_target(cfg: ResidMLPExperimentConfig) -> ResidMLPTargetConfig:
+    assert cfg.pd.identity_decomposition_targets is None, "identity targets unsupported"
+    site_cs = resid_mlp_canonical_site_cs(
+        tuple(SiteC(t.module_pattern, t.C) for t in cfg.pd.decomposition_targets)
+    )
+    return ResidMLPTargetConfig(
+        n_features=cfg.target.n_features,
+        d_embed=cfg.target.d_embed,
+        d_mlp=cfg.target.d_mlp,
+        n_layers=cfg.target.n_layers,
+        act_fn_name=cfg.target.act_fn_name,
+        in_bias=cfg.target.in_bias,
+        out_bias=cfg.target.out_bias,
+        fixed_identity_embedding=cfg.target.fixed_identity_embedding,
+        sites=site_cs,
+        pretrain_steps=cfg.target.pretrain.steps,
+        pretrain_batch_size=cfg.target.pretrain.batch_size,
+        pretrain_lr=cfg.target.pretrain.lr,
+        pretrain_seed=cfg.target.pretrain.seed,
+        feature_probability=cfg.data.feature_probability,
+        data_generation_type=cfg.data.data_generation_type,
+    )
+
+
+def build_resid_mlp_experiment_config(
+    cfg: ResidMLPExperimentConfig,
+    run_name: str,
+    run_id: str,
+    out_dir: Path,
+    remat_recon_forwards: bool,
+    wandb_group: str | None = None,
+    wandb_tags: tuple[str, ...] = (),
+) -> ExperimentConfig:
+    target = _resid_mlp_target(cfg)
+    shared = _convert_shared(cfg)
+    loss_metrics = tuple(cfg.pd.loss_metrics)
+    build_recon_terms(
+        loss_metrics, tuple(sc.name for sc in target.sites), cfg.pd.n_mask_samples, cfg.pd.sampling
+    )
+    assert cfg.eval is None, (
+        "ResidMLP in-loop eval is the standalone target-CI metric (run.py::train_resid_mlp), "
+        "not the LM CEandKLLosses pass; omit the eval: block"
+    )
+    data = ResidMLPDataConfig(
+        n_features=cfg.target.n_features,
+        global_batch=cfg.pd.batch_size,
+        feature_probability=cfg.data.feature_probability,
+        data_generation_type=cfg.data.data_generation_type,
+    )
+    return ExperimentConfig(
+        run_name=run_name,
+        run_id=run_id,
+        out_dir=out_dir,
+        seed=cfg.pd.seed,
+        steps=cfg.pd.steps,
+        target=target,
+        data=data,
+        loss_metrics=loss_metrics,
+        n_mask_samples=cfg.pd.n_mask_samples,
+        sampling=cfg.pd.sampling,
+        remat_recon_forwards=remat_recon_forwards,
+        vu_optimizer=shared.vu_optimizer,
+        ci_optimizer=shared.ci_optimizer,
+        ci_fn=_layerwise_mlp_ci_arch(cfg),
+        faith_warmup=shared.faith_warmup,
+        cadence=shared.cadence,
+        eval=None,
+        wandb=cfg.wandb,
+        wandb_group=wandb_group,
+        wandb_tags=wandb_tags,
+    )
+
+
 _RUN_ID_PATTERN = re.compile(r"^p-[0-9a-f]{8}$")
 
 
 def _is_tms_schema(schema_raw: dict[str, Any]) -> bool:
-    """TMS vs LM schemas differ in their `target` block: the LM target carries a `spec`
-    discriminated union, the TMS target carries `n_features`. The schema yaml has no top-
-    level kind tag, so dispatch on this structural marker."""
+    """TMS vs LM/ResidMLP schemas differ in their `target` block: the LM target carries a
+    `spec` discriminated union, the TMS target carries `n_hidden` (ResidMLP carries
+    `d_embed`/`n_layers` instead). The schema yaml has no top-level kind tag, so dispatch
+    on this structural marker."""
     target = schema_raw.get("target", {})
-    return isinstance(target, dict) and "n_features" in target
+    return isinstance(target, dict) and "n_hidden" in target
+
+
+def _is_resid_mlp_schema(schema_raw: dict[str, Any]) -> bool:
+    """The ResidMLP target carries `d_embed` (a residual-stream width with no TMS or LM
+    analog) — the structural marker distinguishing it from TMS (`n_hidden`) and the LM
+    (`spec`)."""
+    target = schema_raw.get("target", {})
+    return isinstance(target, dict) and "d_embed" in target
 
 
 def _build_from_schema(
@@ -639,6 +763,16 @@ def _build_from_schema(
     if _is_tms_schema(schema_raw):
         return build_tms_experiment_config(
             TMSExperimentConfig(**schema_raw),
+            run_name=run_name,
+            run_id=run_id,
+            out_dir=out_dir,
+            remat_recon_forwards=remat_recon_forwards,
+            wandb_group=wandb_group,
+            wandb_tags=wandb_tags,
+        )
+    if _is_resid_mlp_schema(schema_raw):
+        return build_resid_mlp_experiment_config(
+            ResidMLPExperimentConfig(**schema_raw),
             run_name=run_name,
             run_id=run_id,
             out_dir=out_dir,

--- a/param_decomp_jax/jax_single_pool/configs/resid_mlp_1l_SMOKE.yaml
+++ b/param_decomp_jax/jax_single_pool/configs/resid_mlp_1l_SMOKE.yaml
@@ -1,0 +1,5 @@
+# ResidualMLP 1-layer SMOKE wrapper — jsp-train full-loop validation (pretrain + decompose
+# + ckpt + in-loop target-CI metric).
+torch_config: torch/resid_mlp_1l_SMOKE.yaml
+run_name: jax-resid-mlp-1l-smoke
+remat_recon_forwards: false

--- a/param_decomp_jax/jax_single_pool/configs/resid_mlp_1l_from_torch.yaml
+++ b/param_decomp_jax/jax_single_pool/configs/resid_mlp_1l_from_torch.yaml
@@ -1,0 +1,4 @@
+# ResidualMLP 1-layer wrapper — JAX counterpart of torch resid_mlp1_config.yaml.
+torch_config: torch/resid_mlp_1l.yaml
+run_name: jax-resid-mlp-1l
+remat_recon_forwards: false

--- a/param_decomp_jax/jax_single_pool/configs/torch/resid_mlp_1l.yaml
+++ b/param_decomp_jax/jax_single_pool/configs/torch/resid_mlp_1l.yaml
@@ -1,0 +1,78 @@
+# ResidualMLP 1-layer PD decomposition — the JAX counterpart of the torch
+# resid_mlp1_config.yaml (n_features=100, d_embed=1000, d_mlp=50, fixed random embedding).
+# The torch target read from a wandb pretrain run; here the target is pretrained from
+# scratch in-process (the read-off `act_fn(x) + x` objective), so the run is reproducible
+# from this config alone.
+pd:
+  seed: 0
+  n_mask_samples: 1
+  sampling: continuous
+  ci_config:
+    mode: layerwise
+    fn_type: mlp
+    hidden_dims:
+    - 16
+  sigmoid_type: leaky_hard
+  use_delta_component: true
+  tied_weights: null
+  decomposition_targets:
+  - module_pattern: layers.0.mlp_in
+    C: 100
+  - module_pattern: layers.0.mlp_out
+    C: 100
+  loss_metrics:
+  - type: ImportanceMinimalityLoss
+    coeff: 1e-5
+    pnorm: 2.0
+    beta: 0.0
+    p_anneal_start_frac: 0.0
+    p_anneal_final_p: 2.0
+    p_anneal_end_frac: 1.0
+  - type: StochasticReconLayerwiseLoss
+    coeff: 1.0
+  - type: StochasticReconLoss
+    coeff: 1.0
+  - type: FaithfulnessLoss
+    coeff: 1.0
+  batch_size: 2048
+  steps: 20000
+  components_optimizer:
+    grad_clip_norm: 0.01
+    lr_schedule:
+      start_val: 2e-3
+      fn_type: cosine
+      warmup_pct: 0.0
+      final_val_frac: 0.1
+  ci_fn_optimizer:
+    lr_schedule:
+      start_val: 2e-3
+      fn_type: cosine
+      warmup_pct: 0.0
+      final_val_frac: 0.1
+  faithfulness_warmup_steps: 200
+  faithfulness_warmup_lr: 0.01
+  faithfulness_warmup_weight_decay: 0.0
+runtime:
+  autocast_bf16: true
+  device: cuda
+  dp: null
+cadence:
+  train_log_every: 100
+  save_every: 5000
+  keep_last_n_checkpoints: 2
+target:
+  n_features: 100
+  d_embed: 1000
+  d_mlp: 50
+  n_layers: 1
+  act_fn_name: relu
+  in_bias: false
+  out_bias: false
+  pretrain:
+    steps: 2000
+    batch_size: 2048
+    lr: 3e-3
+    seed: 0
+data:
+  feature_probability: 0.01
+  data_generation_type: at_least_zero_active

--- a/param_decomp_jax/jax_single_pool/configs/torch/resid_mlp_1l_SMOKE.yaml
+++ b/param_decomp_jax/jax_single_pool/configs/torch/resid_mlp_1l_SMOKE.yaml
@@ -1,0 +1,78 @@
+# ResidualMLP 1-layer SMOKE PD decomposition — the clean recovers-identity regime
+# (d_mlp == n_features == d_embed, no superposition), tiny step count for a jsp-train
+# smoke (full-loop composition-root validation: pretrain -> faith warmup -> step loop ->
+# checkpoint -> in-loop target-CI metric). 1 GPU / CPU.
+pd:
+  seed: 0
+  n_mask_samples: 1
+  sampling: continuous
+  ci_config:
+    mode: layerwise
+    fn_type: mlp
+    hidden_dims:
+    - 16
+  sigmoid_type: leaky_hard
+  use_delta_component: true
+  tied_weights: null
+  decomposition_targets:
+  - module_pattern: layers.0.mlp_in
+    C: 5
+  - module_pattern: layers.0.mlp_out
+    C: 5
+  loss_metrics:
+  - type: ImportanceMinimalityLoss
+    coeff: 3e-3
+    pnorm: 1.0
+    beta: 0.0
+    p_anneal_start_frac: 0.0
+    p_anneal_final_p: 1.0
+    p_anneal_end_frac: 1.0
+  - type: StochasticReconLoss
+    coeff: 1.0
+  - type: StochasticReconLayerwiseLoss
+    coeff: 1.0
+  - type: FaithfulnessLoss
+    coeff: 1.0
+  batch_size: 256
+  steps: 20
+  components_optimizer:
+    grad_clip_norm: 0.01
+    lr_schedule:
+      start_val: 1e-3
+      fn_type: cosine
+      warmup_pct: 0.0
+      final_val_frac: 0.1
+  ci_fn_optimizer:
+    lr_schedule:
+      start_val: 1e-3
+      fn_type: cosine
+      warmup_pct: 0.0
+      final_val_frac: 0.1
+  faithfulness_warmup_steps: 50
+  faithfulness_warmup_lr: 0.01
+  faithfulness_warmup_weight_decay: 0.0
+runtime:
+  autocast_bf16: true
+  device: cuda
+  dp: null
+cadence:
+  train_log_every: 5
+  save_every: 10
+  keep_last_n_checkpoints: 2
+target:
+  n_features: 5
+  d_embed: 5
+  d_mlp: 5
+  n_layers: 1
+  act_fn_name: relu
+  in_bias: false
+  out_bias: false
+  fixed_identity_embedding: true
+  pretrain:
+    steps: 500
+    batch_size: 256
+    lr: 1e-2
+    seed: 0
+data:
+  feature_probability: 0.05
+  data_generation_type: at_least_zero_active

--- a/param_decomp_jax/jax_single_pool/load_run.py
+++ b/param_decomp_jax/jax_single_pool/load_run.py
@@ -39,6 +39,7 @@ from jax_single_pool.ci_fn import CIFn
 from jax_single_pool.config import (
     ExperimentConfig,
     LlamaSimpleMLPTargetConfig,
+    ResidMLPTargetConfig,
     TargetConfig,
     TMSTargetConfig,
     load_run_dir_config,
@@ -77,9 +78,9 @@ def build_target(
     """`(lm, frozen target, prefix, prefix_residual_fn, vocab_size)` for the run's target
     config. SimpleMLP reads its local pretrain cache (no network); llama8b reads the HF
     snapshot (frozen bf16 target + fp32-compute, matching `run.py::main`)."""
-    assert not isinstance(cfg.target, TMSTargetConfig), (
-        "harvest/slow-eval over the TMS target is not wired (TMS validates via the in-loop "
-        "target-CI metric in run.py::train_tms)"
+    assert not isinstance(cfg.target, (TMSTargetConfig, ResidMLPTargetConfig)), (
+        "harvest/slow-eval over the TMS/ResidMLP targets is not wired (they validate via "
+        "the in-loop target-CI metric in run.py::train_tms / train_resid_mlp)"
     )
     match cfg.target:
         case LlamaSimpleMLPTargetConfig():

--- a/param_decomp_jax/jax_single_pool/resid_mlp.py
+++ b/param_decomp_jax/jax_single_pool/resid_mlp.py
@@ -1,0 +1,509 @@
+"""Vendored JAX ResidualMLP target — the fourth `DecomposedModel` and the second
+non-LM bundle, positionless (`leading_axes=()`; the waist is the residual stream
+`[B, d_embed]`).
+
+Torch reference (read-only ground truth): `param_decomp_lab/experiments/resid_mlp/`
+(`models.py` the architecture, `train_resid_mlp.py` the read-off pretrain objective,
+`data.py` the synthetic sparse features). The target is the SPD/APD residual-stream toy:
+
+    resid = x @ W_E
+    for layer in layers:          # n_layers MLP blocks reading/writing the residual stream
+        h = act(resid @ W_inᵀ + b_in)
+        resid = resid + (h @ W_outᵀ + b_out)
+    out = resid @ W_U
+
+`W_E` `(n_features, d_embed)` and `W_U` `(d_embed, n_features)` are FIXED (the canonical
+toy uses a random unit-norm embedding with `W_U = W_Eᵀ`); the per-layer MLP matrices
+train. The DECOMPOSITION targets the MLP matrices: sites `layers.{i}.mlp_in`
+`(d_embed → d_mlp)` and `layers.{i}.mlp_out` `(d_mlp → d_embed)`, each an UNTIED
+`(V, U)` (`tied_weights: null`).
+
+`W_E` is the PREFIX: the residual entering the decomposed part is `x @ W_E` and
+`resid_mlp_input_residual` maps `(W_E, x) -> x @ W_E`. The recon comparison is MSE on the
+model OUTPUT `[B, n_features]` (NOT KL): `recon_loss_fn = resid_mlp_mse`.
+
+Site weights are right-mult oriented like the LM targets (`site_out = x @ Wᵀ`): for
+`mlp_in` `W` is `(d_mlp, d_embed)`; for `mlp_out` `(d_embed, d_mlp)`."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Protocol
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+from jaxtyping import Array, Float
+
+from jax_single_pool.ci_fn import CIValues
+from jax_single_pool.llama8b import DecompVU, _site_out
+from jax_single_pool.lm import DecomposedModel, SiteC, SiteSpec
+
+MLP_IN = "mlp_in"
+MLP_OUT = "mlp_out"
+KINDS = (MLP_IN, MLP_OUT)
+
+
+class CIFnCallable(Protocol):
+    """The CI-fn surface the ResidMLP target-CI probe needs: `__call__(site_inputs) ->
+    CIValues` (satisfied by both `ci_fn.CIFn` and `ci_fn_mlp.LayerwiseMLPCIFn`)."""
+
+    def __call__(self, site_inputs: dict[str, Array]) -> CIValues: ...
+
+
+@dataclass(frozen=True)
+class ResidMLPConfig:
+    n_features: int
+    d_embed: int
+    d_mlp: int
+    n_layers: int
+    act_fn_name: str
+    in_bias: bool
+    out_bias: bool
+    fixed_identity_embedding: bool
+    """`W_E = I` (requires `n_features == d_embed`): the residual stream IS the feature
+    basis, the unambiguous clean ground-truth regime (torch `fixed_identity_embedding`).
+    False uses a fixed random unit-norm embedding (torch `fixed_random_embedding`)."""
+
+
+def _act_fn(name: str) -> Callable[[Array], Array]:
+    match name:
+        case "gelu":
+            return lambda x: jax.nn.gelu(x, approximate=False)
+        case "relu":
+            return jax.nn.relu
+        case _:
+            raise AssertionError(f"unknown ResidMLP act fn {name!r}")
+
+
+class ResidMLPLayer(eqx.Module):
+    """One MLP block, right-mult oriented. `W_in` `(d_mlp, d_embed)`, `W_out`
+    `(d_embed, d_mlp)`; biases are `None` when the config disables them."""
+
+    W_in: Float[Array, "d_mlp d_embed"]
+    W_out: Float[Array, "d_embed d_mlp"]
+    b_in: Float[Array, " d_mlp"] | None
+    b_out: Float[Array, " d_embed"] | None
+
+
+class ResidMLPTarget(eqx.Module):
+    """Frozen ResidualMLP weights: fixed `W_E` / `W_U` embeddings and the per-layer MLP
+    blocks (ordered by layer index)."""
+
+    W_E: Float[Array, "n_features d_embed"]
+    W_U: Float[Array, "d_embed n_features"]
+    layers: tuple[ResidMLPLayer, ...]
+    act_fn_name: str = eqx.field(static=True)
+
+
+def parse_site_name(name: str) -> tuple[int, str]:
+    """`layers.{i}.{mlp_in,mlp_out}` -> (layer, kind); rejects anything else."""
+    parts = name.split(".")
+    assert len(parts) == 3 and parts[0] == "layers" and parts[2] in KINDS, (
+        f"unsupported ResidMLP site name {name!r}"
+    )
+    return int(parts[1]), parts[2]
+
+
+def site_name(layer: int, kind: str) -> str:
+    assert kind in KINDS, kind
+    return f"layers.{layer}.{kind}"
+
+
+def canonical_site_cs(site_cs: tuple[SiteC, ...]) -> tuple[SiteC, ...]:
+    """Canonical site order: layer-ascending, `mlp_in` before `mlp_out` within a layer
+    (= computation order). Names must parse and be unique."""
+    names = [s.name for s in site_cs]
+    assert len(set(names)) == len(names), f"duplicate sites in {names}"
+
+    def order_key(site: SiteC) -> tuple[int, int]:
+        layer, kind = parse_site_name(site.name)
+        return layer, KINDS.index(kind)
+
+    return tuple(sorted(site_cs, key=order_key))
+
+
+def site_dims(cfg: ResidMLPConfig, kind: str) -> tuple[int, int]:
+    """(d_in, d_out) right-mult orientation."""
+    match kind:
+        case "mlp_in":
+            return cfg.d_embed, cfg.d_mlp
+        case "mlp_out":
+            return cfg.d_mlp, cfg.d_embed
+        case _:
+            raise AssertionError(f"unknown ResidMLP kind {kind!r}")
+
+
+def site_specs(cfg: ResidMLPConfig, site_cs: tuple[SiteC, ...]) -> tuple[SiteSpec, ...]:
+    """Shape-resolved specs in canonical order. Every layer must contribute BOTH its
+    `mlp_in` and `mlp_out` site (the masked forward threads the residual through both)."""
+    site_cs = canonical_site_cs(site_cs)
+    expected = {site_name(layer, kind) for layer in range(cfg.n_layers) for kind in KINDS}
+    got = {s.name for s in site_cs}
+    assert got == expected, f"ResidMLP sites must be exactly {sorted(expected)}, got {sorted(got)}"
+    specs = []
+    for site in site_cs:
+        assert site.C >= 1, site
+        _, kind = parse_site_name(site.name)
+        specs.append(SiteSpec(site.name, *site_dims(cfg, kind), site.C))
+    return tuple(specs)
+
+
+def _frozen_site_weight(target: ResidMLPTarget, name: str) -> Array:
+    layer, kind = parse_site_name(name)
+    block = target.layers[layer]
+    match kind:
+        case "mlp_in":
+            return block.W_in
+        case "mlp_out":
+            return block.W_out
+        case _:
+            raise AssertionError(f"unknown ResidMLP kind {kind!r}")
+
+
+def clean_output(target: ResidMLPTarget, resid: Float[Array, "B d_embed"]) -> Array:
+    """The all-frozen forward — the recon target (SPEC S3). `resid` is `x @ W_E`."""
+    act = _act_fn(target.act_fn_name)
+    for block in target.layers:
+        h = resid @ block.W_in.T
+        if block.b_in is not None:
+            h = h + block.b_in
+        out = act(h) @ block.W_out.T
+        if block.b_out is not None:
+            out = out + block.b_out
+        resid = resid + out
+    return resid @ target.W_U
+
+
+def site_inputs(target: ResidMLPTarget, resid: Float[Array, "B d_embed"]) -> dict[str, Array]:
+    """Clean CI inputs per site (SPEC S4): `mlp_in` reads the clean residual entering its
+    layer; `mlp_out` reads the clean post-activation hidden of its layer."""
+    act = _act_fn(target.act_fn_name)
+    inputs: dict[str, Array] = {}
+    for layer, block in enumerate(target.layers):
+        inputs[site_name(layer, MLP_IN)] = resid
+        pre = resid @ block.W_in.T
+        if block.b_in is not None:
+            pre = pre + block.b_in
+        hidden = act(pre)
+        inputs[site_name(layer, MLP_OUT)] = hidden
+        out = hidden @ block.W_out.T
+        if block.b_out is not None:
+            out = out + block.b_out
+        resid = resid + out
+    return inputs
+
+
+def _decomposed_or_frozen(
+    components: DecompVU,
+    site: str,
+    W: Array,
+    x_in: Array,
+    masks: dict[str, Array],
+    delta_masks: dict[str, Array],
+    routes: dict[str, Array] | None,
+    live_set: frozenset[str],
+    has_delta: bool,
+    collect: dict[str, Array] | None,
+) -> Array:
+    """One site's output: the decomposed `_site_out` if live, else the frozen `x @ Wᵀ`."""
+    if site not in live_set:
+        return x_in @ W.T
+    V, U = components.site(site)
+    out = _site_out(
+        x_in, V, U, W, masks[site], delta_masks[site] if has_delta else None,
+        None if routes is None else routes[site],
+    )  # fmt: skip
+    if collect is not None:
+        collect[site] = out
+    return out
+
+
+def _run_masked(
+    target: ResidMLPTarget,
+    components: DecompVU,
+    resid: Float[Array, "B d_embed"],
+    masks: dict[str, Array],
+    delta_masks: dict[str, Array],
+    routes: dict[str, Array] | None,
+    live: tuple[str, ...],
+    has_delta: bool,
+    collect: dict[str, Array] | None,
+) -> Array:
+    """The masked decomposed forward (SPEC §4.1, S2): each layer's `mlp_in`/`mlp_out` runs
+    its decomposed forward if live, else the frozen path. The biases are added AFTER the
+    site output (they live outside the decomposed matrix), the residual accumulates as in
+    the frozen forward, and the readout `resid @ W_U` is frozen."""
+    act = _act_fn(target.act_fn_name)
+    site_args = (masks, delta_masks, routes, frozenset(live), has_delta, collect)
+    for layer, block in enumerate(target.layers):
+        pre = _decomposed_or_frozen(
+            components, site_name(layer, MLP_IN), block.W_in, resid, *site_args
+        )
+        if block.b_in is not None:
+            pre = pre + block.b_in
+        hidden = act(pre)
+        out = _decomposed_or_frozen(
+            components, site_name(layer, MLP_OUT), block.W_out, hidden, *site_args
+        )
+        if block.b_out is not None:
+            out = out + block.b_out
+        resid = resid + out
+    return resid @ target.W_U
+
+
+def masked_output(
+    target: ResidMLPTarget,
+    components: DecompVU,
+    resid: Float[Array, "B d_embed"],
+    masks: dict[str, Array],
+    delta_masks: dict[str, Array],
+    routes: dict[str, Array] | None,
+    live: tuple[str, ...],
+    has_delta: bool,
+) -> Array:
+    return _run_masked(target, components, resid, masks, delta_masks, routes, live, has_delta, None)
+
+
+def masked_site_outputs(
+    target: ResidMLPTarget,
+    components: DecompVU,
+    resid: Float[Array, "B d_embed"],
+    masks: dict[str, Array],
+    delta_masks: dict[str, Array],
+    routes: dict[str, Array] | None,
+    live: tuple[str, ...],
+    has_delta: bool,
+) -> dict[str, Array]:
+    """Per-`live`-site decomposed output of the masked forward (SPEC S31)."""
+    collect: dict[str, Array] = {}
+    _run_masked(target, components, resid, masks, delta_masks, routes, live, has_delta, collect)
+    assert set(collect) == set(live), (sorted(collect), sorted(live))
+    return collect
+
+
+def weight_deltas_fp32(
+    target: ResidMLPTarget, components: DecompVU, sites: tuple[SiteSpec, ...]
+) -> dict[str, Array]:
+    """fp32 `W − (V@U)ᵀ` per site from fp32 masters (SPEC N2; faithfulness input)."""
+    out: dict[str, Array] = {}
+    for spec in sites:
+        W = _frozen_site_weight(target, spec.name)
+        V, U = components.site(spec.name)
+        out[spec.name] = W.astype(jnp.float32) - (V.astype(jnp.float32) @ U.astype(jnp.float32)).T
+    return out
+
+
+def resid_mlp_mse(
+    masked: Float[Array, "B n_features"], clean: Float[Array, "B n_features"]
+) -> Array:
+    """MSE recon over the model output, mean over batch × features (fp32)."""
+    masked = masked.astype(jnp.float32)
+    clean = clean.astype(jnp.float32)
+    return jnp.mean((masked - clean) ** 2)
+
+
+def resid_mlp_decomposed_model(cfg: ResidMLPConfig, sites: tuple[SiteSpec, ...]) -> DecomposedModel:
+    sites = site_specs(cfg, tuple(SiteC(s.name, s.C) for s in sites))
+    return DecomposedModel(
+        sites=sites,
+        leading_axes=(),
+        clean_output=clean_output,
+        site_inputs=site_inputs,
+        masked_output=masked_output,
+        masked_site_outputs=masked_site_outputs,
+        weight_deltas=lambda target, components: weight_deltas_fp32(target, components, sites),
+        recon_loss_fn=resid_mlp_mse,
+    )
+
+
+def replicate_target(target: ResidMLPTarget, mesh: Mesh) -> ResidMLPTarget:
+    """Replicate the tiny frozen ResidMLP weights on every device (V/U / CI placement
+    reuses the generic replicated plan, as for TMS)."""
+    repl = NamedSharding(mesh, P())
+    return jax.tree.map(lambda a: jax.device_put(a, repl) if eqx.is_array(a) else a, target)
+
+
+def resid_mlp_input_residual(prefix: ResidMLPTarget, inputs: Float[Array, "B n_features"]) -> Array:
+    """The residual entering the decomposed model is `x @ W_E`. The prefix IS the frozen
+    target (it carries `W_E`); kept as a `prefix_residual_fn` so the generic harvest path
+    is uniform across targets."""
+    return inputs @ prefix.W_E
+
+
+# ----------------------------- from-scratch pretraining -----------------------------
+
+
+class _ResidMLPTrainable(eqx.Module):
+    """The pretrain-trainable subset: the per-layer MLP blocks (the embeddings `W_E`/`W_U`
+    are FIXED — `fixed_random_embedding` — so they never appear here)."""
+
+    layers: tuple[ResidMLPLayer, ...]
+
+
+def _init_layer(cfg: ResidMLPConfig, key: Array) -> ResidMLPLayer:
+    """One MLP block, torch `nn.Linear` Kaiming-uniform init (`init_param_` fan-in
+    uniform `bound = 1/√fan_in`), zero biases when enabled."""
+    in_key, out_key = jax.random.split(key)
+    in_bound = 1.0 / cfg.d_embed**0.5
+    out_bound = 1.0 / cfg.d_mlp**0.5
+    W_in = jax.random.uniform(in_key, (cfg.d_mlp, cfg.d_embed), minval=-in_bound, maxval=in_bound)
+    W_out = jax.random.uniform(
+        out_key, (cfg.d_embed, cfg.d_mlp), minval=-out_bound, maxval=out_bound
+    )
+    return ResidMLPLayer(
+        W_in=W_in,
+        W_out=W_out,
+        b_in=jnp.zeros((cfg.d_mlp,)) if cfg.in_bias else None,
+        b_out=jnp.zeros((cfg.d_embed,)) if cfg.out_bias else None,
+    )
+
+
+def _init_embedding(cfg: ResidMLPConfig, key: Array) -> Float[Array, "n_features d_embed"]:
+    """`W_E = I` for the identity regime, else a fixed random unit-norm embedding."""
+    if cfg.fixed_identity_embedding:
+        assert cfg.n_features == cfg.d_embed, (cfg.n_features, cfg.d_embed)
+        return jnp.eye(cfg.n_features)
+    raw = jax.random.normal(key, (cfg.n_features, cfg.d_embed))
+    return raw / jnp.linalg.norm(raw, axis=-1, keepdims=True)
+
+
+def init_resid_mlp_target(cfg: ResidMLPConfig, key: Array) -> ResidMLPTarget:
+    """Untrained ResidMLP target: a FIXED embedding (`W_U = W_Eᵀ`) and Kaiming-uniform MLP
+    blocks. `fixed_identity_embedding` gives `W_E = I` (the residual stream IS the feature
+    basis — the unambiguous clean ground-truth regime); otherwise a random unit-norm
+    embedding."""
+    embed_key, layers_key = jax.random.split(key)
+    W_E = _init_embedding(cfg, embed_key)
+    layer_keys = jax.random.split(layers_key, cfg.n_layers)
+    layers = tuple(_init_layer(cfg, layer_keys[i]) for i in range(cfg.n_layers))
+    return ResidMLPTarget(W_E=W_E, W_U=W_E.T, layers=layers, act_fn_name=cfg.act_fn_name)
+
+
+def sample_sparse_features(
+    key: Array,
+    batch: int,
+    n_features: int,
+    feature_probability: float,
+    generation_type: str,
+) -> Float[Array, "B n_features"]:
+    """Synthetic sparse-feature batch (torch `SparseFeatureDataset` with ResidMLP's
+    `value_range=(-1, 1)`): each feature takes a `U[-1, 1]` value, gated by
+    `feature_probability` (`at_least_zero_active`) or exactly one active per row
+    (`exactly_one_active`)."""
+    value_key, gate_key = jax.random.split(key)
+    values = jax.random.uniform(value_key, (batch, n_features), minval=-1.0, maxval=1.0)
+    match generation_type:
+        case "at_least_zero_active":
+            mask = jax.random.uniform(gate_key, (batch, n_features)) < feature_probability
+            return values * mask
+        case "exactly_one_active":
+            active = jax.random.randint(gate_key, (batch,), 0, n_features)
+            return values * jax.nn.one_hot(active, n_features)
+        case _:
+            raise AssertionError(f"unsupported ResidMLP generation type {generation_type!r}")
+
+
+def readoff_labels(
+    target: ResidMLPTarget, x: Float[Array, "B n_features"]
+) -> Float[Array, "B n_features"]:
+    """The read-off pretrain target `act_fn(coeffs·x) + x` with trivial unit coeffs (torch
+    `calc_act_plus_resid_labels` + `use_trivial_label_coeffs`)."""
+    return _act_fn(target.act_fn_name)(x) + x
+
+
+def pretrain_resid_mlp_target(
+    cfg: ResidMLPConfig,
+    feature_probability: float,
+    generation_type: str,
+    steps: int,
+    batch_size: int,
+    lr: float,
+    seed: int,
+) -> ResidMLPTarget:
+    """From-scratch pretrain of the frozen ResidMLP target (the read-off MSE objective
+    `mean((out − (act_fn(x) + x))²)`, trivial unit label coeffs). The fixed embedding
+    `W_E`/`W_U` is held constant; only the MLP blocks train.
+
+    Deterministic in `seed`: this replaces the missing wandb pretrain checkpoint so a
+    ResidMLP PD run is reproducible from the config alone."""
+    import optax
+
+    key = jax.random.PRNGKey(seed)
+    init_key, data_key = jax.random.split(key)
+    target = init_resid_mlp_target(cfg, init_key)
+    trainable = _ResidMLPTrainable(layers=target.layers)
+    optimizer = optax.adamw(lr, weight_decay=0.0)
+    opt_state = optimizer.init(eqx.filter(trainable, eqx.is_array))
+
+    @jax.jit
+    def step(
+        trainable: "_ResidMLPTrainable", opt_state: optax.OptState, x: Array
+    ) -> tuple["_ResidMLPTrainable", optax.OptState]:
+        def loss_fn(trainable: "_ResidMLPTrainable") -> Array:
+            frozen = eqx.tree_at(lambda t: t.layers, target, trainable.layers)
+            out = clean_output(frozen, x @ target.W_E)
+            return jnp.mean((out - readoff_labels(target, x)) ** 2)
+
+        grad = eqx.filter_grad(loss_fn)(trainable)
+        updates, opt_state = optimizer.update(grad, opt_state, eqx.filter(trainable, eqx.is_array))
+        return eqx.apply_updates(trainable, updates), opt_state
+
+    for s in range(steps):
+        x = sample_sparse_features(
+            jax.random.fold_in(data_key, s), batch_size, cfg.n_features,
+            feature_probability, generation_type,
+        )  # fmt: skip
+        trainable, opt_state = step(trainable, opt_state, x)
+    return eqx.tree_at(lambda t: t.layers, target, trainable.layers)
+
+
+# ----------------------------- ground-truth target-CI eval -----------------------------
+
+
+def identity_ci_error(ci_vals: Float[Array, "n_features C"], tolerance: float) -> int:
+    """Discrete identity-CI distance (torch `IdentityCIPattern.distance_from`): permute
+    columns toward identity (Hungarian on `-ci`), then over the `min(shape)` square block
+    count off-diagonal entries `> tolerance` plus on-diagonal entries `< 1 - tolerance`.
+
+    `ci_vals` is the `lower_leaky` CI of the single-feature probe (one row per feature)."""
+    from scipy.optimize import linear_sum_assignment
+
+    ci = np.asarray(ci_vals, dtype=np.float64)
+    assert ci.ndim == 2, ci.shape
+    n_features, C = ci.shape
+    size = min(n_features, C)
+    _, col_indices = linear_sum_assignment(-ci[:size])
+    assigned = list(col_indices)
+    remaining = [c for c in range(C) if c not in set(assigned)]
+    perm = np.array(assigned + remaining, dtype=np.int64)
+    ci = ci[:, perm]
+
+    block = ci[:size, :size]
+    off_diag_mask = ~np.eye(size, dtype=bool)
+    off_diag_errors = int((block[off_diag_mask] > tolerance).sum())
+    on_diag_errors = int((np.diagonal(block) < (1 - tolerance)).sum())
+    return off_diag_errors + on_diag_errors
+
+
+SINGLE_FEATURE_PROBE_MAGNITUDE = 0.75
+"""The single-active-feature probe value (torch `IdentityCIError.input_magnitude`)."""
+
+
+def single_feature_probe(n_features: int) -> Float[Array, "n_features n_features"]:
+    """The single-feature probe: `eye(n_features) * 0.75`, one active feature per row."""
+    return jnp.eye(n_features) * SINGLE_FEATURE_PROBE_MAGNITUDE
+
+
+def single_feature_ci(
+    lm: DecomposedModel,
+    target: ResidMLPTarget,
+    ci_fn: "CIFnCallable",
+    n_features: int,
+) -> dict[str, Array]:
+    """Feed the single-feature probe (embedded through `W_E`) and read the `lower_leaky`
+    CI per site, `{site: [n_features, C]}`."""
+    resid = single_feature_probe(n_features) @ target.W_E
+    return ci_fn(lm.site_inputs(target, resid)).lower

--- a/param_decomp_jax/jax_single_pool/run.py
+++ b/param_decomp_jax/jax_single_pool/run.py
@@ -33,7 +33,7 @@ from jax import random
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 
-from jax_single_pool import llama_simple_mlp, tms
+from jax_single_pool import llama_simple_mlp, resid_mlp, tms
 from jax_single_pool.attn_patterns_eval import (
     accumulate_attn_patterns,
     attn_pattern_for,
@@ -46,6 +46,8 @@ from jax_single_pool.config import (
     DataConfig,
     ExperimentConfig,
     LlamaSimpleMLPTargetConfig,
+    ResidMLPDataConfig,
+    ResidMLPTargetConfig,
     TargetConfig,
     TMSDataConfig,
     TMSTargetConfig,
@@ -548,6 +550,121 @@ def train_tms(
                 print(f"checkpoint saved @ step {now_step}", flush=True)
 
 
+def train_resid_mlp(
+    cfg: ExperimentConfig,
+    raw_cfg: dict[str, object],
+    lm: DecomposedModel,
+    frozen: resid_mlp.ResidMLPTarget,
+    mesh: Mesh,
+) -> None:
+    """The ResidMLP composition over the unified core: same `init_train_state` / faith
+    warmup / `make_train_step` / orbax checkpointing as the LM path, but with in-process
+    synthetic sparse-feature data, the `W_E` embedding as the residual prefix, and the
+    standalone ground-truth target-CI metric (`resid_mlp.identity_ci_error`) instead of
+    the LM CEandKLLosses eval pass.
+
+    The residual entering the decomposed model is `x @ W_E`; the step factory, recon terms
+    (MSE recon_loss_fn), losses and adversaries are all the generic core, unchanged."""
+    data_cfg = cfg.data
+    assert isinstance(data_cfg, ResidMLPDataConfig) and isinstance(cfg.target, ResidMLPTargetConfig)
+    is_main = jax.process_index() == 0
+    ndev = mesh.devices.size
+    assert data_cfg.global_batch % ndev == 0, (data_cfg.global_batch, ndev)
+
+    cfg.run_dir.mkdir(parents=True, exist_ok=True)
+    opt_vu, opt_ci, (sched_vu, sched_ci) = build_optimizers(cfg)
+
+    key = random.PRNGKey(cfg.seed)
+    init_key, src_key, run_key, data_key = random.split(key, 4)
+    state = _ensure_global(init_train_state(cfg, lm, opt_vu, opt_ci, init_key, src_key, mesh), mesh)
+
+    checkpoint_manager = make_checkpoint_manager(cfg.run_dir / "ckpts", cfg.cadence.keep_last)
+    restored = restore_latest(checkpoint_manager, state)
+    if restored is not None:
+        state, ckpt_step = restored
+        assert int(state.step) == ckpt_step, (int(state.step), ckpt_step)
+        start_step = ckpt_step
+        if is_main:
+            print(f"resumed from checkpoint step {ckpt_step}", flush=True)
+    else:
+        start_step = 0
+        if cfg.faith_warmup.steps > 0:
+            faith_warmup_optimizer = optax.adamw(cfg.faith_warmup.lr, weight_decay=0.0)
+            faith_warmup_opt_state = faith_warmup_optimizer.init(
+                eqx.filter(state.components, eqx.is_array)
+            )
+            faith_warmup_step = make_faith_warmup_step(lm, faith_warmup_optimizer)
+            warmed_components = state.components
+            faith_warmup_loss = None
+            for _ in range(cfg.faith_warmup.steps):
+                warmed_components, faith_warmup_opt_state, faith_warmup_loss = faith_warmup_step(
+                    warmed_components, faith_warmup_opt_state, frozen
+                )
+            assert faith_warmup_loss is not None
+            jax.block_until_ready(faith_warmup_loss)
+            new_opt_vu = _ensure_global(
+                opt_vu.init(eqx.filter(warmed_components, eqx.is_array)), mesh
+            )
+            state = dataclasses.replace(
+                state, components=warmed_components, components_opt_state=new_opt_vu
+            )
+            if is_main:
+                print(f"faith warmup: final faith {float(faith_warmup_loss):.3e}", flush=True)
+        save_state(checkpoint_manager, 0, state)
+
+    step_fn = make_train_step(
+        lm=lm,
+        loss_spec=build_recon_terms(
+            cfg.loss_metrics, lm.site_names, cfg.n_mask_samples, cfg.sampling
+        ),
+        components_optimizer=opt_vu,
+        ci_fn_optimizer=opt_ci,
+        total_steps=cfg.steps,
+        remat_recon_forwards=cfg.remat_recon_forwards,
+        mesh=mesh,
+    )
+
+    @jax.jit
+    def sample_residual(step_key: jax.Array) -> jax.Array:
+        x = resid_mlp.sample_sparse_features(
+            step_key,
+            data_cfg.global_batch,
+            data_cfg.n_features,
+            data_cfg.feature_probability,
+            data_cfg.data_generation_type,
+        )
+        residual = resid_mlp.resid_mlp_input_residual(frozen, x)
+        return jax.lax.with_sharding_constraint(residual, NamedSharding(mesh, P("dp")))
+
+    @jax.jit
+    def single_feature_ci(components: Any, ci_fn: Any) -> dict[str, jax.Array]:
+        resid = resid_mlp.single_feature_probe(data_cfg.n_features) @ frozen.W_E
+        return ci_fn(lm.site_inputs(frozen, resid)).lower
+
+    wandb_config = flatten_typed_lists(
+        dict(raw_cfg, jax_runtime={"n_devices": ndev, "run_id": cfg.run_id})
+    )
+    sink = MetricsSink(cfg, wandb_config, is_main)
+
+    for step in range(start_step, cfg.steps):
+        residual = sample_residual(random.fold_in(data_key, step))
+        state, metrics = step_fn(state, frozen, residual, random.fold_in(run_key, step))
+        now_step = step + 1
+        if now_step % cfg.cadence.log_every == 0 or now_step == cfg.steps:
+            jax.block_until_ready(metrics["total"])
+            record = {k: float(v) for k, v in metrics.items()}
+            ci_lower = single_feature_ci(state.components, state.ci_fn)
+            for site, ci in ci_lower.items():
+                record[f"eval/identity_ci_error/{site}"] = float(
+                    resid_mlp.identity_ci_error(ci, tolerance=0.1)
+                )
+            sink.log(now_step, record)
+        if now_step % cfg.cadence.save_every == 0 or now_step == cfg.steps:
+            save_state(checkpoint_manager, now_step, state)
+            if is_main:
+                print(f"checkpoint saved @ step {now_step}", flush=True)
+
+
 def offline_eval_submission_argv(run_dir: Path, step: int) -> list[str] | None:
     """The sbatch argv for the push-triggered offline eval of this checkpoint, or None
     for step 0 (the init checkpoint). `-J jsp-oeval-<run> --dependency=singleton`
@@ -618,7 +735,7 @@ def main() -> None:
         site_summary = " ".join(f"{s.name}:C{s.C}" for s in cfg.target.sites)
         shape_summary = (
             f"n_features={cfg.data.n_features}"
-            if isinstance(cfg.data, TMSDataConfig)
+            if isinstance(cfg.data, (TMSDataConfig, ResidMLPDataConfig))
             else f"seq={cfg.data.seq_len}"
         )
         print(
@@ -646,6 +763,42 @@ def main() -> None:
             mesh,
         )
         train_tms(cfg, raw_cfg, lm, frozen, mesh)
+        if jax.process_count() > 1:
+            import jax.experimental.multihost_utils as mhu
+
+            mhu.sync_global_devices("train_done")
+            jax.distributed.shutdown()
+        return
+
+    if isinstance(cfg.target, ResidMLPTargetConfig):
+        resid_cfg = resid_mlp.ResidMLPConfig(
+            n_features=cfg.target.n_features,
+            d_embed=cfg.target.d_embed,
+            d_mlp=cfg.target.d_mlp,
+            n_layers=cfg.target.n_layers,
+            act_fn_name=cfg.target.act_fn_name,
+            in_bias=cfg.target.in_bias,
+            out_bias=cfg.target.out_bias,
+            fixed_identity_embedding=cfg.target.fixed_identity_embedding,
+        )
+        lm = resid_mlp.resid_mlp_decomposed_model(
+            resid_cfg, resid_mlp.site_specs(resid_cfg, cfg.target.sites)
+        )
+        if is_main:
+            print(f"pretraining ResidMLP target ({cfg.target.pretrain_steps} steps)...", flush=True)
+        frozen = resid_mlp.replicate_target(
+            resid_mlp.pretrain_resid_mlp_target(
+                resid_cfg,
+                cfg.target.feature_probability,
+                cfg.target.data_generation_type,
+                cfg.target.pretrain_steps,
+                cfg.target.pretrain_batch_size,
+                cfg.target.pretrain_lr,
+                cfg.target.pretrain_seed,
+            ),
+            mesh,
+        )
+        train_resid_mlp(cfg, raw_cfg, lm, frozen, mesh)
         if jax.process_count() > 1:
             import jax.experimental.multihost_utils as mhu
 

--- a/param_decomp_jax/jax_single_pool/target_aliases.py
+++ b/param_decomp_jax/jax_single_pool/target_aliases.py
@@ -3,8 +3,11 @@
 
 from jax_single_pool.llama8b import Prefix, Target
 from jax_single_pool.llama_simple_mlp import SimpleMLPPrefix, SimpleMLPTarget
+from jax_single_pool.resid_mlp import ResidMLPTarget
 from jax_single_pool.tms import TMSTarget
 
-AnyFrozenTarget = Target | SimpleMLPTarget | TMSTarget
+AnyFrozenTarget = Target | SimpleMLPTarget | TMSTarget | ResidMLPTarget
 AnyPrefix = Prefix | SimpleMLPPrefix | None
-"""TMS has no prefix (the whole model is decomposed); its `prefix` slot is `None`."""
+"""TMS has no prefix (the whole model is decomposed); its `prefix` slot is `None`. ResidMLP
+carries its `W_E` prefix inside the frozen target itself, so it also uses no `prefix` slot
+(`train_resid_mlp` embeds via `resid_mlp.resid_mlp_input_residual`)."""

--- a/param_decomp_jax/jax_single_pool/tests/test_resid_mlp.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_resid_mlp.py
@@ -1,0 +1,408 @@
+"""CPU tests for the ResidualMLP target + layerwise-MLP CI fn over the generic
+positionless (`leading_axes=()`) core.
+
+Covers the `DecomposedModel` contract (clean == all-frozen masked forward, masked
+identity, MSE recon, residual accumulation), the reused MLP CI fn, the full SPEC step
+trains, and the ground-truth target-CI eval — including an end-to-end pretrain →
+decompose → recovers-identity-structure validation on a tiny single-layer ResidMLP.
+"""
+
+from collections.abc import Callable
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import optax
+import pytest
+
+from jax_single_pool.ci_fn import CIValues
+from jax_single_pool.ci_fn_mlp import MLPCIArch, init_layerwise_mlp_ci_fn
+from jax_single_pool.llama8b import DecompVU, init_decomp_vu
+from jax_single_pool.lm import DecomposedModel, SiteC, SiteSpec
+from jax_single_pool.recon import build_recon_terms
+from jax_single_pool.resid_mlp import (
+    ResidMLPConfig,
+    ResidMLPTarget,
+    canonical_site_cs,
+    identity_ci_error,
+    init_resid_mlp_target,
+    pretrain_resid_mlp_target,
+    readoff_labels,
+    resid_mlp_decomposed_model,
+    resid_mlp_mse,
+    sample_sparse_features,
+    single_feature_ci,
+    site_specs,
+)
+from jax_single_pool.train import TrainState, make_faith_warmup_step, make_train_step
+from param_decomp_config.losses import (
+    FaithfulnessLossConfig,
+    ImportanceMinimalityLossConfig,
+    StochasticReconLayerwiseLossConfig,
+    StochasticReconLossConfig,
+)
+
+
+def _tiny_cfg(n_layers: int = 1) -> ResidMLPConfig:
+    return ResidMLPConfig(
+        n_features=5,
+        d_embed=5,
+        d_mlp=8,
+        n_layers=n_layers,
+        act_fn_name="relu",
+        in_bias=False,
+        out_bias=False,
+        fixed_identity_embedding=False,
+    )
+
+
+def _site_cs(n_layers: int = 1) -> tuple[SiteC, ...]:
+    return tuple(
+        SiteC(f"layers.{i}.{kind}", C)
+        for i in range(n_layers)
+        for kind, C in (("mlp_in", 6), ("mlp_out", 7))
+    )
+
+
+def test_canonical_order_and_dims():
+    cfg = _tiny_cfg(n_layers=2)
+    scrambled = (
+        SiteC("layers.1.mlp_out", 7),
+        SiteC("layers.0.mlp_out", 7),
+        SiteC("layers.1.mlp_in", 6),
+        SiteC("layers.0.mlp_in", 6),
+    )
+    ordered = canonical_site_cs(scrambled)
+    assert [s.name for s in ordered] == [
+        "layers.0.mlp_in",
+        "layers.0.mlp_out",
+        "layers.1.mlp_in",
+        "layers.1.mlp_out",
+    ]
+
+    specs = site_specs(cfg, _site_cs(n_layers=2))
+    dims = {s.name: (s.d_in, s.d_out, s.C) for s in specs}
+    # right-mult orientation: mlp_in (d_embed -> d_mlp), mlp_out (d_mlp -> d_embed)
+    assert dims["layers.0.mlp_in"] == (5, 8, 6)
+    assert dims["layers.0.mlp_out"] == (8, 5, 7)
+
+
+def test_site_specs_requires_both_sites_per_layer():
+    cfg = _tiny_cfg(n_layers=1)
+    with pytest.raises(AssertionError):
+        site_specs(cfg, (SiteC("layers.0.mlp_in", 6),))  # missing mlp_out
+
+
+def test_leading_axes_empty_and_ci_expects_axes_match():
+    cfg = _tiny_cfg()
+    sites = site_specs(cfg, _site_cs())
+    lm = resid_mlp_decomposed_model(cfg, sites)
+    ci_fn = init_layerwise_mlp_ci_fn(MLPCIArch(hidden_dims=(16,)), sites, jax.random.PRNGKey(0))
+    assert lm.leading_axes == ()  # positionless target
+    assert ci_fn.expects_axes == ()
+    assert ci_fn.expects_axes == lm.leading_axes
+
+
+def test_clean_path_and_masked_identity():
+    cfg = _tiny_cfg(n_layers=2)
+    sites = site_specs(cfg, _site_cs(n_layers=2))
+    lm = resid_mlp_decomposed_model(cfg, sites)
+    target = init_resid_mlp_target(cfg, jax.random.PRNGKey(0))
+    vu = init_decomp_vu(sites, jax.random.PRNGKey(1))
+    b = 7
+    x = sample_sparse_features(
+        jax.random.PRNGKey(2), b, cfg.n_features, 0.5, "at_least_zero_active"
+    )
+    resid = x @ target.W_E
+
+    clean = lm.clean_output(target, resid)
+    assert clean.shape == (b, cfg.n_features)
+
+    # SPEC S2: live=() is the exact frozen path.
+    none_masked = lm.masked_output(target, vu, resid, {}, {}, None, (), True)
+    assert jnp.array_equal(clean, none_masked), "live=() must be the exact frozen path"
+
+    # All-live, masks=1, delta=1 reconstructs the frozen path up to decomposition rounding.
+    names = lm.site_names
+    ones_masks = {s.name: jnp.ones((b, s.C)) for s in lm.sites}
+    ones_delta = {s: jnp.ones((b,)) for s in names}
+    full = lm.masked_output(target, vu, resid, ones_masks, ones_delta, None, names, True)
+    assert jnp.allclose(clean, full, atol=1e-4), "mask=1 identity drifted"
+
+    # site_inputs: mlp_in reads the residual entering its layer, mlp_out the post-act hidden.
+    site_in = lm.site_inputs(target, resid)
+    assert set(site_in) == set(names)
+    assert jnp.array_equal(site_in["layers.0.mlp_in"], resid)
+    assert site_in["layers.0.mlp_in"].shape == (b, cfg.d_embed)
+    assert site_in["layers.0.mlp_out"].shape == (b, cfg.d_mlp)
+    expected_hidden0 = jax.nn.relu(resid @ target.layers[0].W_in.T)
+    assert jnp.allclose(site_in["layers.0.mlp_out"], expected_hidden0, atol=1e-5)
+
+    deltas = lm.weight_deltas(target, vu)
+    assert deltas["layers.0.mlp_in"].shape == (cfg.d_mlp, cfg.d_embed)
+    assert deltas["layers.0.mlp_out"].shape == (cfg.d_embed, cfg.d_mlp)
+    assert all(v.dtype == jnp.float32 for v in deltas.values())
+
+
+def test_zero_masking_one_site_changes_output():
+    cfg = _tiny_cfg()
+    sites = site_specs(cfg, _site_cs())
+    lm = resid_mlp_decomposed_model(cfg, sites)
+    target = init_resid_mlp_target(cfg, jax.random.PRNGKey(0))
+    vu = init_decomp_vu(sites, jax.random.PRNGKey(1))
+    b = 7
+    x = sample_sparse_features(
+        jax.random.PRNGKey(2), b, cfg.n_features, 0.8, "at_least_zero_active"
+    )
+    resid = x @ target.W_E
+    clean = lm.clean_output(target, resid)
+    C = {s.name: s.C for s in sites}["layers.0.mlp_out"]
+    ablated = lm.masked_output(
+        target, vu, resid, {"layers.0.mlp_out": jnp.zeros((b, C))},
+        {"layers.0.mlp_out": jnp.zeros((b,))}, None, ("layers.0.mlp_out",), True,
+    )  # fmt: skip
+    assert not jnp.allclose(clean, ablated, atol=1e-5), "ablating mlp_out did nothing"
+
+
+def test_residual_accumulation_across_layers():
+    # Two layers must accumulate into the residual: the 2-layer clean output differs from a
+    # 1-layer one with the same first layer.
+    cfg2 = _tiny_cfg(n_layers=2)
+    target2 = init_resid_mlp_target(cfg2, jax.random.PRNGKey(0))
+    lm2 = resid_mlp_decomposed_model(cfg2, site_specs(cfg2, _site_cs(n_layers=2)))
+    x = sample_sparse_features(
+        jax.random.PRNGKey(2), 4, cfg2.n_features, 1.0, "at_least_zero_active"
+    )
+    resid = x @ target2.W_E
+    one_layer_target = eqx.tree_at(lambda t: t.layers, target2, target2.layers[:1])
+    cfg1 = _tiny_cfg(n_layers=1)
+    lm1 = resid_mlp_decomposed_model(cfg1, site_specs(cfg1, _site_cs(n_layers=1)))
+    assert not jnp.allclose(
+        lm2.clean_output(target2, resid), lm1.clean_output(one_layer_target, resid), atol=1e-4
+    )
+
+
+def test_mlp_ci_fn_per_site_logits_and_values():
+    cfg = _tiny_cfg()
+    sites = site_specs(cfg, _site_cs())
+    target = init_resid_mlp_target(cfg, jax.random.PRNGKey(0))
+    lm = resid_mlp_decomposed_model(cfg, sites)
+    ci_fn = init_layerwise_mlp_ci_fn(MLPCIArch(hidden_dims=(16,)), sites, jax.random.PRNGKey(3))
+    b = 7
+    x = sample_sparse_features(
+        jax.random.PRNGKey(2), b, cfg.n_features, 0.3, "at_least_zero_active"
+    )
+    inputs = lm.site_inputs(target, x @ target.W_E)
+    values = ci_fn(inputs)
+    assert isinstance(values, CIValues)
+    assert values.lower["layers.0.mlp_in"].shape == (b, 6)
+    assert values.lower["layers.0.mlp_out"].shape == (b, 7)
+    for v in values.lower.values():
+        assert float(v.min()) >= 0.0 and float(v.max()) <= 1.0
+
+
+def test_resid_mlp_mse_matches_hand_computed():
+    a = jax.random.normal(jax.random.PRNGKey(0), (4, 5))
+    b = jax.random.normal(jax.random.PRNGKey(1), (4, 5))
+    assert jnp.allclose(resid_mlp_mse(a, b), jnp.mean((a - b) ** 2))
+
+
+def test_recon_loss_fn_is_mse_on_the_model():
+    cfg = _tiny_cfg()
+    lm = resid_mlp_decomposed_model(cfg, site_specs(cfg, _site_cs()))
+    assert lm.recon_loss_fn is resid_mlp_mse
+
+
+def _loss_metrics():
+    return (
+        FaithfulnessLossConfig(coeff=1e3),
+        ImportanceMinimalityLossConfig(
+            coeff=3e-3,
+            pnorm=1.0,
+            beta=0.0,
+            p_anneal_start_frac=0.0,
+            p_anneal_final_p=1.0,
+            p_anneal_end_frac=1.0,
+        ),  # fmt: skip
+        StochasticReconLossConfig(coeff=1.0),
+        StochasticReconLayerwiseLossConfig(coeff=1.0),
+    )
+
+
+def _make_state_and_step(
+    cfg: ResidMLPConfig, sites: tuple[SiteSpec, ...], total_steps: int
+) -> tuple[DecomposedModel, TrainState, Callable[..., tuple[TrainState, dict[str, jax.Array]]]]:
+    lm = resid_mlp_decomposed_model(cfg, sites)
+    vu = init_decomp_vu(sites, jax.random.PRNGKey(1))
+    ci_fn = init_layerwise_mlp_ci_fn(MLPCIArch(hidden_dims=(16,)), sites, jax.random.PRNGKey(2))
+    opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
+    opt_ci = optax.adamw(1e-3, weight_decay=0.0)
+    state = TrainState(
+        components=vu, ci_fn=ci_fn,
+        components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
+        ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
+        sources={}, sources_opt_state={}, step=jnp.zeros((), jnp.int32),
+    )  # fmt: skip
+    loss_spec = build_recon_terms(
+        _loss_metrics(), lm.site_names, n_mask_samples=1, sampling="continuous"
+    )
+    step = make_train_step(
+        lm=lm, loss_spec=loss_spec, components_optimizer=opt_vu, ci_fn_optimizer=opt_ci,
+        total_steps=total_steps, remat_recon_forwards=False, mesh=None,
+    )  # fmt: skip
+    return lm, state, step
+
+
+def test_step_trains_positionless_no_persistent_sources():
+    cfg = _tiny_cfg()
+    sites = site_specs(cfg, _site_cs())
+    target = init_resid_mlp_target(cfg, jax.random.PRNGKey(0))
+    lm, state, step = _make_state_and_step(cfg, sites, total_steps=20)
+    losses = []
+    for i in range(6):
+        x = sample_sparse_features(
+            jax.random.fold_in(jax.random.PRNGKey(99), i), 64, cfg.n_features, 0.1,
+            "at_least_zero_active",
+        )  # fmt: skip
+        state, m = step(state, target, x @ target.W_E, jax.random.PRNGKey(100 + i))
+        losses.append({k: float(v) for k, v in m.items()})
+    assert all(jnp.isfinite(jnp.array(list(m.values()))).all() for m in losses)
+    assert int(state.step) == 6
+    assert state.sources == {}  # no persistent sources for the stochastic configs
+    assert isinstance(state.components, DecompVU)
+    for V, U in state.components.vu.values():
+        assert V.dtype == jnp.float32 and U.dtype == jnp.float32
+
+
+def test_faith_warmup_decreases_faith():
+    cfg = _tiny_cfg()
+    sites = site_specs(cfg, _site_cs())
+    target = init_resid_mlp_target(cfg, jax.random.PRNGKey(0))
+    lm = resid_mlp_decomposed_model(cfg, sites)
+    vu = init_decomp_vu(sites, jax.random.PRNGKey(1))
+    opt = optax.adamw(1e-2, weight_decay=0.0)
+    wstep = make_faith_warmup_step(lm, opt)
+    ostate = opt.init(eqx.filter(vu, eqx.is_array))
+    first_loss = None
+    loss = None
+    for _ in range(40):
+        vu, ostate, loss = wstep(vu, ostate, target)
+        first_loss = float(loss) if first_loss is None else first_loss
+    assert first_loss is not None and loss is not None
+    assert float(loss) < first_loss * 0.9, (first_loss, float(loss))
+
+
+def test_identity_ci_error_perfect_and_imperfect():
+    perfect = jnp.eye(5)
+    assert identity_ci_error(perfect, tolerance=0.1) == 0
+    permuted = jnp.eye(5)[:, jnp.array([2, 0, 4, 1, 3])]
+    assert identity_ci_error(permuted, tolerance=0.1) == 0
+    assert identity_ci_error(jnp.zeros((5, 5)), tolerance=0.1) == 5
+    wide = jnp.concatenate([jnp.eye(5), jnp.zeros((5, 3))], axis=1)
+    assert identity_ci_error(wide, tolerance=0.1) == 0
+
+
+def test_pretrain_drives_readoff_recon_down():
+    cfg = _tiny_cfg(n_layers=1)
+    target = pretrain_resid_mlp_target(
+        cfg, feature_probability=0.1, generation_type="at_least_zero_active",
+        steps=400, batch_size=512, lr=1e-2, seed=0,
+    )  # fmt: skip
+    lm = resid_mlp_decomposed_model(cfg, site_specs(cfg, _site_cs()))
+    x = sample_sparse_features(
+        jax.random.PRNGKey(7), 512, cfg.n_features, 0.1, "at_least_zero_active"
+    )
+    out = lm.clean_output(target, x @ target.W_E)
+    recon = jnp.mean((out - readoff_labels(target, x)) ** 2)
+    assert float(recon) < 0.05, f"pretrained ResidMLP read-off recon too high: {recon}"
+
+
+def _recovery_loss_metrics():
+    return (
+        FaithfulnessLossConfig(coeff=1.0),
+        ImportanceMinimalityLossConfig(
+            coeff=3e-3,
+            pnorm=1.0,
+            beta=0.0,
+            p_anneal_start_frac=0.0,
+            p_anneal_final_p=1.0,
+            p_anneal_end_frac=1.0,
+        ),  # fmt: skip
+        StochasticReconLossConfig(coeff=1.0),
+        StochasticReconLayerwiseLossConfig(coeff=1.0),
+    )
+
+
+def _faith_warmed_state(
+    lm: DecomposedModel,
+    sites: tuple[SiteSpec, ...],
+    target: ResidMLPTarget,
+    total_steps: int,
+    warmup_steps: int,
+) -> tuple[TrainState, Callable[..., tuple[TrainState, dict[str, jax.Array]]]]:
+    vu = init_decomp_vu(sites, jax.random.PRNGKey(1))
+    ci_fn = init_layerwise_mlp_ci_fn(MLPCIArch(hidden_dims=(16,)), sites, jax.random.PRNGKey(2))
+    warm_opt = optax.adamw(1e-2, weight_decay=0.0)
+    wstep = make_faith_warmup_step(lm, warm_opt)
+    warm_state = warm_opt.init(eqx.filter(vu, eqx.is_array))
+    for _ in range(warmup_steps):
+        vu, warm_state, _ = wstep(vu, warm_state, target)
+    opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
+    opt_ci = optax.adamw(1e-3, weight_decay=0.0)
+    state = TrainState(
+        components=vu, ci_fn=ci_fn,
+        components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
+        ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
+        sources={}, sources_opt_state={}, step=jnp.zeros((), jnp.int32),
+    )  # fmt: skip
+    loss_spec = build_recon_terms(_recovery_loss_metrics(), lm.site_names, 1, "continuous")
+    step = make_train_step(
+        lm=lm, loss_spec=loss_spec, components_optimizer=opt_vu, ci_fn_optimizer=opt_ci,
+        total_steps=total_steps, remat_recon_forwards=False, mesh=None,
+    )  # fmt: skip
+    return state, step
+
+
+@pytest.mark.slow
+def test_end_to_end_pretrain_decompose_recovers_identity():
+    """The end-to-end correctness proof: pretrain a single-layer ResidMLP (d_mlp == n_features
+    == d_embed, so the ground truth is a clean per-feature MLP-in decomposition) on the
+    read-off objective, run the full PD decomposition over the unified core, and show the
+    recovered `mlp_in` CI is the IDENTITY up to permutation — zero `IdentityCIError`.
+
+    `mlp_out` is a dense read-back (each neuron writes a feature direction into the residual)
+    so its CI is not identity-patterned; the `mlp_in` site is the unambiguous structure
+    gate. Exercises pretrain + faith warmup + the generic step + MSE recon + the MLP CI fn +
+    the target-CI eval, end to end."""
+    cfg = ResidMLPConfig(
+        n_features=5, d_embed=5, d_mlp=5, n_layers=1, act_fn_name="relu",
+        in_bias=False, out_bias=False, fixed_identity_embedding=True,
+    )  # fmt: skip
+    sites = site_specs(cfg, (SiteC("layers.0.mlp_in", 5), SiteC("layers.0.mlp_out", 5)))
+    target = pretrain_resid_mlp_target(
+        cfg, feature_probability=0.05, generation_type="at_least_zero_active",
+        steps=5000, batch_size=2048, lr=1e-2, seed=0,
+    )  # fmt: skip
+    lm = resid_mlp_decomposed_model(cfg, sites)
+    x = sample_sparse_features(jax.random.PRNGKey(7), 1024, 5, 0.05, "at_least_zero_active")
+    recon = jnp.mean((lm.clean_output(target, x @ target.W_E) - readoff_labels(target, x)) ** 2)
+    assert float(recon) < 0.05, f"pretrained ResidMLP recon too high: {recon}"
+
+    state, step = _faith_warmed_state(lm, sites, target, total_steps=8000, warmup_steps=200)
+    data_key = jax.random.PRNGKey(123)
+    totals: list[float] = []
+    for i in range(8000):
+        x = sample_sparse_features(
+            jax.random.fold_in(data_key, i), 2048, 5, 0.05, "at_least_zero_active"
+        )
+        state, m = step(
+            state, target, x @ target.W_E, jax.random.fold_in(jax.random.PRNGKey(321), i)
+        )
+        totals.append(float(m["total"]))
+    assert totals[-1] < totals[0], (totals[0], totals[-1])
+
+    ci_lower = single_feature_ci(lm, target, state.ci_fn, n_features=5)
+    err = identity_ci_error(ci_lower["layers.0.mlp_in"], tolerance=0.2)
+    assert err == 0, (
+        f"mlp_in did not recover identity (err={err}):\n{jnp.round(ci_lower['layers.0.mlp_in'], 2)}"
+    )


### PR DESCRIPTION
## What

Adds a **ResidualMLP** decomposition target to the JAX single-pool stack — the fourth `DecomposedModel` and the second non-LM bundle over the generic positionless (`leading_axes=()`) core. The ResidualMLP half of #4, mirroring how TMS was added (#861).

The target is the SPD/APD residual-stream toy:

    resid = x @ W_E
    for layer in layers:            # n_layers MLP blocks over the d_embed residual stream
        resid = resid + mlp(resid)
    out = resid @ W_U

- Fixed `W_E`/`W_U` embeddings (random unit-norm or identity); the per-layer MLP matrices train.
- Decomposition targets the MLP matrices: sites `layers.{i}.mlp_in` / `layers.{i}.mlp_out`, untied `(V, U)`.
- `W_E` is the **prefix** (`residual = x @ W_E`, carried inside the frozen target).
- Recon is **MSE on the model output** (`recon_loss_fn = resid_mlp_mse`, NOT KL).
- Frozen target **pretrained from scratch in-process** on the read-off `mean((out − (act_fn(x)+x))²)` objective (no wandb/cache) — reproducible from config alone.
- **Reuses `LayerwiseMLPCIFn`** (`fn_type=mlp`) — no new CI arch.
- Ground-truth identity-CI recovery metric (`resid_mlp.identity_ci_error`) like TMS.

## Core change

**ZERO** generic-core change (`train.py` / `losses.py` / `recon.py` / `lm.py` untouched) — only ADDED a target + config/run dispatch, exactly like TMS. `ResidMLPTarget` joins `AnyFrozenTarget`. The `_is_tms_schema` structural marker moved `n_features` → `n_hidden` so it stays disjoint from ResidMLP's `d_embed` marker (both also disjoint from the LM `spec` block).

## Files

- `param_decomp_config/resid_mlp.py` — torch-free `ResidMLP{Experiment,Target,Data,Pretrain}Config`.
- `param_decomp_jax/jax_single_pool/resid_mlp.py` — vendored JAX model + `DecomposedModel` (5 pure fns), MSE recon, in-process pretrain, ground-truth CI metric.
- `config.py` / `run.py` / `load_run.py` / `target_aliases.py` — dispatch + unions.
- `tests/test_resid_mlp.py` — contract + end-to-end pretrain→decompose→identity recovery.
- Example configs (SMOKE + from-torch).
- `CLAUDE.md` — documents `resid_mlp.py` as the fourth target.

## Design notes

- **Tying**: the *target* ties `W_U = W_Eᵀ`; the *decomposition* is untied (`tied_weights: null`), matching the SPD/APD convention. The MLP sites are two independent `(V, U)`.
- In the identity-embedding regime the JAX code sets `W_U = W_Eᵀ = I` (the torch reference leaves `W_U` at its discarded random init there, but only `mlp_in` CI structure is asserted, so this cleaner self-consistent toy is equivalent for the recovery test).

## Validation

- JAX venv: `basedpyright jax_single_pool/` → 0 errors. `pytest test_resid_mlp.py test_tms.py test_config.py` → 37 passed, 2 skipped; with `--runslow` test_resid_mlp → 14 passed (incl. e2e identity recovery); `tests/equivalence/` → 12 passed (LM trajectory bit-identical).
- Dev venv: `make type` → 0 errors; `make test` → 407 passed, 4 skipped (needed `uv pip install beartype==0.22.2` per the documented collection gotcha).

🤖 Generated with [Claude Code](https://claude.com/claude-code)