### PR TITLE
fix(slow_eval): chunkwise CI fn slow-eval on multi-host GPU (bf16 + gather)

### DIFF
--- a/param_decomp/slow_eval.py
+++ b/param_decomp/slow_eval.py
@@ -120,8 +120,6 @@ def make_slow_eval_step(lm: DecomposedModel, ci_alive_threshold: float) -> SlowE
     ) -> tuple[dict[str, Array], dict[str, Array], Array, dict[str, Array], dict[str, Array]]:
         taps = model.read_activations(residual, ci_fn.input_names)
         ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
-        # bf16 weights (training/cuDNN), f32 readout: bf16 host reductions over ~B*T
-        # positions lose precision, and matplotlib rejects bfloat16.
         logits = {s: v.astype(jnp.float32) for s, v in ci_fn_bf16(taps).logits.items()}
         lower = {s: lower_leaky_hard_sigmoid(logits[s]) for s in site_names}
 
@@ -167,9 +165,8 @@ def accumulate_site_reductions(
             density[site] = counts if batch_idx == 0 else density[site] + counts
             sums[site] = ci_sum if batch_idx == 0 else sums[site] + ci_sum
             if keep_sample:
-                # flat_lower/flat_logits are dp-sharded → np.asarray raises on >1 process.
-                # Gather them (density/sums above are already all-reduced); tiled=True
-                # concatenates the per-process shards.
+                # flat_lower/flat_logits are dp-sharded → np.asarray raises on >1 process;
+                # gather them (density/sums above are already all-reduced).
                 lower_chunks.setdefault(site, []).append(
                     np.asarray(multihost_utils.process_allgather(flat_lower[site], tiled=True))
                 )
@@ -211,8 +208,6 @@ def make_position_ci_step(lm: DecomposedModel) -> PositionCIStep:
     ) -> tuple[dict[str, Array], dict[str, Array], Array]:
         taps = model.read_activations(residual, ci_fn.input_names)
         ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
-        # bf16 weights (training/cuDNN), f32 readout: bf16 host reductions over ~B*T
-        # positions lose precision, and matplotlib rejects bfloat16.
         logits = {s: v.astype(jnp.float32) for s, v in ci_fn_bf16(taps).logits.items()}
         lower = {s: lower_leaky_hard_sigmoid(logits[s]) for s in site_names}
         upper = {s: upper_leaky_hard_sigmoid(logits[s]) for s in site_names}

--- a/param_decomp/slow_eval.py
+++ b/param_decomp/slow_eval.py
@@ -120,6 +120,8 @@ def make_slow_eval_step(lm: DecomposedModel, ci_alive_threshold: float) -> SlowE
     ) -> tuple[dict[str, Array], dict[str, Array], Array, dict[str, Array], dict[str, Array]]:
         taps = model.read_activations(residual, ci_fn.input_names)
         ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
+        # bf16 weights (training/cuDNN), f32 readout: bf16 host reductions over ~B*T
+        # positions lose precision, and matplotlib rejects bfloat16.
         logits = {s: v.astype(jnp.float32) for s, v in ci_fn_bf16(taps).logits.items()}
         lower = {s: lower_leaky_hard_sigmoid(logits[s]) for s in site_names}
 
@@ -209,6 +211,8 @@ def make_position_ci_step(lm: DecomposedModel) -> PositionCIStep:
     ) -> tuple[dict[str, Array], dict[str, Array], Array]:
         taps = model.read_activations(residual, ci_fn.input_names)
         ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
+        # bf16 weights (training/cuDNN), f32 readout: bf16 host reductions over ~B*T
+        # positions lose precision, and matplotlib rejects bfloat16.
         logits = {s: v.astype(jnp.float32) for s, v in ci_fn_bf16(taps).logits.items()}
         lower = {s: lower_leaky_hard_sigmoid(logits[s]) for s in site_names}
         upper = {s: upper_leaky_hard_sigmoid(logits[s]) for s in site_names}

--- a/param_decomp/slow_eval.py
+++ b/param_decomp/slow_eval.py
@@ -54,6 +54,7 @@ import equinox as eqx
 import jax.numpy as jnp
 import numpy as np
 from jax import random
+from jax.experimental import multihost_utils
 from jaxtyping import Array, Float
 from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
@@ -73,6 +74,7 @@ from param_decomp.hidden_acts_eval import (
     make_stochastic_hidden_acts_step,
 )
 from param_decomp.lm import DecomposedModel
