### PR TITLE
refactor(sharding): model-owned placement (Megatron CI fn) — delete inferred shardable + replicate-fallback

### DIFF
--- a/param_decomp/ci_fn.py
+++ b/param_decomp/ci_fn.py
@@ -30,9 +30,12 @@ import einops
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, Float, PRNGKeyArray
 
 from param_decomp.components import SiteSpec
+from param_decomp.sharding import assert_divisible
 from vendored_jax.llama import apply_rope, attn_implementation, rms_norm, rope_cos_sin
 
 CI_FN_RMS_EPS = float(jnp.finfo(jnp.float32).eps)
@@ -105,6 +108,12 @@ class CIFn(Protocol):
 
     def __call__(self, taps: dict[str, Array]) -> CI: ...
 
+    def shardings(self, mesh: Mesh) -> "CIFn":
+        """Per-leaf `dp` placement matching this CI fn's pytree structure (each array leaf
+        → a `NamedSharding`; `P()` to replicate). Asserts every declared shard axis tiles
+        the mesh. Applied via `jax.jit(init, out_shardings=...)`."""
+        ...
+
 
 # ----------------------------- transformer building blocks -----------------------------
 
@@ -127,6 +136,41 @@ class CIBlock(eqx.Module):
     b2: Array
     n_head: int = eqx.field(static=True)
     eps: float = eqx.field(static=True)
+
+    def shardings(self, mesh: Mesh) -> "CIBlock":
+        """Megatron-style placement, with a leading un-sharded `n_chunks` axis (flat dp;
+        chunk-parallel out of scope). All arrays are stored `[n_chunks, ...]`.
+
+        Attention col/row-parallel: qkv (`[nc, out, in]`) shard their OUTPUT (head) dim
+        (axis 1) so each device owns a head slab; the out-proj shards its INPUT dim (axis 2),
+        so the per-head attention output flows sharded and a single all-reduce closes it.
+
+        MLP row-parallel: up-proj `w1 [nc, d_model, mlp_hidden]` shards its OUTPUT
+        (`mlp_hidden`, axis 2); down-proj `w2 [nc, mlp_hidden, d_model]` shards its INPUT
+        (`mlp_hidden`, axis 1). The hidden flows sharded; no intermediate gather. Biases
+        replicate."""
+        shard_axis1 = NamedSharding(mesh, P(None, "dp", None))
+        shard_axis2 = NamedSharding(mesh, P(None, None, "dp"))
+        repl = NamedSharding(mesh, P())
+        for w in (self.wq, self.wk, self.wv):
+            assert_divisible(w.shape[1], mesh, "CIBlock attn qkv out (head dim)")
+        assert_divisible(self.wo.shape[2], mesh, "CIBlock attn out-proj in (head dim)")
+        assert_divisible(self.w1.shape[2], mesh, "CIBlock mlp up-proj out (mlp_hidden)")
+        assert_divisible(self.w2.shape[1], mesh, "CIBlock mlp down-proj in (mlp_hidden)")
+        return eqx.tree_at(
+            lambda b: (b.wq, b.wk, b.wv, b.wo, b.w1, b.b1, b.w2, b.b2),
+            self,
+            (
+                shard_axis1,
+                shard_axis1,
+                shard_axis1,
+                shard_axis2,
+                shard_axis2,
+                repl,
+                shard_axis1,
+                repl,
+            ),
+        )
 
     def __call__(self, x: Float[Array, "b t d"], inv_freq: Array) -> Array:
         t = x.shape[1]
@@ -206,6 +250,20 @@ class ChunkTransformer(eqx.Module):
     out_w: Float[Array, "d_model c_chunk"]
     out_b: Float[Array, " c_chunk"]
 
+    def shardings(self, mesh: Mesh) -> "ChunkTransformer":
+        """Per-leaf `dp` placement, leading un-sharded `n_chunks` axis. `in_proj_w
+        [nc, total_d_in, d_model]` shards `d_model` (axis 2); `out_w [nc, d_model, c_chunk]`
+        shards `c_chunk` (axis 2); blocks delegate to `CIBlock.shardings`; biases replicate."""
+        shard_last = NamedSharding(mesh, P(None, None, "dp"))
+        repl = NamedSharding(mesh, P())
+        assert_divisible(self.in_proj_w.shape[2], mesh, "ChunkTransformer in_proj_w d_model")
+        assert_divisible(self.out_w.shape[2], mesh, "ChunkTransformer out_w c_chunk")
+        return eqx.tree_at(
+            lambda ct: (ct.in_proj_w, ct.in_proj_b, ct.blocks, ct.out_w, ct.out_b),
+            self,
+            (shard_last, repl, [b.shardings(mesh) for b in self.blocks], shard_last, repl),
+        )
+
     def __call__(self, x: Float[Array, "*leading total_d_in"], inv_freq: Array) -> Array:
         x = einops.einsum(x, self.in_proj_w, "... i, i o -> ... o") + self.in_proj_b
         for block in self.blocks:
@@ -227,6 +285,15 @@ class ChunkwiseTransformerCIFn(eqx.Module):
     chunk_meta: tuple[_ChunkMeta, ...] = eqx.field(static=True)  # per-chunk routing
     eps: float = eqx.field(static=True)
     expects_axes: tuple[str, ...] = eqx.field(static=True)
