### PR TITLE
Add experiments/mnist VPD family (memorization-vs-generalization study)

### DIFF
--- a/param_decomp_lab/eval_metrics/__init__.py
+++ b/param_decomp_lab/eval_metrics/__init__.py
@@ -15,6 +15,7 @@ from param_decomp.metrics.stochastic_hidden_acts_recon import (
     StochasticHiddenActsReconLoss,
     StochasticHiddenActsReconLossConfig,
 )
+from param_decomp.metrics.unmasked_recon import UnmaskedReconLoss, UnmaskedReconLossConfig
 from param_decomp_lab.eval_metrics.attn_patterns_recon_loss import (
     CIMaskedAttnPatternsReconLoss,
     CIMaskedAttnPatternsReconLossConfig,
@@ -53,6 +54,7 @@ AnyEvalMetricConfig = Annotated[
     | PGDReconLossConfig
     | StochasticAttnPatternsReconLossConfig
     | StochasticHiddenActsReconLossConfig
+    | UnmaskedReconLossConfig
     | UVPlotsConfig,
     Discriminator("type"),
 ]
@@ -72,6 +74,7 @@ EVAL_METRIC_CLASSES: dict[str, type[Metric[Any]]] = {
         PGDReconLoss,
         StochasticAttnPatternsReconLoss,
         StochasticHiddenActsReconLoss,
+        UnmaskedReconLoss,
         UVPlots,
     )
 }

--- a/param_decomp_lab/experiments/mnist/data.py
+++ b/param_decomp_lab/experiments/mnist/data.py
@@ -113,15 +113,22 @@ class MnistMemorizedDataset(IterableDataset[tuple[Tensor, Tensor]]):
     @override
     def __iter__(self) -> Iterator[tuple[Tensor, Tensor]]:
         n = self.images.shape[0]
