### PR TITLE
fix(jax-launch): set NCCL_DEBUG=WARN so slurm logs aren't flooded with collectives

### DIFF
--- a/param_decomp_lab/experiments/lm/launch.py
+++ b/param_decomp_lab/experiments/lm/launch.py
@@ -48,8 +48,11 @@ _SRUN_FLAGS = (
 # Default 0.75 caps the XLA pool too low for production steps (OOM, job 50644);
 # CUDA-graph capture (XLA command buffers) intermittently dies with
 # CUDA_ERROR_STREAM_CAPTURE_INVALIDATED on disjoint allocations — disabling
-# measured ~0% cost (8,007 vs 8,015 tok/s/GPU).
+# measured ~0% cost (8,007 vs 8,015 tok/s/GPU). NCCL_DEBUG=WARN overrides the cluster
+# default (NCCL_DEBUG=INFO / NCCL_DEBUG_SUBSYS=ALL), which logs every collective and
+# bloats the slurm logs to tens of GB per run.
 _RANK_ENV = """\
+export NCCL_DEBUG=WARN
 export XLA_PYTHON_CLIENT_MEM_FRACTION=0.92
 export XLA_FLAGS="--xla_gpu_enable_command_buffer=\""""
 


### PR DESCRIPTION
## Description

`pd-lm`'s `_RANK_ENV` now exports `NCCL_DEBUG=WARN`.

## Motivation and Context

The cluster nodes set `NCCL_DEBUG=INFO` with `NCCL_DEBUG_SUBSYS=ALL` in their environment (confirmed on both login and compute nodes), which makes NCCL log **every collective** (`AllGather: opCount … sendbuff …`). The result: slurm logs that are ~100% NCCL spam — the in-flight chunkwise pile-4L runs hit **10–12 GB each in ~30 min** (~27 GB across three jobs).

`infra/slurm.py` already documents the intended `NCCL_DEBUG=WARN`, but the `pd-lm` rank env (`_RANK_ENV`) only exported the two XLA vars, so the inherited `INFO`/`ALL` won. Exporting `WARN` in the rank command overrides it.

No effect on training — purely log volume. (The FS has plenty of headroom, so this isn't a correctness/space emergency; it just makes logs readable and avoids hundreds of GB of waste per long run.)

## How Has This Been Tested?

- `make type` / basedpyright clean; ruff clean.
- `param_decomp_lab/tests/test_launch.py`: 5 passed.
- Verified the inherited values on btdr: `NCCL_DEBUG=INFO`, `NCCL_DEBUG_SUBSYS=ALL` on login and on a running job's compute node.

## Does this PR introduce a breaking change?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)