+from param_decomp.train import COMPUTE_DT, cast_floating
 
 IDENTITY_CI_ERROR_TOLERANCE = 0.1
 """Torch `IdentityCIPattern.distance_from` / `compute_target_metrics` default tolerance —
@@ -116,14 +118,9 @@ def make_slow_eval_step(lm: DecomposedModel, ci_alive_threshold: float) -> SlowE
     def slow_eval_step(
         model: DecomposedModel, ci_fn: Any, residual: Float[Array, "*leading d"]
     ) -> tuple[dict[str, Array], dict[str, Array], Array, dict[str, Array], dict[str, Array]]:
-        # CI fn stays fp32 (its master dtype): torch offline-eval keeps V/U + CI fn fp32,
-        # casting only the frozen target to bf16. The slow plot metrics are a
-        # fp32-CI-fn readout, so we don't take eval.py's bf16-compute path here.
-        taps = {
-            k: x.astype(jnp.float32)
-            for k, x in model.read_activations(residual, ci_fn.input_names).items()
-        }
-        logits = ci_fn(taps).logits
+        taps = model.read_activations(residual, ci_fn.input_names)
+        ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
+        logits = {s: v.astype(jnp.float32) for s, v in ci_fn_bf16(taps).logits.items()}
         lower = {s: lower_leaky_hard_sigmoid(logits[s]) for s in site_names}
 
         density_counts = {
@@ -168,8 +165,15 @@ def accumulate_site_reductions(
             density[site] = counts if batch_idx == 0 else density[site] + counts
             sums[site] = ci_sum if batch_idx == 0 else sums[site] + ci_sum
             if keep_sample:
-                lower_chunks.setdefault(site, []).append(np.asarray(flat_lower[site]))
-                logits_chunks.setdefault(site, []).append(np.asarray(flat_logits[site]))
+                # flat_lower/flat_logits are dp-sharded → np.asarray raises on >1 process.
+                # Gather them (density/sums above are already all-reduced); tiled=True
+                # concatenates the per-process shards.
+                lower_chunks.setdefault(site, []).append(
+                    np.asarray(multihost_utils.process_allgather(flat_lower[site], tiled=True))
+                )
+                logits_chunks.setdefault(site, []).append(
+                    np.asarray(multihost_utils.process_allgather(flat_logits[site], tiled=True))
+                )
 
     return {
         site: SiteReduction(
@@ -203,11 +207,9 @@ def make_position_ci_step(lm: DecomposedModel) -> PositionCIStep:
     def position_ci_step(
         model: DecomposedModel, ci_fn: Any, residual: Float[Array, "*leading d"]
     ) -> tuple[dict[str, Array], dict[str, Array], Array]:
-        taps = {
-            k: x.astype(jnp.float32)
-            for k, x in model.read_activations(residual, ci_fn.input_names).items()
-        }
-        logits = ci_fn(taps).logits
+        taps = model.read_activations(residual, ci_fn.input_names)
+        ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
+        logits = {s: v.astype(jnp.float32) for s, v in ci_fn_bf16(taps).logits.items()}
         lower = {s: lower_leaky_hard_sigmoid(logits[s]) for s in site_names}
         upper = {s: upper_leaky_hard_sigmoid(logits[s]) for s in site_names}
         first = lower[site_names[0]]

--- a/param_decomp/tests/test_slow_eval.py
+++ b/param_decomp/tests/test_slow_eval.py
@@ -54,6 +54,7 @@ from param_decomp.tests.test_llama8b import (
     _tiny_cfg,
     _tiny_decomposed_lm,
 )
+from param_decomp.train import COMPUTE_DT, cast_floating
 
 
 def _build_ci_fn(lm: DecomposedModel, n_embd: int, key: jax.Array) -> CIFn:
@@ -90,7 +91,8 @@ def test_reductions_match_hand_rolled_per_component():
     reductions = accumulate_site_reductions(step, lm, ci_fn, [residual], n_batches_accum=None)
 
     taps = lm.read_activations(residual, ci_fn.input_names)
-    logits = ci_fn(taps).logits
+    ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
+    logits = {s: v.astype(np.float32) for s, v in ci_fn_bf16(taps).logits.items()}
     lower = {s: lower_leaky_hard_sigmoid(logits[s]) for s in lm.site_names}
     for site in lm.site_names:
         flat = np.asarray(lower[site]).reshape(-1, C).astype(np.float32)


### PR DESCRIPTION
## Description

The slow/plot eval tier crashes **every** multi-host GPU LM run that uses a chunkwise (transformer) CI fn, at the first slow eval. Two independent bugs, both fixed here in `slow_eval.py`:

1. **cuDNN-fp32 attention.** The slow tier read the CI fn out in **fp32**, but the CI transformer's attention requests the cuDNN flash impl (`attn_implementation()`), which only accepts fp16/bf16/fp8 on GPU:
   ```
   NotImplementedError: Q must be fp16/bf16/fp8_e4m3fn/fp8_e5m2, got float32
   ```
   The fp32 readout was **unintentional**. Fix: run the CI fn in **bf16** (`COMPUTE_DT`), exactly like training and fast eval (`eval.py` / `hidden_acts_eval.py`), and cast the readout *statistics* to fp32 (matplotlib rejects `bfloat16` arrays).

2. **`np.asarray` on a process-sharded array.** `accumulate_site_reductions` did `np.asarray(flat_lower[site])` / `flat_logits[site]`, which keep the dp-sharded batch axis. On >1 process those span non-addressable devices:
   ```
   RuntimeError: Fetching value for `jax.Array` that spans non-addressable (non process local) devices ...
   ```
   Fix: `multihost_utils.process_allgather(..., tiled=True)`. (The density/sum reductions are all-reduced → already addressable.)

## Motivation and Context

Together these abort every multi-GPU LM decomposition at its first slow eval (the gRPC coordination cascade these exceptions trigger on the other ranks shows up as "connection refused" noise). The chunkwise CI fn is the first CI fn with attention, so it's the first to hit (1); the MLP CI fns have no attention.

Supersedes the fp32→XLA-fallback approach in #885: per Oli the fp32 readout was unintentional, so this removes it (run bf16) rather than working around it. #885 can be closed in favor of this. `ci_fn.py` is left untouched.

## How Has This Been Tested?

- `make type` / basedpyright clean.
- `param_decomp/tests/test_slow_eval.py`: 26 passed (`MPLBACKEND=agg`). The hand-rolled reference in `test_reductions_match_hand_rolled_per_component` now mirrors the bf16 readout (a borderline near-`>0.0` count flipped by one under bf16 weight rounding).
- On and-btdr (2 nodes / 16 GPU): pre-fix the chunkwise pile-4L runs abort at the first slow eval; with this fix the slow tier (CI histograms, activation density, component-CI plots) renders and training continues.

## Does this PR introduce a breaking change?

No. Training and fast-eval paths are unchanged; only the slow tier switches its CI-fn readout from fp32 to bf16 and gathers the sharded histogram sample across processes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)