+        # Always emit full `batch_size` batches (drop the partial remainder). VPD's
+        # persistent-PGD adversary sizes its per-datapoint sources from the first batch,
+        # so a smaller final batch would break the expand. With reshuffling every epoch
+        # all examples are still seen across epochs. If the set is smaller than one batch,
+        # fall back to a single full-set batch.
+        n_full = (n // self.batch_size) * self.batch_size
         gen = torch.Generator(device=self.device).manual_seed(self.seed)
-        epoch = 0
         while True:
             order = (
                 torch.randperm(n, generator=gen, device=self.device)
                 if self.shuffle
                 else torch.arange(n, device=self.device)
             )
-            for start in range(0, n, self.batch_size):
+            if n_full == 0:
+                yield self.images, self.labels
+                continue
+            for start in range(0, n_full, self.batch_size):
                 idx = order[start : start + self.batch_size]
                 yield self.images[idx], self.labels[idx]
-            epoch += 1

--- a/param_decomp_lab/experiments/mnist/data.py
+++ b/param_decomp_lab/experiments/mnist/data.py
@@ -1,0 +1,127 @@
+"""MNIST data for the memorization PD experiment.
+
+Provides the raw-tensor MNIST loader, the deterministic memorized-set builder (label
+corruption + optional subsampling), and an infinite batch iterator over the fixed
+memorized set used by both pretraining and decomposition.
+"""
+
+from collections.abc import Iterator
+from typing import override
+
+import torch
+from jaxtyping import Float, Int
+from torch import Tensor
+from torch.utils.data import IterableDataset
+from torchvision import datasets
+
+# Standard MNIST normalization constants.
+MNIST_MEAN = 0.1307
+MNIST_STD = 0.3081
+
+
+def load_raw_mnist(
+    data_dir: str, normalize: bool = True, download: bool = True
+) -> tuple[
+    Float[Tensor, "n_train 784"],
+    Int[Tensor, " n_train"],
+    Float[Tensor, "n_test 784"],
+    Int[Tensor, " n_test"],
+]:
+    """Load MNIST as flattened float tensors + integer labels (deterministic order)."""
+    train = datasets.MNIST(root=data_dir, train=True, download=download)
+    test = datasets.MNIST(root=data_dir, train=False, download=download)
+
+    def to_x(data: Tensor) -> Tensor:
+        x = data.float() / 255.0
+        if normalize:
+            x = (x - MNIST_MEAN) / MNIST_STD
+        return x.reshape(x.shape[0], -1).contiguous()
+
+    return (
+        to_x(train.data),
+        train.targets.long(),
+        to_x(test.data),
+        test.targets.long(),
+    )
+
+
+def build_memorized_set(
+    train_labels: Int[Tensor, " n_train"],
+    *,
+    label_noise_p: float,
+    label_noise_seed: int,
+    n_train_examples: int | None,
+    subsample_seed: int,
+    n_classes: int = 10,
+) -> tuple[Int[Tensor, " n"], Int[Tensor, " n"]]:
+    """Return (indices into the full MNIST train set, possibly-corrupted labels).
+
+    Subsampling (if `n_train_examples` is set) and label corruption are both deterministic
+    given their seeds. A fraction `label_noise_p` of the selected examples have their label
+    overwritten with a uniformly random class (which may coincide with the true class — at
+    p=1 this yields ~90% wrong labels, learnable only by memorization).
+    """
+    n_full = train_labels.shape[0]
+
+    # 1. Subsample a fixed index set (full set when n_train_examples is None).
+    if n_train_examples is None or n_train_examples >= n_full:
+        indices = torch.arange(n_full)
+    else:
+        gen = torch.Generator().manual_seed(subsample_seed)
+        indices = torch.randperm(n_full, generator=gen)[:n_train_examples].sort().values
+
+    labels = train_labels[indices].clone()
+
+    # 2. Corrupt a deterministic fraction of the selected labels.
+    if label_noise_p > 0.0:
+        n = labels.shape[0]
+        gen = torch.Generator().manual_seed(label_noise_seed)
+        n_corrupt = int(round(label_noise_p * n))
+        corrupt_pos = torch.randperm(n, generator=gen)[:n_corrupt]
+        random_labels = torch.randint(0, n_classes, (n_corrupt,), generator=gen)
+        labels[corrupt_pos] = random_labels
+
+    return indices, labels
+
+
+class MnistMemorizedDataset(IterableDataset[tuple[Tensor, Tensor]]):
+    """Infinite (image, label) batch iterator over a fixed in-memory memorized set.
+
+    Yields full pre-collated batches (use `DataLoader(ds, batch_size=None)`), matching the
+    resid_mlp convention. When `shuffle` is True a fresh permutation is drawn each epoch;
+    when False, batches are produced in a fixed order (used for eval so per-component
+    density/L0 are measured over the whole memorized set deterministically).
+    """
+
+    def __init__(
+        self,
+        images: Float[Tensor, "n 784"],
+        labels: Int[Tensor, " n"],
+        batch_size: int,
+        device: str,
+        shuffle: bool = True,
+        seed: int = 0,
+    ):
+        super().__init__()
+        self.images = images.to(device)
+        self.labels = labels.to(device)
+        self.batch_size = batch_size
+        self.device = device
+        self.shuffle = shuffle
+        self.seed = seed
+
+    @override
+    def __iter__(self) -> Iterator[tuple[Tensor, Tensor]]:
+        n = self.images.shape[0]
+        gen = torch.Generator(device=self.device).manual_seed(self.seed)
+        epoch = 0
+        while True:
+            order = (
+                torch.randperm(n, generator=gen, device=self.device)
+                if self.shuffle
+                else torch.arange(n, device=self.device)
+            )
+            for start in range(0, n, self.batch_size):
+                idx = order[start : start + self.batch_size]
+                yield self.images[idx], self.labels[idx]
+            epoch += 1

--- a/param_decomp_lab/experiments/mnist/models.py
+++ b/param_decomp_lab/experiments/mnist/models.py
@@ -1,0 +1,130 @@
+"""MNIST MLP target model for the memorization-vs-generalization PD experiment.
+
+A plain feed-forward classifier with named `nn.Linear` modules (`fc_in`, `fc_h.*`,
+`fc_out`) so VPD can decompose each weight matrix. The same architecture is used for
+every label-noise / size condition; only the (possibly corrupted) labels differ.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal, override
+
+import torch
+import torch.nn.functional as F
+from jaxtyping import Float, Int
+from pydantic import PositiveInt
+from torch import Tensor, nn
+
+from param_decomp.base_config import BaseConfig
+from param_decomp.schedule import ScheduleConfig
+from param_decomp_lab.infra.paths import ModelPath
+from param_decomp_lab.infra.run_files import resolve_run_files
+
+
+class MnistMLPModelConfig(BaseConfig):
+    """Architecture of the MNIST MLP target.
+
+    Modules: `fc_in` (d_input -> width), `fc_h.{0..n_hidden_layers-2}` (width -> width),
+    `fc_out` (width -> n_classes), with `act_fn` between hidden layers. `n_hidden_layers`
+    counts the hidden representations; with the default 2, the network is
+    d_input -> width (fc_in) -> width (fc_h.0) -> n_classes (fc_out).
+    """
+
+    d_input: PositiveInt = 784
+    width: PositiveInt = 2048
+    n_hidden_layers: PositiveInt = 2
+    n_classes: PositiveInt = 10
+    act_fn_name: Literal["gelu", "relu"] = "gelu"
+    bias: bool = True
+
+
+class MnistTrainConfig(BaseConfig):
+    """Training recipe for an MNIST MLP target. Identical across conditions except for
+    `label_noise_p` (and, for the size-ladder facet, `n_train_examples`)."""
+
+    wandb_project: str | None = None
+    seed: int = 0
+    mnist_model_config: MnistMLPModelConfig
+    # Fraction of training labels to randomize (0.0 = clean generalizer, 1.0 = pure memorizer).
+    label_noise_p: float = 0.0
+    label_noise_seed: int = 0
+    # Number of training examples to memorize (None = full 60k). Used by the size ladder.
+    n_train_examples: int | None = None
+    subsample_seed: int = 0
+    normalize: bool = True
+    data_dir: str
+    batch_size: PositiveInt = 1024
+    steps: PositiveInt = 20000
+    eval_every: PositiveInt = 1000
+    print_freq: PositiveInt = 200
+    lr_schedule: ScheduleConfig
+    weight_decay: float = 0.0
+
+
+MNIST_TRAIN_CONFIG_FILENAME = "mnist_train_config.yaml"
+MNIST_CHECKPOINT_FILENAME = "mnist_mlp.pth"
+# Saved (subsample-index, possibly-corrupted-label) spec so the decomposition loader
+# reproduces the exact memorized training set the target saw.
+MNIST_MEMSET_FILENAME = "memorized_dataset.pt"
+
+
+@dataclass
+class MnistTargetRunInfo:
+    """Run info from training an MNIST MLP target."""
+
+    checkpoint_path: Path
+    config: MnistTrainConfig
+    train_indices: Int[Tensor, " n"]
+    train_labels: Int[Tensor, " n"]
+
+    @classmethod
+    def from_path(cls, path: ModelPath) -> "MnistTargetRunInfo":
+        files = resolve_run_files(
+            path,
+            config_filename=MNIST_TRAIN_CONFIG_FILENAME,
+            checkpoint_filename=MNIST_CHECKPOINT_FILENAME,
+            extras_from_config_path=lambda _: [MNIST_MEMSET_FILENAME],
+        )
+        memset = torch.load(files.extras[MNIST_MEMSET_FILENAME], weights_only=True)
+        return cls(
+            checkpoint_path=files.checkpoint_path,
+            config=MnistTrainConfig.from_file(files.config_path),
+            train_indices=memset["indices"],
+            train_labels=memset["labels"],
+        )
+
+
+class MnistMLP(nn.Module):
+    def __init__(self, config: MnistMLPModelConfig):
+        super().__init__()
+        self.config = config
+        assert config.act_fn_name in ["gelu", "relu"]
+        self.act_fn = F.gelu if config.act_fn_name == "gelu" else F.relu
+
+        self.fc_in = nn.Linear(config.d_input, config.width, bias=config.bias)
+        self.fc_h = nn.ModuleList(
+            [
+                nn.Linear(config.width, config.width, bias=config.bias)
+                for _ in range(config.n_hidden_layers - 1)
+            ]
+        )
+        self.fc_out = nn.Linear(config.width, config.n_classes, bias=config.bias)
+
+    @override
+    def forward(self, x: Float[Tensor, "... d_input"]) -> Float[Tensor, "... n_classes"]:
+        x = self.act_fn(self.fc_in(x))
+        for layer in self.fc_h:
+            x = self.act_fn(layer(x))
+        return self.fc_out(x)
+
+    @classmethod
+    def from_run_info(cls, run_info: MnistTargetRunInfo) -> "MnistMLP":
+        model = cls(config=run_info.config.mnist_model_config)
+        model.load_state_dict(
+            torch.load(run_info.checkpoint_path, weights_only=True, map_location="cpu")
+        )
+        return model
+
+    @classmethod
+    def from_pretrained(cls, path: ModelPath) -> "MnistMLP":
+        return cls.from_run_info(MnistTargetRunInfo.from_path(path))

--- a/param_decomp_lab/experiments/mnist/run.py
+++ b/param_decomp_lab/experiments/mnist/run.py
@@ -1,0 +1,192 @@
+"""MNIST MLP PD experiment: YAML -> `Trainer` glue, plus the `SavedMnistRun` reload class.
+
+Run via `pd-mnist path/to/config.yaml`. Uses the categorical KL reconstruction objective
+(`recon_loss_kl`) since the target output is a 10-class logit distribution, and unwraps the
+`(image, label)` batch tuple via `run_batch_first_element`.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+import fire
+from torch.utils.data import DataLoader
+
+from param_decomp.base_config import BaseConfig
+from param_decomp.batch_and_loss_fns import RunBatch
+from param_decomp.component_model import ComponentModel
+from param_decomp.distributed import DistributedState
+from param_decomp.log import logger
+from param_decomp.optimize import EvalLoop, Trainer
+from param_decomp_lab.batch_and_loss_fns import recon_loss_kl, run_batch_first_element
+from param_decomp_lab.component_model_io import load_component_model
+from param_decomp_lab.distributed import get_device
+from param_decomp_lab.eval_metrics import EVAL_METRIC_CLASSES
+from param_decomp_lab.experiments.mnist.data import (
+    MnistMemorizedDataset,
+    load_raw_mnist,
+)
+from param_decomp_lab.experiments.mnist.models import MnistMLP, MnistTargetRunInfo
+from param_decomp_lab.experiments.utils import (
+    EXPERIMENT_CONFIG_FILENAME,
+    ExperimentConfig,
+    init_pd_run,
+)
+from param_decomp_lab.infra.paths import ModelPath
+from param_decomp_lab.infra.run_files import resolve_run_files
+from param_decomp_lab.seed import set_seed
+
+try:
+    from silico.slurm_telemetry import register_wandb_url
+except Exception:  # pragma: no cover - silico not installed
+
+    def register_wandb_url() -> None:  # type: ignore[misc]
+        return None
+
+
+class MnistTargetConfig(BaseConfig):
+    run_path: ModelPath
+
+
+class MnistDataConfig(BaseConfig):
+    """Decomposition reads the target's exact memorized set; the only knob is whether the
+    train loader reshuffles each epoch."""
+
+    shuffle_train: bool = True
+
+
+class MnistExperimentConfig(ExperimentConfig[MnistTargetConfig, MnistDataConfig]):
+    pass
+
+
+def build_target(target_cfg: MnistTargetConfig) -> MnistMLP:
+    run_info = MnistTargetRunInfo.from_path(target_cfg.run_path)
+    target_model = MnistMLP.from_run_info(run_info)
+    target_model.eval()
+    return target_model
+
+
+def build_mnist_loader(
+    target_cfg: MnistTargetConfig,
+    data_cfg: MnistDataConfig,
+    *,
+    split: Literal["train", "eval"],
+    device: str,
+    batch_size: int,
+    dist_state: DistributedState | None = None,
+    seed: int | None = None,
+) -> DataLoader[Any]:
+    """Loader over the target's exact memorized set (same images + labels it was trained on).
+
+    Train reshuffles each epoch; eval iterates the whole set in fixed order so per-component
+    density / L0 are measured deterministically over every memorized input.
+    """
+    del dist_state
+    run_info = MnistTargetRunInfo.from_path(target_cfg.run_path)
+    train_x_full, _, _, _ = load_raw_mnist(
+        run_info.config.data_dir, normalize=run_info.config.normalize
+    )
+    mem_x = train_x_full[run_info.train_indices]
+    mem_y = run_info.train_labels
+    shuffle = data_cfg.shuffle_train if split == "train" else False
+    dataset = MnistMemorizedDataset(
+        mem_x, mem_y, batch_size=batch_size, device=device, shuffle=shuffle, seed=(seed or 0)
+    )
+    return DataLoader(dataset, batch_size=None)
+
+
+def make_run_batch(target_cfg: MnistTargetConfig) -> RunBatch:
+    del target_cfg
+    return run_batch_first_element
+
+
+@dataclass(frozen=True)
+class SavedMnistRun:
+    """Handle to a completed MNIST PD run on disk or in W&B."""
+
+    cfg: MnistExperimentConfig
+    checkpoint_path: Path
+
+    @classmethod
+    def from_path(cls, path: ModelPath) -> "SavedMnistRun":
+        files = resolve_run_files(
+            path, config_filename=EXPERIMENT_CONFIG_FILENAME, checkpoint_prefix="model"
+        )
+        return cls(
+            cfg=MnistExperimentConfig.from_file(files.config_path),
+            checkpoint_path=files.checkpoint_path,
+        )
+
+    def load_model(self) -> ComponentModel:
+        return load_component_model(
+            pd_config=self.cfg.pd,
+            checkpoint_path=self.checkpoint_path,
+            target_model=build_target(self.cfg.target),
+            run_batch=make_run_batch(self.cfg.target),
+        )
+
+
+def _build_eval_loop(cfg: MnistExperimentConfig, device: str) -> EvalLoop | None:
+    if cfg.eval is None:
+        return None
+    return EvalLoop(
+        loader=build_mnist_loader(
+            cfg.target, cfg.data, split="eval", device=device, batch_size=cfg.eval.batch_size
+        ),
+        metrics=[EVAL_METRIC_CLASSES[m.type](m) for m in cfg.eval.metrics],
+        n_steps=cfg.eval.n_steps,
+        every=cfg.eval.every,
+        slow_every=cfg.eval.slow_every,
+        slow_on_first_step=cfg.eval.slow_on_first_step,
+    )
+
+
+def main(
+    config_path: str | Path,
+    *,
+    group: str | None = None,
+    tags: str | None = None,
+) -> None:
+    """Run an MNIST MLP PD experiment end-to-end from a YAML config. `group`/`tags` are
+    wandb-only."""
+    cfg = MnistExperimentConfig.from_file(config_path)
+
+    set_seed(cfg.pd.seed)
+    device = get_device()
+    logger.info(f"Using device: {device}")
+    cfg = cfg.model_copy(update={"runtime": cfg.runtime.model_copy(update={"device": device})})
+
+    target_model = build_target(cfg.target).to(device)
+
+    train_loader = build_mnist_loader(
+        cfg.target,
+        cfg.data,
+        split="train",
+        device=device,
+        batch_size=cfg.pd.batch_size,
+        seed=cfg.pd.seed,
+    )
+    eval_loop = _build_eval_loop(cfg, device)
+
+    sink = init_pd_run(cfg, group=group, tags=tags)
+    register_wandb_url()
+
+    try:
+        trainer = Trainer(
+            target_model=target_model,
+            run_batch=make_run_batch(cfg.target),
+            reconstruction_loss=recon_loss_kl,
+            pd_config=cfg.pd,
+            runtime_config=cfg.runtime,
+        )
+        trainer.run(train_loader, sink, cfg.cadence, eval_loop)
+    finally:
+        sink.finish()
+
+
+def cli() -> None:
+    fire.Fire(main)
+
+
+if __name__ == "__main__":
+    cli()

--- a/param_decomp_lab/experiments/mnist/train_mnist.py
+++ b/param_decomp_lab/experiments/mnist/train_mnist.py
@@ -1,0 +1,190 @@
+"""Pretrain an MNIST MLP target for the memorization PD experiment.
+
+YAML-driven (`pd-mnist-pretrain path/to/train_config.yaml`). Trains the same architecture
+and recipe across conditions; only `label_noise_p` (and, for the size ladder,
+`n_train_examples`) change. Saves the checkpoint, the train config, and the exact
+memorized-set spec (subsample indices + possibly-corrupted labels) so the decomposition
+loader can reproduce the training distribution.
+"""
+
+from pathlib import Path
+
+import fire
+import torch
+import wandb
+from jaxtyping import Float, Int
+from torch import Tensor
+
+from param_decomp.log import logger
+from param_decomp.schedule import get_scheduled_value
+from param_decomp_lab.distributed import get_device
+from param_decomp_lab.experiments.mnist.data import (
+    MnistMemorizedDataset,
+    build_memorized_set,
+    load_raw_mnist,
+)
+from param_decomp_lab.experiments.mnist.models import (
+    MNIST_CHECKPOINT_FILENAME,
+    MNIST_MEMSET_FILENAME,
+    MNIST_TRAIN_CONFIG_FILENAME,
+    MnistMLP,
+    MnistTrainConfig,
+)
+from param_decomp_lab.infra.run_files import ExecutionStamp, save_file
+from param_decomp_lab.infra.wandb import init_wandb
+from param_decomp_lab.seed import set_seed
+
+# Optional silico live-telemetry integration (no-op when silico is absent).
+try:
+    from silico.slurm_telemetry import register_wandb_url, report_progress
+except Exception:  # pragma: no cover - silico not installed
+
+    def register_wandb_url() -> None:  # type: ignore[misc]
+        return None
+
+    def report_progress(**_: object) -> None:  # type: ignore[misc]
+        return None
+
+
+@torch.no_grad()
+def accuracy(
+    model: MnistMLP,
+    images: Float[Tensor, "n 784"],
+    labels: Int[Tensor, " n"],
+    chunk: int = 10000,
+) -> float:
+    model.eval()
+    correct = 0
+    for start in range(0, images.shape[0], chunk):
+        logits = model(images[start : start + chunk])
+        correct += (logits.argmax(-1) == labels[start : start + chunk]).sum().item()
+    model.train()
+    return correct / images.shape[0]
+
+
+def run_train(config: MnistTrainConfig, device: str) -> dict[str, float]:
+    stamp = ExecutionStamp.create(run_type="train", create_snapshot=False)
+    out_dir = stamp.out_dir
+    logger.info(f"Run ID: {stamp.run_id}  out_dir: {out_dir}")
+
+    model_cfg = config.mnist_model_config
+    run_name = (
+        f"mnist_mlp_p{config.label_noise_p}_N{config.n_train_examples or 60000}"
+        f"_w{model_cfg.width}_L{model_cfg.n_hidden_layers}_seed{config.seed}"
+    )
+
+    if config.wandb_project:
+        init_wandb(
+            project=config.wandb_project,
+            run_id=stamp.run_id,
+            config=config,
+            name=run_name,
+            tags=[
+                "mnist-target",
+                f"p{config.label_noise_p}",
+                f"N{config.n_train_examples or 60000}",
+            ],
+        )
+        register_wandb_url()
+        print(f"WANDB_URL {wandb.run.get_url()}", flush=True)  # type: ignore[union-attr]
+
+    # --- Data: build the (possibly corrupted, possibly subsampled) memorized set. ---
+    train_x_full, train_y_full, test_x, test_y = load_raw_mnist(
+        config.data_dir, normalize=config.normalize
+    )
+    indices, mem_labels = build_memorized_set(
+        train_y_full,
+        label_noise_p=config.label_noise_p,
+        label_noise_seed=config.label_noise_seed,
+        n_train_examples=config.n_train_examples,
+        subsample_seed=config.subsample_seed,
+        n_classes=model_cfg.n_classes,
+    )
+    mem_x = train_x_full[indices].to(device)
+    mem_y = mem_labels.to(device)
+    test_x, test_y = test_x.to(device), test_y.to(device)
+    # Clean (true) labels of the memorized examples, for a "memorization gap" readout.
+    clean_mem_y = train_y_full[indices].to(device)
+    frac_corrupted = (mem_y != clean_mem_y).float().mean().item()
+    logger.info(
+        f"Memorized set: N={mem_x.shape[0]}, fraction labels != true = {frac_corrupted:.3f}"
+    )
+
+    # --- Save config + memorized-set spec up front (so resume/inspection works). ---
+    save_file(config.model_dump(mode="json"), out_dir / MNIST_TRAIN_CONFIG_FILENAME)
+    save_file(
+        {"indices": indices.cpu(), "labels": mem_labels.cpu()},
+        out_dir / MNIST_MEMSET_FILENAME,
+    )
+
+    model = MnistMLP(model_cfg).to(device)
+    model.train()
+    optimizer = torch.optim.AdamW(
+        model.parameters(),
+        lr=config.lr_schedule.start_val,
+        weight_decay=config.weight_decay,
+    )
+
+    loader = MnistMemorizedDataset(
+        mem_x, mem_y, batch_size=config.batch_size, device=device, shuffle=True, seed=config.seed
+    )
+    data_iter = iter(loader)
+
+    for step in range(config.steps):
+        lr = get_scheduled_value(step, config.steps, config.lr_schedule)
+        for g in optimizer.param_groups:
+            g["lr"] = lr
+
+        batch_x, batch_y = next(data_iter)
+        optimizer.zero_grad()
+        logits = model(batch_x)
+        loss = torch.nn.functional.cross_entropy(logits, batch_y)
+        loss.backward()
+        optimizer.step()
+
+        if step % config.print_freq == 0:
+            logger.info(f"step {step}: loss={loss.item():.4e} lr={lr:.2e}")
+            if config.wandb_project:
+                wandb.log({"train/loss": loss.item(), "train/lr": lr}, step=step)
+        if step % config.eval_every == 0 or step == config.steps - 1:
+            train_acc = accuracy(model, mem_x, mem_y)
+            test_acc = accuracy(model, test_x, test_y)
+            logger.info(f"step {step}: train_acc={train_acc:.4f} test_acc={test_acc:.4f}")
+            if config.wandb_project:
+                wandb.log({"eval/train_acc": train_acc, "eval/test_acc": test_acc}, step=step)
+        report_progress(step=step + 1, total_steps=config.steps, phase="train")
+
+    train_acc = accuracy(model, mem_x, mem_y)
+    test_acc = accuracy(model, test_x, test_y)
+    save_file(model.state_dict(), out_dir / MNIST_CHECKPOINT_FILENAME)
+    logger.info(f"FINAL: train_acc={train_acc:.4f} test_acc={test_acc:.4f}  saved to {out_dir}")
+
+    metrics = {
+        "final_train_acc": train_acc,
+        "final_test_acc": test_acc,
+        "frac_corrupted": frac_corrupted,
+        "n_train": float(mem_x.shape[0]),
+    }
+    if config.wandb_project:
+        wandb.log({f"final/{k}": v for k, v in metrics.items()}, step=config.steps - 1)
+        wandb.summary.update(
+            {"run_dir": str(out_dir), **{f"final/{k}": v for k, v in metrics.items()}}
+        )
+        wandb.finish()
+    return metrics
+
+
+def main(config_path: str | Path) -> None:
+    config = MnistTrainConfig.from_file(config_path)
+    set_seed(config.seed)
+    device = get_device()
+    logger.info(f"Using device: {device}")
+    run_train(config, device)
+
+
+def cli() -> None:
+    fire.Fire(main)
+
+
+if __name__ == "__main__":
+    cli()

--- a/param_decomp_lab/pyproject.toml
+++ b/param_decomp_lab/pyproject.toml
@@ -32,6 +32,8 @@ dependencies = [
 # Per-experiment runners — directly invoke the experiment's `main`.
 pd-tms = "param_decomp_lab.experiments.tms.run:cli"
 pd-resid-mlp = "param_decomp_lab.experiments.resid_mlp.run:cli"
+pd-mnist-pretrain = "param_decomp_lab.experiments.mnist.train_mnist:cli"
+pd-mnist = "param_decomp_lab.experiments.mnist.run:cli"
 pd-lm = "param_decomp_lab.experiments.lm.run:cli"
 pd-lm-layerwise = "param_decomp_lab.experiments.lm.layerwise:cli"
 pd-pretrain = "param_decomp_lab.experiments.lm.pretrain.cli:cli"
@@ -76,6 +78,7 @@ packages = [
     "param_decomp_lab.experiments.lm",
     "param_decomp_lab.experiments.lm.pretrain",
     "param_decomp_lab.experiments.lm.pretrain.models",
+    "param_decomp_lab.experiments.mnist",
     "param_decomp_lab.experiments.resid_mlp",
     "param_decomp_lab.experiments.tms",
     "param_decomp_lab.graph_interp",


### PR DESCRIPTION
Adds a reusable MNIST MLP experiment family for adVersarial Parameter Decomposition (VPD), mirroring `experiments/resid_mlp`, used for the memorization-vs-generalization decomposition study (Silico issue 6).

## What's added
- `param_decomp_lab/experiments/mnist/`
  - `models.py` — `MnistMLP` (named `fc_in`/`fc_h.*`/`fc_out` Linears, GELU) + train config + `MnistTargetRunInfo`
  - `data.py` — raw-tensor MNIST loader, deterministic label-corruption/subsample builder, full-batch memorized-set iterator (drops the partial final batch so VPD's per-datapoint persistent-PGD adversary stays batch-uniform)
  - `train_mnist.py` — `pd-mnist-pretrain` CLI (label-noise sweep + size ladder)
  - `run.py` — `pd-mnist` CLI, categorical KL reconstruction path (`recon_loss_kl`) + `run_batch_first_element`, `SavedMnistRun`
- `pd-mnist-pretrain` / `pd-mnist` entry points in `param_decomp_lab/pyproject.toml`
- Registered the existing generic `UnmaskedReconLoss` as a YAML eval metric (gives the `kl_unmasked` faithfulness check on categorical, non-LM targets; `CEandKLLosses` is LM-only)

## Result (Silico issue 6)
At matched decomposition faithfulness, a pure memorizer decomposes into ~130x more live components (and ~240x more per input) than a generalizer, but the components are distributed/redundant, not per-example (density, ablation, and specimen evidence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)