### PR TITLE
Add Silico post-sync hook to install param_decomp_lab CLIs

### DIFF
--- a/scripts/silico-post-sync.sh
+++ b/scripts/silico-post-sync.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Silico library post-sync hook: the Lab runs this after its `uv sync` when this
+# repo is provisioned under ~/.silico/libraries/. A default sync installs only the
+# root `param_decomp` package; --all-packages also installs the `param_decomp_lab`
+# workspace member, putting pd-lm (and the other pd-* CLIs) on PATH.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+uv sync --all-packages --no-dev


### PR DESCRIPTION
## What
Adds `scripts/silico-post-sync.sh` — the per-library post-sync hook that Silico's Lab runs after its `uv sync` when this repo is provisioned as an ecosystem library under `~/.silico/libraries/`.

## Why
Silico's library provisioner runs `uv sync` with `--extra` flags only. In this uv workspace that installs the root `param_decomp` package but **not** the `param_decomp_lab` member, so the `pd-*` CLIs (`pd-lm`, `pd-clustering`, …) and deps like `fire` are missing from the provisioned venv.

The hook runs `uv sync --all-packages --no-dev` (matching `make install-lab`) so the CLIs land on PATH. No change to the dependency graph or to Silico's generic provisioning code.

This unblocks registering `param-decomp` as a Silico library (follow-up in the silico repo), which the `parameter-decomposition` skill depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
