### PR TITLE
refactor(loss): first-class PersistentAdversary (PPGD) + smooth-L0 imp-min penalty

### DIFF
--- a/param_decomp/adversary.py
+++ b/param_decomp/adversary.py
@@ -11,11 +11,13 @@ else (SPEC §3):
 - **Fresh PGD** — `PGDReconLossConfig` (torch `PGDReconLoss` as a TRAINING loss).
   Sources are re-initialized every step, ascended `n_steps` times by
   `step_size * sign(grad)` with clamp to [0,1], and carry NO state across steps —
-  `TrainState.sources` stays empty for this variant.
+  `TrainState.adversaries` stays empty for this variant.
 """
 
+from collections.abc import Callable
 from dataclasses import dataclass
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 from jax import random
@@ -23,6 +25,7 @@ from jaxtyping import Array, Float, PRNGKeyArray
 
 from param_decomp.components import SiteSpec
 from param_decomp.configs import AdamPGDConfig, MaskScopeLiteral, PGDInitStrategy
+from param_decomp.losses import warmup_then_constant_lr
 
 
 @jax.tree_util.register_dataclass
@@ -138,3 +141,81 @@ def source_masks(
         masks[site] = ci_lower[site] + (1.0 - ci_lower[site]) * source[..., :-1]
         delta_masks[site] = source[..., -1]
     return masks, delta_masks
+
+
+class PersistentAdversary(eqx.Module):
+    """One persistent-PGD adversary (SPEC §3): the per-site sources + their Adam moments
+    that persist across steps, plus the lifecycle the trainer drives around the shared
+    backward. `sources` / `opt_state` are dynamic state; the rest is static config.
+
+    Per step: `warmup_ascend` (n_warmup supplemental ascents vs a scoring forward, params
+    + CI detached) → the warmed sources enter the main `value_and_grad` as leaves →
+    `final_ascend` (one more ascent from the SAME backward's source-grad, unscaled by the
+    term's `coeff` — exact since one source bundle feeds exactly one term, SPEC S23).
+    `start_frac` freezes every update until `step/total_steps >= start_frac` (SPEC S32)."""
+
+    sources: dict[str, Array]  # site -> source in [0,1], `(*scope_leading, C+1)`
+    opt_state: SourcesAdamState
+    state_key: str = eqx.field(static=True)
+    coeff: float = eqx.field(static=True)
+    adam: AdamPGDConfig = eqx.field(static=True)
+    start_frac: float = eqx.field(static=True)
+    n_warmup: int = eqx.field(static=True)
+
+    def source_lr(self, step_f32: Array, total_steps: int) -> Array:
+        return warmup_then_constant_lr(
+            step_f32,
+            total_steps,
+            self.adam.lr_schedule.start_val,
+            self.adam.lr_schedule.warmup_pct,
+        )
+
+    def _gate[T](self, step_f32: Array, total_steps: int, updated: T, base: T) -> T:
+        """Freeze updates until `start_frac` of training (SPEC S32). No-op (zero-overhead)
+        when `start_frac == 0.0`; otherwise `where`-selects per leaf."""
+        if self.start_frac == 0.0:
+            return updated
+        active = step_f32 >= self.start_frac * total_steps
+        return jax.tree.map(lambda u, b: jnp.where(active, u, b), updated, base)
+
+    def warmup_ascend(
+        self, scoring_loss: Callable[[dict[str, Array]], Array], step_f32: Array, total_steps: int
+    ) -> "PersistentAdversary":
+        """`n_warmup` supplemental Adam ascents on the sources vs `scoring_loss` (the
+        route-all all-sites recon forward, params/CI detached — provided by the step). The
+        warmed sources are `stop_gradient`'d: they enter the main backward as leaves, so
+        the main graph differentiates w.r.t. them, not back through this scan."""
+        lr = self.source_lr(step_f32, total_steps)
+
+        def body(
+            carry: tuple[dict[str, Array], SourcesAdamState], _: None
+        ) -> tuple[tuple[dict[str, Array], SourcesAdamState], None]:
+            sources, opt = carry
+            grad = jax.grad(scoring_loss)(sources)
+            return sources_adam_ascend_project(sources, grad, opt, lr, self.adam), None
+
+        (warmed, warmed_opt), _ = jax.lax.scan(
+            body, (self.sources, self.opt_state), None, length=self.n_warmup
+        )
+        warmed, warmed_opt = self._gate(
+            step_f32, total_steps, (warmed, warmed_opt), (self.sources, self.opt_state)
+        )
+        return eqx.tree_at(
+            lambda a: (a.sources, a.opt_state), self, (jax.lax.stop_gradient(warmed), warmed_opt)
+        )
+
+    def final_ascend(
+        self, source_grad_scaled: dict[str, Array], step_f32: Array, total_steps: int
+    ) -> "PersistentAdversary":
+        """One final ascent from the shared backward's source-grad (SPEC S13'/S14'). The
+        backward saw `coeff·L_term`, so the grad is unscaled by `coeff` to ascend on
+        `L_term` itself (exact: each source bundle feeds exactly one term, SPEC S23)."""
+        lr = self.source_lr(step_f32, total_steps)
+        grad = {s: g / self.coeff for s, g in source_grad_scaled.items()}
+        ascended, ascended_opt = sources_adam_ascend_project(
+            self.sources, grad, self.opt_state, lr, self.adam
+        )
+        ascended, ascended_opt = self._gate(
+            step_f32, total_steps, (ascended, ascended_opt), (self.sources, self.opt_state)
+        )
+        return eqx.tree_at(lambda a: (a.sources, a.opt_state), self, (ascended, ascended_opt))

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -161,6 +161,38 @@ class ImportanceMinimalityLossConfig(LossMetricConfig):
     eps: NonNegativeFloat = 1e-12
 
 
+class SmoothL0ImportanceMinimalityLossConfig(LossMetricConfig):
+    """Geman–McClure smooth-L0 importance-minimality penalty on upper-leaky CI values.
+
+    Per-value penalty `phi_gamma(c) = c^2 / (c^2 + gamma^2)` — a smooth approximation to
+    the active-component count `1[c>0]`, exact only as `gamma -> 0` — fed through the same
+    per-site `lp + beta * mean * log2(1 + sum)` structure as `ImportanceMinimalityLoss`.
+    Differs from the `L_p` penalty only in the per-value shape: `phi'(0) = 0` and
+    `|phi'| <= 0.65/gamma` everywhere, so there is no singularity at the origin (no `eps`
+    floor, no aggressive grad clip) — the gradient is localized on the threshold band
+    `c ~ gamma/sqrt(3)` and redescends for clearly-on components.
+
+    `gamma` is annealed linearly toward `gamma_anneal_final_gamma` between
+    `gamma_anneal_start_frac` and `gamma_anneal_end_frac` of training; annealing it down
+    sharpens the count. A constant schedule is `gamma_anneal_final_gamma == gamma`.
+    """
+
+    type: Literal["SmoothL0ImportanceMinimalityLoss"] = "SmoothL0ImportanceMinimalityLoss"
+    gamma: PositiveFloat
+    beta: NonNegativeFloat
+    gamma_anneal_start_frac: Probability = 1.0
+    gamma_anneal_final_gamma: PositiveFloat | None = None
+    gamma_anneal_end_frac: Probability = 1.0
+
+
+# The two imp-min penalties share the `coeff`/`beta` surface and the `lp + beta * entropy`
+# aggregation; they differ only in the per-value penalty shape and its annealed parameter
+# (`p` vs `gamma`). The trainer's single imp-min slot accepts either.
+AnyImportanceMinimalityLossConfig = (
+    ImportanceMinimalityLossConfig | SmoothL0ImportanceMinimalityLossConfig
+)
+
+
 class CIMaskedReconLossConfig(LossMetricConfig):
     type: Literal["CIMaskedReconLoss"] = "CIMaskedReconLoss"
 
@@ -529,6 +561,7 @@ AnyLossMetricConfig = Annotated[
     | PGDReconLayerwiseLossConfig
     | PGDReconLossConfig
     | PGDReconSubsetLossConfig
+    | SmoothL0ImportanceMinimalityLossConfig
     | StochasticHiddenActsReconLossConfig
     | StochasticReconLayerwiseLossConfig
     | StochasticReconLossConfig

--- a/param_decomp/experiments/invariance_check.py
+++ b/param_decomp/experiments/invariance_check.py
@@ -25,7 +25,11 @@ import jax.numpy as jnp
 import optax
 from jax import random
 
-from param_decomp.adversary import init_persistent_sources, init_sources_adam_state
+from param_decomp.adversary import (
+    PersistentAdversary,
+    init_persistent_sources,
+    init_sources_adam_state,
+)
 from param_decomp.ci_fn import (
     Chunk,
     ChunkwiseTransformerCIArch,
@@ -78,12 +82,31 @@ def _run(steps: int, sharded: bool) -> list[dict[str, float]]:
     if mesh is not None:
         resid = shard_batch(resid, mesh, batch_axis=0)
 
+    ppgd_cfg = PersistentPGDReconLossConfig(
+        coeff=0.5,
+        scope=SCScope(),
+        optimizer=AdamPGDConfig(
+            beta1=0.5, beta2=0.99,
+            lr_schedule=ScheduleConfig(start_val=0.01, warmup_pct=0.025),
+        ),
+        n_warmup_steps=2,
+    )  # fmt: skip
+    assert ppgd_cfg.coeff is not None
     state = TrainState(
         components=vu, ci_fn=ci_fn,
         components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
         ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
-        sources={"PersistentPGDReconLoss": src},
-        sources_opt_state={"PersistentPGDReconLoss": init_sources_adam_state(src)},
+        adversaries={
+            ppgd_cfg.type: PersistentAdversary(
+                sources=src,
+                opt_state=init_sources_adam_state(src),
+                state_key=ppgd_cfg.type,
+                coeff=ppgd_cfg.coeff,
+                adam=ppgd_cfg.optimizer,
+                start_frac=ppgd_cfg.start_frac,
+                n_warmup=ppgd_cfg.n_warmup_steps,
+            )
+        },
         step=jnp.zeros((), jnp.int32),
     )  # fmt: skip
     loss_terms = build_loss_terms(
@@ -94,15 +117,7 @@ def _run(steps: int, sharded: bool) -> list[dict[str, float]]:
                 p_anneal_start_frac=0.0, p_anneal_final_p=0.4, p_anneal_end_frac=1.0,
             ),
             ChunkwiseSubsetReconLossConfig(routing=UniformKSubsetRoutingConfig(), coeff=0.5, sites_per_chunk=3, n_samples=1),
-            PersistentPGDReconLossConfig(
-                coeff=0.5,
-                scope=SCScope(),
-                optimizer=AdamPGDConfig(
-                    beta1=0.5, beta2=0.99,
-                    lr_schedule=ScheduleConfig(start_val=0.01, warmup_pct=0.025),
-                ),
-                n_warmup_steps=2,
-            ),
+            ppgd_cfg,
         ),
         lm.site_names,
     )  # fmt: skip

--- a/param_decomp/experiments/llama8b_real.py
+++ b/param_decomp/experiments/llama8b_real.py
@@ -38,7 +38,11 @@ from jax import random
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 
-from param_decomp.adversary import init_persistent_sources, init_sources_adam_state
+from param_decomp.adversary import (
+    PersistentAdversary,
+    init_persistent_sources,
+    init_sources_adam_state,
+)
 from param_decomp.ci_fn import (
     Chunk,
     ChunkwiseTransformerCIArch,
@@ -230,13 +234,33 @@ def main():
                 f"final faith {float(wloss):.3e}"
             )
 
+    ppgd_cfg = PersistentPGDReconLossConfig(
+        coeff=0.5,
+        scope=SCScope(),
+        optimizer=AdamPGDConfig(
+            beta1=0.5,
+            beta2=0.99,
+            lr_schedule=ScheduleConfig(start_val=0.01, warmup_pct=0.025),
+        ),
+        n_warmup_steps=args.n_warmup,
+    )
+    assert ppgd_cfg.coeff is not None
     state = TrainState(
         components=vu,
         ci_fn=ci_fn,
         components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
         ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
-        sources={"PersistentPGDReconLoss": src},
-        sources_opt_state={"PersistentPGDReconLoss": init_sources_adam_state(src)},
+        adversaries={
+            ppgd_cfg.type: PersistentAdversary(
+                sources=src,
+                opt_state=init_sources_adam_state(src),
+                state_key=ppgd_cfg.type,
+                coeff=ppgd_cfg.coeff,
+                adam=ppgd_cfg.optimizer,
+                start_frac=ppgd_cfg.start_frac,
+                n_warmup=ppgd_cfg.n_warmup_steps,
+            )
+        },
         step=jnp.zeros((), jnp.int32),
     )
     loss_terms = build_loss_terms(
@@ -253,16 +277,7 @@ def main():
             ChunkwiseSubsetReconLossConfig(
                 routing=UniformKSubsetRoutingConfig(), coeff=0.5, sites_per_chunk=3, n_samples=1
             ),
-            PersistentPGDReconLossConfig(
-                coeff=0.5,
-                scope=SCScope(),
-                optimizer=AdamPGDConfig(
-                    beta1=0.5,
-                    beta2=0.99,
-                    lr_schedule=ScheduleConfig(start_val=0.01, warmup_pct=0.025),
-                ),
-                n_warmup_steps=args.n_warmup,
-            ),
+            ppgd_cfg,
         ),
         lm.site_names,
     )
@@ -279,13 +294,13 @@ def main():
     m: dict[str, jax.Array] = {}
     for _ in range(2):
         state, m = step(lm, state, resid, random.PRNGKey(7))
-        jax.block_until_ready((state.sources, m["total"]))
+        jax.block_until_ready((state.adversaries, m["total"]))
 
     per = []
     for s in range(args.steps):
         t = time.time()
         state, m = step(lm, state, resid, random.PRNGKey(1000 + s))
-        jax.block_until_ready((state.sources, m["total"]))
+        jax.block_until_ready((state.adversaries, m["total"]))
         per.append(time.time() - t)
     blocked = sum(per) / len(per)
 
@@ -293,7 +308,7 @@ def main():
     for s in range(args.steps):
         state, m = step(lm, state, resid, random.PRNGKey(2000 + s))
     dispatch = (time.time() - t) / args.steps
-    jax.block_until_ready((state.sources, m["total"]))
+    jax.block_until_ready((state.adversaries, m["total"]))
 
     peak_gb = max(
         d.memory_stats()["peak_bytes_in_use"] / 1e9

--- a/param_decomp/experiments/mem_probe.py
+++ b/param_decomp/experiments/mem_probe.py
@@ -32,7 +32,11 @@ from jax import random
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 
-from param_decomp.adversary import init_persistent_sources, init_sources_adam_state
+from param_decomp.adversary import (
+    PersistentAdversary,
+    init_persistent_sources,
+    init_sources_adam_state,
+)
 from param_decomp.ci_fn import (
     Chunk,
     ChunkwiseTransformerCIArch,
@@ -78,7 +82,8 @@ def _place_state(typed: TrainState, mesh: Mesh) -> TrainState:
     """Attach the trainer's GSPMD shardings to the typed abstract `TrainState`, reusing each
     param owner's OWN `.shardings` (so the probe sees the exact production placement, incl.
     the chunkwise CI fn's Megatron layout). The Adam mu/nu mirror their params' shardings;
-    every other leaf (sources/SCScope, scalars/1-D, opt counts) replicates."""
+    every other leaf (the adversaries' sources + Adam moments, scalars/1-D, opt counts)
+    replicates."""
     comp_shardings = typed.components.shardings(mesh)
     ci_shardings = typed.ci_fn.shardings(mesh)
     components = _attach(typed.components, comp_shardings)
@@ -87,11 +92,10 @@ def _place_state(typed: TrainState, mesh: Mesh) -> TrainState:
     ci_fn_opt_state = _place_adam_state(typed.ci_fn_opt_state, ci_shardings, mesh)
     return eqx.tree_at(
         lambda s: (s.components, s.ci_fn, s.components_opt_state, s.ci_fn_opt_state,
-                   s.sources, s.sources_opt_state, s.step),
+                   s.adversaries, s.step),
         typed,
         (components, ci_fn, components_opt_state, ci_fn_opt_state,
-         _abstract_replicated(typed.sources, mesh),
-         _abstract_replicated(typed.sources_opt_state, mesh),
+         _abstract_replicated(typed.adversaries, mesh),
          _abstract_replicated(typed.step, mesh)),
     )  # fmt: skip
 
