### PR TITLE
feat(jax): assert LM-only axis-semantics on in-loop eval metrics (#12)

### DIFF
--- a/param_decomp_jax/jax_single_pool/attn_patterns_eval.py
+++ b/param_decomp_jax/jax_single_pool/attn_patterns_eval.py
@@ -181,9 +181,20 @@ def _masked_patterns_kl(
     }
 
 
+def _assert_attention_sequence_axes(lm: DecomposedModel) -> None:
+    """Attention patterns are `(B, H, T_query, T_key)` causal maps over a sequence axis;
+    the metric only applies to a sequence-axis LM target (complements the per-target
+    `attn_pattern_for` dispatch, which rejects non-attention targets)."""
+    assert lm.leading_axes == ("sequence",), (
+        f"attn-patterns eval is LM-only (causal attention over a sequence axis); model "
+        f"has leading_axes={lm.leading_axes}"
+    )
+
+
 def make_ci_attn_patterns_step(lm: DecomposedModel, pattern_fn: AttnPatternFn) -> AttnPatternsStep:
     """Deterministic CI-mask attn-patterns step: `lower_leaky` CI, no delta, one masked
     forward + one clean (all-false) forward."""
+    _assert_attention_sequence_axes(lm)
     site_names = lm.site_names
     layer_pairs = _attn_layer_sites(site_names)
 
@@ -221,6 +232,7 @@ def make_stochastic_attn_patterns_step(
     """Stochastic-mask attn-patterns step: `n_mask_samples` draws of `mask = ci + (1−ci)·s`
     (with weight deltas), per-draw per-layer pattern KL summed. RNG via per-draw / per-site
     `fold_in` (the eval-step discipline, mirrors `hidden_acts_eval`)."""
+    _assert_attention_sequence_axes(lm)
     assert n_mask_samples >= 1, n_mask_samples
     site_names = lm.site_names
     layer_pairs = _attn_layer_sites(site_names)

--- a/param_decomp_jax/jax_single_pool/eval.py
+++ b/param_decomp_jax/jax_single_pool/eval.py
@@ -86,7 +86,16 @@ def make_eval_step(
     `(1, 1, C+1)` source shared across batch AND positions, `n_steps` ascents of
     `source += step_size * sign(∂KL/∂source)` clamped to `[0, 1]`, KL evaluated at the
     final source. The global-mean KL makes the source gradient the global-batch
-    gradient under GSPMD (torch all-reduce-AVG parity)."""
+    gradient under GSPMD (torch all-reduce-AVG parity).
+
+    CEandKLLosses / CI_L0 read tokens + vocab logits (next-token CE, KL over the vocab
+    axis) and the fresh-PGD source is `(1, 1, C+1)` over a `(batch, sequence)` waist, so
+    this metric is LM-only — asserted on `leading_axes` at construction (localize-and-
+    assert: fail loudly, never silently mis-shape a positionless target)."""
+    assert lm.leading_axes == ("sequence",), (
+        f"CEandKLLosses/CI_L0 eval is LM-only (tokens + vocab logits over a sequence "
+        f"axis); model has leading_axes={lm.leading_axes}"
+    )
     site_names = lm.site_names
     site_component_counts = {s.name: s.C for s in lm.sites}
     l0_groups: dict[str, tuple[str, ...]] = {}

--- a/param_decomp_jax/jax_single_pool/tests/test_attn_patterns_eval.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_attn_patterns_eval.py
@@ -182,3 +182,20 @@ def test_simple_mlp_step_runs_end_to_end():
     assert set(sum_kl) == {"h.0.attn.q_proj"}
     assert int(n_dist["h.0.attn.q_proj"]) == b * cfg.n_head * t
     assert np.isfinite(float(sum_kl["h.0.attn.q_proj"]))
+
+
+def test_attn_patterns_steps_reject_positionless_target():
+    """Attention patterns are causal maps over a sequence axis; both step constructors
+    must fail loud against a positionless (`leading_axes=()`) target. The leading-axes
+    guard fires before site/pattern inspection, so a dummy pattern fn is fine."""
+    from jax_single_pool.tms import TMSConfig, site_specs, tms_decomposed_model
+
+    cfg = TMSConfig(n_features=5, n_hidden=2)
+    sites = site_specs(cfg, (SiteC("linear1", 8), SiteC("linear2", 6)))
+    lm = tms_decomposed_model(cfg, sites)
+    assert lm.leading_axes == ()
+    dummy_pattern_fn = lambda q, k: q  # noqa: E731 — never reached; assert fires first
+    with pytest.raises(AssertionError, match="LM-only"):
+        make_ci_attn_patterns_step(lm, dummy_pattern_fn)
+    with pytest.raises(AssertionError, match="LM-only"):
+        make_stochastic_attn_patterns_step(lm, dummy_pattern_fn, 1, "continuous")

--- a/param_decomp_jax/jax_single_pool/tests/test_eval.py
+++ b/param_decomp_jax/jax_single_pool/tests/test_eval.py
@@ -236,3 +236,20 @@ def test_eval_step_l0_groups_sum_member_sites():
             lm, rounding_threshold=0.0, ci_alive_threshold=0.0,
             l0_group_patterns={"ghost": ("layers.99.*",)}, pgd=None, mesh=None,
         )  # fmt: skip
+
+
+def test_make_eval_step_rejects_positionless_target():
+    """CEandKLLosses/CI_L0 is LM-only (tokens + vocab logits over a sequence axis);
+    constructing it against a positionless (`leading_axes=()`) target must fail loud."""
+    from jax_single_pool.lm import SiteC
+    from jax_single_pool.tms import TMSConfig, site_specs, tms_decomposed_model
+
+    cfg = TMSConfig(n_features=5, n_hidden=2)
+    sites = site_specs(cfg, (SiteC("linear1", 8), SiteC("linear2", 6)))
+    lm = tms_decomposed_model(cfg, sites)
+    assert lm.leading_axes == ()
+    with pytest.raises(AssertionError, match="LM-only"):
+        make_eval_step(
+            lm, rounding_threshold=0.0, ci_alive_threshold=0.0,
+            l0_group_patterns=None, pgd=None, mesh=None,
+        )  # fmt: skip


### PR DESCRIPTION
## What

Task #12: generalize the established **localize-and-assert** pattern (the `ci_fn.expects_axes == model.leading_axes` check in `init_train_state`; `attn_pattern_for`'s non-attention raise; the harvest/clustering `isinstance(data, DataConfig)` asserts) to the **in-loop eval metric constructors**, which consumed tokens / vocab / attention without declaring their leading-axes compatibility.

Additive only — asserts at construction, no new abstractions, no core changes.

## Coverage

| Metric / data source | Constructor | LM-only? | Assert |
|---|---|---|---|
| CEandKLLosses + CI_L0 + fresh-PGD probe | `eval.make_eval_step` | LM-only (next-token CE, KL over vocab, `(1,1,C+1)` source over `(batch, sequence)`) | **added** `leading_axes == ("sequence",)` |
| Attn patterns (CI) | `make_ci_attn_patterns_step` | LM-only (causal `(B,H,T,T)` over sequence) | **added** (shared `_assert_attention_sequence_axes`) |
| Attn patterns (stochastic) | `make_stochastic_attn_patterns_step` | LM-only | **added** (same guard) |
| Attn pattern recipe | `attn_pattern_for` | LM-only (attention target) | already raises — confirmed |
| Hidden-acts recon (CI / stochastic) | `make_*_hidden_acts_step` | domain-generic (per-site MSE over `[*leading,d]`) | n/a (generic, correctly unguarded) |
| Slow-eval plots (CIHistograms / density / mean) | `make_slow_eval_step` | domain-generic (CI arrays only) | n/a; driver `run_offline_slow_eval` already asserts `DataConfig` |
| LM parquet data | `train()` / `ShardServer` | LM | already asserts `DataConfig` + shard width vs `seq_len` |
| TMS / ResidMLP synthetic samplers | `train_tms` / `train_resid_mlp` | TMS / ResidMLP | already assert `TMSDataConfig` / `ResidMLPDataConfig` + matching target |

## Tests added

- `test_eval.py::test_make_eval_step_rejects_positionless_target`
- `test_attn_patterns_eval.py::test_attn_patterns_steps_reject_positionless_target`

Both construct an LM-only metric against a `leading_axes=()` TMS `lm` and assert it raises.

## Validation

- JAX venv: `basedpyright jax_single_pool/` → `0 errors, 0 warnings, 0 notes`; `pytest jax_single_pool/tests/` → `190 passed, 2 skipped` (equivalence goldens bit-identical).
- Dev venv: `make type` → `0 errors`; `pytest param_decomp param_decomp_lab -m "not slow"` → `407 passed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)