+
+    def shardings(self, mesh: Mesh) -> "ChunkwiseTransformerCIFn":
+        """The stacked per-chunk transformer's Megatron layout (`ChunkTransformer.shardings`,
+        leading `n_chunks` axis un-sharded); `inv_freq` (a 1-D RoPE buffer) replicates."""
+        return eqx.tree_at(
+            lambda f: (f.chunks, f.inv_freq),
+            self,
+            (self.chunks.shardings(mesh), NamedSharding(mesh, P())),
+        )
 
     def __call__(self, taps: dict[str, Array]) -> CI:
         per_chunk_in = [
@@ -361,6 +428,19 @@ class SiteMLP(eqx.Module):
     weights: list[Float[Array, "d_in d_out"]]
     biases: list[Float[Array, " d_out"]]
 
+    def shardings(self, mesh: Mesh) -> "SiteMLP":
+        """Each `[d_in, d_out]` weight shards its OUTPUT axis (axis 1) over `dp`; 1-D biases
+        replicate. Asserts every output dim tiles the mesh."""
+        shard_out = NamedSharding(mesh, P(None, "dp"))
+        repl = NamedSharding(mesh, P())
+        for layer_idx, w in enumerate(self.weights):
+            assert_divisible(w.shape[1], mesh, f"SiteMLP.weights[{layer_idx}].d_out")
+        return eqx.tree_at(
+            lambda m: (m.weights, m.biases),
+            self,
+            ([shard_out] * len(self.weights), [repl] * len(self.biases)),
+        )
+
     def __call__(self, x: Float[Array, "*leading d_in"]) -> Float[Array, "*leading C"]:
         n_hidden = len(self.weights) - 1
         for layer_idx, (w, b) in enumerate(zip(self.weights, self.biases, strict=True)):
@@ -378,6 +458,13 @@ class LayerwiseMLPCIFn(eqx.Module):
     input_names: tuple[str, ...] = eqx.field(static=True)
     output_names: tuple[str, ...] = eqx.field(static=True)
     expects_axes: tuple[str, ...] = eqx.field(static=True)
+
+    def shardings(self, mesh: Mesh) -> "LayerwiseMLPCIFn":
+        return eqx.tree_at(
+            lambda f: f.site_mlps,
+            self,
+            {name: mlp.shardings(mesh) for name, mlp in self.site_mlps.items()},
+        )
 
     def site_logits(self, taps: dict[str, Array]) -> dict[str, Array]:
         assert set(taps) == set(self.input_names), (
@@ -439,6 +526,9 @@ class GlobalMLPCIFn(eqx.Module):
     in_sizes: tuple[int, ...] = eqx.field(static=True)
     c_sizes: tuple[int, ...] = eqx.field(static=True)
     expects_axes: tuple[str, ...] = eqx.field(static=True)
+
+    def shardings(self, mesh: Mesh) -> "GlobalMLPCIFn":
+        return eqx.tree_at(lambda f: f.mlp, self, self.mlp.shardings(mesh))
 
     def site_logits(self, taps: dict[str, Array]) -> dict[str, Array]:
         assert set(taps) == set(self.input_names), (

--- a/param_decomp/components.py
+++ b/param_decomp/components.py
@@ -13,7 +13,11 @@ from dataclasses import dataclass
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, Float
+
+from param_decomp.sharding import assert_divisible
 
 
 @dataclass(frozen=True)
@@ -42,6 +46,18 @@ class DecompVU(eqx.Module):
 
     def site(self, name: str) -> tuple[Array, Array]:
         return self.vu[name]
+
+    def shardings(self, mesh: "Mesh") -> "DecompVU":
+        """Per-leaf `dp` placement matching this tree's structure: V `(d_in, C)` shards its
+        C axis (axis 1), U `(C, d_out)` shards its C axis (axis 0). Asserts every site's C
+        tiles the mesh."""
+        shard_V = NamedSharding(mesh, P(None, "dp"))
+        shard_U = NamedSharding(mesh, P("dp", None))
+        placed: dict[str, tuple[NamedSharding, NamedSharding]] = {}
+        for name, (V, _U) in self.vu.items():
+            assert_divisible(V.shape[1], mesh, f"DecompVU[{name}].V.C")
+            placed[name] = (shard_V, shard_U)
+        return DecompVU(vu=placed)  # pyright: ignore[reportArgumentType]
 
 
 def init_decomp_vu(sites: tuple[SiteSpec, ...], key: Array) -> DecompVU:

--- a/param_decomp/experiments/llama8b_real.py
+++ b/param_decomp/experiments/llama8b_real.py
@@ -75,7 +75,7 @@ from param_decomp.targets.llama8b_sharding import (
     init_ci_fn_placed,
     init_decomp_vu_placed,
     init_sources_sharded,
-    replicate_target,
+    place_target,
     shard_batch,
 )
 from param_decomp.train import TrainState, make_faith_warmup_step, make_train_step
@@ -191,13 +191,12 @@ def main():
     )
     opt_ci = optax.adamw(sched_ci, b1=0.9, b2=0.999, eps=1e-8, weight_decay=0.0)
 
-    lm = replicate_target(lm, mesh)
+    lm = place_target(lm, mesh)
     site_Cs = tuple(s.C for s in lm.sites)
     # fp32 masters; source init U[0,1] (SPEC S15), trailing channel = the weight-delta source.
     if args.shard:
-        shardable = ndev > 1 and all(s.C % ndev == 0 for s in lm.sites)
-        vu = init_decomp_vu_placed(lm.sites, random.PRNGKey(1), mesh, shardable)
-        ci_fn = init_ci_fn_placed(arch, lm.sites, random.PRNGKey(2), mesh, shardable)
+        vu = init_decomp_vu_placed(lm.sites, random.PRNGKey(1), mesh)
+        ci_fn = init_ci_fn_placed(arch, lm.sites, random.PRNGKey(2), mesh)
         src = init_sources_sharded(
             lm.site_names, site_Cs, args.seq, SCScope(), 1, random.PRNGKey(3), mesh
         )

--- a/param_decomp/experiments/mem_probe.py
+++ b/param_decomp/experiments/mem_probe.py
@@ -63,35 +63,60 @@ from param_decomp.targets.llama8b_sharding import dp_mesh
 from param_decomp.train import TrainState, make_train_step
 
 
+def _attach(leaves_tree: Any, shardings_tree: Any) -> Any:
+    """Re-attach a same-structure tree of `NamedSharding`s onto a tree of abstract
+    `ShapeDtypeStruct` leaves."""
+    return jax.tree.map(
+        lambda leaf, sharding: jax.ShapeDtypeStruct(leaf.shape, leaf.dtype, sharding=sharding),
+        leaves_tree,
+        shardings_tree,
+        is_leaf=lambda x: isinstance(x, jax.ShapeDtypeStruct),
+    )
+
+
 def _place_state(typed: TrainState, mesh: Mesh) -> TrainState:
-    """Attach the trainer's GSPMD shardings to the typed abstract `TrainState`,
-    re-deriving the `llama8b_sharding.py` placement per leaf from its field group +
-    shape (so the Adam mu/nu mirror their params):
+    """Attach the trainer's GSPMD shardings to the typed abstract `TrainState`, reusing each
+    param owner's OWN `.shardings` (so the probe sees the exact production placement, incl.
+    the chunkwise CI fn's Megatron layout). The Adam mu/nu mirror their params' shardings;
+    every other leaf (sources/SCScope, scalars/1-D, opt counts) replicates."""
+    comp_shardings = typed.components.shardings(mesh)
+    ci_shardings = typed.ci_fn.shardings(mesh)
+    components = _attach(typed.components, comp_shardings)
+    ci_fn = _attach(typed.ci_fn, ci_shardings)
+    components_opt_state = _place_adam_state(typed.components_opt_state, comp_shardings, mesh)
+    ci_fn_opt_state = _place_adam_state(typed.ci_fn_opt_state, ci_shardings, mesh)
+    return eqx.tree_at(
+        lambda s: (s.components, s.ci_fn, s.components_opt_state, s.ci_fn_opt_state,
+                   s.sources, s.sources_opt_state, s.step),
+        typed,
+        (components, ci_fn, components_opt_state, ci_fn_opt_state,
+         _abstract_replicated(typed.sources, mesh),
+         _abstract_replicated(typed.sources_opt_state, mesh),
+         _abstract_replicated(typed.step, mesh)),
+    )  # fmt: skip
 
-      components V `(d_in, C)` -> P(None, 'dp'); U `(C, d_out)` -> P('dp', None)
-      ci_fn 2-D weight with `dp`-divisible last axis -> P(None, 'dp'); else replicate
-      sources (SCScope), all scalars/1-D, opt counts -> replicate
-    """
-    n = mesh.devices.size
-    repl = NamedSharding(mesh, P())
-    model_dims = {4096, 14336}  # Llama-8B d_model / d_mlp; the C axis is neither
 
-    def place(path: tuple[Any, ...], leaf: Any) -> Any:
-        group = str(getattr(path[0], "key", getattr(path[0], "name", getattr(path[0], "idx", ""))))
-        if leaf.ndim == 2 and group.startswith("components"):
-            # V `(d_in, C)` shards axis 1, U `(C, d_out)` shards axis 0; the C axis is
-            # the one NOT a model dim (V/U Adam mu/nu share their param's layout).
-            c_axis = 0 if leaf.shape[0] not in model_dims else 1
-            spec = ["dp" if ax == c_axis else None for ax in range(2)]
-            sharding = NamedSharding(mesh, P(*spec))
-        elif leaf.ndim == 2 and group.startswith("ci_fn") and leaf.shape[-1] % n == 0:
-            sharding = NamedSharding(mesh, P(None, "dp"))
-        else:
-            sharding = repl
-        return jax.ShapeDtypeStruct(leaf.shape, leaf.dtype, sharding=sharding)
+def _place_adam_state(opt_state: Any, param_shardings: Any, mesh: Mesh) -> Any:
+    """Place an optax AdamW state: the `mu`/`nu` param-shaped subtrees mirror their params'
+    shardings; every scalar (the `count`s, the global-norm clip's `EmptyState`) replicates.
+    The param-shaped subtrees are exactly the members of `opt_state` whose pytree structure
+    equals `param_shardings`."""
+    param_treedef = jax.tree.structure(
+        param_shardings, is_leaf=lambda x: isinstance(x, NamedSharding)
+    )
 
-    return jax.tree_util.tree_map_with_path(
-        place, typed, is_leaf=lambda x: isinstance(x, jax.ShapeDtypeStruct)
+    def is_param_subtree(member: Any) -> bool:
+        return (
+            jax.tree.structure(member, is_leaf=lambda x: isinstance(x, jax.ShapeDtypeStruct))
+            == param_treedef
+        )
+
+    return jax.tree.map(
+        lambda m: _attach(m, param_shardings)
+        if is_param_subtree(m)
+        else _abstract_replicated(m, mesh),
+        opt_state,
+        is_leaf=is_param_subtree,
     )
 
 

--- a/param_decomp/lm.py
+++ b/param_decomp/lm.py
@@ -26,6 +26,7 @@ frozen 8B target captured as a constant bakes multi-GB weights into the HLO.
 from typing import Any, Protocol, runtime_checkable
 
 import jax.numpy as jnp
+from jax.sharding import Mesh
 from jaxtyping import Array, Bool, Float
 
 from param_decomp.components import DecompVU, SiteSpec
@@ -75,6 +76,13 @@ class DecomposedModel(Protocol):
 
     @property
     def site_names(self) -> tuple[str, ...]: ...
+
+    def shardings(self, mesh: Mesh) -> "DecomposedModel":
+        """Per-leaf `dp` placement of the frozen target weights, matching this model's
+        pytree structure (each array leaf → a `NamedSharding`). The frozen target is
+        REPLICATED on every device (small relative to activations; replicating avoids
+        all-gathering it every forward). Applied via `jax.jit(..., out_shardings=...)`."""
+        ...
 
     def recon_loss_fn(self, masked_output: Any, clean_output: Any) -> Float[Array, ""]:
         """Recon comparison the step minimizes (SPEC §2.3). LM: `kl_per_position`."""

--- a/param_decomp/run_state.py
+++ b/param_decomp/run_state.py
@@ -116,13 +116,10 @@ def init_train_state(
     mesh: Mesh,
 ) -> TrainState:
     ci_key = random.fold_in(init_key, 1)
-    # Sharding is a SCALE decision, not an arch one: C-shard V/U + CI when the mesh has >1
-    # device and every site's C tiles it; otherwise replicate (single-device / toy meshes,
-    # or C not dividing the mesh). Same path for every CI-fn arch.
-    n = mesh.devices.size
-    shardable = n > 1 and all(s.C % n == 0 for s in lm.sites)
-    components = init_decomp_vu_placed(lm.sites, init_key, mesh, shardable)
-    ci_fn = init_ci_fn_placed(ci_fn_arch, lm.sites, ci_key, mesh, shardable)
+    # Placement is MODEL-OWNED: V/U + CI declare their own per-leaf shardings (asserting
+    # divisibility), uniformly across mesh sizes — no scale inference, no replicate fallback.
+    components = init_decomp_vu_placed(lm.sites, init_key, mesh)
+    ci_fn = init_ci_fn_placed(ci_fn_arch, lm.sites, ci_key, mesh)
     assert ci_fn.expects_axes == lm.leading_axes, (
         f"CI fn expects leading axes {ci_fn.expects_axes} but model has {lm.leading_axes}"
     )

--- a/param_decomp/sharding.py
+++ b/param_decomp/sharding.py
@@ -52,6 +52,29 @@ def dp_mesh() -> Mesh:
     return Mesh(np.array(jax.devices()), axis_names=("dp",))
 
 
+def place_via_shardings[T](tree: T, shardings: T) -> T:
+    """Eager `device_put` of each array leaf of `tree` onto the matching `NamedSharding`
+    leaf of `shardings` (a same-structure pytree, e.g. from a model's `.shardings(mesh)`).
+    Static / non-array leaves pass through. The apply path for an already-loaded frozen
+    model (vs the jitted `out_shardings` init path for freshly-seeded params)."""
+    is_array = lambda x: hasattr(x, "shape") and hasattr(x, "dtype")  # noqa: E731
+    return jax.tree.map(
+        lambda a, s: jax.device_put(a, s) if is_array(a) else a,
+        tree,
+        shardings,
+        is_leaf=lambda x: isinstance(x, NamedSharding),
+    )
+
+
+def assert_divisible(dim: int, mesh: Mesh, what: str) -> None:
+    """Fail loud if a declared `dp`-shard axis cannot tile the mesh. Uniform across mesh
+    sizes — at `n == 1` it is trivially true, so there is no single-device special case.
+    `what` names the model / field / axis so a non-dividing dim crashes with a clear
+    message rather than silently replicating."""
+    n = mesh.devices.size
+    assert dim % n == 0, f"{what}: dim {dim} not divisible by mesh size {n}"
+
+
 def batch_shard_leading(x: jax.Array, mesh: Mesh | None) -> jax.Array:
     """In-jit `with_sharding_constraint` pinning the LEADING (batch) axis to `'dp'`, the
     rest replicated. `mesh is None` (single device) is a passthrough. Keeps the masked

--- a/param_decomp/targets/llama8b.py
+++ b/param_decomp/targets/llama8b.py
@@ -24,6 +24,8 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, Float
 from safetensors import safe_open
 
@@ -314,6 +316,13 @@ class LlamaDecomposedModel(eqx.Module):
     @property
     def site_names(self) -> tuple[str, ...]:
         return tuple(s.name for s in self.sites)
+
+    def shardings(self, mesh: "Mesh") -> "LlamaDecomposedModel":
+        """Replicate every frozen leaf on the `dp` mesh (the FSDP-style memory story: the
+        ~3.6B bf16 suffix is small vs activations, so replicating avoids all-gathering the
+        target each forward)."""
+        repl = NamedSharding(mesh, P())
+        return jax.tree.map(lambda _a: repl, self)
 
     @staticmethod
     def recon_loss_fn(masked_output: Array, clean_output: Array) -> Array:

--- a/param_decomp/targets/llama8b_sharding.py
+++ b/param_decomp/targets/llama8b_sharding.py
@@ -21,10 +21,19 @@ The memory consumers, and how each is placed on the 1-D `dp` mesh:
 Sharding V/U over the C axis keeps every einsum valid: `x @ V` contracts d_in and
 produces a C-sharded result; `(.) @ U` contracts the sharded C and `jax.jit` inserts
 the reduce-scatter / all-reduce. No manual collectives.
+
+Placement is MODEL-OWNED: each param owner declares its per-leaf `NamedSharding` via a
+`.shardings(mesh)` method (V/U on `DecompVU`, the Megatron layout on the chunkwise CI fn,
+all-replicate on the frozen target). The helpers below only drive the apply: compute the
+shardings on the `eqx.filter_eval_shape`'d abstract model, then run the seeded init under
+`jax.jit(init, out_shardings=...)` so each device generates only its own shard and no
+host-side full tree exists — eager `device_put` of a host tree onto a multi-process
+non-replicated sharding triggers a `process_allgather` (a 168 GiB allocation for a
+12-layer chunk at C=24576). A non-dividing declared shard axis is a loud crash inside
+`.shardings` (fail-fast), never a silent replicate.
 """
 
 from functools import partial
-from typing import Any
 
 import equinox as eqx
 import jax
@@ -36,14 +45,13 @@ from param_decomp.adversary import init_persistent_sources
 from param_decomp.ci_fn import CIFn, CIFnArch, build_ci_fn
 from param_decomp.components import DecompVU, SiteSpec, init_decomp_vu
 from param_decomp.configs import BSCScope, SCScope
-from param_decomp.log import logger
-from param_decomp.sharding import dp_mesh
+from param_decomp.sharding import dp_mesh, place_via_shardings
 from param_decomp.sharding import shard_batch as _generic_shard_batch
 from param_decomp.targets.llama8b import LlamaDecomposedModel
 
 __all__ = [
     "dp_mesh",
-    "replicate_target",
+    "place_target",
     "init_decomp_vu_placed",
     "init_ci_fn_placed",
     "init_sources_sharded",
@@ -51,85 +59,29 @@ __all__ = [
 ]
 
 
-def _put(x: Any, sharding: NamedSharding) -> Any:
-    return jax.device_put(x, sharding) if eqx.is_array(x) else x
+def place_target(tgt: LlamaDecomposedModel, mesh: Mesh) -> LlamaDecomposedModel:
+    """Eager `device_put` of the already-loaded frozen target onto its own declared
+    placement (`tgt.shardings(mesh)` — all-replicate)."""
+    return place_via_shardings(tgt, tgt.shardings(mesh))
 
 
-def replicate_target(tgt: LlamaDecomposedModel, mesh: Mesh) -> LlamaDecomposedModel:
-    repl = NamedSharding(mesh, P())
-    return jax.tree.map(lambda a: _put(a, repl), tgt)
-
-
-def init_decomp_vu_placed(
-    sites: tuple[SiteSpec, ...], key: PRNGKeyArray, mesh: Mesh, shardable: bool
-) -> DecompVU:
-    """Seeded per-site V/U init, placed by SCALE (not by CI-fn arch). `shardable` (the
-    caller's scale decision: mesh > 1 and every C divides it) → C-sharded; else replicated.
-
-    Either way the init runs under jit with `out_shardings`, so each device generates only
-    its own shard and no host-side full tree exists — eager `device_put` of a host tree onto
-    a multi-process non-replicated sharding triggers a `process_allgather` (a 168 GiB
-    allocation for a 12-layer chunk at C=24576). When sharded, per site: V `(d_in, C_s)` on
-    axis 1; U `(C_s, d_out)` on axis 0."""
+def init_decomp_vu_placed(sites: tuple[SiteSpec, ...], key: PRNGKeyArray, mesh: Mesh) -> DecompVU:
+    """Seeded per-site V/U init placed by `DecompVU.shardings` (V `(d_in, C)` shards axis 1,
+    U `(C, d_out)` shards axis 0). The shardings are computed on the abstract model and the
+    init runs under jit with `out_shardings`."""
     init = partial(init_decomp_vu, sites)
-    if not shardable:
-        return jax.jit(init, out_shardings=NamedSharding(mesh, P()))(key)
-    site_c = {spec.name: spec.C for spec in sites}
-    shard_V = NamedSharding(mesh, P(None, "dp"))
-    shard_U = NamedSharding(mesh, P("dp", None))
-
-    def place(path: tuple[Any, ...], shape: jax.ShapeDtypeStruct) -> NamedSharding:
-        *_, site_key, vu_key = path
-        assert isinstance(site_key, jax.tree_util.DictKey), path
-        assert isinstance(vu_key, jax.tree_util.SequenceKey), path
-        is_V = vu_key.idx == 0
-        assert shape.shape[1 if is_V else 0] == site_c[site_key.key], (path, shape.shape)
-        return shard_V if is_V else shard_U
-
-    out_shardings = jax.tree_util.tree_map_with_path(place, jax.eval_shape(init, key))
+    out_shardings = eqx.filter_eval_shape(init, key).shardings(mesh)
     return jax.jit(init, out_shardings=out_shardings)(key)
 
 
-def _shard_last_axis(mesh: Mesh, ndim: int) -> NamedSharding:
-    """Tile an array's LAST axis over `dp`, replicating every earlier axis."""
-    return NamedSharding(mesh, P(*([None] * (ndim - 1)), "dp"))
-
-
 def init_ci_fn_placed(
-    arch: CIFnArch, sites: tuple[SiteSpec, ...], key: PRNGKeyArray, mesh: Mesh, shardable: bool
+    arch: CIFnArch, sites: tuple[SiteSpec, ...], key: PRNGKeyArray, mesh: Mesh
 ) -> CIFn:
-    """Seeded CI-fn init (any arch, via `build_ci_fn`), placed by SCALE — not arch type.
-    `shardable` → shard every 2-D+ matrix on its LAST axis where it tiles the mesh (the
-    chunkwise `out_w` ΣC axis, attention / in_proj output axes; 1-D vectors replicate);
-    else replicate everything. Same jit + `out_shardings` no-host-tree rationale as V/U.
-
-    A 2-D+ matrix whose last axis does NOT tile the mesh falls back to replication — fine
-    for correctness but a potential memory surprise at scale, so it's logged rather than
-    silent."""
-    n = mesh.devices.size
-    repl = NamedSharding(mesh, P())
+    """Seeded CI-fn init (any arch, via `build_ci_fn`) placed by the CI fn's own
+    `.shardings` (the chunkwise transformer's Megatron layout; the toy MLPs shard each
+    weight's output axis). Shardings computed on the abstract model, init under jit."""
     init = partial(build_ci_fn, arch, sites)
-    if not shardable:
-        return jax.jit(init, out_shardings=repl)(key)
-
-    untiled: list[tuple[int, ...]] = []  # 2-D+ matrices whose last axis isn't mesh-divisible
-
-    def place(shape: jax.ShapeDtypeStruct) -> NamedSharding:
-        if shape.ndim < 2:
-            return repl  # 1-D vectors (biases, inv_freq) always replicate
-        if shape.shape[-1] % n == 0:
-            return _shard_last_axis(mesh, shape.ndim)
-        untiled.append(shape.shape)
-        return repl
-
-    out_shardings = jax.tree.map(place, jax.eval_shape(init, key))
-    if untiled:
-        logger.info(
-            "ci_fn placement: %d matrices replicated (last axis not divisible by mesh=%d): %s",
-            len(untiled),
-            n,
-            untiled,
-        )
+    out_shardings = eqx.filter_eval_shape(init, key).shardings(mesh)
     return jax.jit(init, out_shardings=out_shardings)(key)
 
 

--- a/param_decomp/targets/llama_simple_mlp.py
+++ b/param_decomp/targets/llama_simple_mlp.py
@@ -322,6 +322,12 @@ class SimpleMLPDecomposedModel(eqx.Module):
     def site_names(self) -> tuple[str, ...]:
         return tuple(s.name for s in self.sites)
 
+    def shardings(self, mesh: Mesh) -> "SimpleMLPDecomposedModel":
+        """Replicate every frozen leaf on the `dp` mesh — this target is small (~67M
+        params), so replicating it is the whole frozen-weight sharding story."""
+        repl = NamedSharding(mesh, P())
+        return jax.tree.map(lambda _a: repl, self)
+
     @staticmethod
     def recon_loss_fn(masked_output: Array, clean_output: Array) -> Array:
         return kl_per_position(masked_output, clean_output)
@@ -647,11 +653,9 @@ def load_prefix_from_pretrain_cache(
     return prefix_from_weights(_checkpoint_weight_getter(cache_dir, dtype), cfg, first_layer)
 
 
-def replicate_frozen[FrozenTree: (SimpleMLPDecomposedModel, SimpleMLPPrefix)](
-    tree: FrozenTree, mesh: Mesh
-) -> FrozenTree:
-    """This target is small (~67M params); replicating the frozen weights on every
-    device is the whole sharding story (the `llama8b_sharding.replicate_target`
-    analog). V/U / CI / source placement reuses the generic per-site plan."""
+def replicate_prefix(prefix: SimpleMLPPrefix, mesh: Mesh) -> SimpleMLPPrefix:
+    """Replicate the small frozen prefix (embedding + earlier blocks) on every device — it
+    only harvests the residual entering the suffix, never enters a gradient graph. The
+    decomposed model itself owns its placement via `SimpleMLPDecomposedModel.shardings`."""
     repl = NamedSharding(mesh, P())
-    return jax.tree.map(lambda a: jax.device_put(a, repl) if eqx.is_array(a) else a, tree)
+    return jax.tree.map(lambda a: jax.device_put(a, repl) if eqx.is_array(a) else a, prefix)

--- a/param_decomp/tests/test_attn_patterns_eval.py
+++ b/param_decomp/tests/test_attn_patterns_eval.py
@@ -213,6 +213,10 @@ class _PositionlessStub(eqx.Module):
     def site_names(self) -> tuple[str, ...]:
         return tuple(s.name for s in self.sites)
 
+    def shardings(self, mesh: Any) -> "_PositionlessStub":
+        del mesh
+        raise AssertionError("positionless stub fn must not be called")
+
     def recon_loss_fn(self, masked_output: Any, clean_output: Any) -> jax.Array:
         del masked_output, clean_output
         raise AssertionError("positionless stub fn must not be called")

--- a/param_decomp/tests/test_checkpoint.py
+++ b/param_decomp/tests/test_checkpoint.py
@@ -220,10 +220,9 @@ def _build_sharded(seed: int, mesh: Mesh):
     C, seq = 8 * n, 16
     sites = llama_site_specs(cfg, mlp_family_site_cs(3, 4, C))
     lm = _tiny_decomposed_lm(cfg, sites, jax.random.PRNGKey(0))
-    shardable = n > 1 and all(s.C % n == 0 for s in sites)
-    vu = init_decomp_vu_placed(sites, jax.random.PRNGKey(seed), mesh, shardable)
+    vu = init_decomp_vu_placed(sites, jax.random.PRNGKey(seed), mesh)
     ci_fn = init_ci_fn_placed(
-        _chunkwise_arch(lm, cfg), lm.sites, jax.random.PRNGKey(seed + 1), mesh, shardable
+        _chunkwise_arch(lm, cfg), lm.sites, jax.random.PRNGKey(seed + 1), mesh
     )
     opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)

--- a/param_decomp/tests/test_checkpoint_production_topology.py
+++ b/param_decomp/tests/test_checkpoint_production_topology.py
@@ -86,8 +86,6 @@ def _build_sharded(seed: int):
     sites = llama_site_specs(cfg, mlp_family_site_cs(3, 4, C))
     lm = _tiny_decomposed_lm(cfg, sites, jax.random.PRNGKey(0))
 
-    n = mesh.devices.size
-    shardable = n > 1 and all(s.C % n == 0 for s in lm.sites)
     first_block = min(int(s.name.split(".")[1]) for s in lm.sites)
     ci_arch = ChunkwiseTransformerCIArch(
         chunks=(Chunk(input_taps=(f"resid.{first_block}",), output_sites=lm.site_names),),
@@ -97,8 +95,8 @@ def _build_sharded(seed: int):
         n_heads=2,
         mlp_hidden=32,
     )
-    vu = init_decomp_vu_placed(lm.sites, jax.random.PRNGKey(seed), mesh, shardable)
-    ci_fn = init_ci_fn_placed(ci_arch, lm.sites, jax.random.PRNGKey(seed + 1), mesh, shardable)
+    vu = init_decomp_vu_placed(lm.sites, jax.random.PRNGKey(seed), mesh)
+    ci_fn = init_ci_fn_placed(ci_arch, lm.sites, jax.random.PRNGKey(seed + 1), mesh)
     opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)
     site_cs = tuple(s.C for s in lm.sites)

--- a/param_decomp/tests/test_eval.py
+++ b/param_decomp/tests/test_eval.py
@@ -56,6 +56,10 @@ class _PositionlessStub(eqx.Module):
     def site_names(self) -> tuple[str, ...]:
         return tuple(s.name for s in self.sites)
 
+    def shardings(self, mesh: Any) -> "_PositionlessStub":
+        del mesh
+        raise AssertionError("positionless stub fn must not be called")
+
     def recon_loss_fn(self, masked_output: Any, clean_output: Any) -> jax.Array:
         del masked_output, clean_output
         raise AssertionError("positionless stub fn must not be called")

--- a/param_decomp/tests/test_generic_model_io.py
+++ b/param_decomp/tests/test_generic_model_io.py
@@ -63,6 +63,10 @@ class SyntheticDecomposedModel(eqx.Module):
     def site_names(self) -> tuple[str, ...]:
         return tuple(s.name for s in self.sites)
 
+    def shardings(self, mesh: "jax.sharding.Mesh") -> "SyntheticDecomposedModel":
+        repl = jax.sharding.NamedSharding(mesh, jax.sharding.PartitionSpec())
+        return jax.tree.map(lambda _a: repl, self)
+
     @staticmethod
     def recon_loss_fn(
         masked_output: tuple[Array, Array], clean_output: tuple[Array, Array]

--- a/param_decomp/tests/test_sharding.py
+++ b/param_decomp/tests/test_sharding.py
@@ -45,11 +45,11 @@ def test_shard_batch_requires_divisible_batch():
 
 
 def test_jitted_sharded_inits_match_eager_values():
-    """`init_*_placed` with `shardable=True` must be a placement-only change: same values as
-    the host (unsharded) init fns (threefry is partitionable, so generating under jit with
-    `out_shardings` cannot perturb the stream — only op fusion can reassociate the scaling,
-    SPEC D4: rel ~1e-7), with the expected per-site placements (V shards C on axis 1, U on
-    axis 0) — for a heterogeneous-C site set spanning attention and MLP matrices."""
+    """`init_*_placed` (model-owned `.shardings`) must be a placement-only change: same
+    values as the host (unsharded) init fns (threefry is partitionable, so generating under
+    jit with `out_shardings` cannot perturb the stream — only op fusion can reassociate the
+    scaling, SPEC D4: rel ~1e-7), with the expected per-site placements (V shards C on axis
+    1, U on axis 0) — for a heterogeneous-C site set spanning attention and MLP matrices."""
     from jax.sharding import NamedSharding
     from jax.sharding import PartitionSpec as P
 

--- a/param_decomp/tests/test_sharding.py
+++ b/param_decomp/tests/test_sharding.py
@@ -83,30 +83,30 @@ def test_jitted_sharded_inits_match_eager_values():
             )
         ),
     )
-    # The caller's scale decision (run_state.init_train_state): shard only when the mesh
-    # tiles and every C divides it. At n==1 this is False → the placed init replicates.
-    shardable = n > 1 and all(s.C % n == 0 for s in sites)
-
-    vu_placed = init_decomp_vu_placed(sites, jax.random.PRNGKey(1), mesh, shardable)
+    # Placement is MODEL-OWNED and uniform across mesh sizes: V/U always declare their C
+    # axis sharded (`P(None,"dp")` / `P("dp",None)`); at n==1 the dp axis has size 1 so it
+    # is trivially divisible and effectively replicated, but the SPEC is still C-sharded.
+    vu_placed = init_decomp_vu_placed(sites, jax.random.PRNGKey(1), mesh)
     vu_eager = init_decomp_vu(sites, jax.random.PRNGKey(1))
     for spec in sites:
         V, U = vu_placed.site(spec.name)
         assert isinstance(V.sharding, NamedSharding) and isinstance(U.sharding, NamedSharding)
-        if shardable:
-            assert V.sharding.spec == P(None, "dp"), spec.name
-            assert U.sharding.spec == P("dp", None), spec.name
-        else:
-            assert V.sharding.spec == P(), spec.name
-            assert U.sharding.spec == P(), spec.name
+        assert V.sharding.spec == P(None, "dp"), spec.name
+        assert U.sharding.spec == P("dp", None), spec.name
     for got, want in zip(jax.tree.leaves(vu_placed), jax.tree.leaves(vu_eager), strict=True):
         assert got.shape == want.shape and got.dtype == want.dtype
         assert jnp.allclose(jnp.asarray(got), want, rtol=1e-6, atol=0)
 
-    # A C not divisible by the mesh is not shardable: the caller's predicate is False, so
-    # the placed init replicates rather than tiling the C axis.
+    # A declared shard axis that does NOT tile the mesh is a loud crash inside `.shardings`
+    # (fail-fast), not a silent replicate. (Only observable at n > 1.)
     if n > 1:
         indivisible = llama_site_specs(cfg, (SiteC("layers.2.mlp.gate_proj", n + 1),))
-        assert not all(s.C % n == 0 for s in indivisible)
+        try:
+            init_decomp_vu_placed(indivisible, jax.random.PRNGKey(1), mesh)
+        except AssertionError:
+            pass
+        else:
+            raise AssertionError("expected a non-dividing C to fail in DecompVU.shardings")
 
     first_block = min(int(s.name.split(".")[1]) for s in sites)
     arch = ChunkwiseTransformerCIArch(
@@ -119,7 +119,7 @@ def test_jitted_sharded_inits_match_eager_values():
         n_heads=2,
         mlp_hidden=8 * n,
     )
-    ci_placed = init_ci_fn_placed(arch, sites, jax.random.PRNGKey(2), mesh, shardable)
+    ci_placed = init_ci_fn_placed(arch, sites, jax.random.PRNGKey(2), mesh)
     ci_eager = build_ci_fn(arch, sites, jax.random.PRNGKey(2))
     for got, want in zip(jax.tree.leaves(ci_placed), jax.tree.leaves(ci_eager), strict=True):
         assert got.shape == want.shape and got.dtype == want.dtype

--- a/param_decomp_lab/experiments/lm/load_run.py
+++ b/param_decomp_lab/experiments/lm/load_run.py
@@ -41,7 +41,7 @@ from param_decomp.ci_fn import CIFn
 from param_decomp.components import DecompVU
 from param_decomp.lm import DecomposedModel
 from param_decomp.run_state import build_optimizers, init_train_state
-from param_decomp.sharding import dp_mesh
+from param_decomp.sharding import dp_mesh, place_via_shardings
 from param_decomp.targets import llama_simple_mlp
 from param_decomp.targets.llama8b import (
     first_decomposed_layer,
@@ -51,7 +51,7 @@ from param_decomp.targets.llama8b import (
     load_prefix_from_hf,
     prefix_residual,
 )
-from param_decomp.targets.llama8b_sharding import replicate_target
+from param_decomp.targets.llama8b_sharding import place_target
 from param_decomp.targets.target_aliases import AnyPrefix
 from param_decomp.train import COMPUTE_DT, TrainState, cast_floating
 from param_decomp_lab.experiments.lm.config import (
@@ -86,14 +86,12 @@ def build_target(
             cache_dir = llama_simple_mlp.pretrain_cache_dir(cfg.target.pretrain_run_path)
             simple_cfg = llama_simple_mlp.load_model_config(cache_dir)
             sites = llama_simple_mlp.site_specs(simple_cfg, cfg.target.sites)
-            lm = llama_simple_mlp.replicate_frozen(
-                llama_simple_mlp.load_decomposed_lm_from_pretrain_cache(
-                    cache_dir, simple_cfg, sites, jnp.bfloat16
-                ),
-                mesh,
+            loaded_lm = llama_simple_mlp.load_decomposed_lm_from_pretrain_cache(
+                cache_dir, simple_cfg, sites, jnp.bfloat16
             )
+            lm = place_via_shardings(loaded_lm, loaded_lm.shardings(mesh))
             first_layer = llama_simple_mlp.first_decomposed_layer(lm.site_names)
-            prefix = llama_simple_mlp.replicate_frozen(
+            prefix = llama_simple_mlp.replicate_prefix(
                 llama_simple_mlp.load_prefix_from_pretrain_cache(
                     cache_dir, simple_cfg, first_layer, jnp.bfloat16
                 ),
@@ -103,7 +101,7 @@ def build_target(
         case TargetConfig():
             llama_cfg = llama31_8b_config()
             sites = llama_site_specs(llama_cfg, cfg.target.sites)
-            lm = replicate_target(
+            lm = place_target(
                 load_decomposed_lm_from_hf(cfg.target.model_name, llama_cfg, sites), mesh
             )
             first_layer = first_decomposed_layer(lm.site_names)

--- a/param_decomp_lab/experiments/resid_mlp/model.py
+++ b/param_decomp_lab/experiments/resid_mlp/model.py
@@ -369,6 +369,11 @@ class ResidMLPDecomposedModel(eqx.Module):
     def site_names(self) -> tuple[str, ...]:
         return tuple(s.name for s in self.sites)
 
+    def shardings(self, mesh: Mesh) -> "ResidMLPDecomposedModel":
+        """Replicate every frozen leaf on the `dp` mesh — ResidualMLP weights are tiny."""
+        repl = NamedSharding(mesh, P())
+        return jax.tree.map(lambda _a: repl, self)
+
     @staticmethod
     def recon_loss_fn(
         masked_output: Float[Array, "B n_features"], clean_output: Float[Array, "B n_features"]

--- a/param_decomp_lab/experiments/tms/model.py
+++ b/param_decomp_lab/experiments/tms/model.py
@@ -301,6 +301,11 @@ class TMSDecomposedModel(eqx.Module):
     def site_names(self) -> tuple[str, ...]:
         return tuple(s.name for s in self.sites)
 
+    def shardings(self, mesh: Mesh) -> "TMSDecomposedModel":
+        """Replicate every frozen leaf on the `dp` mesh — TMS weights are tiny."""
+        repl = NamedSharding(mesh, P())
+        return jax.tree.map(lambda _a: repl, self)
+
     @staticmethod
     def recon_loss_fn(
         masked_output: Float[Array, "B n_features"], clean_output: Float[Array, "B n_features"]


### PR DESCRIPTION
## Description
Replace the trainer's arbitrary shape-based sharding ("shard the last axis") + inferred `shardable` flag + silent replicate-fallback with **model-owned placement**: each param owner declares its per-leaf `dp` placement via an explicit `.shardings(mesh)` method.

Pure **placement** change — no compute changes, so the equivalence + stacked-parity **goldens are bit-identical** (verified). Flat `dp` mesh kept (no 2-D mesh / chunk-parallel — deferred until a measured bottleneck).

## What each model declares
- **`DecompVU`:** `V` shard `C` (axis 1), `U` shard `C` (axis 0). (= prior behaviour.)
- **Chunkwise CI fn** (leading `n_chunks` axis un-sharded): `in_proj_w`→`d_model`, `out_w`→`c_chunk`; **MLP row-parallel** (up-proj output / down-proj input on `mlp_hidden`); **attention col/row-parallel** (qkv output/head dim, out-proj input dim); biases + `inv_freq` replicate.
- **Toy MLP CI fns:** each weight shards its output axis; biases replicate.
- **Targets** (llama8b / llama_simple_mlp / toys): replicate every frozen leaf.

## Mechanism
- Deleted: the last-axis logic + `_shard_last_axis` + untiled replicate-fallback in `llama8b_sharding.py`; the `shardable = n>1 and all(C%n==0)` inference in `run_state.py`.
- `sharding.assert_divisible(dim, mesh, what)` — uniform fail-fast (trivially true at n==1); a non-dividing declared axis now crashes naming model/field/dim/mesh instead of silently replicating.
- Fresh-seeded params placed via `jax.jit(init, out_shardings=model.shardings(mesh))` on the `eqx.filter_eval_shape`'d abstract; loaded frozen models via `place_via_shardings`.

## How tested
- `make check` clean.
- Full suite @ 1 device **and** @ 4 sim-devices: 448 passed / 9 skipped / 1 xfailed, counts identical.
- Multidevice tests @ 4 sim-devices (`-m multidevice`): 5 passed (sharded checkpoint roundtrip, production topology, placement, fresh-PGD dp-invariance — exercise the Megatron layout).
- Goldens `--runslow`: green and **bit-identical** (no `.npz`/`.npy`/fixture touched).

## Breaking change?
A config whose declared shard dim doesn't tile the device count now **asserts** (was: silent replicate). That's the intended fail-fast. Real configs use round dims (`d_model`/`mlp_hidden`/`C` divisible by the mesh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