@@ -125,6 +129,7 @@ def _typed_state_struct(
     opt_vu: Any,
     opt_ci: Any,
     ci_arch: ChunkwiseTransformerCIArch,
+    ppgd_cfg: PersistentPGDReconLossConfig,
     src_leading: tuple[int, int],
     key: Any,
 ) -> TrainState:
@@ -136,12 +141,22 @@ def _typed_state_struct(
     sources = init_persistent_sources(
         lm.site_names, tuple(s.C for s in lm.sites), src_leading, random.fold_in(key, 2)
     )
+    assert ppgd_cfg.coeff is not None
     return TrainState(
         components=components, ci_fn=ci_fn,
         components_opt_state=opt_vu.init(eqx.filter(components, eqx.is_array)),
         ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
-        sources={"PersistentPGDReconLoss": sources},
-        sources_opt_state={"PersistentPGDReconLoss": init_sources_adam_state(sources)},
+        adversaries={
+            ppgd_cfg.type: PersistentAdversary(
+                sources=sources,
+                opt_state=init_sources_adam_state(sources),
+                state_key=ppgd_cfg.type,
+                coeff=ppgd_cfg.coeff,
+                adam=ppgd_cfg.optimizer,
+                start_frac=ppgd_cfg.start_frac,
+                n_warmup=ppgd_cfg.n_warmup_steps,
+            )
+        },
         step=jnp.zeros((), jnp.int32),
     )  # fmt: skip
 
@@ -208,6 +223,8 @@ def main() -> None:
             n_warmup_steps=2,
         ),
     )  # fmt: skip
