### PR TITLE
feat(losses): smooth-L0 (Geman–McClure) importance-minimality penalty

### DIFF
--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -161,6 +161,38 @@ class ImportanceMinimalityLossConfig(LossMetricConfig):
     eps: NonNegativeFloat = 1e-12
 
 
+class SmoothL0ImportanceMinimalityLossConfig(LossMetricConfig):
+    """Geman–McClure smooth-L0 importance-minimality penalty on upper-leaky CI values.
+
+    Per-value penalty `phi_gamma(c) = c^2 / (c^2 + gamma^2)` — a smooth approximation to
+    the active-component count `1[c>0]`, exact only as `gamma -> 0` — fed through the same
+    per-site `lp + beta * mean * log2(1 + sum)` structure as `ImportanceMinimalityLoss`.
+    Differs from the `L_p` penalty only in the per-value shape: `phi'(0) = 0` and
+    `|phi'| <= 0.65/gamma` everywhere, so there is no singularity at the origin (no `eps`
+    floor, no aggressive grad clip) — the gradient is localized on the threshold band
+    `c ~ gamma/sqrt(3)` and redescends for clearly-on components.
+
+    `gamma` is annealed linearly toward `gamma_anneal_final_gamma` between
+    `gamma_anneal_start_frac` and `gamma_anneal_end_frac` of training; annealing it down
+    sharpens the count. A constant schedule is `gamma_anneal_final_gamma == gamma`.
+    """
+
+    type: Literal["SmoothL0ImportanceMinimalityLoss"] = "SmoothL0ImportanceMinimalityLoss"
+    gamma: PositiveFloat
+    beta: NonNegativeFloat
+    gamma_anneal_start_frac: Probability = 1.0
+    gamma_anneal_final_gamma: PositiveFloat | None = None
+    gamma_anneal_end_frac: Probability = 1.0
+
+
+# The two imp-min penalties share the `coeff`/`beta` surface and the `lp + beta * entropy`
+# aggregation; they differ only in the per-value penalty shape and its annealed parameter
+# (`p` vs `gamma`). The trainer's single imp-min slot accepts either.
+AnyImportanceMinimalityLossConfig = (
+    ImportanceMinimalityLossConfig | SmoothL0ImportanceMinimalityLossConfig
+)
+
+
 class CIMaskedReconLossConfig(LossMetricConfig):
     type: Literal["CIMaskedReconLoss"] = "CIMaskedReconLoss"
 
