### PR TITLE
feat(eval): L0 + ci_masked-zeroed KL at multiple CI-aliveness thresholds

### DIFF
--- a/param_decomp/built_run.py
+++ b/param_decomp/built_run.py
@@ -69,7 +69,7 @@ class EvalConfig:
     `every` steps; the SLOW/plot tier (CI histograms, activation density, mean-CI,
     hidden-acts recon) runs every `slow_every` steps, reusing the same eval batches
     (SPEC S28/S29). `rounding_threshold` binarises CI for the CE/KL `rounded_masked`
-    variant; `ci_alive_threshold` is the CI-L0 aliveness cutoff."""
+    variant; `ci_alive_thresholds` are the CI-L0 aliveness cutoffs."""
 
     batch_size: int
     every: int
@@ -84,7 +84,8 @@ class EvalConfig:
     """The torch `CIHistograms.n_batches_accum` cap on the histogram raw-value sample
     (None caps nothing). Read from the `CIHistograms` eval metric when present."""
     rounding_threshold: float
-    ci_alive_threshold: float
+    ci_alive_thresholds: tuple[float, ...]
+    """CI-L0 cutoffs; L0 is reported at each. The first is primary (slow-tier density cutoff)."""
     l0_groups: dict[str, tuple[str, ...]] | None
     """torch CI_L0 `groups`: fnmatch site patterns whose member L0s sum into a
     group-named key. None = per-site keys only."""

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -394,7 +394,10 @@ class CI_L0Config(BaseConfig):
 
     type: Literal["CI_L0"] = "CI_L0"
     groups: dict[str, list[str]] | None
-    ci_alive_threshold: float = 0.0
+    ci_alive_thresholds: tuple[float, ...] = (0.0, 0.01)
+    """CI-aliveness cutoffs; L0 (+ a `kl_ci_masked_zeroed_<thr>` diagnostic per nonzero one)
+    is reported at each. 0.0 counts any nonzero CI; 0.01 ignores tiny sediment values. The
+    first is primary (also the slow-tier activation-density cutoff)."""
 
 
 class _AttnPatternsBaseConfig(BaseConfig):

--- a/param_decomp/configs/llama8b_l18-26_9layer_chunkwise.yaml
+++ b/param_decomp/configs/llama8b_l18-26_9layer_chunkwise.yaml
@@ -61,7 +61,7 @@ eval:
     type: CIHistograms
   - ci_alive_threshold: 0.0
     type: ComponentActivationDensity
-  - ci_alive_threshold: 0.0
+  - ci_alive_thresholds: [0.0, 0.01]
     groups: null
     type: CI_L0
   - rounding_threshold: 0.0

--- a/param_decomp/configs/llama8b_l18_C49k_200k.yaml
+++ b/param_decomp/configs/llama8b_l18_C49k_200k.yaml
@@ -48,7 +48,7 @@ eval:
     type: CIHistograms
   - ci_alive_threshold: 0.0
     type: ComponentActivationDensity
-  - ci_alive_threshold: 0.0
+  - ci_alive_thresholds: [0.0, 0.01]
     groups: null
     type: CI_L0
   - rounding_threshold: 0.0

--- a/param_decomp/configs/pile_pgd1.yaml
+++ b/param_decomp/configs/pile_pgd1.yaml
@@ -42,7 +42,7 @@ eval:
     type: CIHistograms
   - ci_alive_threshold: 0.0
     type: ComponentActivationDensity
-  - ci_alive_threshold: 0.0
+  - ci_alive_thresholds: [0.0, 0.01]
     groups:
       layer_0:
       - h.0.*

--- a/param_decomp/configs/pile_ppgd_bsc.yaml
+++ b/param_decomp/configs/pile_ppgd_bsc.yaml
@@ -49,7 +49,7 @@ eval:
     type: CIHistograms
   - ci_alive_threshold: 0.0
     type: ComponentActivationDensity
-  - ci_alive_threshold: 0.0
+  - ci_alive_thresholds: [0.0, 0.01]
     groups:
       layer_0:
       - h.0.*