+    ppgd_cfg = loss_metrics[-1]
+    assert isinstance(ppgd_cfg, PersistentPGDReconLossConfig)
     loss_terms = build_loss_terms(loss_metrics, lm.site_names)
 
     ci_arch = ChunkwiseTransformerCIArch(
@@ -221,7 +238,8 @@ def main() -> None:
     key_repl = jax.ShapeDtypeStruct((2,), jnp.uint32, sharding=NamedSharding(mesh, P()))
 
     typed = jax.eval_shape(
-        lambda k: _typed_state_struct(lm, opt_vu, opt_ci, ci_arch, (1, seq), k), key_repl
+        lambda k: _typed_state_struct(lm, opt_vu, opt_ci, ci_arch, ppgd_cfg, (1, seq), k),
+        key_repl,
     )
     state_in = _place_state(typed, mesh)
 

--- a/param_decomp/losses.py
+++ b/param_decomp/losses.py
@@ -1,13 +1,18 @@
 """The pure loss terms (SPEC §2) and their schedules — fp32 reductions, no state."""
 
 import math
+from collections.abc import Callable
 
 import jax
 import jax.numpy as jnp
 from beartype import beartype
 from jaxtyping import Array, Float, jaxtyped
 
-from param_decomp.configs import ImportanceMinimalityLossConfig
+from param_decomp.configs import (
+    AnyImportanceMinimalityLossConfig,
+    ImportanceMinimalityLossConfig,
+    SmoothL0ImportanceMinimalityLossConfig,
+)
 
 
 @jaxtyped(typechecker=beartype)
@@ -37,14 +42,13 @@ def faithfulness_loss(weight_deltas: dict[str, Float[Array, "_ _"]]) -> Float[Ar
     return numerator / denominator
 
 
-@jaxtyped(typechecker=beartype)
-def importance_minimality_terms(
-    ci_upper: dict[str, Float[Array, "*leading _"]], pnorm: Float[Array, ""], eps: float
+def _imp_min_terms(
+    ci_upper: dict[str, Float[Array, "*leading _"]],
+    per_value_penalty: Callable[[Float[Array, "*leading _"]], Float[Array, "*leading _"]],
 ) -> tuple[Float[Array, ""], Float[Array, ""]]:
-    """`(lp, entropy)` with per-site grouping and the global-batch sum inside the log2
-    (SPEC S7/S8); the loss is `lp + beta * entropy`. Torch's `_no_beta` diagnostic (`lp`
-    alone) is emitted only on the eval path (`Metric.compute`), never from the train
-    step, so this trainer does not log a `train/loss/*_no_beta` key.
+    """`(lp, entropy)` for any per-value penalty `psi`, with per-site grouping and the
+    global-batch sum inside the log2 (SPEC S7/S8); the loss is `lp + beta * entropy`. The
+    two imp-min penalties (`L_p`, smooth-L0) differ ONLY in `psi`.
 
     Under GSPMD the `*leading` axes are the global batch, so `jnp.sum` IS the exact
     global per-component sum — XLA reduces across shards inside the graph."""
@@ -54,20 +58,102 @@ def importance_minimality_terms(
         ci = ci.astype(jnp.float32)  # (*leading, C)
         leading_axes = tuple(range(ci.ndim - 1))
         n_positions = math.prod(ci.shape[:-1])
-        per_component_sums = jnp.sum((ci + eps) ** pnorm, axis=leading_axes)  # (C,)
+        per_component_sums = jnp.sum(per_value_penalty(ci), axis=leading_axes)  # (C,)
         per_component_means = per_component_sums / n_positions
         lp = lp + jnp.sum(per_component_means)
         entropy = entropy + jnp.sum(per_component_means * jnp.log2(1.0 + per_component_sums))
     return lp, entropy
 
 
+@jaxtyped(typechecker=beartype)
+def importance_minimality_terms(
+    ci_upper: dict[str, Float[Array, "*leading _"]], pnorm: Float[Array, ""], eps: float
+) -> tuple[Float[Array, ""], Float[Array, ""]]:
+    """`L_p` imp-min terms: per-value penalty `(c + eps)^pnorm`, singular at `c=0` for
+    `pnorm < 1` (the `eps` floor caps the gradient there). Torch's `_no_beta` diagnostic
+    (`lp` alone) is emitted only on the eval path, never from the train step, so this
+    trainer does not log a `train/loss/*_no_beta` key."""
+    return _imp_min_terms(ci_upper, lambda ci: (ci + eps) ** pnorm)
+
+
+@jaxtyped(typechecker=beartype)
+def smooth_l0_importance_minimality_terms(
+    ci_upper: dict[str, Float[Array, "*leading _"]], gamma: Float[Array, ""]
+) -> tuple[Float[Array, ""], Float[Array, ""]]:
+    """Geman–McClure smooth-L0 imp-min terms: per-value penalty `c^2 / (c^2 + gamma^2)`.
+    Flat at the origin (`phi'(0)=0`) and bounded (`|phi'| <= 0.65/gamma`) — no singularity,
+    no `eps` floor. Approaches the true `L_0` count as `gamma -> 0`."""
+    gamma_sq = gamma * gamma
+    return _imp_min_terms(ci_upper, lambda ci: ci**2 / (ci**2 + gamma_sq))
+
+
+def _linear_anneal(
+    step_f32: Array,
+    total_steps: int,
+    initial: float,
+    final: float,
+    start_frac: float,
+    end_frac: float,
+) -> Array:
+    span = max(end_frac - start_frac, 1e-9)
+    progress = jnp.clip((step_f32 / total_steps - start_frac) / span, 0.0, 1.0)
+    return jnp.asarray(initial + (final - initial) * progress)
+
+
 def annealed_pnorm(step_f32: Array, total_steps: int, cfg: ImportanceMinimalityLossConfig) -> Array:
     """`p` anneals linearly `pnorm → p_anneal_final_p` over
     `[p_anneal_start_frac, p_anneal_end_frac]` of training (SPEC S9)."""
     assert cfg.p_anneal_final_p is not None
-    span = max(cfg.p_anneal_end_frac - cfg.p_anneal_start_frac, 1e-9)
-    progress = jnp.clip((step_f32 / total_steps - cfg.p_anneal_start_frac) / span, 0.0, 1.0)
-    return jnp.asarray(cfg.pnorm + (cfg.p_anneal_final_p - cfg.pnorm) * progress)
+    return _linear_anneal(
+        step_f32,
+        total_steps,
+        cfg.pnorm,
+        cfg.p_anneal_final_p,
+        cfg.p_anneal_start_frac,
+        cfg.p_anneal_end_frac,
+    )
+
+
+def annealed_gamma(
+    step_f32: Array, total_steps: int, cfg: SmoothL0ImportanceMinimalityLossConfig
+) -> Array:
+    """`gamma` anneals linearly `gamma → gamma_anneal_final_gamma` over
+    `[gamma_anneal_start_frac, gamma_anneal_end_frac]` of training (SPEC S9', the smooth-L0
+    analogue of S9)."""
+    assert cfg.gamma_anneal_final_gamma is not None
+    return _linear_anneal(
+        step_f32,
+        total_steps,
+        cfg.gamma,
+        cfg.gamma_anneal_final_gamma,
+        cfg.gamma_anneal_start_frac,
+        cfg.gamma_anneal_end_frac,
+    )
+
+
+def annealed_imp_min_param(
+    step_f32: Array, total_steps: int, cfg: AnyImportanceMinimalityLossConfig
+) -> Array:
+    """The annealed per-value-penalty parameter at this step (`p` for `L_p`, `gamma` for
+    smooth-L0). Pure in the step, so the train step hoists it out of the loss `grad`."""
+    match cfg:
+        case ImportanceMinimalityLossConfig():
+            return annealed_pnorm(step_f32, total_steps, cfg)
+        case SmoothL0ImportanceMinimalityLossConfig():
+            return annealed_gamma(step_f32, total_steps, cfg)
+
+
+def imp_min_terms(
+    ci_upper: dict[str, Float[Array, "*leading _"]],
+    cfg: AnyImportanceMinimalityLossConfig,
+    annealed_param: Array,
+) -> tuple[Float[Array, ""], Float[Array, ""]]:
+    """Dispatch `(lp, entropy)` on the imp-min penalty kind, given its annealed parameter."""
+    match cfg:
+        case ImportanceMinimalityLossConfig():
+            return importance_minimality_terms(ci_upper, annealed_param, cfg.eps)
+        case SmoothL0ImportanceMinimalityLossConfig():
+            return smooth_l0_importance_minimality_terms(ci_upper, annealed_param)
 
 
 def warmup_then_constant_lr(

--- a/param_decomp/recon.py
+++ b/param_decomp/recon.py
@@ -88,10 +88,10 @@ class FreshPGDSources:
 
 @dataclass(frozen=True)
 class PersistentSources:
-    """Sources living in `TrainState.sources[state_key]` across steps (PPGD). Carries
+    """Sources living in `TrainState.adversaries[state_key]` across steps (PPGD). Carries
     the shared `PersistentPGDReconLossConfig` so the term is self-describing — the step
     reads its scope/optimizer/warmup/`start_frac` straight off `cfg`. `state_key` indexes
-    `TrainState.sources` / `.sources_opt_state` (one key per persistent term, SPEC S23)."""
+    `TrainState.adversaries` (one key per persistent term, SPEC S23)."""
 
     state_key: str
     cfg: PersistentPGDReconLossConfig

--- a/param_decomp/recon.py
+++ b/param_decomp/recon.py
@@ -21,6 +21,7 @@ from jaxtyping import Array, PRNGKeyArray
 
 from param_decomp.configs import (
     AllRoutingConfig,
+    AnyImportanceMinimalityLossConfig,
     AnyLossMetricConfig,
     ChunkwiseSubsetReconLossConfig,
     CIMaskedReconLayerwiseLossConfig,
@@ -34,6 +35,7 @@ from param_decomp.configs import (
     PGDReconLayerwiseLossConfig,
     PGDReconLossConfig,
     PGDReconSubsetLossConfig,
+    SmoothL0ImportanceMinimalityLossConfig,
     StaticProbabilityRoutingConfig,
     StochasticReconLayerwiseLossConfig,
     StochasticReconLossConfig,
@@ -146,12 +148,13 @@ class FaithfulnessTerm:
 
 @dataclass(frozen=True)
 class ImportanceMinimalityTerm:
-    """CI-space `L_p` + entropy term (SPEC S7-S9). Carries the config so the step reads
-    `pnorm` / p-anneal / `beta` / `eps` straight off `cfg`."""
+    """CI-space imp-min + entropy term (SPEC S7-S9). Carries the config so the step reads
+    the annealed penalty parameter (`pnorm` / `gamma`) and `beta` straight off `cfg`. The
+    config is either of the two imp-min penalties (`L_p` or smooth-L0)."""
 
     name: str
     coeff: float
-    cfg: ImportanceMinimalityLossConfig
+    cfg: AnyImportanceMinimalityLossConfig
 
 
 LossTerm = FaithfulnessTerm | ImportanceMinimalityTerm | ReconLossTerm
@@ -341,6 +344,11 @@ def build_loss_terms(
             case ImportanceMinimalityLossConfig():
                 assert not has_imp_min
                 assert cfg.p_anneal_final_p is not None
+                has_imp_min = True
+                terms.append(ImportanceMinimalityTerm(unique_name(cfg), cfg.coeff, cfg))
+            case SmoothL0ImportanceMinimalityLossConfig():
+                assert not has_imp_min
+                assert cfg.gamma_anneal_final_gamma is not None
                 has_imp_min = True
                 terms.append(ImportanceMinimalityTerm(unique_name(cfg), cfg.coeff, cfg))
             case UnmaskedReconLossConfig() | CIMaskedReconLossConfig():

--- a/param_decomp/run_state.py
+++ b/param_decomp/run_state.py
@@ -18,12 +18,17 @@ from jax.sharding import Mesh
 from jax.typing import ArrayLike
 from jaxtyping import Array, PRNGKeyArray
 
-from param_decomp.adversary import init_sources_adam_state
+from param_decomp.adversary import PersistentAdversary, init_sources_adam_state
 from param_decomp.built_run import DataConfig
 from param_decomp.ci_fn import CIFnArch
-from param_decomp.configs import OptimizerConfig, PDConfig
+from param_decomp.configs import AdamPGDConfig, OptimizerConfig, PDConfig
 from param_decomp.lm import DecomposedModel
-from param_decomp.recon import build_loss_terms, persistent_configs
+from param_decomp.recon import (
+    PersistentSources,
+    ReconLossTerm,
+    build_loss_terms,
+    persistent_configs,
+)
 from param_decomp.targets.llama8b_sharding import (
     init_ci_fn_placed,
     init_decomp_vu_placed,
@@ -123,31 +128,48 @@ def init_train_state(
     assert ci_fn.expects_axes == lm.leading_axes, (
         f"CI fn expects leading axes {ci_fn.expects_axes} but model has {lm.leading_axes}"
     )
-    persistent = persistent_configs(build_loss_terms(pd.loss_metrics, lm.site_names))
-    sources: dict[str, dict[str, Array]] = {}
+    loss_terms = build_loss_terms(pd.loss_metrics, lm.site_names)
+    persistent = persistent_configs(loss_terms)
+    term_coeff_by_state_key = {
+        entry.sources.state_key: term.coeff
+        for term in loss_terms
+        if isinstance(term, ReconLossTerm)
+        for entry in term.plan
+        if isinstance(entry.sources, PersistentSources)
+    }
+    assert set(term_coeff_by_state_key) == set(persistent)
+    adversaries: dict[str, PersistentAdversary] = {}
     if persistent:
         # Persistent sources live on a position axis; TMS (no position axis) carries none.
         assert isinstance(data, DataConfig), (
             "persistent PGD sources need a sequence axis; TMS (leading_axes=()) has none"
         )
-        sources = {
-            state_key: init_sources_sharded(
+        for term_idx, state_key in enumerate(persistent):
+            cfg = persistent[state_key]
+            assert isinstance(cfg.optimizer, AdamPGDConfig)
+            sources = init_sources_sharded(
                 lm.site_names,
                 tuple(s.C for s in lm.sites),
                 data.seq_len,
-                persistent[state_key].scope,
+                cfg.scope,
                 data.global_batch,
                 random.fold_in(src_key, term_idx),
                 mesh,
             )
-            for term_idx, state_key in enumerate(persistent)
-        }
+            adversaries[state_key] = PersistentAdversary(
+                sources=sources,
+                opt_state=init_sources_adam_state(sources),
+                state_key=state_key,
+                coeff=term_coeff_by_state_key[state_key],
+                adam=cfg.optimizer,
+                start_frac=cfg.start_frac,
+                n_warmup=cfg.n_warmup_steps,
+            )
     return TrainState(
         components=components,
         ci_fn=ci_fn,
         components_opt_state=opt_vu.init(eqx.filter(components, eqx.is_array)),
         ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
-        sources=sources,
-        sources_opt_state={k: init_sources_adam_state(v) for k, v in sources.items()},
+        adversaries=adversaries,
         step=jnp.zeros((), jnp.int32),
     )

--- a/param_decomp/tests/stacked_parity/test_stacked_parity.py
+++ b/param_decomp/tests/stacked_parity/test_stacked_parity.py
@@ -27,7 +27,11 @@ import optax
 import pytest
 from jax import random
 
-from param_decomp.adversary import init_persistent_sources, init_sources_adam_state
+from param_decomp.adversary import (
+    PersistentAdversary,
+    init_persistent_sources,
+    init_sources_adam_state,
+)
 from param_decomp.components import DecompVU
 from param_decomp.configs import (
     AdamPGDConfig,
@@ -215,12 +219,32 @@ def test_train_trajectory_matches():
 
     opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)
+    ppgd_cfg = PersistentPGDReconLossConfig(
+        coeff=0.5,
+        scope=SCScope(),
+        optimizer=AdamPGDConfig(
+            beta1=0.5,
+            beta2=0.99,
+            lr_schedule=ScheduleConfig(start_val=0.01, warmup_pct=0.025),
+        ),
+        n_warmup_steps=n_warmup,
+    )
+    assert ppgd_cfg.coeff is not None
     state = TrainState(
         components=vu, ci_fn=ci_fn,
         components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
         ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
-        sources={"PersistentPGDReconLoss": sources},
-        sources_opt_state={"PersistentPGDReconLoss": init_sources_adam_state(sources)},
+        adversaries={
+            ppgd_cfg.type: PersistentAdversary(
+                sources=sources,
+                opt_state=init_sources_adam_state(sources),
+                state_key=ppgd_cfg.type,
+                coeff=ppgd_cfg.coeff,
+                adam=ppgd_cfg.optimizer,
+                start_frac=ppgd_cfg.start_frac,
+                n_warmup=ppgd_cfg.n_warmup_steps,
+            )
+        },
         step=jnp.zeros((), jnp.int32),
     )  # fmt: skip
     loss_terms = build_loss_terms(
@@ -237,16 +261,7 @@ def test_train_trajectory_matches():
             ChunkwiseSubsetReconLossConfig(
                 routing=UniformKSubsetRoutingConfig(), coeff=0.5, sites_per_chunk=3, n_samples=1
             ),
-            PersistentPGDReconLossConfig(
-                coeff=0.5,
-                scope=SCScope(),
-                optimizer=AdamPGDConfig(
-                    beta1=0.5,
-                    beta2=0.99,
-                    lr_schedule=ScheduleConfig(start_val=0.01, warmup_pct=0.025),
-                ),
-                n_warmup_steps=n_warmup,
-            ),
+            ppgd_cfg,
         ),
         lm.site_names,
     )
@@ -275,6 +290,6 @@ def test_train_trajectory_matches():
         V, U = state.components.site(name)
         _assert_close(V, f[f"out::final_V::{name}"], f"final V {name}")
         _assert_close(U, f[f"out::final_U::{name}"], f"final U {name}")
-    final_sources = state.sources["PersistentPGDReconLoss"]
+    final_sources = state.adversaries["PersistentPGDReconLoss"].sources
     for name in lm.site_names:
         _assert_close(final_sources[name], f[f"out::final_src::{name}"], f"final src {name}")

--- a/param_decomp/tests/test_checkpoint.py
+++ b/param_decomp/tests/test_checkpoint.py
@@ -11,6 +11,7 @@ import optax
 from jax.sharding import Mesh
 
 from param_decomp.adversary import (
+    PersistentAdversary,
     init_persistent_sources,
     init_sources_adam_state,
     sources_adam_ascend_project,
@@ -54,6 +55,31 @@ from param_decomp.train import TrainState, make_train_step
 from vendored_jax.llama import LlamaConfig
 
 
+def _ppgd_cfg(n_warmup: int) -> PersistentPGDReconLossConfig:
+    return PersistentPGDReconLossConfig(
+        coeff=0.5,
+        scope=SCScope(),
+        optimizer=AdamPGDConfig(
+            beta1=0.5, beta2=0.99,
+            lr_schedule=ScheduleConfig(start_val=0.01, warmup_pct=0.025),
+        ),
+        n_warmup_steps=n_warmup,
+    )  # fmt: skip
+
+
+def _adversary(src: dict[str, jax.Array], cfg: PersistentPGDReconLossConfig) -> PersistentAdversary:
+    assert cfg.coeff is not None
+    return PersistentAdversary(
+        sources=src,
+        opt_state=init_sources_adam_state(src),
+        state_key=cfg.type,
+        coeff=cfg.coeff,
+        adam=cfg.optimizer,
+        start_frac=cfg.start_frac,
+        n_warmup=cfg.n_warmup_steps,
+    )
+
+
 def _chunkwise_arch(lm: DecomposedModel, cfg: LlamaConfig) -> ChunkwiseTransformerCIArch:
     """The old `CIArch(16, 2, 2, 32)` → one chunk reading the residual entering the first
     decomposed block and emitting CI for every site; `input_dim` is the residual width."""
@@ -81,12 +107,12 @@ def _build(seed: int):
     src = init_persistent_sources(
         lm.site_names, tuple(s.C for s in lm.sites), (1, seq), jax.random.PRNGKey(seed + 2)
     )
+    ppgd_cfg = _ppgd_cfg(n_warmup=1)
     state = TrainState(
         components=vu, ci_fn=ci_fn,
         components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
         ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
-        sources={"PersistentPGDReconLoss": src},
-        sources_opt_state={"PersistentPGDReconLoss": init_sources_adam_state(src)},
+        adversaries={ppgd_cfg.type: _adversary(src, ppgd_cfg)},
         step=jnp.zeros((), jnp.int32),
     )  # fmt: skip
     loss_terms = build_loss_terms(
@@ -97,15 +123,7 @@ def _build(seed: int):
                 p_anneal_start_frac=0.0, p_anneal_final_p=0.4, p_anneal_end_frac=1.0,
             ),
             ChunkwiseSubsetReconLossConfig(routing=UniformKSubsetRoutingConfig(), coeff=0.5, sites_per_chunk=3, n_samples=1),
-            PersistentPGDReconLossConfig(
-                coeff=0.5,
-                scope=SCScope(),
-                optimizer=AdamPGDConfig(
-                    beta1=0.5, beta2=0.99,
-                    lr_schedule=ScheduleConfig(start_val=0.01, warmup_pct=0.025),
-                ),
-                n_warmup_steps=1,
-            ),
+            ppgd_cfg,
         ),
         lm.site_names,
     )  # fmt: skip
@@ -158,7 +176,7 @@ def test_persistent_adam_step_count_roundtrip_and_post_resume_bias_correction(tm
     for i in range(3):
         state, _ = step(lm, state, resid, jax.random.PRNGKey(i))
 
-    pre_save = state.sources_opt_state[state_key]
+    pre_save = state.adversaries[state_key].opt_state
     n_ascents = int(pre_save.step_count)
     # Each train step runs n_warmup_steps (1) supplemental ascents + 1 final ascent.
     assert n_ascents == 3 * (1 + 1)
@@ -170,10 +188,10 @@ def test_persistent_adam_step_count_roundtrip_and_post_resume_bias_correction(tm
     restored = restore_latest(mgr, fresh)
     assert restored is not None
     loaded, _ = restored
-    loaded_adam = loaded.sources_opt_state[state_key]
+    loaded_adam = loaded.adversaries[state_key].opt_state
 
     # (a) the step_count leaf survived the round-trip: present, fp32 scalar, value N.
-    assert state_key in loaded.sources_opt_state
+    assert state_key in loaded.adversaries
     assert loaded_adam.step_count.dtype == jnp.float32
     assert loaded_adam.step_count.shape == ()
     assert float(loaded_adam.step_count) == float(n_ascents)
@@ -187,9 +205,10 @@ def test_persistent_adam_step_count_roundtrip_and_post_resume_bias_correction(tm
     adam_cfg = AdamPGDConfig(
         beta1=beta1, beta2=beta2, lr_schedule=ScheduleConfig(start_val=0.01, warmup_pct=0.025)
     )
-    grads = {site: jnp.ones_like(v) for site, v in loaded.sources[state_key].items()}
+    loaded_sources = loaded.adversaries[state_key].sources
+    grads = {site: jnp.ones_like(v) for site, v in loaded_sources.items()}
     _, post_resume = sources_adam_ascend_project(
-        loaded.sources[state_key], grads, loaded_adam, jnp.asarray(0.01), adam_cfg
+        loaded_sources, grads, loaded_adam, jnp.asarray(0.01), adam_cfg
     )
     assert float(post_resume.step_count) == float(n_ascents + 1)
     expected_bc1 = 1.0 - beta1 ** (n_ascents + 1)
@@ -234,12 +253,12 @@ def _build_sharded(seed: int, mesh: Mesh):
         jax.random.PRNGKey(seed + 2),
         mesh,
     )
+    ppgd_cfg = _ppgd_cfg(n_warmup=1)
     state = TrainState(
         components=vu, ci_fn=ci_fn,
         components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
         ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
-        sources={"PersistentPGDReconLoss": src},
-        sources_opt_state={"PersistentPGDReconLoss": init_sources_adam_state(src)},
+        adversaries={ppgd_cfg.type: _adversary(src, ppgd_cfg)},
         step=jnp.asarray(7, jnp.int32),
     )  # fmt: skip
     return state

--- a/param_decomp/tests/test_checkpoint_production_topology.py
+++ b/param_decomp/tests/test_checkpoint_production_topology.py
@@ -10,7 +10,7 @@ topology:
   * the V/U + Adam states are C-SHARDED and the sources/moments REPLICATED over a
     multi-device `dp` mesh (`llama8b_sharding.py`), exactly as `init_train_state` places
     them — so the test exercises the sharded save/restore path, not the all-on-one path;
-  * MULTIPLE persistent terms (SPEC S23: one `sources_opt_state` entry per term), so a
+  * MULTIPLE persistent terms (SPEC S23: one `adversaries` entry per term), so a
     per-term moment tree that got dropped would surface;
   * an explicit structural assertion that the RESTORED pytree carries `m`, `v`, and a
     non-zero `step_count` for every persistent term and every site — not just that the
@@ -31,7 +31,11 @@ import optax
 import pytest
 from jax.sharding import NamedSharding
 
-from param_decomp.adversary import SourcesAdamState, init_sources_adam_state
+from param_decomp.adversary import (
+    PersistentAdversary,
+    SourcesAdamState,
+    init_sources_adam_state,
+)
 from param_decomp.checkpoint import make_checkpoint_manager, restore_latest, save_state
 from param_decomp.ci_fn import Chunk, ChunkwiseTransformerCIArch
 from param_decomp.configs import (
@@ -100,8 +104,11 @@ def _build_sharded(seed: int):
     opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
     opt_ci = optax.adamw(1e-3, weight_decay=0.0)
     site_cs = tuple(s.C for s in lm.sites)
-    sources = {
-        name: init_sources_sharded(
+    ppgd_cfgs = (_persistent_cfg(None), _persistent_cfg("ppgd_second"))
+    adversaries: dict[str, PersistentAdversary] = {}
+    for i, (state_key, ppgd_cfg) in enumerate(zip(PERSISTENT_TERMS, ppgd_cfgs, strict=True)):
+        assert ppgd_cfg.coeff is not None
+        src = init_sources_sharded(
             lm.site_names,
             site_cs,
             seq,
@@ -110,14 +117,20 @@ def _build_sharded(seed: int):
             jax.random.fold_in(jax.random.PRNGKey(seed + 2), i),
             mesh,
         )
-        for i, name in enumerate(PERSISTENT_TERMS)
-    }
+        adversaries[state_key] = PersistentAdversary(
+            sources=src,
+            opt_state=init_sources_adam_state(src),
+            state_key=state_key,
+            coeff=ppgd_cfg.coeff,
+            adam=ppgd_cfg.optimizer,
+            start_frac=ppgd_cfg.start_frac,
+            n_warmup=ppgd_cfg.n_warmup_steps,
+        )
     state = TrainState(
         components=vu, ci_fn=ci_fn,
         components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
         ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
-        sources=sources,
-        sources_opt_state={k: init_sources_adam_state(v) for k, v in sources.items()},
+        adversaries=adversaries,
         step=jnp.zeros((), jnp.int32),
     )  # fmt: skip
     # run.py:185 — normalize eager scalar stragglers (Adam `count`, `step`) onto the mesh
@@ -133,8 +146,7 @@ def _build_sharded(seed: int):
                 p_anneal_start_frac=0.0, p_anneal_final_p=0.4, p_anneal_end_frac=1.0,
             ),
             ChunkwiseSubsetReconLossConfig(routing=UniformKSubsetRoutingConfig(), coeff=0.5, sites_per_chunk=3, n_samples=1),
-            _persistent_cfg(None),
-            _persistent_cfg("ppgd_second"),
+            *ppgd_cfgs,
         ),
         lm.site_names,
     )  # fmt: skip
@@ -154,19 +166,17 @@ def _build_sharded(seed: int):
     return lm, state, step, resid
 
 
-def _assert_moments_present(
-    sources: dict[str, dict[str, jax.Array]],
-    sources_opt_state: dict[str, SourcesAdamState],
-) -> None:
+def _assert_moments_present(adversaries: dict[str, PersistentAdversary]) -> None:
     """SPEC S22/S23: every persistent term carries m, v (one leaf per source site, same
     shape as the source) and a non-zero step_count."""
-    assert tuple(sources_opt_state) == PERSISTENT_TERMS, sources_opt_state.keys()
+    assert tuple(adversaries) == PERSISTENT_TERMS, adversaries.keys()
     for term in PERSISTENT_TERMS:
-        adam = sources_opt_state[term]
+        adv = adversaries[term]
+        adam = adv.opt_state
         assert isinstance(adam, SourcesAdamState)
-        assert set(adam.m) == set(sources[term]), (term, adam.m.keys())
-        assert set(adam.v) == set(sources[term]), (term, adam.v.keys())
-        for site, src in sources[term].items():
+        assert set(adam.m) == set(adv.sources), (term, adam.m.keys())
+        assert set(adam.v) == set(adv.sources), (term, adam.v.keys())
+        for site, src in adv.sources.items():
             assert adam.m[site].shape == src.shape, (term, site)
             assert adam.v[site].shape == src.shape, (term, site)
         assert float(adam.step_count) > 0.0, (term, float(adam.step_count))
@@ -180,7 +190,7 @@ def test_sharded_roundtrip_persists_source_moments(tmp_path: Path):
     for i in range(2):
         state, _ = step(lm, state, resid, jax.random.PRNGKey(i))
     # The ascents must have advanced each term's Adam counter before we save.
-    _assert_moments_present(state.sources, state.sources_opt_state)
+    _assert_moments_present(state.adversaries)
 
     mgr = make_checkpoint_manager(tmp_path / "ckpts", keep_last=2)
     save_state(mgr, 2, state)
@@ -194,7 +204,7 @@ def test_sharded_roundtrip_persists_source_moments(tmp_path: Path):
     assert ckpt_step == 2
 
     # The persisted pytree itself carries the moments + step_count for every term.
-    _assert_moments_present(loaded.sources, loaded.sources_opt_state)
+    _assert_moments_present(loaded.adversaries)
 
     # Values come from disk, and each leaf is reconstructed onto the REFERENCE sharding.
     # Pull leaves to host before comparing: a sharded leaf and a single-device leaf can't

--- a/param_decomp/tests/test_config.py
+++ b/param_decomp/tests/test_config.py
@@ -12,7 +12,11 @@ from pydantic import ValidationError
 
 from param_decomp.built_run import DataConfig
 from param_decomp.components import SiteC
-from param_decomp.configs import PDConfig, PersistentPGDReconLossConfig
+from param_decomp.configs import (
+    ImportanceMinimalityLossConfig,
+    PDConfig,
+    PersistentPGDReconLossConfig,
+)
 from param_decomp.recon import (
     FaithfulnessTerm,
     ImportanceMinimalityTerm,
@@ -95,6 +99,7 @@ def test_b128_config_converts():
     )
     (faith,) = (t for t in terms if isinstance(t, FaithfulnessTerm))
     (imp,) = (t for t in terms if isinstance(t, ImportanceMinimalityTerm))
+    assert isinstance(imp.cfg, ImportanceMinimalityLossConfig)
     assert faith.coeff == 1e5 and imp.cfg.pnorm == 2.0
     (ppgd,) = persistent_configs(terms).values()
     assert isinstance(ppgd, PersistentPGDReconLossConfig)

--- a/param_decomp/tests/test_finetune_resume.py
+++ b/param_decomp/tests/test_finetune_resume.py
@@ -55,11 +55,12 @@ def test_init_from_parent_loads_components_resets_schedule(tmp_path: Path):
 
     # optimizer states + sources are the FRESH reference's (not the parent's). The fresh
     # sources are RNG-drawn from seed 7; the parent's from seed 1 — they must differ.
-    for state_key, fresh_src in fresh.sources.items():
-        for site, arr in fresh_src.items():
-            assert jnp.array_equal(finetuned.sources[state_key][site], arr)
+    for state_key, fresh_adv in fresh.adversaries.items():
+        for site, arr in fresh_adv.sources.items():
+            assert jnp.array_equal(finetuned.adversaries[state_key].sources[site], arr)
             assert not jnp.array_equal(
-                finetuned.sources[state_key][site], parent_state.sources[state_key][site]
+                finetuned.adversaries[state_key].sources[site],
+                parent_state.adversaries[state_key].sources[site],
             )
     for a, b in zip(
         jax.tree.leaves(finetuned.components_opt_state),

--- a/param_decomp/tests/test_generic_model_io.py
+++ b/param_decomp/tests/test_generic_model_io.py
@@ -201,8 +201,7 @@ def _initial_state(lm: DecomposedModel, components: DecompVU, ci_arch: Chunkwise
         ci_fn=ci_fn,
         components_opt_state=opt_vu.init(eqx.filter(components, eqx.is_array)),
         ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
-        sources={},
-        sources_opt_state={},
+        adversaries={},
         step=jnp.zeros((), jnp.int32),
     )
     return state, opt_vu, opt_ci

--- a/param_decomp/tests/test_llama8b.py
+++ b/param_decomp/tests/test_llama8b.py
@@ -12,7 +12,11 @@ import jax.numpy as jnp
 import optax
 import pytest
 
-from param_decomp.adversary import init_persistent_sources, init_sources_adam_state
+from param_decomp.adversary import (
+    PersistentAdversary,
+    init_persistent_sources,
+    init_sources_adam_state,
+)
 from param_decomp.ci_fn import (
     Chunk,
     ChunkwiseTransformerCIArch,
@@ -307,12 +311,32 @@ def test_step_trains_and_has_vpd_signature(site_cs: tuple[SiteC, ...]):
     src = init_persistent_sources(
         lm.site_names, tuple(s.C for s in lm.sites), (1, seq), jax.random.PRNGKey(3)
     )
+    ppgd_cfg = PersistentPGDReconLossConfig(
+        coeff=0.5,
+        scope=SCScope(),
+        optimizer=AdamPGDConfig(
+            beta1=0.5,
+            beta2=0.99,
+            lr_schedule=ScheduleConfig(start_val=0.01, warmup_pct=0.025),
+        ),
+        n_warmup_steps=n_warmup,
+    )
+    assert ppgd_cfg.coeff is not None
     state = TrainState(
         components=vu, ci_fn=ci_fn,
         components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
         ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
-        sources={"PersistentPGDReconLoss": src},
-        sources_opt_state={"PersistentPGDReconLoss": init_sources_adam_state(src)},
+        adversaries={
+            ppgd_cfg.type: PersistentAdversary(
+                sources=src,
+                opt_state=init_sources_adam_state(src),
+                state_key=ppgd_cfg.type,
+                coeff=ppgd_cfg.coeff,
+                adam=ppgd_cfg.optimizer,
+                start_frac=ppgd_cfg.start_frac,
+                n_warmup=ppgd_cfg.n_warmup_steps,
+            )
+        },
         step=jnp.zeros((), jnp.int32),
     )  # fmt: skip
     loss_terms = build_loss_terms(
@@ -329,16 +353,7 @@ def test_step_trains_and_has_vpd_signature(site_cs: tuple[SiteC, ...]):
             ChunkwiseSubsetReconLossConfig(
                 routing=UniformKSubsetRoutingConfig(), coeff=0.5, sites_per_chunk=3, n_samples=1
             ),
-            PersistentPGDReconLossConfig(
-                coeff=0.5,
-                scope=SCScope(),
-                optimizer=AdamPGDConfig(
-                    beta1=0.5,
-                    beta2=0.99,
-                    lr_schedule=ScheduleConfig(start_val=0.01, warmup_pct=0.025),
-                ),
-                n_warmup_steps=n_warmup,
-            ),
+            ppgd_cfg,
         ),
         lm.site_names,
     )
@@ -362,10 +377,10 @@ def test_step_trains_and_has_vpd_signature(site_cs: tuple[SiteC, ...]):
     assert all(jnp.isfinite(jnp.array(list(m.values()))).all() for m in losses)
     assert int(state.step) == n_steps
     # SPEC S13: n_warmup + 1 source-Adam updates per training step, moments persist.
-    ppgd_opt_state = state.sources_opt_state["PersistentPGDReconLoss"]
-    assert float(ppgd_opt_state.step_count) == n_steps * (n_warmup + 1)
+    ppgd_adv = state.adversaries["PersistentPGDReconLoss"]
+    assert float(ppgd_adv.opt_state.step_count) == n_steps * (n_warmup + 1)
     # SPEC S15: sources stay projected to [0,1].
-    for v in state.sources["PersistentPGDReconLoss"].values():
+    for v in ppgd_adv.sources.values():
         assert float(v.min()) >= 0.0 and float(v.max()) <= 1.0
     # SPEC S9: p annealed below its 2.0 start by step 4 of 100.
     assert losses[-1]["p_imp"] < 2.0
@@ -434,7 +449,7 @@ def test_fresh_pgd_adversary_step():
             components=vu, ci_fn=ci_fn,
             components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
             ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
-            sources={}, sources_opt_state={},
+            adversaries={},
             step=jnp.zeros((), jnp.int32),
         )  # fmt: skip
 
@@ -486,8 +501,7 @@ def test_fresh_pgd_adversary_step():
             ]
         )
     ).all()
-    assert state.sources == {}, "fresh adversary carries no persistent sources"
-    assert state.sources_opt_state == {}
+    assert state.adversaries == {}, "fresh adversary carries no persistent sources"
     assert int(state.step) == 1
 
     _, metrics_unascended = run_step(n_ascent_steps=0)

--- a/param_decomp/tests/test_llama_simple_mlp.py
+++ b/param_decomp/tests/test_llama_simple_mlp.py
@@ -13,7 +13,11 @@ import jax.numpy as jnp
 import optax
 import pytest
 
-from param_decomp.adversary import init_persistent_sources, init_sources_adam_state
+from param_decomp.adversary import (
+    PersistentAdversary,
+    init_persistent_sources,
+    init_sources_adam_state,
+)
 from param_decomp.ci_fn import (
     Chunk,
     ChunkwiseTransformerCIArch,
@@ -396,12 +400,32 @@ def test_step_trains_and_has_vpd_signature():
     src = init_persistent_sources(
         lm.site_names, tuple(s.C for s in lm.sites), (1, seq), jax.random.PRNGKey(3)
     )
+    ppgd_cfg = PersistentPGDReconLossConfig(
+        coeff=0.5,
+        scope=SCScope(),
+        optimizer=AdamPGDConfig(
+            beta1=0.5,
+            beta2=0.99,
+            lr_schedule=ScheduleConfig(start_val=0.01, warmup_pct=0.025),
+        ),
+        n_warmup_steps=n_warmup,
+    )
+    assert ppgd_cfg.coeff is not None
     state = TrainState(
         components=vu, ci_fn=ci_fn,
         components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
         ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
-        sources={"PersistentPGDReconLoss": src},
-        sources_opt_state={"PersistentPGDReconLoss": init_sources_adam_state(src)},
+        adversaries={
+            ppgd_cfg.type: PersistentAdversary(
+                sources=src,
+                opt_state=init_sources_adam_state(src),
+                state_key=ppgd_cfg.type,
+                coeff=ppgd_cfg.coeff,
+                adam=ppgd_cfg.optimizer,
+                start_frac=ppgd_cfg.start_frac,
+                n_warmup=ppgd_cfg.n_warmup_steps,
+            )
+        },
         step=jnp.zeros((), jnp.int32),
     )  # fmt: skip
     loss_terms = build_loss_terms(
@@ -418,16 +442,7 @@ def test_step_trains_and_has_vpd_signature():
             ChunkwiseSubsetReconLossConfig(
                 routing=UniformKSubsetRoutingConfig(), coeff=0.5, sites_per_chunk=2, n_samples=1
             ),
-            PersistentPGDReconLossConfig(
-                coeff=0.5,
-                scope=SCScope(),
-                optimizer=AdamPGDConfig(
-                    beta1=0.5,
-                    beta2=0.99,
-                    lr_schedule=ScheduleConfig(start_val=0.01, warmup_pct=0.025),
-                ),
-                n_warmup_steps=n_warmup,
-            ),
+            ppgd_cfg,
         ),
         lm.site_names,
     )
@@ -451,10 +466,10 @@ def test_step_trains_and_has_vpd_signature():
     assert all(jnp.isfinite(jnp.array(list(m.values()))).all() for m in losses)
     assert int(state.step) == n_steps
     # SPEC S13: n_warmup + 1 source-Adam updates per training step, moments persist.
-    ppgd_opt_state = state.sources_opt_state["PersistentPGDReconLoss"]
-    assert float(ppgd_opt_state.step_count) == n_steps * (n_warmup + 1)
+    ppgd_adv = state.adversaries["PersistentPGDReconLoss"]
+    assert float(ppgd_adv.opt_state.step_count) == n_steps * (n_warmup + 1)
     # SPEC S15: sources stay projected to [0,1].
-    for v in state.sources["PersistentPGDReconLoss"].values():
+    for v in ppgd_adv.sources.values():
         assert float(v.min()) >= 0.0 and float(v.max()) <= 1.0
     # SPEC S9: p annealed below its 2.0 start by step 4 of 100.
     assert losses[-1]["p_imp"] < 2.0

--- a/param_decomp/tests/test_no_bake_invariant.py
+++ b/param_decomp/tests/test_no_bake_invariant.py
@@ -62,8 +62,7 @@ def _build_step_and_args():
         ci_fn=ci_fn,
         components_opt_state=opt_vu.init(eqx.filter(components, eqx.is_array)),
         ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
-        sources={},
-        sources_opt_state={},
+        adversaries={},
         step=jnp.zeros((), jnp.int32),
     )
     loss_terms = build_loss_terms(

--- a/param_decomp/tests/test_smooth_l0_imp_min.py
+++ b/param_decomp/tests/test_smooth_l0_imp_min.py
@@ -1,0 +1,86 @@
+"""smooth-L0 (Geman–McClure) importance-minimality penalty (SPEC S7/S8/S9').
+
+The penalty shares the per-site `lp + beta * mean * log2(1 + sum)` structure with the
+`L_p` penalty and differs ONLY in the per-value shape `phi_gamma(c) = c^2/(c^2+gamma^2)`.
+These checks pin the properties that motivate it over `L_p`: flat at the origin
+(`phi'(0)=0`, no singularity to clip), bounded gradient (`|phi'| <= 0.65/gamma`),
+redescent for clearly-on components, and the half-saturation crossover `phi(gamma) = 1/2`.
+"""
+
+import jax
+import jax.numpy as jnp
+
+from param_decomp.configs import SmoothL0ImportanceMinimalityLossConfig
+from param_decomp.losses import (
+    annealed_gamma,
+    annealed_imp_min_param,
+    imp_min_terms,
+    smooth_l0_importance_minimality_terms,
+)
+
+
+def _phi(c: jax.Array, gamma: float) -> jax.Array:
+    return c**2 / (c**2 + gamma**2)
+
+
+def test_phi_shape_invariants():
+    for gamma in (1.0, 0.1):
+        assert float(_phi(jnp.array(0.0), gamma)) == 0.0  # off -> exactly 0
+        assert abs(float(_phi(jnp.array(gamma), gamma)) - 0.5) < 1e-6  # half-saturation
+        assert float(_phi(jnp.array(10.0 * gamma), gamma)) > 0.99  # clearly-on -> ~1
+
+
+def test_phi_gradient_flat_at_origin_and_bounded():
+    """phi'(0) = 0 (no L_p cliff) and the peak |phi'| ~ 0.65/gamma sits at c = gamma/sqrt(3)."""
+    for gamma in (1.0, 0.1):
+        dphi = jax.grad(lambda c, g=gamma: _phi(c, g))
+        assert float(dphi(jnp.array(0.0))) == 0.0
+        cs = jnp.linspace(0.0, 5.0 * gamma, 4096)
+        grads = jnp.abs(jax.vmap(dphi)(cs))
+        peak = float(grads.max())
+        assert peak <= 0.65 / gamma + 1e-3
+        c_peak = float(cs[jnp.argmax(grads)])
+        assert abs(c_peak - gamma / jnp.sqrt(3.0)) < 0.02 * gamma
+        # redescent: gradient at a clearly-on point is far below the peak.
+        assert float(dphi(jnp.array(5.0 * gamma))) < 0.2 * peak
+
+
+def test_terms_match_manual_per_site_structure():
+    ci = {
+        "a": jnp.array([[0.0, 0.5, 1.0], [0.2, 0.0, 0.9]]),
+        "b": jnp.array([[0.3], [0.7]]),
+    }
+    gamma = 0.1
+    lp, entropy = smooth_l0_importance_minimality_terms(ci, jnp.asarray(gamma))
+
+    exp_lp = jnp.zeros(())
+    exp_entropy = jnp.zeros(())
+    for v in ci.values():
+        sums = _phi(v, gamma).sum(axis=0)
+        means = sums / v.shape[0]
+        exp_lp = exp_lp + means.sum()
+        exp_entropy = exp_entropy + (means * jnp.log2(1.0 + sums)).sum()
+    assert jnp.allclose(lp, exp_lp)
+    assert jnp.allclose(entropy, exp_entropy)
+
+
+def test_anneal_and_dispatch():
+    cfg = SmoothL0ImportanceMinimalityLossConfig(
+        coeff=2e-4,
+        gamma=1.0,
+        beta=0.5,
+        gamma_anneal_start_frac=0.0,
+        gamma_anneal_final_gamma=0.1,
+        gamma_anneal_end_frac=1.0,
+    )
+    total = 100
+    assert abs(float(annealed_gamma(jnp.asarray(0.0), total, cfg)) - 1.0) < 1e-6
+    assert abs(float(annealed_gamma(jnp.asarray(50.0), total, cfg)) - 0.55) < 1e-6
+    assert abs(float(annealed_gamma(jnp.asarray(total), total, cfg)) - 0.1) < 1e-6
+
+    ci = {"a": jnp.array([[0.0, 0.5, 1.0], [0.2, 0.0, 0.9]])}
+    param = annealed_imp_min_param(jnp.asarray(float(total)), total, cfg)
+    via_dispatch = imp_min_terms(ci, cfg, param)
+    direct = smooth_l0_importance_minimality_terms(ci, param)
+    assert jnp.allclose(via_dispatch[0], direct[0])
+    assert jnp.allclose(via_dispatch[1], direct[1])

--- a/param_decomp/tools/migrate_c49k_checkpoint.py
+++ b/param_decomp/tools/migrate_c49k_checkpoint.py
@@ -21,12 +21,12 @@ The remap (OLD leaf -> NEW leaf), confirmed against orbax metadata of both trees
 
   ci_fn / ci_fn_opt_state   IDENTICAL leaf names old and new -> straight copy.
 
-  sources / sources_opt_state
+  adversaries
                         OLD sources.<short_site>                  (no state-key level)
-                        NEW sources.<state_key>.<short_site>      state_key = the
-                        PersistentPGD term's instance key ("PersistentPGDReconLoss").
+                        NEW adversaries.<state_key>.sources.<short_site>   state_key =
+                        the PersistentPGD term's instance key ("PersistentPGDReconLoss").
                         OLD sources_adam_state.{m,v}.<site> + .step_count
-                        NEW sources_opt_state.<state_key>.{m,v}.<site> + .step_count.
+                        NEW adversaries.<state_key>.opt_state.{m,v}.<site> + .step_count.
                         Site names already match (short `layers.18.mlp.*_proj`).
 
   step                  scalar, copied through (restores as 175000).
@@ -128,12 +128,13 @@ def _flatten_old(old: dict[str, Any]) -> dict[str, Array]:
     add_ci_fn(".ci_fn_opt_state[0].nu", cio[0]["nu"])
 
     adam = old["sources_adam_state"]
+    adv = f".adversaries['{SOURCE_STATE_KEY}']"
     for site, src in old["sources"].items():
-        out[f".sources['{SOURCE_STATE_KEY}']['{site}']"] = src
+        out[f"{adv}.sources['{site}']"] = src
     for moment in ("m", "v"):
         for site, value in adam[moment].items():
-            out[f".sources_opt_state['{SOURCE_STATE_KEY}'].{moment}['{site}']"] = value
-    out[f".sources_opt_state['{SOURCE_STATE_KEY}'].step_count"] = adam["step_count"]
+            out[f"{adv}.opt_state.{moment}['{site}']"] = value
+    out[f"{adv}.opt_state.step_count"] = adam["step_count"]
 
     out[".step"] = old["step"]
     return out
@@ -220,7 +221,7 @@ def _verify(dst_run_dir: Path, reference: TrainState, lm: Any, cfg: Any) -> None
         assert jnp.all(jnp.isfinite(V)) and jnp.all(jnp.isfinite(U)), f"{site}: non-finite V/U"
     print(f"  components shapes + finiteness OK for {list(lm.site_names)}")
 
-    src = state.sources[SOURCE_STATE_KEY]["layers.18.mlp.gate_proj"]
+    src = state.adversaries[SOURCE_STATE_KEY].sources["layers.18.mlp.gate_proj"]
     assert jnp.all((src >= 0.0) & (src <= 1.0)), "source values out of [0,1]"
     print(f"  sources in [0,1]; gate source shape {src.shape}")
 

--- a/param_decomp/tools/verify_c49k_migration.py
+++ b/param_decomp/tools/verify_c49k_migration.py
@@ -123,17 +123,18 @@ def build_leaf_pairs() -> list[LeafPair]:
     for moment in ("mu", "nu"):
         pairs += _ci_fn_pairs("ci_fn_opt_state", f"{cio_dst}['{moment}']", f"{cio_src}['{moment}']")
 
+    adv_dst = f"['adversaries']['{SOURCE_STATE_KEY}']"
     sites = [f"layers.18.mlp.{suffix}" for suffix in KIND_TO_SITE_SUFFIX.values()]
     for site in sites:
         pairs.append(
             LeafPair(
                 "sources",
-                f"['sources']['{SOURCE_STATE_KEY}']['{site}']",
+                f"{adv_dst}['sources']['{site}']",
                 f"['sources']['{site}']",
                 False,
             )
         )
-    so_dst = f"['sources_opt_state']['{SOURCE_STATE_KEY}']"
+    so_dst = f"{adv_dst}['opt_state']"
     for moment in ("m", "v"):
         for site in sites:
             pairs.append(

--- a/param_decomp/train.py
+++ b/param_decomp/train.py
@@ -28,20 +28,17 @@ from jax.sharding import Mesh
 from jaxtyping import Array, Bool, Float, PRNGKeyArray, jaxtyped
 
 from param_decomp.adversary import (
-    SourcesAdamState,
+    PersistentAdversary,
     init_fresh_pgd_sources,
     source_masks,
-    sources_adam_ascend_project,
 )
 from param_decomp.ci_fn import CI, CIFn
 from param_decomp.components import DecompVU
-from param_decomp.configs import AdamPGDConfig
 from param_decomp.lm import DecomposedModel
 from param_decomp.losses import (
     annealed_pnorm,
     faithfulness_loss,
     importance_minimality_terms,
-    warmup_then_constant_lr,
 )
 from param_decomp.recon import (
     ConstantSources,
@@ -54,7 +51,6 @@ from param_decomp.recon import (
     ReconLossTerm,
     Routes,
     StochasticSources,
-    persistent_configs,
 )
 from param_decomp.sharding import batch_shard_leading
 
@@ -65,15 +61,6 @@ def cast_floating(tree: Any, dtype: Any) -> Any:
     return jax.tree.map(lambda a: a.astype(dtype) if eqx.is_inexact_array(a) else a, tree)
 
 
-def _select_pytree(active: Array, when_active: Any, when_inactive: Any) -> Any:
-    """Element-wise `where(active, when_active, when_inactive)` over matching pytrees.
-
-    Gates a persistent term's source/optimizer updates on `start_frac` (SPEC S32):
-    when inactive the leaf is left untouched, matching torch's `update()`-returns-None
-    (the term is absent, its state frozen at init until `step/total >= start_frac`)."""
-    return jax.tree.map(lambda a, b: jnp.where(active, a, b), when_active, when_inactive)
-
-
 @jax.tree_util.register_dataclass
 @dataclass(frozen=True)
 class TrainState:
@@ -81,11 +68,10 @@ class TrainState:
     ci_fn: CIFn  # fp32 masters
     components_opt_state: optax.OptState
     ci_fn_opt_state: optax.OptState
-    sources: dict[str, dict[str, Array]]
-    """Persistent adversarial sources, `state_key -> site -> source` in [0,1]; per-site
-    shape spells the scope (`sc` -> `(1, T, C+1)`, `bsc` -> `(B, T, C+1)` batch-sharded).
-    One state_key per persistent loss term (SPEC S23); empty when no persistent term."""
-    sources_opt_state: dict[str, SourcesAdamState]
+    adversaries: dict[str, PersistentAdversary]
+    """Persistent-PGD adversaries, `state_key -> adversary` (each owns its sources + Adam
+    state + static config). One state_key per persistent loss term (SPEC S23); empty when
+    no persistent term."""
     step: Array
 
 
@@ -144,20 +130,6 @@ def make_train_step(
     imp_min = imp_term.cfg
     imp_coeff = imp_term.coeff
     assert imp_min.p_anneal_final_p is not None
-
-    persistent = persistent_configs(loss_terms)
-    term_coeff_by_state_key = {
-        entry.sources.state_key: term.coeff
-        for term in recon_terms
-        for entry in term.plan
-        if isinstance(entry.sources, PersistentSources)
-    }
-    assert set(term_coeff_by_state_key) == set(persistent)
-    persistent_adams: dict[str, AdamPGDConfig] = {}
-    for state_key, ppgd_cfg in persistent.items():
-        optimizer = ppgd_cfg.optimizer
-        assert isinstance(optimizer, AdamPGDConfig)
-        persistent_adams[state_key] = optimizer
 
     def batch_sharded(x: Array) -> Array:
         return batch_shard_leading(x, mesh)
@@ -282,72 +254,21 @@ def make_train_step(
         ci_fn_detached = jax.lax.stop_gradient(cast_floating(state.ci_fn, COMPUTE_DT))
         ci_lower_detached = batch_sharded_ci(ci_fn_detached(taps)).lower
 
-        # Persistent terms: n_warmup supplemental Adam ascents each, against the
-        # route-ALL all-sites forward (SPEC S24 — torch warmup parity, NOT the term's
-        # loss plan), sequential per term as in torch.
-        source_lrs: dict[str, Array] = {}
-        warmed_sources: dict[str, dict[str, Array]] = {}
-        warmup_opt_states: dict[str, SourcesAdamState] = {}
-        # `start_frac` gating (SPEC S32): a term contributes nothing — no loss, no
-        # source/optimizer update — until `step/total_steps >= start_frac`. `start_frac`
-        # is a static config float, so the no-gating common case (`== 0.0`) keeps the
-        # zero-overhead path; a positive `start_frac` pays the adversary forward before
-        # activation and `where`-gates every state update (LOSS_PARITY_DESIGN Q3).
-        term_active: dict[str, Array] = {}
-        for state_key, ppgd_cfg in persistent.items():
-            adam = persistent_adams[state_key]
-            if ppgd_cfg.start_frac > 0.0:
-                term_active[state_key] = step_f32 >= ppgd_cfg.start_frac * total_steps
-            source_lr = warmup_then_constant_lr(
-                step_f32,
-                total_steps,
-                adam.lr_schedule.start_val,
-                adam.lr_schedule.warmup_pct,
+        # ── persistent adversaries: each runs its supplemental ascents vs the route-ALL
+        # all-sites forward (SPEC S24 — torch warmup parity, NOT the term's loss plan),
+        # params + CI detached. The warmed sources then enter the main backward as leaves;
+        # the LR schedule + `start_frac` gating (SPEC S32) live in `PersistentAdversary`. ──
+        def warmup_scoring_loss(sources: dict[str, Array]) -> Array:
+            masks, delta_masks = source_masks(ci_lower_detached, sources, site_names)
+            masked = masked_forward(
+                model, components_detached, residual, masks, delta_masks, None, site_names, True
             )
-            source_lrs[state_key] = source_lr
+            return recon_loss_fn(masked, clean_output)
 
-            def warmup_loss(sources: dict[str, Array]) -> Array:
-                masks, delta_masks = source_masks(ci_lower_detached, sources, site_names)
-                masked = masked_forward(
-                    model,
-                    components_detached,
-                    residual,
-                    masks,
-                    delta_masks,
-                    None,
-                    site_names,
-                    True,
-                )
-                return recon_loss_fn(masked, clean_output)
-
-            def warmup_body(
-                carry: tuple[dict[str, Array], SourcesAdamState],
-                _: None,
-                source_lr: Array = source_lr,
-                adam: AdamPGDConfig = adam,
-                warmup_loss: Callable[[dict[str, Array]], Array] = warmup_loss,
-            ) -> tuple[tuple[dict[str, Array], SourcesAdamState], None]:
-                sources, adam_state = carry
-                sources_grad = jax.grad(warmup_loss)(sources)
-                sources, adam_state = sources_adam_ascend_project(
-                    sources, sources_grad, adam_state, source_lr, adam
-                )
-                return (sources, adam_state), None
-
-            base_sources = state.sources[state_key]
-            base_opt = state.sources_opt_state[state_key]
-            (warmed, warmed_opt), _ = jax.lax.scan(
-                warmup_body,
-                (base_sources, base_opt),
-                None,
-                length=ppgd_cfg.n_warmup_steps,
-            )
-            if ppgd_cfg.start_frac > 0.0:
-                warmed, warmed_opt = _select_pytree(
-                    term_active[state_key], (warmed, warmed_opt), (base_sources, base_opt)
-                )
-            warmed_sources[state_key] = jax.lax.stop_gradient(warmed)
-            warmup_opt_states[state_key] = warmed_opt
+        warmed_advs = {
+            state_key: adv.warmup_ascend(warmup_scoring_loss, step_f32, total_steps)
+            for state_key, adv in state.adversaries.items()
+        }
 
         # Fresh-PGD entries: ONE routing draw per entry per step, shared by all
         # ascents and the main loss forward (SPEC S24); sign-ascend `n_steps`, then
@@ -467,11 +388,10 @@ def make_train_step(
                 assert n_forwards > 0, f"term {term.name!r} produced no forwards"
                 term_loss = total / n_forwards
                 first_sources = term.plan[0].sources
-                if (
-                    isinstance(first_sources, PersistentSources)
-                    and persistent[first_sources.state_key].start_frac > 0.0
-                ):
-                    term_loss = term_active[first_sources.state_key] * term_loss
+                if isinstance(first_sources, PersistentSources):
+                    start_frac = state.adversaries[first_sources.state_key].start_frac
+                    if start_frac > 0.0:
+                        term_loss = (step_f32 >= start_frac * total_steps) * term_loss
                 term_losses.append(term_loss)
 
             total_loss = faith_coeff * faith_loss + imp_coeff * imp_loss
@@ -481,35 +401,19 @@ def make_train_step(
 
         (total_loss, (faith_loss, imp_loss, term_losses)), grads = eqx.filter_value_and_grad(
             loss_fn, has_aux=True
-        )((state.components, state.ci_fn, warmed_sources))
+        )((state.components, state.ci_fn, {k: a.sources for k, a in warmed_advs.items()}))
         components_grad, ci_fn_grad, persistent_grads_scaled = grads
         grad_norm_metrics = _grad_norm_metrics(components_grad, ci_fn_grad)
 
-        # ── each persistent term's final ascent, from the fused graph (SPEC S13'/S14');
-        # the backward saw coeff·L_term, the adversary ascends on L_term itself, and the
-        # division is exact because each source bundle feeds exactly one term (S23). ──
-        new_sources: dict[str, dict[str, Array]] = {}
-        new_sources_opt_state: dict[str, SourcesAdamState] = {}
-        for state_key in persistent:
-            coeff = term_coeff_by_state_key[state_key]
-            sources_grad = {
-                site: g / coeff for site, g in persistent_grads_scaled[state_key].items()
-            }
-            ascended, ascended_opt = sources_adam_ascend_project(
-                warmed_sources[state_key],
-                sources_grad,
-                warmup_opt_states[state_key],
-                source_lrs[state_key],
-                persistent_adams[state_key],
+        # ── each adversary's final ascent from the fused graph (SPEC S13'/S14'): the
+        # backward saw coeff·L_term, so it ascends on L_term itself (unscaled by its coeff
+        # inside `final_ascend`, exact since one source bundle feeds one term, S23). ──
+        new_adversaries = {
+            state_key: warmed_advs[state_key].final_ascend(
+                persistent_grads_scaled[state_key], step_f32, total_steps
             )
-            if persistent[state_key].start_frac > 0.0:
-                ascended, ascended_opt = _select_pytree(
-                    term_active[state_key],
-                    (ascended, ascended_opt),
-                    (warmed_sources[state_key], warmup_opt_states[state_key]),
-                )
-            new_sources[state_key] = ascended
-            new_sources_opt_state[state_key] = ascended_opt
+            for state_key in warmed_advs
+        }
 
         components_updates, new_components_opt_state = components_optimizer.update(
             components_grad,
@@ -527,8 +431,7 @@ def make_train_step(
             ci_fn=new_ci_fn,
             components_opt_state=new_components_opt_state,
             ci_fn_opt_state=new_ci_fn_opt_state,
-            sources=new_sources,
-            sources_opt_state=new_sources_opt_state,
+            adversaries=new_adversaries,
             step=state.step + 1,
         )
         metrics = {
@@ -538,6 +441,9 @@ def make_train_step(
             "p_imp": pnorm,
             **{f"loss/{t.name}": v for t, v in zip(recon_terms, term_losses, strict=True)},
             **grad_norm_metrics,
+        }
+        source_lrs = {
+            k: adv.source_lr(step_f32, total_steps) for k, adv in state.adversaries.items()
         }
         if len(source_lrs) == 1:
             metrics["src_lr"] = next(iter(source_lrs.values()))

--- a/param_decomp/train.py
+++ b/param_decomp/train.py
@@ -36,9 +36,9 @@ from param_decomp.ci_fn import CI, CIFn
 from param_decomp.components import DecompVU
 from param_decomp.lm import DecomposedModel
 from param_decomp.losses import (
-    annealed_pnorm,
+    annealed_imp_min_param,
     faithfulness_loss,
-    importance_minimality_terms,
+    imp_min_terms,
 )
 from param_decomp.recon import (
     ConstantSources,
@@ -129,7 +129,6 @@ def make_train_step(
     faith_coeff = faith_term.coeff
     imp_min = imp_term.cfg
     imp_coeff = imp_term.coeff
-    assert imp_min.p_anneal_final_p is not None
 
     def batch_sharded(x: Array) -> Array:
         return batch_shard_leading(x, mesh)
@@ -242,7 +241,7 @@ def make_train_step(
         key: PRNGKeyArray,
     ) -> tuple[TrainState, dict[str, Array]]:
         step_f32 = state.step.astype(jnp.float32)
-        pnorm = annealed_pnorm(step_f32, total_steps, imp_min)
+        imp_min_param = annealed_imp_min_param(step_f32, total_steps, imp_min)
         leading = residual.shape[:-1]
 
         residual = batch_sharded(residual)
@@ -337,7 +336,7 @@ def make_train_step(
             ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
             ci = batch_sharded_ci(ci_fn_bf16(taps))
             faith_loss = faithfulness_loss(model.weight_deltas(components))
-            imp_lp, imp_entropy = importance_minimality_terms(ci.upper, pnorm, imp_min.eps)
+            imp_lp, imp_entropy = imp_min_terms(ci.upper, imp_min, imp_min_param)
             imp_loss = imp_lp + imp_min.beta * imp_entropy
 
             term_losses: list[Array] = []
@@ -438,7 +437,7 @@ def make_train_step(
             "total": total_loss,
             "faith": faith_loss,
             "imp": imp_loss,
-            "p_imp": pnorm,
+            "p_imp": imp_min_param,
             **{f"loss/{t.name}": v for t, v in zip(recon_terms, term_losses, strict=True)},
             **grad_norm_metrics,
         }

--- a/param_decomp_lab/experiments/resid_mlp/test_resid_mlp.py
+++ b/param_decomp_lab/experiments/resid_mlp/test_resid_mlp.py
@@ -253,7 +253,7 @@ def _make_state_and_step(
         components=vu, ci_fn=ci_fn,
         components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
         ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
-        sources={}, sources_opt_state={}, step=jnp.zeros((), jnp.int32),
+        adversaries={}, step=jnp.zeros((), jnp.int32),
     )  # fmt: skip
     loss_terms = build_loss_terms(_loss_metrics(), lm.site_names)
     step = make_train_step(
@@ -278,7 +278,7 @@ def test_step_trains_positionless_no_persistent_sources():
         losses.append({k: float(v) for k, v in m.items()})
     assert all(jnp.isfinite(jnp.array(list(m.values()))).all() for m in losses)
     assert int(state.step) == 6
-    assert state.sources == {}  # no persistent sources for the stochastic configs
+    assert state.adversaries == {}  # no persistent sources for the stochastic configs
     assert isinstance(state.components, DecompVU)
     for V, U in state.components.vu.values():
         assert V.dtype == jnp.float32 and U.dtype == jnp.float32
@@ -363,7 +363,7 @@ def _faith_warmed_state(
         components=vu, ci_fn=ci_fn,
         components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
         ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
-        sources={}, sources_opt_state={}, step=jnp.zeros((), jnp.int32),
+        adversaries={}, step=jnp.zeros((), jnp.int32),
     )  # fmt: skip
     loss_terms = build_loss_terms(_recovery_loss_metrics(), lm.site_names)
     step = make_train_step(

--- a/param_decomp_lab/experiments/tms/test_tms.py
+++ b/param_decomp_lab/experiments/tms/test_tms.py
@@ -203,7 +203,7 @@ def _make_state_and_step(
         components=vu, ci_fn=ci_fn,
         components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
         ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
-        sources={}, sources_opt_state={}, step=jnp.zeros((), jnp.int32),
+        adversaries={}, step=jnp.zeros((), jnp.int32),
     )  # fmt: skip
     loss_terms = build_loss_terms(_loss_metrics(), lm.site_names)
     step = make_train_step(
@@ -229,7 +229,7 @@ def test_step_trains_positionless_no_persistent_sources():
     assert all(jnp.isfinite(jnp.array(list(m.values()))).all() for m in losses)
     assert int(state.step) == 6
     # no persistent sources for the TMS stochastic configs
-    assert state.sources == {}
+    assert state.adversaries == {}
     # fp32 masters preserved
     assert isinstance(state.components, DecompVU)
     for V, U in state.components.vu.values():
@@ -307,7 +307,7 @@ def _faith_warmed_state(
         components=vu, ci_fn=ci_fn,
         components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
         ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
-        sources={}, sources_opt_state={}, step=jnp.zeros((), jnp.int32),
+        adversaries={}, step=jnp.zeros((), jnp.int32),
     )  # fmt: skip
     loss_terms = build_loss_terms(_recovery_loss_metrics(), lm.site_names)
     step = make_train_step(


### PR DESCRIPTION
## Description
Two stacked, independent changes to the loss machinery (both **placement/structure only — goldens bit-identical**):

**1. PPGD → first-class `PersistentAdversary` (`c7d8165f6`).** The persistent-PGD lifecycle was smeared across the train step as parallel `dict[state_key, …]` bookkeeping. It's now a first-class `eqx.Module` in `adversary.py` owning its `sources` + Adam `opt_state` + static config, with three hooks — `warmup_ascend`, `final_ascend`, `source_lr`. `TrainState.{sources, sources_opt_state}` collapse into `TrainState.adversaries`. The step reads as the real lifecycle: warmup all → one `value_and_grad` over `(components, ci_fn, {sources})` → each adversary's `final_ascend` from the shared backward's source-grad. (Note: changes the checkpoint pytree structure — pre-refactor checkpoints won't resume; fresh runs unaffected.)

**2. smooth-L0 (Geman–McClure) imp-min penalty (`230f82e52`, ported from #887, credit @danbraunai).** A shared `_imp_min_terms(ci_upper, ψ)` core; L_p (`(c+eps)^pnorm`) and smooth-L0 (`c²/(c²+γ²)`) differ only in ψ. New `SmoothL0ImportanceMinimalityLossConfig` (+ γ-anneal) and `AnyImportanceMinimalityLossConfig` union; `train.py` dispatches via `imp_min_terms`/`annealed_imp_min_param`. Opt-in/config-gated — the existing L_p path is unchanged.

## How tested
- `make check` clean.
- Full suite @1: **453 passed**, 0 failed; new `test_smooth_l0_imp_min.py` 4 passed; checkpoint round-trip passes on the new `adversaries` pytree.
- Goldens `--runslow` (equivalence + stacked_parity): green and **bit-identical** @1 (and @4 for PPGD) — no `.npz`/fixture touched. Proves both changes preserve numerics (the PPGD reorg and the L_p rewrap are exact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