@@ -521,6 +553,7 @@ AnyLossMetricConfig = Annotated[
     | CIMaskedReconSubsetLossConfig
     | FaithfulnessLossConfig
     | ImportanceMinimalityLossConfig
+    | SmoothL0ImportanceMinimalityLossConfig
     | PersistentPGDReconLossConfig
     | PGDReconLayerwiseLossConfig
     | PGDReconLossConfig

--- a/param_decomp/losses.py
+++ b/param_decomp/losses.py
@@ -1,13 +1,18 @@
 """The pure loss terms (SPEC §2) and their schedules — fp32 reductions, no state."""
 
 import math
+from collections.abc import Callable
 
 import jax
 import jax.numpy as jnp
 from beartype import beartype
 from jaxtyping import Array, Float, jaxtyped
 
-from param_decomp.configs import ImportanceMinimalityLossConfig
+from param_decomp.configs import (
+    AnyImportanceMinimalityLossConfig,
+    ImportanceMinimalityLossConfig,
+    SmoothL0ImportanceMinimalityLossConfig,
+)
 
 
 @jaxtyped(typechecker=beartype)
@@ -37,14 +42,13 @@ def faithfulness_loss(weight_deltas: dict[str, Float[Array, "_ _"]]) -> Float[Ar
     return numerator / denominator
 
 
-@jaxtyped(typechecker=beartype)
-def importance_minimality_terms(
-    ci_upper: dict[str, Float[Array, "*leading _"]], pnorm: Float[Array, ""], eps: float
+def _imp_min_terms(
+    ci_upper: dict[str, Float[Array, "*leading _"]],
+    per_value_penalty: Callable[[Float[Array, "*leading _"]], Float[Array, "*leading _"]],
 ) -> tuple[Float[Array, ""], Float[Array, ""]]:
-    """`(lp, entropy)` with per-site grouping and the global-batch sum inside the log2
-    (SPEC S7/S8); the loss is `lp + beta * entropy`. Torch's `_no_beta` diagnostic (`lp`
-    alone) is emitted only on the eval path (`Metric.compute`), never from the train
-    step, so this trainer does not log a `train/loss/*_no_beta` key.
+    """`(lp, entropy)` for any per-value penalty `psi`, with per-site grouping and the
+    global-batch sum inside the log2 (SPEC S7/S8); the loss is `lp + beta * entropy`. The
+    two imp-min penalties (`L_p`, smooth-L0) differ ONLY in `psi`.
 
     Under GSPMD the `*leading` axes are the global batch, so `jnp.sum` IS the exact
     global per-component sum — XLA reduces across shards inside the graph."""
@@ -54,20 +58,102 @@ def importance_minimality_terms(
         ci = ci.astype(jnp.float32)  # (*leading, C)
         leading_axes = tuple(range(ci.ndim - 1))
         n_positions = math.prod(ci.shape[:-1])
-        per_component_sums = jnp.sum((ci + eps) ** pnorm, axis=leading_axes)  # (C,)
+        per_component_sums = jnp.sum(per_value_penalty(ci), axis=leading_axes)  # (C,)
         per_component_means = per_component_sums / n_positions
         lp = lp + jnp.sum(per_component_means)
         entropy = entropy + jnp.sum(per_component_means * jnp.log2(1.0 + per_component_sums))
     return lp, entropy
 
 
+@jaxtyped(typechecker=beartype)
+def importance_minimality_terms(
+    ci_upper: dict[str, Float[Array, "*leading _"]], pnorm: Float[Array, ""], eps: float
+) -> tuple[Float[Array, ""], Float[Array, ""]]:
+    """`L_p` imp-min terms: per-value penalty `(c + eps)^pnorm`, singular at `c=0` for
+    `pnorm < 1` (the `eps` floor caps the gradient there). Torch's `_no_beta` diagnostic
+    (`lp` alone) is emitted only on the eval path, never from the train step, so this
+    trainer does not log a `train/loss/*_no_beta` key."""
+    return _imp_min_terms(ci_upper, lambda ci: (ci + eps) ** pnorm)
+
+
+@jaxtyped(typechecker=beartype)
+def smooth_l0_importance_minimality_terms(
+    ci_upper: dict[str, Float[Array, "*leading _"]], gamma: Float[Array, ""]
+) -> tuple[Float[Array, ""], Float[Array, ""]]:
+    """Geman–McClure smooth-L0 imp-min terms: per-value penalty `c^2 / (c^2 + gamma^2)`.
+    Flat at the origin (`phi'(0)=0`) and bounded (`|phi'| <= 0.65/gamma`) — no singularity,
+    no `eps` floor. Approaches the true `L_0` count as `gamma -> 0`."""
+    gamma_sq = gamma * gamma
+    return _imp_min_terms(ci_upper, lambda ci: ci**2 / (ci**2 + gamma_sq))
+
+
+def _linear_anneal(
+    step_f32: Array,
+    total_steps: int,
+    initial: float,
+    final: float,
+    start_frac: float,
+    end_frac: float,
+) -> Array:
+    span = max(end_frac - start_frac, 1e-9)
+    progress = jnp.clip((step_f32 / total_steps - start_frac) / span, 0.0, 1.0)
+    return jnp.asarray(initial + (final - initial) * progress)
+
+
 def annealed_pnorm(step_f32: Array, total_steps: int, cfg: ImportanceMinimalityLossConfig) -> Array:
     """`p` anneals linearly `pnorm → p_anneal_final_p` over
     `[p_anneal_start_frac, p_anneal_end_frac]` of training (SPEC S9)."""
     assert cfg.p_anneal_final_p is not None
-    span = max(cfg.p_anneal_end_frac - cfg.p_anneal_start_frac, 1e-9)
-    progress = jnp.clip((step_f32 / total_steps - cfg.p_anneal_start_frac) / span, 0.0, 1.0)
-    return jnp.asarray(cfg.pnorm + (cfg.p_anneal_final_p - cfg.pnorm) * progress)
+    return _linear_anneal(
+        step_f32,
+        total_steps,
+        cfg.pnorm,
+        cfg.p_anneal_final_p,
+        cfg.p_anneal_start_frac,
+        cfg.p_anneal_end_frac,
+    )
+
+
+def annealed_gamma(
+    step_f32: Array, total_steps: int, cfg: SmoothL0ImportanceMinimalityLossConfig
+) -> Array:
+    """`gamma` anneals linearly `gamma → gamma_anneal_final_gamma` over
+    `[gamma_anneal_start_frac, gamma_anneal_end_frac]` of training (SPEC S9', the smooth-L0
+    analogue of S9)."""
+    assert cfg.gamma_anneal_final_gamma is not None
+    return _linear_anneal(
+        step_f32,
+        total_steps,
+        cfg.gamma,
+        cfg.gamma_anneal_final_gamma,
+        cfg.gamma_anneal_start_frac,
+        cfg.gamma_anneal_end_frac,
+    )
+
+
+def annealed_imp_min_param(
+    step_f32: Array, total_steps: int, cfg: AnyImportanceMinimalityLossConfig
+) -> Array:
+    """The annealed per-value-penalty parameter at this step (`p` for `L_p`, `gamma` for
+    smooth-L0). Pure in the step, so the train step hoists it out of the loss `grad`."""
+    match cfg:
+        case ImportanceMinimalityLossConfig():
+            return annealed_pnorm(step_f32, total_steps, cfg)
+        case SmoothL0ImportanceMinimalityLossConfig():
+            return annealed_gamma(step_f32, total_steps, cfg)
+
+
+def imp_min_terms(
+    ci_upper: dict[str, Float[Array, "*leading _"]],
+    cfg: AnyImportanceMinimalityLossConfig,
+    annealed_param: Array,
+) -> tuple[Float[Array, ""], Float[Array, ""]]:
+    """Dispatch `(lp, entropy)` on the imp-min penalty kind, given its annealed parameter."""
+    match cfg:
+        case ImportanceMinimalityLossConfig():
+            return importance_minimality_terms(ci_upper, annealed_param, cfg.eps)
+        case SmoothL0ImportanceMinimalityLossConfig():
+            return smooth_l0_importance_minimality_terms(ci_upper, annealed_param)
 
 
 def warmup_then_constant_lr(

--- a/param_decomp/recon.py
+++ b/param_decomp/recon.py
@@ -20,6 +20,7 @@ from jaxtyping import Array, PRNGKeyArray
 
 from param_decomp.configs import (
     AllRoutingConfig,
+    AnyImportanceMinimalityLossConfig,
     AnyLossMetricConfig,
     ChunkwiseSubsetReconLossConfig,
     CIMaskedReconLayerwiseLossConfig,
@@ -33,6 +34,7 @@ from param_decomp.configs import (
     PGDReconLayerwiseLossConfig,
     PGDReconLossConfig,
     PGDReconSubsetLossConfig,
+    SmoothL0ImportanceMinimalityLossConfig,
     StaticProbabilityRoutingConfig,
     StochasticReconLayerwiseLossConfig,
     StochasticReconLossConfig,
@@ -270,7 +272,7 @@ class LossSpec:
     (state_key -> shared config; SPEC S23: each key feeds exactly one term)."""
 
     faith_coeff: float
-    imp_min: ImportanceMinimalityLossConfig
+    imp_min: AnyImportanceMinimalityLossConfig
     recon_terms: ReconLossTerms
     persistent: dict[str, PersistentPGDReconLossConfig]
 
@@ -286,7 +288,7 @@ def build_recon_terms(
     Term ORDER follows the config list (recon terms only) — per-term RNG keys are
     derived from that order, so it is semantically load-bearing (SPEC R1)."""
     faith_coeff: float | None = None
-    imp_min: ImportanceMinimalityLossConfig | None = None
+    imp_min: AnyImportanceMinimalityLossConfig | None = None
     terms: list[ReconLossTerm] = []
     persistent: dict[str, PersistentPGDReconLossConfig] = {}
 
@@ -304,6 +306,10 @@ def build_recon_terms(
             case ImportanceMinimalityLossConfig():
                 assert imp_min is None
                 assert cfg.p_anneal_final_p is not None
+                imp_min = cfg
+            case SmoothL0ImportanceMinimalityLossConfig():
+                assert imp_min is None
+                assert cfg.gamma_anneal_final_gamma is not None
                 imp_min = cfg
             case UnmaskedReconLossConfig() | CIMaskedReconLossConfig():
                 value = 1.0 if isinstance(cfg, UnmaskedReconLossConfig) else 0.0
@@ -381,7 +387,8 @@ def build_recon_terms(
                 raise AssertionError(f"unsupported training loss {cfg.type!r}")
 
     assert faith_coeff is not None and imp_min is not None, (
-        f"need FaithfulnessLoss + ImportanceMinimalityLoss, got {[m.type for m in loss_metrics]}"
+        "need FaithfulnessLoss + an importance-minimality loss (ImportanceMinimalityLoss | "
+        f"SmoothL0ImportanceMinimalityLoss), got {[m.type for m in loss_metrics]}"
     )
     assert terms, "no recon loss terms configured"
     for term in terms:

--- a/param_decomp/tests/test_config.py
+++ b/param_decomp/tests/test_config.py
@@ -12,7 +12,11 @@ from pydantic import ValidationError
 
 from param_decomp.built_run import DataConfig
 from param_decomp.components import SiteC
-from param_decomp.configs import PDConfig, PersistentPGDReconLossConfig
+from param_decomp.configs import (
+    ImportanceMinimalityLossConfig,
+    PDConfig,
+    PersistentPGDReconLossConfig,
+)
 from param_decomp.recon import build_recon_terms
 from param_decomp.targets.llama8b import mlp_family_site_cs
 from param_decomp_lab.experiments.lm.config import (
@@ -66,7 +70,8 @@ def test_b128_config_converts():
         converted.pd.loss_metrics, tuple(sc.name for sc in converted.target.sites),
         converted.pd.n_mask_samples,
     )  # fmt: skip
-    assert spec.faith_coeff == 1e5 and spec.imp_min.pnorm == 2.0
+    assert spec.faith_coeff == 1e5
+    assert isinstance(spec.imp_min, ImportanceMinimalityLossConfig) and spec.imp_min.pnorm == 2.0
     (ppgd,) = spec.persistent.values()
     assert isinstance(ppgd, PersistentPGDReconLossConfig)
     assert ppgd.n_warmup_steps == 2

--- a/param_decomp/tests/test_smooth_l0_imp_min.py
+++ b/param_decomp/tests/test_smooth_l0_imp_min.py
@@ -1,0 +1,86 @@
+"""smooth-L0 (Geman–McClure) importance-minimality penalty (SPEC S7/S8/S9').
+
+The penalty shares the per-site `lp + beta * mean * log2(1 + sum)` structure with the
+`L_p` penalty and differs ONLY in the per-value shape `phi_gamma(c) = c^2/(c^2+gamma^2)`.
+These checks pin the properties that motivate it over `L_p`: flat at the origin
+(`phi'(0)=0`, no singularity to clip), bounded gradient (`|phi'| <= 0.65/gamma`),
+redescent for clearly-on components, and the half-saturation crossover `phi(gamma) = 1/2`.
+"""
+
+import jax
+import jax.numpy as jnp
+
+from param_decomp.configs import SmoothL0ImportanceMinimalityLossConfig
+from param_decomp.losses import (
+    annealed_gamma,
+    annealed_imp_min_param,
+    imp_min_terms,
+    smooth_l0_importance_minimality_terms,
+)
+
+
+def _phi(c: jax.Array, gamma: float) -> jax.Array:
+    return c**2 / (c**2 + gamma**2)
+
+
+def test_phi_shape_invariants():
+    for gamma in (1.0, 0.1):
+        assert float(_phi(jnp.array(0.0), gamma)) == 0.0  # off -> exactly 0
+        assert abs(float(_phi(jnp.array(gamma), gamma)) - 0.5) < 1e-6  # half-saturation
+        assert float(_phi(jnp.array(10.0 * gamma), gamma)) > 0.99  # clearly-on -> ~1
+
+
+def test_phi_gradient_flat_at_origin_and_bounded():
+    """phi'(0) = 0 (no L_p cliff) and the peak |phi'| ~ 0.65/gamma sits at c = gamma/sqrt(3)."""
+    for gamma in (1.0, 0.1):
+        dphi = jax.grad(lambda c, g=gamma: _phi(c, g))
+        assert float(dphi(jnp.array(0.0))) == 0.0
+        cs = jnp.linspace(0.0, 5.0 * gamma, 4096)
+        grads = jnp.abs(jax.vmap(dphi)(cs))
+        peak = float(grads.max())
+        assert peak <= 0.65 / gamma + 1e-3
+        c_peak = float(cs[jnp.argmax(grads)])
+        assert abs(c_peak - gamma / jnp.sqrt(3.0)) < 0.02 * gamma
+        # redescent: gradient at a clearly-on point is far below the peak.
+        assert float(dphi(jnp.array(5.0 * gamma))) < 0.2 * peak
+
+
+def test_terms_match_manual_per_site_structure():
+    ci = {
+        "a": jnp.array([[0.0, 0.5, 1.0], [0.2, 0.0, 0.9]]),
+        "b": jnp.array([[0.3], [0.7]]),
+    }
+    gamma = 0.1
+    lp, entropy = smooth_l0_importance_minimality_terms(ci, jnp.asarray(gamma))
+
+    exp_lp = jnp.zeros(())
+    exp_entropy = jnp.zeros(())
+    for v in ci.values():
+        sums = _phi(v, gamma).sum(axis=0)
+        means = sums / v.shape[0]
+        exp_lp = exp_lp + means.sum()
+        exp_entropy = exp_entropy + (means * jnp.log2(1.0 + sums)).sum()
+    assert jnp.allclose(lp, exp_lp)
+    assert jnp.allclose(entropy, exp_entropy)
+
+
+def test_anneal_and_dispatch():
+    cfg = SmoothL0ImportanceMinimalityLossConfig(
+        coeff=2e-4,
+        gamma=1.0,
+        beta=0.5,
+        gamma_anneal_start_frac=0.0,
+        gamma_anneal_final_gamma=0.1,
+        gamma_anneal_end_frac=1.0,
+    )
+    total = 100
+    assert abs(float(annealed_gamma(jnp.asarray(0.0), total, cfg)) - 1.0) < 1e-6
+    assert abs(float(annealed_gamma(jnp.asarray(50.0), total, cfg)) - 0.55) < 1e-6
+    assert abs(float(annealed_gamma(jnp.asarray(total), total, cfg)) - 0.1) < 1e-6
+
+    ci = {"a": jnp.array([[0.0, 0.5, 1.0], [0.2, 0.0, 0.9]])}
+    param = annealed_imp_min_param(jnp.asarray(float(total)), total, cfg)
+    via_dispatch = imp_min_terms(ci, cfg, param)
+    direct = smooth_l0_importance_minimality_terms(ci, param)
+    assert jnp.allclose(via_dispatch[0], direct[0])
+    assert jnp.allclose(via_dispatch[1], direct[1])

--- a/param_decomp/train.py
+++ b/param_decomp/train.py
@@ -38,9 +38,9 @@ from param_decomp.components import DecompVU
 from param_decomp.configs import AdamPGDConfig
 from param_decomp.lm import DecomposedModel
 from param_decomp.losses import (
-    annealed_pnorm,
+    annealed_imp_min_param,
     faithfulness_loss,
-    importance_minimality_terms,
+    imp_min_terms,
     warmup_then_constant_lr,
 )
 from param_decomp.recon import (
@@ -134,7 +134,7 @@ def make_train_step(
     recon_terms = loss_spec.recon_terms
     imp_min = loss_spec.imp_min
     faith_coeff = loss_spec.faith_coeff
-    assert imp_min.coeff is not None and imp_min.p_anneal_final_p is not None
+    assert imp_min.coeff is not None
     imp_coeff = imp_min.coeff
     term_coeff_by_state_key = {
         entry.sources.state_key: term.coeff
@@ -260,7 +260,7 @@ def make_train_step(
         key: PRNGKeyArray,
     ) -> tuple[TrainState, dict[str, Array]]:
         step_f32 = state.step.astype(jnp.float32)
-        pnorm = annealed_pnorm(step_f32, total_steps, imp_min)
+        imp_min_param = annealed_imp_min_param(step_f32, total_steps, imp_min)
         leading = residual.shape[:-1]
 
         residual = batch_sharded(residual)
@@ -406,7 +406,7 @@ def make_train_step(
             ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
             ci = batch_sharded_ci(ci_fn_bf16(taps))
             faith_loss = faithfulness_loss(model.weight_deltas(components))
-            imp_lp, imp_entropy = importance_minimality_terms(ci.upper, pnorm, imp_min.eps)
+            imp_lp, imp_entropy = imp_min_terms(ci.upper, imp_min, imp_min_param)
             imp_loss = imp_lp + imp_min.beta * imp_entropy
 
             term_losses: list[Array] = []
@@ -525,7 +525,7 @@ def make_train_step(
             "total": total_loss,
             "faith": faith_loss,
             "imp": imp_loss,
-            "p_imp": pnorm,
+            "p_imp": imp_min_param,
             **{f"loss/{t.name}": v for t, v in zip(recon_terms, term_losses, strict=True)},
             **grad_norm_metrics,
         }


### PR DESCRIPTION
## Description

Adds `SmoothL0ImportanceMinimalityLoss` as a second importance-minimality penalty alongside the existing `L_p` one, ported from `feature/smooth-l0-investigation` onto the post-refactor feature/jax engine.

Per-value penalty `phi_gamma(c) = c² / (c² + gamma²)` — a smooth approximation to the active-component count `1[c>0]`, exact only as `gamma → 0`. It is flat at the origin (`phi'(0)=0`) and has a bounded gradient (`|phi'| ≤ 0.65/gamma`), so unlike `L_p` there is no singularity at `c=0` to `eps`-floor or aggressively grad-clip; the gradient is localized on the threshold band `c ~ gamma/√3` and redescends for clearly-on components. `gamma` anneals linearly (the `L_p` `p`-anneal analogue).

It feeds the **same** per-site `lp + beta · log2(1 + sum)` aggregation as `L_p` — the two penalties differ only in the per-value shape and which parameter anneals. So:
- `losses.py` factors the shared aggregation into `_imp_min_terms(penalty)` and the shared anneal into `_linear_anneal`; the trainer's single imp-min slot dispatches on config type via `annealed_imp_min_param` / `imp_min_terms`.
- The `L_p` path is **numerically unchanged** — same `importance_minimality_terms` / `annealed_pnorm` signatures, pinned by the existing equivalence + global-reduction tests.

## Motivation and Context

Enables a clean feature/jax run with the smooth-L0 sparsity loss (the loss your recent and-btdr runs used, which previously lived only on the smooth-l0 branch). Unblocks the chunkwise-CI 50k run.

## How Has This Been Tested?

- New `param_decomp/tests/test_smooth_l0_imp_min.py`: pins `phi` shape invariants (off→0, half-saturation `phi(gamma)=½`, clearly-on→~1), the flat-origin/bounded/redescending gradient, the per-site aggregation, and the anneal + dispatch.
- `param_decomp/tests/` green **except** two failures that are pre-existing on `feature/jax` and unrelated (verified by re-running on the base branch): `stacked_parity::test_clean_output_bit_identical` (≈1e-7 float reassociation vs a committed golden) and four `test_slow_eval` background-thread matplotlib renders — both local-environment.
- `make type` and `make format` clean; pre-commit passed.

## Does this PR introduce a breaking change?

No. Purely additive — a new opt-in loss type. No SPEC.md change (the docstrings cite `S7/S8/S9'`, mirroring the source branch, which shares S7/S8 with `L_p` and adds the `S9'` gamma-anneal analogue); flag if you'd prefer a formal SPEC entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)