--- a/param_decomp/eval.py
+++ b/param_decomp/eval.py
@@ -76,7 +76,7 @@ def next_token_cross_entropy(
 def make_eval_step(
     lm: DecomposedModel,
     rounding_threshold: float,
-    ci_alive_threshold: float,
+    ci_alive_thresholds: tuple[float, ...],
     l0_group_patterns: dict[str, tuple[str, ...]] | None,
     pgd: EvalPGDConfig | None,
     mesh: Mesh | None,
@@ -181,6 +181,18 @@ def make_eval_step(
             {site: jnp.zeros_like(ci_lower[site]) for site in site_names},
             zeros_delta,
         )
+        # ci_masked with every CI in (0, thr] zeroed: KL vs plain ci_masked shows whether
+        # those tiny-CI components matter. KL-only (no ce_difference / ce_unrecovered).
+        kl_only_variants: set[str] = set()
+        for thr in ci_alive_thresholds:
+            if thr <= 0.0:
+                continue
+            name = f"ci_masked_zeroed_{thr}"
+            kl_only_variants.add(name)
+            variant_masks[name] = (
+                {site: jnp.where(ci_lower[site] > thr, ci_lower[site], 0.0) for site in site_names},
+                zeros_delta,
+            )
 
         kl: dict[str, Array] = {}
         ce: dict[str, Array] = {}
@@ -193,24 +205,27 @@ def make_eval_step(
         out: dict[str, Array] = {}
         for variant in variant_masks:
             out[f"ce_kl/kl_{variant}"] = kl[variant]
-        difference_variants = tuple(v for v in variant_masks if v != "zero_masked")
+        difference_variants = tuple(
+            v for v in variant_masks if v != "zero_masked" and v not in kl_only_variants
+        )
         for variant in difference_variants:
             out[f"ce_kl/ce_difference_{variant}"] = ce[variant] - target_ce
         for variant in difference_variants:
             out[f"ce_kl/ce_unrecovered_{variant}"] = (ce[variant] - target_ce) / (
                 ce["zero_masked"] - target_ce
             )
-        site_l0 = {
-            site: (ci_lower[site] > ci_alive_threshold).astype(jnp.float32).sum(-1).mean()
-            for site in site_names
-        }
-        for site, value in site_l0.items():
-            out[f"l0/{ci_alive_threshold}_{site}"] = value
-        # torch CI_L0 groups: the group's L0 is the SUM of its member sites' L0s
-        for group_name, members in l0_groups.items():
-            out[f"l0/{ci_alive_threshold}_{group_name}"] = sum(
-                (site_l0[site] for site in members), start=jnp.zeros((), jnp.float32)
-            )
+        for threshold in ci_alive_thresholds:
+            site_l0 = {
+                site: (ci_lower[site] > threshold).astype(jnp.float32).sum(-1).mean()
+                for site in site_names
+            }
+            for site, value in site_l0.items():
+                out[f"l0/{threshold}_{site}"] = value
+            # torch CI_L0 groups: the group's L0 is the SUM of its member sites' L0s
+            for group_name, members in l0_groups.items():
+                out[f"l0/{threshold}_{group_name}"] = sum(
+                    (site_l0[site] for site in members), start=jnp.zeros((), jnp.float32)
+                )
 
         if pgd is not None:
             pgd_n_steps = pgd.n_steps

--- a/param_decomp/tests/test_config.py
+++ b/param_decomp/tests/test_config.py
@@ -89,7 +89,7 @@ def test_eval_block_maps_slow_tier_and_defers_offline_only_metrics(
         "slow_on_first_step": True,
         "metrics": [
             {"type": "CEandKLLosses", "rounding_threshold": 0.0},
-            {"type": "CI_L0", "groups": None, "ci_alive_threshold": 0.0},
+            {"type": "CI_L0", "groups": None, "ci_alive_thresholds": [0.0, 0.01]},
             {
                 "type": "PGDReconLoss",
                 "coeff": None,
@@ -109,7 +109,7 @@ def test_eval_block_maps_slow_tier_and_defers_offline_only_metrics(
     assert (cfg.eval.batch_size, cfg.eval.every, cfg.eval.n_steps) == (128, 1000, 1)
     assert (cfg.eval.slow_every, cfg.eval.slow_on_first_step) == (10000, True)
     assert cfg.eval.slow_n_batches_accum == 7  # read off the CIHistograms metric
-    assert cfg.eval.rounding_threshold == 0.0 and cfg.eval.ci_alive_threshold == 0.0
+    assert cfg.eval.rounding_threshold == 0.0 and cfg.eval.ci_alive_thresholds == (0.0, 0.01)
     assert cfg.eval.pgd is not None and (cfg.eval.pgd.n_steps, cfg.eval.pgd.step_size) == (20, 0.1)
     # the plot / permutation / UV / identity metrics all run in-loop — `_eval` accepts them
     # without raising, and nothing is deferred (no offline path)

--- a/param_decomp/tests/test_eval.py
+++ b/param_decomp/tests/test_eval.py
@@ -133,11 +133,11 @@ def test_eval_step_keys_identities_and_determinism():
     residual = jax.random.normal(jax.random.PRNGKey(4), (b, t, cfg.n_embd)) * 0.5
 
     # rounding_threshold=-1 makes the rounded mask all-ones == the unmasked variant;
-    # ci_alive_threshold=-1 makes every component alive -> L0 == C exactly.
+    # an L0 threshold of -1 makes every component alive -> L0 == C exactly.
     eval_step = make_eval_step(
         lm,
         rounding_threshold=-1.0,
-        ci_alive_threshold=-1.0,
+        ci_alive_thresholds=(-1.0,),
         l0_group_patterns=None,
         pgd=None,
         mesh=None,
@@ -176,7 +176,7 @@ def test_eval_step_keys_identities_and_determinism():
     eval_step_dead = make_eval_step(
         lm,
         rounding_threshold=-1.0,
-        ci_alive_threshold=1.5,
+        ci_alive_thresholds=(1.5,),
         l0_group_patterns=None,
         pgd=None,
         mesh=None,
@@ -205,7 +205,7 @@ def test_eval_step_fresh_pgd_probe():
     ascended = make_eval_step(
         lm,
         rounding_threshold=0.0,
-        ci_alive_threshold=0.0,
+        ci_alive_thresholds=(0.0,),
         l0_group_patterns=None,
         pgd=EvalPGDConfig(n_steps=8, step_size=0.1),
         mesh=None,
@@ -213,7 +213,7 @@ def test_eval_step_fresh_pgd_probe():
     unascended = make_eval_step(
         lm,
         rounding_threshold=0.0,
-        ci_alive_threshold=0.0,
+        ci_alive_thresholds=(0.0,),
         l0_group_patterns=None,
         pgd=EvalPGDConfig(n_steps=0, step_size=0.1),
         mesh=None,
@@ -262,11 +262,11 @@ def test_eval_step_fresh_pgd_probe_device_count_invariant():
     residual = jax.random.normal(jax.random.PRNGKey(4), (b, t, cfg.n_embd)) * 0.5
 
     single_step = make_eval_step(
-        lm, rounding_threshold=0.0, ci_alive_threshold=0.0,
+        lm, rounding_threshold=0.0, ci_alive_thresholds=(0.0,),
         l0_group_patterns=None, pgd=EvalPGDConfig(n_steps=8, step_size=0.1), mesh=None,
     )  # fmt: skip
     sharded_step = make_eval_step(
-        lm, rounding_threshold=0.0, ci_alive_threshold=0.0,
+        lm, rounding_threshold=0.0, ci_alive_thresholds=(0.0,),
         l0_group_patterns=None, pgd=EvalPGDConfig(n_steps=8, step_size=0.1), mesh=mesh,
     )  # fmt: skip
 
@@ -302,7 +302,7 @@ def test_eval_step_l0_groups_sum_member_sites():
 
     groups = {"layer_4": ("layers.4.*",), "total": ("*",)}
     eval_step = make_eval_step(
-        lm, rounding_threshold=0.0, ci_alive_threshold=0.0,
+        lm, rounding_threshold=0.0, ci_alive_thresholds=(0.0,),
         l0_group_patterns=groups, pgd=None, mesh=None,
     )  # fmt: skip
     out = eval_step(lm, vu, ci_fn, token_ids, residual, jax.random.PRNGKey(5))
@@ -314,7 +314,7 @@ def test_eval_step_l0_groups_sum_member_sites():
 
     with pytest.raises(AssertionError, match="matches no sites"):
         make_eval_step(
-            lm, rounding_threshold=0.0, ci_alive_threshold=0.0,
+            lm, rounding_threshold=0.0, ci_alive_thresholds=(0.0,),
             l0_group_patterns={"ghost": ("layers.99.*",)}, pgd=None, mesh=None,
         )  # fmt: skip
 
@@ -326,6 +326,6 @@ def test_make_eval_step_rejects_positionless_target():
     assert lm.leading_axes == ()
     with pytest.raises(AssertionError, match="LM-only"):
         make_eval_step(
-            lm, rounding_threshold=0.0, ci_alive_threshold=0.0,
+            lm, rounding_threshold=0.0, ci_alive_thresholds=(0.0,),
             l0_group_patterns=None, pgd=None, mesh=None,
         )  # fmt: skip

--- a/param_decomp_lab/experiments/lm/config.py
+++ b/param_decomp_lab/experiments/lm/config.py
@@ -369,7 +369,7 @@ def _eval(cfg: LMExperimentConfig) -> EvalConfig | None:
         slow_on_first_step=cfg.eval.slow_on_first_step,
         slow_n_batches_accum=slow_n_batches_accum,
         rounding_threshold=ce_kl.rounding_threshold,
-        ci_alive_threshold=ci_l0.ci_alive_threshold,
+        ci_alive_thresholds=ci_l0.ci_alive_thresholds,
         l0_groups=(
             {group: tuple(patterns) for group, patterns in ci_l0.groups.items()}
             if ci_l0.groups is not None

--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -214,7 +214,7 @@ def _make_lm_eval_fn(
     eval_step_fn = make_eval_step(
         lm,
         eval.rounding_threshold,
-        eval.ci_alive_threshold,
+        eval.ci_alive_thresholds,
         eval.l0_groups,
         eval.pgd,
         mesh,
@@ -229,7 +229,7 @@ def _make_lm_eval_fn(
                 lm, pattern_fn, pd.n_mask_samples
             )
 
-    slow_eval_step = make_slow_eval_step(lm, eval.ci_alive_threshold)
+    slow_eval_step = make_slow_eval_step(lm, eval.ci_alive_thresholds[0])
     slow_renderer = SlowEvalRenderer(is_main)
     # The CI-heatmap / permutation / UV / identity-error metrics read off the run's typed
     # `eval.metrics` (re-validated from the pinned config.yaml: the trainer's `EvalConfig`
@@ -322,23 +322,25 @@ def _make_lm_eval_fn(
         if is_main and built.run.wandb is not None:
             # torch CI_L0.compute() emitted a per-layer L0 bar chart alongside the scalars;
             # rebuild it host-side from the `eval/l0/<thr>_<site|group>` scalars already in
-            # the record (the jitted eval can't construct wandb objects).
+            # the record (the jitted eval can't construct wandb objects). One chart per
+            # aliveness threshold (e.g. 0.0 and 0.01).
             import wandb
 
-            l0_prefix = f"eval/l0/{eval.ci_alive_threshold}_"
-            eval_record["eval/l0/bar_chart"] = wandb.plot.bar(
-                wandb.Table(
-                    columns=["layer", "l0"],
-                    data=[
-                        [k.removeprefix(l0_prefix), v]
-                        for k, v in eval_record.items()
-                        if k.startswith(l0_prefix)
-                    ],
-                ),
-                "layer",
-                "l0",
-                title=f"L0_{eval.ci_alive_threshold}",
-            )
+            for threshold in eval.ci_alive_thresholds:
+                l0_prefix = f"eval/l0/{threshold}_"
+                eval_record[f"eval/l0/bar_chart_{threshold}"] = wandb.plot.bar(
+                    wandb.Table(
+                        columns=["layer", "l0"],
+                        data=[
+                            [k.removeprefix(l0_prefix), v]
+                            for k, v in eval_record.items()
+                            if k.startswith(l0_prefix)
+                        ],
+                    ),
+                    "layer",
+                    "l0",
+                    title=f"L0_{threshold}",
+                )
         if is_main:
             headline = {
                 k: eval_record[f"eval/{k}"]


### PR DESCRIPTION
## Description

Generalize the CI_L0 eval from a single cutoff to a tuple **`ci_alive_thresholds`** (default `(0.0, 0.01)`):

- **L0 at each threshold** — `eval/l0/<thr>_<site|group>` scalars + one host-side bar chart per threshold.
- **`kl_ci_masked_zeroed_<thr>`** KL diagnostic at each *nonzero* threshold — the CI-masked forward but with every CI in `(0, thr]` dropped to exactly 0 (CI > thr kept). KL vs the plain `ci_masked` variant answers "do the tiny-CI components carry signal, or are they sediment?". It's a KL-only diagnostic, so it emits no `ce_difference_*` / `ce_unrecovered_*`.

The `0.01` cut matters because smooth-L0 (and L_p annealed toward 1) leave many components at small-but-nonzero CI; L0@0 counts them, L0@0.01 doesn't, and the `ci_masked_zeroed` KL shows whether dropping them changes the output.

## Motivation and Context

One clean concept, not two. The scalar `ci_alive_threshold` is replaced by the tuple `ci_alive_thresholds` **everywhere** (CI_L0Config, EvalConfig, `make_eval_step`, the LM eval builder, the bar-chart host code) — no parallel fields. The **first** entry is the primary threshold and still drives the slow-tier activation-density count. The four `param_decomp/configs/*` that set the old key are migrated; lab configs used the default and are untouched.

## How Has This Been Tested?

- `make type` / basedpyright clean (repo-wide).
- `test_eval.py`, `test_config.py`, `test_slow_eval.py`: 44 passed.
- All four migrated configs load via `LMExperimentConfig` (`ci_alive_thresholds == (0.0, 0.01)`).
- Exercised on btdr (2 nodes / 16 GPU): both `eval/l0/0.0_*` and `eval/l0/0.01_*` scalars + bar charts log, and `eval/ce_kl/kl_ci_masked_zeroed_0.01` tracks `kl_ci_masked` early on (the (0,0.01] components look like sediment so far).

## Does this PR introduce a breaking change?

Config schema: `CI_L0`'s `ci_alive_threshold: float` → `ci_alive_thresholds: tuple[float, ...]`. Run configs that set the old key must rename it (the in-repo ones are migrated here). `ComponentActivationDensity`'s own `ci_alive_threshold` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)