### PR TITLE
perf(jax-launch): hardlink venvs from a same-FS uv cache

### DIFF
--- a/param_decomp_lab/experiments/lm/jax_launch.py
+++ b/param_decomp_lab/experiments/lm/jax_launch.py
@@ -34,13 +34,11 @@ AnyRunConfig = LMExperimentConfig | TMSExperimentConfig | ResidMLPExperimentConf
 GPUS_PER_NODE = 8
 WORKSPACES_DIR = PARAM_DECOMP_OUT_DIR / "workspaces"
 
-# uv materializes a venv by hardlinking wheels from its cache when cache and venv share
-# one filesystem, else copying. The default per-user cache (~/.cache/uv) sits on the home
-# mount while workspaces live on the data mount — different PVCs — so every build copied
-# multi-GB CUDA wheels. Pinning the cache beside the workspaces (same PVC) makes the
-# venv materialization metadata-only hardlinks. Scoped to the build subprocesses below so
-# other uv usage on the cluster keeps its default cache. uv still auto-falls-back to copy
-# if this ever resolves cross-filesystem, so the change is safe everywhere.
+# uv hardlinks wheels from its cache into a venv when both share a filesystem, else
+# copies. The default cache (~/.cache/uv, home mount) and the workspaces (data mount) are
+# different PVCs, so every build copied multi-GB CUDA wheels; co-locating the cache here
+# makes it hardlink instead. Set per-build (below), not globally, so other cluster uv
+# usage keeps its default cache. uv falls back to copy if ever cross-FS — safe anywhere.
 UV_CACHE_DIR = PARAM_DECOMP_OUT_DIR / "uv_cache"
 
 # Mirrors the validated llama8b.sbatch srun line: one task per GPU, block placement.

--- a/param_decomp_lab/experiments/lm/jax_launch.py
+++ b/param_decomp_lab/experiments/lm/jax_launch.py
@@ -11,6 +11,7 @@ The submit side needs no JAX imports, so it lives with the other `pd-*` scripts 
 runs from the torch venv.
 """
 
+import os
 import shlex
 import subprocess
 from pathlib import Path
@@ -32,6 +33,15 @@ AnyRunConfig = LMExperimentConfig | TMSExperimentConfig | ResidMLPExperimentConf
 
 GPUS_PER_NODE = 8
 WORKSPACES_DIR = PARAM_DECOMP_OUT_DIR / "workspaces"
+
+# uv materializes a venv by hardlinking wheels from its cache when cache and venv share
+# one filesystem, else copying. The default per-user cache (~/.cache/uv) sits on the home
+# mount while workspaces live on the data mount — different PVCs — so every build copied
+# multi-GB CUDA wheels. Pinning the cache beside the workspaces (same PVC) makes the
+# venv materialization metadata-only hardlinks. Scoped to the build subprocesses below so
+# other uv usage on the cluster keeps its default cache. uv still auto-falls-back to copy
+# if this ever resolves cross-filesystem, so the change is safe everywhere.
+UV_CACHE_DIR = PARAM_DECOMP_OUT_DIR / "uv_cache"
 
 # Mirrors the validated llama8b.sbatch srun line: one task per GPU, block placement.
 _SRUN_FLAGS = (
@@ -179,9 +189,11 @@ def _build_workspace(
     workspace's single config yaml."""
     assert not workspace.exists(), f"workspace already exists: {workspace}"
     workspace.parent.mkdir(parents=True, exist_ok=True)
+    UV_CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    build_env = {**os.environ, "UV_CACHE_DIR": str(UV_CACHE_DIR)}
 
-    def run(args: list[str], cwd: Path) -> None:
-        subprocess.run(args, cwd=cwd, check=True)
+    def run(args: list[str], cwd: Path, env: dict[str, str] | None = None) -> None:
+        subprocess.run(args, cwd=cwd, check=True, env=env)
 
     logger.info(f"Building workspace {workspace} ...")
     run(["git", "clone", "--quiet", str(REPO_ROOT), str(workspace)], cwd=REPO_ROOT)
@@ -194,9 +206,9 @@ def _build_workspace(
     (workspace / ".env").write_bytes(env_file.read_bytes())
 
     logger.info("torch venv: uv sync --all-packages --no-dev ...")
-    run(["uv", "sync", "--all-packages", "--no-dev", "--link-mode", "copy", "-q"], cwd=workspace)
+    run(["uv", "sync", "--all-packages", "--no-dev", "-q"], cwd=workspace, env=build_env)
     logger.info("jax venv: make install-jax-cuda ...")
-    run(["make", "install-jax-cuda"], cwd=workspace)
+    run(["make", "install-jax-cuda"], cwd=workspace, env=build_env)
 
     _stamp_config(workspace / config_rel, run_id, group, tags)
 


### PR DESCRIPTION
## Description

The `pd-jax-lm` workspace build copies ~7.8 GB of wheels into the per-run venvs every launch. Root cause: uv materializes a venv by **hardlinking** wheels from its cache when the cache and venv share a filesystem, else **copying** — and uv's default per-user cache (`~/.cache/uv`, on the home mount) and the workspaces (data mount) are different PVCs, so it can't hardlink across them. The torch `uv sync` also forced `--link-mode copy` on top.

This pins `UV_CACHE_DIR` to a dir beside the workspaces (`PARAM_DECOMP_OUT_DIR/uv_cache`, same PVC) for the two build subprocesses and drops the explicit `--link-mode copy`. uv then hardlinks the wheels (metadata-only) instead of copying multi-GB CUDA libs.

Scoped to the build subprocesses (via `env=` on the `subprocess.run` calls), so all other uv usage on the cluster keeps its default per-user cache untouched.

## Motivation and Context

Fresh launches take ~2.5 min, almost entirely spent copying ~7.8 GB of wheels (4.3 GB of which is `nvidia/*` CUDA libs) over NFS — verified the workspace venv files are `nlink=1` private copies, not hardlinks. Expected impact:
- **Build time:** ~2.5 min → tens of seconds.
- **Disk:** ~7.8 GB/workspace → near-zero marginal (shared inodes).

Immutability is preserved: uv's cache is content-addressed by wheel hash, and `uv cache clean` only decrements link counts (existing workspaces keep their data). uv auto-falls-back to copy if the cache ever resolves cross-filesystem, so the change is safe on every cluster (it's strictly the copy behavior we have today, with a hardlink fast path when same-FS).

Considered but deliberately *not* done: setting `UV_CACHE_DIR` cluster-wide in andromeda-scripts (`login.sh`) — that would change uv for every user/repo/cluster. This keeps the optimization local to param-decomp.

## How Has This Been Tested?

- `ruff check`, `ruff format --check`, and `basedpyright` clean on the changed file; pre-commit hooks pass.
- Import smoke test of the launcher module.
- Behavior reasoned from the uv link-mode semantics + confirmed on cw-east: the cache (`/mnt/home`) and workspaces (`/mnt/data`) are different PVCs (hence the copies), and hardlinks work within `/mnt/data` (`nlink=2` proof). A follow-up empirical timing of one launch on the warm same-FS cache is the natural confirmation.

## Does this PR introduce a breaking change?

No. Safe fallback to copy preserves existing behavior where the cache and workspaces are not co-located.

🤖 Generated with [Claude Code](https://claude.com/claude-code)