### PR TITLE
feat(losses): split batch-invariant frequency-minimality out of imp-min

### DIFF
--- a/param_decomp/SPEC.md
+++ b/param_decomp/SPEC.md
@@ -59,7 +59,7 @@ and the tables (§2, §3, §6). Prose between them is orientation only. Notation
 | C | 24576 (bench: 8192); the delta component is always built → source channel dim `C+1` |
 | data | fineweb, seq `T=2048`, global batch `B=512`, fresh batch per step |
 | coeffs | faith `1e5` · imp `5e-6` · stoch `0.5` · ppgd `0.5` |
-| imp-min | `beta 0.2`, `eps 1e-12`, `p: 2.0 → 0.4` linear over `[0, 1]`-frac of training |
+| imp-min | `eps 1e-12`, `p: 2.0 → 0.4` linear over `[0, 1]`-frac of training; `frequency` coeff `1e-6` (= imp `5e-6` · old beta `0.2`), `reference_token_count = B·T = 1048576` |
 | stoch | plan = sequential 3-site chunks × `uniform_k_routing(chunk, n_draws=1)` |
 | PPGD | scope `broadcast_across_batch`, `n_warmup 2`, clamp-parameterization, Adam(β₁ .5, β₂ .99, ε 1e-8), lr const `0.01` w/ 2.5% LR-warmup |
 | components opt | AdamW(.9, .999, ε 1e-8, wd 0), lr `1.5e-4` cosine → `0.1×`, **grad-clip 0.01** |
@@ -141,9 +141,14 @@ def kl_per_position(masked_output, clean_output) =
 
 def faithfulness_loss(components) = ( Σ_s ‖W_s − V_s@U_s‖_F² ) / ( Σ_s numel(W_s) )        (S17)
 
-def importance_minimality_loss(ci_upper, pnorm):         # per-site grouping                (S7)
+def imp_min_terms(ci_upper, pnorm, reference_token_count):   # per-site grouping             (S7)
     for s: per_component_sums[c] = Σ_{b,t} (ci_upper_s[b,t,c] + eps) ** pnorm           (S8,S9)
-    return Σ_s Σ_c (per_component_sums[c]/(B·T)) · (1 + beta · log2(1 + per_component_sums[c]))
+           f[s,c] = per_component_sums[c] / (B·T)            # per-token firing frequency
+    lp   = Σ_s Σ_c f[s,c]                                    # bare mean term (imp coeff)
+    freq = Σ_s Σ_c f[s,c] · log2(1 + a' · f[s,c])           # a' = reference_token_count (freq coeff)
+    return lp, freq          # total imp contribution = imp_coeff·lp + freq_coeff·freq   (S8')
+    # freq is omitted (0) when no `frequency` is configured. Setting a' = B·T recovers the
+    # old rolled `Σ_c f·(1 + beta·log2(1 + B·T·f))` with freq_coeff = imp_coeff·beta.
 
 # RECON_PLAN: a static list of entries (live_sites, SAMPLE_ROUTING); each entry's sampler
 # returns a statically-sized FAMILY of routing draws, each draw = one forward (§6).
@@ -270,8 +275,9 @@ faithfulness, sources/PPGD, the squashings (S5/S6), the imp-min reduction, the g
 | S4 | **AMENDED 2026-06-22** (Oli-approved): CI inputs come from `read_activations(batch, ci_fn.input_names)` — a GENERAL clean-path activation accessor keyed by OPAQUE tap keys (was the fixed `site_inputs` seam). `input_names` is the CI fn's static declaration; the target is the SOLE key→activation interpreter, producing exactly the requested taps off the frozen path of the same batch. For the LM these are residual-stream taps `resid.{layer}` (the residual entering block `layer`) and/or per-site matrix-input keys (site names) for harvest; for positionless toys they are the per-site matrix inputs. Core never parses a key. (Was: "CI inputs are the clean site inputs from the frozen path of the same batch.") |
 | S5 | **AMENDED 2026-06-22** (Oli-approved): the CI fn returns a `CI{logits, lower, upper}` bundle (was `(ci_lower, ci_upper)`). `lower` and `upper` are two squashings of the SAME `logits`, centralized in `CI.from_logits` (no impl re-triplicates them); `logits` is KEPT as a consumed view (histograms / heatmaps plot the pre-squash value). `ci_lower ≡ CI.lower` feeds every mask; `ci_upper ≡ CI.upper` feeds imp-min only; no other crossing. The squashings themselves (S6) are UNCHANGED — only the bundling and the `logits` view changed. The CI fn is a protocol `dict[InputTap,Array] → CI` whose output sites PARTITION the model's sites (input keyspace independent of output keyspace). |
 | S6 | The squashings' forward/backward are exactly §4.2 — including `lower_leaky_hard`'s grad-sign-gated lower leak (a custom VJP, not autodiff of the forward). The backward is a nested `where` with `<=` boundaries: on `0 < x <= 1` pass `g`; at `x <= 0` pass `α·g` ONLY where `g < 0`, else `0`; at `x > 1` pass `0`; `α=0.01`. The boundary tie at `x=0` resolves to the LOWER (`x <= 0`) branch — this `<=` placement is exactly what makes torch (`ci_sigmoids.py`) and JAX (`ci_fn.py`, `_lhs_b`) bit-identical and is load-bearing, not incidental. Grad-checked by `tests/test_lower_leaky_hard_grad.py` (`g<0` vs `g>0` at `x<0`, `x∈(0,1]`, `x>1`; #789). |
-| S7 | Imp-min groups per site: the `log2(1+sum)` consumes one site's per-component sum. Merging sites/layers into one group is incorrect (convexity). |
-| S8 | The per-component sums are over the **global batch**, accumulated before the `log2`. (Per-shard results combined after the log are incorrect — Jensen; see D2.) |
+| S7 | Imp-min groups per site: the frequency penalty's `log2(1 + a'·f_c)` consumes one site's per-component frequency. Merging sites/layers into one group is incorrect (convexity). |
+| S8 | The per-component frequencies `f_c = (Σ_{b,t} ψ(c)) / B·T` are over the **global batch**, formed before the `log2`. (Per-shard `f_c` combined after the log are incorrect — Jensen; see D2.) The two imp-min terms (`lp = Σ_c f_c`, `freq = Σ_c f_c·log2(1 + a'·f_c)`) share these per-component sums in one pass. |
+| S8' | Imp-min contributes `imp_coeff·lp + freq_coeff·freq` with INDEPENDENT coefficients; the frequency normalizer `a' = reference_token_count` is explicit (batch-invariant at fixed firing rate), not the implicit `B·T`. `freq` is absent when no `frequency` is configured. `a' = B·T` recovers the old rolled `imp_coeff·Σ_c f·(1 + beta·log2(1 + B·T·f))` with `freq_coeff = imp_coeff·beta`. |
 | S9 | `pnorm(step)` anneals linearly `2.0 → 0.4` over the configured frac window; `eps` sits inside the power. **JAX narrowing:** annealing is REQUIRED — `annealed_pnorm` asserts `cfg.p_anneal_final_p is not None` (`losses.py:53`) and `train.py:122` asserts it too. Torch supports a constant-p config (`importance_minimality.py:16-37` returns `initial_p` when no annealing window). Constant-p in JAX is expressed by setting `p_anneal_final_p == pnorm` (a flat schedule); any other torch constant-p config is REFUSED (fail-fast assert), never silently approximated. |
 | S10′ | The recon objective is a static tuple of coefficiented loss TERMS (one per configured recon loss metric, in config order). Each term is a static plan of `(live_sites, SAMPLE_ROUTING, MASK_SOURCE)` entries; the term's loss = mean over ALL its forwards (every draw of every entry) of `kl_per_position`; the total adds `coeff · term` per term. Plan structures (live-sets, sampler identities, family sizes, strategy kinds) are fixed across steps. The §4 pseudocode shows the production two-term instantiation (`stochastic_recon_loss` + `adversarial_recon_loss`). Recon KL direction is pinned by S25; the mean-over-forwards ≡ accumulator identity by S26. |
 | S11 | `uniform_k_routing`, per position: `k ~ U{1..|live_sites|}` then a uniform `k`-subset of the live sites routes True; non-live sites are not live at all. Routing draws are fresh per step, sampled inside the step. |
@@ -369,8 +375,11 @@ Rationale worth keeping: the two squashings give each consumer gradient only in 
 permitted direction (masks may push CI up out of saturation; the sparsity penalty may
 not push it below 0). The adversary is *persistent* because re-finding the worst-case
 ablation from scratch each step under-trains the adversary at any affordable inner-step
-count. The `log2` term approximates a description-length / frequency penalty (`L_freq`
-in the VPD paper) — its convexity is why S8 demands the true global sum. Fused-linear-KL
+count. The `freq` term is the description-length / frequency penalty (`L_freq` in the VPD
+paper); normalizing its `log2` by an explicit `a' = reference_token_count` (rather than the
+implicit `B·T`) makes its curvature batch-invariant at a fixed firing rate, so batch size
+and frequency-penalty strength are independently tunable. Its convexity is why S8 demands
+the true global per-component frequency. Fused-linear-KL
 and LM-head-bypass are memory/throughput optimizations and must be semantically
 invisible (cf. `recon_loss_kl` equivalence).
 

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -143,18 +143,36 @@ class FaithfulnessLossConfig(LossMetricConfig):
     type: Literal["FaithfulnessLoss"] = "FaithfulnessLoss"
 
 
+class FrequencyMinimalityConfig(BaseConfig):
+    """The frequency-minimality penalty riding on an imp-min term: a component's per-token
+    firing frequency `f_c` (over the whole global batch) penalized by
+    `f_c * log2(1 + reference_token_count * f_c)`, summed over components and scaled by
+    `coeff`.
+
+    `reference_token_count` (`a'`) is the token count the penalty is normalized against, so
+    the curvature is invariant to batch size at a fixed firing rate. Setting it to the run's
+    global `batch_size * seq_len` reproduces the implicit `B*T` the old rolled `beta` term
+    baked inside its `log2`; coefficients then transfer as `coeff = old imp.coeff * old
+    beta`. The `f=0 -> 0` cutoff is inherent to the form.
+    """
+
+    coeff: NonNegativeFloat
+    reference_token_count: PositiveInt
+
+
 class ImportanceMinimalityLossConfig(LossMetricConfig):
     """Config for the `L_p`-style importance-minimality penalty on upper-leaky CI values.
 
-    `pnorm` is the initial `p`; `beta` weights the entropy-like `mean * log2(1 + sum)`
-    term added on top of the `L_p` term. `pnorm` is linearly annealed toward
-    `p_anneal_final_p` between `p_anneal_start_frac` and `p_anneal_end_frac` of training
-    (no-op when `p_anneal_final_p is None` or `p_anneal_start_frac == 1.0`).
+    `pnorm` is the initial `p`, linearly annealed toward `p_anneal_final_p` between
+    `p_anneal_start_frac` and `p_anneal_end_frac` of training (no-op when
+    `p_anneal_final_p is None` or `p_anneal_start_frac == 1.0`). `frequency` (when present)
+    adds the batch-invariant frequency-minimality penalty over the same `(c + eps)^p`
+    per-component sums.
     """
 
     type: Literal["ImportanceMinimalityLoss"] = "ImportanceMinimalityLoss"
     pnorm: NonNegativeFloat
-    beta: NonNegativeFloat
+    frequency: FrequencyMinimalityConfig | None = None
     p_anneal_start_frac: Probability = 1.0
     p_anneal_final_p: NonNegativeFloat | None = None
     p_anneal_end_frac: Probability = 1.0
@@ -166,7 +184,7 @@ class SmoothL0ImportanceMinimalityLossConfig(LossMetricConfig):
 
     Per-value penalty `phi_gamma(c) = c^2 / (c^2 + gamma^2)` — a smooth approximation to
     the active-component count `1[c>0]`, exact only as `gamma -> 0` — fed through the same
-    per-site `lp + beta * mean * log2(1 + sum)` structure as `ImportanceMinimalityLoss`.
+    per-site `lp` mean (plus the optional `frequency` term) as `ImportanceMinimalityLoss`.
     Differs from the `L_p` penalty only in the per-value shape: `phi'(0) = 0` and
     `|phi'| <= 0.65/gamma` everywhere, so there is no singularity at the origin (no `eps`
     floor, no aggressive grad clip) — the gradient is localized on the threshold band
@@ -179,15 +197,15 @@ class SmoothL0ImportanceMinimalityLossConfig(LossMetricConfig):
 
     type: Literal["SmoothL0ImportanceMinimalityLoss"] = "SmoothL0ImportanceMinimalityLoss"
     gamma: PositiveFloat
-    beta: NonNegativeFloat
+    frequency: FrequencyMinimalityConfig | None = None
     gamma_anneal_start_frac: Probability = 1.0
     gamma_anneal_final_gamma: PositiveFloat | None = None
     gamma_anneal_end_frac: Probability = 1.0
 
 
-# The two imp-min penalties share the `coeff`/`beta` surface and the `lp + beta * entropy`
-# aggregation; they differ only in the per-value penalty shape and its annealed parameter
-# (`p` vs `gamma`). The trainer's single imp-min slot accepts either.
+# The two imp-min penalties share the `coeff` + optional `frequency` surface and the
+# `lp` mean aggregation; they differ only in the per-value penalty shape and its annealed
+# parameter (`p` vs `gamma`). The trainer's single imp-min slot accepts either.
 AnyImportanceMinimalityLossConfig = (
     ImportanceMinimalityLossConfig | SmoothL0ImportanceMinimalityLossConfig
 )

--- a/param_decomp/configs/llama8b_full32L_seq512_b128_dp128.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b128_dp128.yaml
@@ -550,7 +550,9 @@ pd:
   faithfulness_warmup_weight_decay: 0.0
   identity_decomposition_targets: null
   loss_metrics:
-  - beta: 0.2
+  - frequency:
+      coeff: 1.0e-06
+      reference_token_count: 65536
     coeff: 5.0e-06
     eps: 1.0e-06
     p_anneal_end_frac: 1.0

--- a/param_decomp/configs/llama8b_l18-26_9layer_chunkwise.yaml
+++ b/param_decomp/configs/llama8b_l18-26_9layer_chunkwise.yaml
@@ -169,7 +169,9 @@ pd:
   faithfulness_warmup_steps: 400
   faithfulness_warmup_weight_decay: 0.0
   loss_metrics:
-  - beta: 0.2
+  - frequency:
+      coeff: 1.0e-06
+      reference_token_count: 65536
     coeff: 5.0e-06
     eps: 1.0e-06
     p_anneal_end_frac: 1.0

--- a/param_decomp/configs/llama8b_l18_C49k_200k.yaml
+++ b/param_decomp/configs/llama8b_l18_C49k_200k.yaml
@@ -108,7 +108,9 @@ pd:
   faithfulness_warmup_steps: 400
   faithfulness_warmup_weight_decay: 0.0
   loss_metrics:
-  - beta: 0.2
+  - frequency:
+      coeff: 1.0e-06
+      reference_token_count: 1048576
     coeff: 5.0e-06
     eps: 1.0e-12
     p_anneal_end_frac: 1.0

--- a/param_decomp/configs/llama8b_l18_b128_cmp32.yaml
+++ b/param_decomp/configs/llama8b_l18_b128_cmp32.yaml
@@ -60,7 +60,9 @@ pd:
   - type: ImportanceMinimalityLoss
     coeff: 5.0e-06
     pnorm: 2.0
-    beta: 0.2
+    frequency:
+      coeff: 1.0e-06
+      reference_token_count: 262144
     p_anneal_start_frac: 0.0
     p_anneal_final_p: 0.4
     p_anneal_end_frac: 1.0

--- a/param_decomp/configs/pile_pgd1.yaml
+++ b/param_decomp/configs/pile_pgd1.yaml
@@ -119,7 +119,9 @@ pd:
   faithfulness_warmup_steps: 400
   faithfulness_warmup_weight_decay: 0.0
   loss_metrics:
-  - beta: 0.5
+  - frequency:
+      coeff: 1.0e-04
+      reference_token_count: 65536
     coeff: 0.0002
     eps: 1.0e-12
     p_anneal_end_frac: 1.0

--- a/param_decomp/configs/pile_ppgd_bsc.yaml
+++ b/param_decomp/configs/pile_ppgd_bsc.yaml
@@ -126,7 +126,9 @@ pd:
   faithfulness_warmup_steps: 400
   faithfulness_warmup_weight_decay: 0.0
   loss_metrics:
-  - beta: 0.5
+  - frequency:
+      coeff: 1.0e-04
+      reference_token_count: 65536
     coeff: 0.0002
     eps: 1.0e-12
     p_anneal_end_frac: 1.0

--- a/param_decomp/experiments/invariance_check.py
+++ b/param_decomp/experiments/invariance_check.py
@@ -40,6 +40,7 @@ from param_decomp.configs import (
     AdamPGDConfig,
     ChunkwiseSubsetReconLossConfig,
     FaithfulnessLossConfig,
+    FrequencyMinimalityConfig,
     ImportanceMinimalityLossConfig,
     PersistentPGDReconLossConfig,
     SCScope,
@@ -113,7 +114,8 @@ def _run(steps: int, sharded: bool) -> list[dict[str, float]]:
         (
             FaithfulnessLossConfig(coeff=1e5),
             ImportanceMinimalityLossConfig(
-                coeff=5e-6, pnorm=2.0, beta=0.2,
+                coeff=5e-6, pnorm=2.0,
+                frequency=FrequencyMinimalityConfig(coeff=1e-6, reference_token_count=128),
                 p_anneal_start_frac=0.0, p_anneal_final_p=0.4, p_anneal_end_frac=1.0,
             ),
             ChunkwiseSubsetReconLossConfig(routing=UniformKSubsetRoutingConfig(), coeff=0.5, sites_per_chunk=3, n_samples=1),

--- a/param_decomp/losses.py
+++ b/param_decomp/losses.py
@@ -47,46 +47,57 @@ def faithfulness_loss(weight_deltas: dict[str, Float[Array, "_ _"]]) -> Float[Ar
 def _imp_min_terms(
     ci_upper: dict[str, Float[Array, "*leading _"]],
     per_value_penalty: Callable[[Float[Array, "*leading _"]], Float[Array, "*leading _"]],
+    reference_token_count: int | None,
 ) -> tuple[Float[Array, ""], Float[Array, ""]]:
-    """`(lp, entropy)` for any per-value penalty `psi`, with per-site grouping and the
-    global-batch sum inside the log2 (SPEC S7/S8); the loss is `lp + beta * entropy`. The
-    two imp-min penalties (`L_p`, smooth-L0) differ ONLY in `psi`.
+    """`(lp, freq)` for any per-value penalty `psi`, with per-site grouping (SPEC S7/S8):
 
-    Under GSPMD the `*leading` axes are the global batch, so `jnp.sum` IS the exact
-    global per-component sum — XLA reduces across shards inside the graph."""
+    - `lp = Σ_s Σ_c f_c`, the bare per-component mean firing rate `f_c = (Σ_{b,t} psi(c)) / B·T`.
+    - `freq = Σ_s Σ_c f_c · log2(1 + a' · f_c)`, the batch-invariant frequency penalty with
+      `a' = reference_token_count`; `0.0` when `reference_token_count is None`.
+
+    The two imp-min penalties (`L_p`, smooth-L0) differ ONLY in `psi`. Under GSPMD the
+    `*leading` axes are the global batch, so `jnp.sum` IS the exact global per-component
+    sum — XLA reduces across shards inside the graph, so `f_c` is the true full-batch
+    frequency inside the convex `log2` (a per-shard `f_c` would give a Jensen bias)."""
     lp = jnp.zeros((), jnp.float32)
-    entropy = jnp.zeros((), jnp.float32)
+    freq = jnp.zeros((), jnp.float32)
     for ci in ci_upper.values():
         ci = ci.astype(jnp.float32)  # (*leading, C)
         leading_axes = tuple(range(ci.ndim - 1))
         n_positions = math.prod(ci.shape[:-1])
         per_component_sums = jnp.sum(per_value_penalty(ci), axis=leading_axes)  # (C,)
-        per_component_means = per_component_sums / n_positions
+        per_component_means = per_component_sums / n_positions  # f_c
         lp = lp + jnp.sum(per_component_means)
-        entropy = entropy + jnp.sum(per_component_means * jnp.log2(1.0 + per_component_sums))
-    return lp, entropy
+        if reference_token_count is not None:
+            freq = freq + jnp.sum(
+                per_component_means * jnp.log2(1.0 + reference_token_count * per_component_means)
+            )
+    return lp, freq
 
 
 @jaxtyped(typechecker=beartype)
 def importance_minimality_terms(
-    ci_upper: dict[str, Float[Array, "*leading _"]], pnorm: Float[Array, ""], eps: float
+    ci_upper: dict[str, Float[Array, "*leading _"]],
+    pnorm: Float[Array, ""],
+    eps: float,
+    reference_token_count: int | None,
 ) -> tuple[Float[Array, ""], Float[Array, ""]]:
     """`L_p` imp-min terms: per-value penalty `(c + eps)^pnorm`, singular at `c=0` for
-    `pnorm < 1` (the `eps` floor caps the gradient there). Torch's `_no_beta` diagnostic
-    (`lp` alone) is emitted only on the eval path, never from the train step, so this
-    trainer does not log a `train/loss/*_no_beta` key."""
-    return _imp_min_terms(ci_upper, lambda ci: (ci + eps) ** pnorm)
+    `pnorm < 1` (the `eps` floor caps the gradient there)."""
+    return _imp_min_terms(ci_upper, lambda ci: (ci + eps) ** pnorm, reference_token_count)
 
 
 @jaxtyped(typechecker=beartype)
 def smooth_l0_importance_minimality_terms(
-    ci_upper: dict[str, Float[Array, "*leading _"]], gamma: Float[Array, ""]
+    ci_upper: dict[str, Float[Array, "*leading _"]],
+    gamma: Float[Array, ""],
+    reference_token_count: int | None,
 ) -> tuple[Float[Array, ""], Float[Array, ""]]:
     """Geman–McClure smooth-L0 imp-min terms: per-value penalty `c^2 / (c^2 + gamma^2)`.
     Flat at the origin (`phi'(0)=0`) and bounded (`|phi'| <= 0.65/gamma`) — no singularity,
     no `eps` floor. Approaches the true `L_0` count as `gamma -> 0`."""
     gamma_sq = gamma * gamma
-    return _imp_min_terms(ci_upper, lambda ci: ci**2 / (ci**2 + gamma_sq))
+    return _imp_min_terms(ci_upper, lambda ci: ci**2 / (ci**2 + gamma_sq), reference_token_count)
 
 
 def _linear_anneal(
@@ -150,12 +161,14 @@ def imp_min_terms(
     cfg: AnyImportanceMinimalityLossConfig,
     annealed_param: Array,
 ) -> tuple[Float[Array, ""], Float[Array, ""]]:
-    """Dispatch `(lp, entropy)` on the imp-min penalty kind, given its annealed parameter."""
+    """Dispatch `(lp, freq)` on the imp-min penalty kind, given its annealed parameter; the
+    `freq` term is `0.0` unless `cfg.frequency` is configured."""
+    ref = cfg.frequency.reference_token_count if cfg.frequency is not None else None
     match cfg:
         case ImportanceMinimalityLossConfig():
-            return importance_minimality_terms(ci_upper, annealed_param, cfg.eps)
+            return importance_minimality_terms(ci_upper, annealed_param, cfg.eps, ref)
         case SmoothL0ImportanceMinimalityLossConfig():
-            return smooth_l0_importance_minimality_terms(ci_upper, annealed_param)
+            return smooth_l0_importance_minimality_terms(ci_upper, annealed_param, ref)
 
 
 def warmup_then_constant_lr(

--- a/param_decomp/run.py
+++ b/param_decomp/run.py
@@ -127,6 +127,7 @@ _METRIC_KEYS = {
     "total": "train/loss/total",
     "faith": "train/loss/FaithfulnessLoss",
     "imp": "train/loss/ImportanceMinimalityLoss",
+    "freq": "train/loss/FrequencyMinimalityLoss",
     "p_imp": "train/schedules/p_imp",
     "src_lr": "train/schedules/lr/src",
     "step_time_s": "train/perf/step_time_s",

--- a/param_decomp/tests/equivalence/jax_equivalence.py
+++ b/param_decomp/tests/equivalence/jax_equivalence.py
@@ -158,10 +158,16 @@ def compute_jax_terms(f: dict[str, np.ndarray]) -> dict[str, float]:
     faith = float(faithfulness_loss(lm.weight_deltas(vu)))
 
     # ---- imp ----
-    imp_lp, imp_entropy = importance_minimality_terms(
-        ci_upper, jnp.asarray(float(f["_scalar_IMP_P"])), float(f["_scalar_IMP_EPS"])
+    # a' = B·T reproduces the old rolled `log2(1 + B·T·f_c)`, so `imp_lp + beta·freq`
+    # equals the old `imp_lp + beta·entropy` the golden was generated against.
+    n_positions = int(np.prod(next(iter(ci_upper.values())).shape[:-1]))
+    imp_lp, imp_freq = importance_minimality_terms(
+        ci_upper,
+        jnp.asarray(float(f["_scalar_IMP_P"])),
+        float(f["_scalar_IMP_EPS"]),
+        reference_token_count=n_positions,
     )
-    imp = float(imp_lp + float(f["_scalar_IMP_BETA"]) * imp_entropy)
+    imp = float(imp_lp + float(f["_scalar_IMP_BETA"]) * imp_freq)
 
     # ---- stoch (per-chunk, FIXED masks) ----
     stoch_u = per_site("stoch_u")

--- a/param_decomp/tests/equivalence/test_imp_min_bf16_seam.py
+++ b/param_decomp/tests/equivalence/test_imp_min_bf16_seam.py
@@ -38,14 +38,20 @@ def test_imp_min_bf16_input_seam_within_tolerance():
     reference = json.loads((HERE / "imp_min_bf16_reference.json").read_text())
     ci_upper = _load_bf16_ci()
 
-    lp, entropy = importance_minimality_terms(
-        ci_upper, jnp.asarray(reference["pnorm"]), reference["eps"]
+    # a' = B·T (the full leading count) reproduces the old rolled `log2(1 + B·T·f_c)`,
+    # so `freq` equals the `torch_entropy` golden the fixture was generated against.
+    n_positions = int(np.prod(next(iter(ci_upper.values())).shape[:-1]))
+    lp, freq = importance_minimality_terms(
+        ci_upper,
+        jnp.asarray(reference["pnorm"]),
+        reference["eps"],
+        reference_token_count=n_positions,
     )
 
     worst_rel = 0.0
     for name, jax_value, torch_value in (
         ("lp", float(lp), reference["torch_lp"]),
-        ("entropy", float(entropy), reference["torch_entropy"]),
+        ("entropy", float(freq), reference["torch_entropy"]),
     ):
         rel = abs(jax_value - torch_value) / abs(torch_value)
         worst_rel = max(worst_rel, rel)

--- a/param_decomp/tests/stacked_parity/gen_stacked_fixtures.py
+++ b/param_decomp/tests/stacked_parity/gen_stacked_fixtures.py
@@ -38,6 +38,7 @@ from param_decomp.adversary import (  # noqa: E402
 from param_decomp.ci_fn import CIArch, init_ci_fn  # noqa: E402
 from param_decomp.configs import (  # noqa: E402
     AdamPGDConfig,
+    FrequencyMinimalityConfig,
     ImportanceMinimalityLossConfig,
     PersistentPGDReconLossConfig,
     SCScope,
@@ -175,7 +176,7 @@ def main() -> None:
         imp_min=ImportanceMinimalityLossConfig(
             coeff=5e-6,
             pnorm=2.0,
-            beta=0.2,
+            frequency=FrequencyMinimalityConfig(coeff=1e-6, reference_token_count=32),
             p_anneal_start_frac=0.0,
             p_anneal_final_p=0.4,
             p_anneal_end_frac=1.0,

--- a/param_decomp/tests/stacked_parity/test_stacked_parity.py
+++ b/param_decomp/tests/stacked_parity/test_stacked_parity.py
@@ -37,6 +37,7 @@ from param_decomp.configs import (
     AdamPGDConfig,
     ChunkwiseSubsetReconLossConfig,
     FaithfulnessLossConfig,
+    FrequencyMinimalityConfig,
     ImportanceMinimalityLossConfig,
     PersistentPGDReconLossConfig,
     SCScope,
@@ -267,7 +268,7 @@ def test_train_trajectory_matches():
             ImportanceMinimalityLossConfig(
                 coeff=5e-6,
                 pnorm=2.0,
-                beta=0.2,
+                frequency=FrequencyMinimalityConfig(coeff=1e-6, reference_token_count=32),
                 p_anneal_start_frac=0.0,
                 p_anneal_final_p=0.4,
                 p_anneal_end_frac=1.0,

--- a/param_decomp/tests/test_checkpoint.py
+++ b/param_decomp/tests/test_checkpoint.py
@@ -119,7 +119,7 @@ def _build(seed: int):
         (
             FaithfulnessLossConfig(coeff=1e5),
             ImportanceMinimalityLossConfig(
-                coeff=5e-6, pnorm=2.0, beta=0.2,
+                coeff=5e-6, pnorm=2.0, 
                 p_anneal_start_frac=0.0, p_anneal_final_p=0.4, p_anneal_end_frac=1.0,
             ),
             ChunkwiseSubsetReconLossConfig(routing=UniformKSubsetRoutingConfig(), coeff=0.5, sites_per_chunk=3, n_samples=1),

--- a/param_decomp/tests/test_checkpoint_production_topology.py
+++ b/param_decomp/tests/test_checkpoint_production_topology.py
@@ -149,7 +149,7 @@ def _build_sharded(seed: int):
         (
             FaithfulnessLossConfig(coeff=1e5),
             ImportanceMinimalityLossConfig(
-                coeff=5e-6, pnorm=2.0, beta=0.2,
+                coeff=5e-6, pnorm=2.0, 
                 p_anneal_start_frac=0.0, p_anneal_final_p=0.4, p_anneal_end_frac=1.0,
             ),
             ChunkwiseSubsetReconLossConfig(routing=UniformKSubsetRoutingConfig(), coeff=0.5, sites_per_chunk=3, n_samples=1),

--- a/param_decomp/tests/test_config.py
+++ b/param_decomp/tests/test_config.py
@@ -76,7 +76,7 @@ def test_legacy_top_level_n_mask_samples_pushes_onto_stochastic_terms():
         "n_mask_samples": 4,
         "loss_metrics": [
             {"type": "FaithfulnessLoss", "coeff": 1.0},
-            {"type": "ImportanceMinimalityLoss", "coeff": 1.0, "pnorm": 2.0, "beta": 0.0},
+            {"type": "ImportanceMinimalityLoss", "coeff": 1.0, "pnorm": 2.0},
             {"type": "StochasticReconLoss", "coeff": 1.0},
             {"type": "StochasticReconSubsetLoss", "coeff": 1.0, "n_mask_samples": 7},
         ],

--- a/param_decomp/tests/test_frequency_minimality.py
+++ b/param_decomp/tests/test_frequency_minimality.py
@@ -1,0 +1,99 @@
+"""Frequency-minimality penalty `Σ_c f_c·log2(1 + a'·f_c)` (SPEC S7/S8).
+
+`importance_minimality_terms` returns `(lp, freq)`: `lp = Σ_c f_c` (the bare per-token
+firing-rate mean) and `freq` the batch-invariant frequency penalty with `a' =
+reference_token_count`. These pin the properties that motivate the split from the old
+rolled `lp + beta·log2(1 + B·T·f_c)`: batch-invariance, the `f=0 → 0` cutoff, and that
+`a' = B·T` reproduces the old implicit-`B·T` value exactly (so coefficients transfer).
+"""
+
+import math
+
+import jax.numpy as jnp
+
+from param_decomp.configs import (
+    FrequencyMinimalityConfig,
+    ImportanceMinimalityLossConfig,
+)
+from param_decomp.losses import annealed_imp_min_param, imp_min_terms, importance_minimality_terms
+
+
+def test_closed_form():
+    # pnorm=1, eps=0: per_component_sums = column sums; f = sums / n; a' = 8.
+    ci = {"a": jnp.array([[1.0, 2.0], [3.0, 4.0]])}  # n=2, sums=[4,6], f=[2,3]
+    lp, freq = importance_minimality_terms(ci, jnp.asarray(1.0), eps=0.0, reference_token_count=8)
+    assert math.isclose(float(lp), 2.0 + 3.0, rel_tol=1e-6)
+    expected = 2.0 * math.log2(1 + 8 * 2.0) + 3.0 * math.log2(1 + 8 * 3.0)
+    assert math.isclose(float(freq), expected, rel_tol=1e-6)
+
+
+def test_zero_frequency_zero_contribution():
+    # A component that never fires (f=0) contributes exactly 0 to freq.
+    ci = {"a": jnp.array([[0.0, 5.0], [0.0, 5.0]])}  # f = [0, 5]
+    _, freq = importance_minimality_terms(ci, jnp.asarray(1.0), eps=0.0, reference_token_count=16)
+    expected = 0.0 + 5.0 * math.log2(1 + 16 * 5.0)
+    assert math.isclose(float(freq), expected, rel_tol=1e-6)
+
+
+def test_batch_invariance():
+    # Same per-token frequency at two batch sizes => same freq (the whole point of a').
+    base = jnp.array([[0.1, 0.4, 0.7]])  # one row of per-token values
+    small = {"a": jnp.tile(base, (4, 1))}  # n=4
+    large = {"a": jnp.tile(base, (64, 1))}  # n=64, identical f_c
+    _, freq_small = importance_minimality_terms(
+        small, jnp.asarray(1.0), 0.0, reference_token_count=1024
+    )
+    _, freq_large = importance_minimality_terms(
+        large, jnp.asarray(1.0), 0.0, reference_token_count=1024
+    )
+    assert jnp.allclose(freq_small, freq_large, rtol=1e-5)
+
+
+def test_a_prime_bt_reproduces_old_rolled_log_term():
+    # Old rolled imp-min: Σ_c f_c + beta·f_c·log2(1 + sum_c), sum_c = f_c·B·T implicit.
+    # New split: lp = Σ_c f_c, freq = Σ_c f_c·log2(1 + a'·f_c). With a' = B·T,
+    # beta·freq == the old log term exactly. Here B·T = n (the leading count).
+    ci = {"a": jnp.array([[0.2, 0.5, 0.9], [0.4, 0.1, 0.7]]), "b": jnp.array([[0.3], [0.6]])}
+    p, eps, beta = 2.0, 1e-9, 0.7
+    n = 2  # rows per site
+
+    old = jnp.zeros(())
+    for v in ci.values():
+        sums = ((v + eps) ** p).sum(axis=0)
+        mean = sums / n
+        old = old + (mean + beta * mean * jnp.log2(1 + sums)).sum()
+
+    lp, freq = importance_minimality_terms(ci, jnp.asarray(p), eps=eps, reference_token_count=n)
+    assert jnp.allclose(lp + beta * freq, old, rtol=1e-6)
+
+
+def test_lp_independent_of_reference_token_count():
+    ci = {"a": jnp.array([[0.5, 1.5], [2.5, 3.5]])}
+    lp_a, _ = importance_minimality_terms(ci, jnp.asarray(1.5), 1e-6, reference_token_count=32)
+    lp_b, _ = importance_minimality_terms(ci, jnp.asarray(1.5), 1e-6, reference_token_count=999)
+    assert jnp.allclose(lp_a, lp_b)
+
+
+def test_dispatch_no_frequency_gives_zero_freq():
+    cfg = ImportanceMinimalityLossConfig(coeff=1.0, pnorm=2.0, p_anneal_final_p=2.0)
+    assert cfg.frequency is None
+    ci = {"a": jnp.array([[0.1, 0.9], [0.4, 0.6]])}
+    param = annealed_imp_min_param(jnp.asarray(0.0), 100, cfg)
+    lp, freq = imp_min_terms(ci, cfg, param)
+    assert float(freq) == 0.0
+    assert float(lp) > 0.0
+
+
+def test_dispatch_with_frequency_matches_direct():
+    cfg = ImportanceMinimalityLossConfig(
+        coeff=1.0,
+        pnorm=2.0,
+        p_anneal_final_p=2.0,
+        frequency=FrequencyMinimalityConfig(coeff=0.5, reference_token_count=128),
+    )
+    ci = {"a": jnp.array([[0.1, 0.9], [0.4, 0.6]])}
+    param = annealed_imp_min_param(jnp.asarray(0.0), 100, cfg)
+    lp, freq = imp_min_terms(ci, cfg, param)
+    lp_d, freq_d = importance_minimality_terms(ci, param, cfg.eps, reference_token_count=128)
+    assert jnp.allclose(lp, lp_d)
+    assert jnp.allclose(freq, freq_d)

--- a/param_decomp/tests/test_generic_model_io.py
+++ b/param_decomp/tests/test_generic_model_io.py
@@ -228,7 +228,7 @@ def test_train_step_runs_through_generic_target():
     loss_terms = build_loss_terms(
         (
             FaithfulnessLossConfig(coeff=1.0),
-            ImportanceMinimalityLossConfig(coeff=1e-4, pnorm=2.0, beta=0.0, p_anneal_final_p=1.0),
+            ImportanceMinimalityLossConfig(coeff=1e-4, pnorm=2.0, p_anneal_final_p=1.0),
             StochasticReconLossConfig(coeff=1.0),
         ),
         lm.site_names,

--- a/param_decomp/tests/test_imp_min_global_reduction.py
+++ b/param_decomp/tests/test_imp_min_global_reduction.py
@@ -42,8 +42,12 @@ def test_imp_min_global_reduction_invariant_to_device_count():
     pnorm = jnp.asarray(2.0)
     eps = 1e-12
     ci_upper = _global_ci_upper()
+    sample = next(iter(ci_upper.values()))
+    n_positions = sample.shape[0] * sample.shape[1]
 
-    lp_single, entropy_single = importance_minimality_terms(ci_upper, pnorm, eps)
+    lp_single, freq_single = importance_minimality_terms(
+        ci_upper, pnorm, eps, reference_token_count=n_positions
+    )
 
     mesh = dp_mesh()
 
@@ -53,15 +57,15 @@ def test_imp_min_global_reduction_invariant_to_device_count():
             site: jax.lax.with_sharding_constraint(v, NamedSharding(mesh, P("dp", None, None)))
             for site, v in ci.items()
         }
-        return importance_minimality_terms(ci, pnorm, eps)
+        return importance_minimality_terms(ci, pnorm, eps, reference_token_count=n_positions)
 
     ci_sharded = {site: shard_batch(v, mesh, batch_axis=0) for site, v in ci_upper.items()}
-    lp_sharded, entropy_sharded = sharded_terms(ci_sharded)
+    lp_sharded, freq_sharded = sharded_terms(ci_sharded)
 
-    # entropy is the Jensen-sensitive term (global sum INSIDE log2); lp is linear.
+    # freq is the Jensen-sensitive term (global f_c INSIDE log2); lp is linear.
     for name, single, sharded in (
         ("lp", lp_single, lp_sharded),
-        ("entropy", entropy_single, entropy_sharded),
+        ("freq", freq_single, freq_sharded),
     ):
         single_f, sharded_f = float(single), float(sharded)
         rel = abs(single_f - sharded_f) / (abs(single_f) + 1e-30)

--- a/param_decomp/tests/test_llama8b.py
+++ b/param_decomp/tests/test_llama8b.py
@@ -343,7 +343,6 @@ def test_step_trains_and_has_vpd_signature(site_cs: tuple[SiteC, ...]):
             ImportanceMinimalityLossConfig(
                 coeff=5e-6,
                 pnorm=2.0,
-                beta=0.2,
                 p_anneal_start_frac=0.0,
                 p_anneal_final_p=0.4,
                 p_anneal_end_frac=1.0,
@@ -459,7 +458,6 @@ def test_fresh_pgd_adversary_step():
                 ImportanceMinimalityLossConfig(
                     coeff=2e-4,
                     pnorm=2.0,
-                    beta=0.5,
                     p_anneal_start_frac=0.0,
                     p_anneal_final_p=0.4,
                     p_anneal_end_frac=1.0,

--- a/param_decomp/tests/test_llama_simple_mlp.py
+++ b/param_decomp/tests/test_llama_simple_mlp.py
@@ -397,7 +397,6 @@ def test_step_trains_and_has_vpd_signature():
             ImportanceMinimalityLossConfig(
                 coeff=5e-6,
                 pnorm=2.0,
-                beta=0.2,
                 p_anneal_start_frac=0.0,
                 p_anneal_final_p=0.4,
                 p_anneal_end_frac=1.0,

--- a/param_decomp/tests/test_no_bake_invariant.py
+++ b/param_decomp/tests/test_no_bake_invariant.py
@@ -68,7 +68,7 @@ def _build_step_and_args():
     loss_terms = build_loss_terms(
         (
             FaithfulnessLossConfig(coeff=1.0),
-            ImportanceMinimalityLossConfig(coeff=1e-4, pnorm=2.0, beta=0.0, p_anneal_final_p=1.0),
+            ImportanceMinimalityLossConfig(coeff=1e-4, pnorm=2.0, p_anneal_final_p=1.0),
             StochasticReconLossConfig(coeff=1.0),
         ),
         lm.site_names,

--- a/param_decomp/tests/test_recon_log_keys.py
+++ b/param_decomp/tests/test_recon_log_keys.py
@@ -66,7 +66,7 @@ RECON_CONFIGS = (
 def _non_recon_configs() -> tuple[FaithfulnessLossConfig, ImportanceMinimalityLossConfig]:
     return (
         FaithfulnessLossConfig(coeff=1.0),
-        ImportanceMinimalityLossConfig(coeff=1.0, pnorm=0.9, beta=0.0, p_anneal_final_p=0.9),
+        ImportanceMinimalityLossConfig(coeff=1.0, pnorm=0.9, p_anneal_final_p=0.9),
     )
 
 

--- a/param_decomp/tests/test_smooth_l0_imp_min.py
+++ b/param_decomp/tests/test_smooth_l0_imp_min.py
@@ -1,6 +1,6 @@
 """smooth-L0 (Geman–McClure) importance-minimality penalty (SPEC S7/S8/S9').
 
-The penalty shares the per-site `lp + beta * mean * log2(1 + sum)` structure with the
+The penalty shares the per-site `lp` mean (plus the optional frequency term) with the
 `L_p` penalty and differs ONLY in the per-value shape `phi_gamma(c) = c^2/(c^2+gamma^2)`.
 These checks pin the properties that motivate it over `L_p`: flat at the origin
 (`phi'(0)=0`, no singularity to clip), bounded gradient (`|phi'| <= 0.65/gamma`),
@@ -10,7 +10,10 @@ redescent for clearly-on components, and the half-saturation crossover `phi(gamm
 import jax
 import jax.numpy as jnp
 
-from param_decomp.configs import SmoothL0ImportanceMinimalityLossConfig
+from param_decomp.configs import (
+    FrequencyMinimalityConfig,
+    SmoothL0ImportanceMinimalityLossConfig,
+)
 from param_decomp.losses import (
     annealed_gamma,
     annealed_imp_min_param,
@@ -51,24 +54,27 @@ def test_terms_match_manual_per_site_structure():
         "b": jnp.array([[0.3], [0.7]]),
     }
     gamma = 0.1
-    lp, entropy = smooth_l0_importance_minimality_terms(ci, jnp.asarray(gamma))
+    n_positions = 2  # both sites have 2 rows; a' = B·T reproduces the old `log2(1 + sum)`
+    lp, freq = smooth_l0_importance_minimality_terms(
+        ci, jnp.asarray(gamma), reference_token_count=n_positions
+    )
 
     exp_lp = jnp.zeros(())
-    exp_entropy = jnp.zeros(())
+    exp_freq = jnp.zeros(())
     for v in ci.values():
         sums = _phi(v, gamma).sum(axis=0)
         means = sums / v.shape[0]
         exp_lp = exp_lp + means.sum()
-        exp_entropy = exp_entropy + (means * jnp.log2(1.0 + sums)).sum()
+        exp_freq = exp_freq + (means * jnp.log2(1.0 + n_positions * means)).sum()
     assert jnp.allclose(lp, exp_lp)
-    assert jnp.allclose(entropy, exp_entropy)
+    assert jnp.allclose(freq, exp_freq)
 
 
 def test_anneal_and_dispatch():
     cfg = SmoothL0ImportanceMinimalityLossConfig(
         coeff=2e-4,
         gamma=1.0,
-        beta=0.5,
+        frequency=FrequencyMinimalityConfig(coeff=1e-4, reference_token_count=64),
         gamma_anneal_start_frac=0.0,
         gamma_anneal_final_gamma=0.1,
         gamma_anneal_end_frac=1.0,
@@ -81,6 +87,6 @@ def test_anneal_and_dispatch():
     ci = {"a": jnp.array([[0.0, 0.5, 1.0], [0.2, 0.0, 0.9]])}
     param = annealed_imp_min_param(jnp.asarray(float(total)), total, cfg)
     via_dispatch = imp_min_terms(ci, cfg, param)
-    direct = smooth_l0_importance_minimality_terms(ci, param)
+    direct = smooth_l0_importance_minimality_terms(ci, param, reference_token_count=64)
     assert jnp.allclose(via_dispatch[0], direct[0])
     assert jnp.allclose(via_dispatch[1], direct[1])

--- a/param_decomp/train.py
+++ b/param_decomp/train.py
@@ -130,6 +130,7 @@ def make_train_step(
     faith_coeff = faith_term.coeff
     imp_min = imp_term.cfg
     imp_coeff = imp_term.coeff
+    freq_coeff = imp_min.frequency.coeff if imp_min.frequency is not None else 0.0
 
     def batch_sharded(x: Array) -> Array:
         return batch_shard_leading(x, mesh)
@@ -343,14 +344,13 @@ def make_train_step(
         # gets too (sources are leaves). ──
         def loss_fn(
             trainable: tuple[DecompVU, CIFn, dict[str, dict[str, Array]]],
-        ) -> tuple[Array, tuple[Array, Array, tuple[Array, ...]]]:
+        ) -> tuple[Array, tuple[Array, Array, Array, tuple[Array, ...]]]:
             components, ci_fn, persistent_sources = trainable
             components_bf16 = cast_floating(components, COMPUTE_DT)
             ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
             ci = batch_sharded_ci(apply_ci_fn(ci_fn_bf16, taps))
             faith_loss = faithfulness_loss(model.weight_deltas(components))
-            imp_lp, imp_entropy = imp_min_terms(ci.upper, imp_min, imp_min_param)
-            imp_loss = imp_lp + imp_min.beta * imp_entropy
+            imp_lp, imp_freq = imp_min_terms(ci.upper, imp_min, imp_min_param)
 
             term_losses: list[Array] = []
             for term_idx, term in enumerate(recon_terms):
@@ -406,14 +406,16 @@ def make_train_step(
                         term_loss = (step_f32 >= start_frac * total_steps) * term_loss
                 term_losses.append(term_loss)
 
-            total_loss = faith_coeff * faith_loss + imp_coeff * imp_loss
+            total_loss = faith_coeff * faith_loss + imp_coeff * imp_lp + freq_coeff * imp_freq
             for term, term_loss in zip(recon_terms, term_losses, strict=True):
                 total_loss = total_loss + term.coeff * term_loss
-            return total_loss, (faith_loss, imp_loss, tuple(term_losses))
+            return total_loss, (faith_loss, imp_lp, imp_freq, tuple(term_losses))
 
-        (total_loss, (faith_loss, imp_loss, term_losses)), grads = eqx.filter_value_and_grad(
-            loss_fn, has_aux=True
-        )((state.components, state.ci_fn, {k: a.sources for k, a in warmed_advs.items()}))
+        (total_loss, (faith_loss, imp_lp, imp_freq, term_losses)), grads = (
+            eqx.filter_value_and_grad(loss_fn, has_aux=True)(
+                (state.components, state.ci_fn, {k: a.sources for k, a in warmed_advs.items()})
+            )
+        )
         components_grad, ci_fn_grad, persistent_grads_scaled = grads
         grad_norm_metrics = _grad_norm_metrics(components_grad, ci_fn_grad)
 
@@ -449,7 +451,8 @@ def make_train_step(
         metrics = {
             "total": total_loss,
             "faith": faith_loss,
-            "imp": imp_loss,
+            "imp": imp_lp,
+            "freq": imp_freq,
             "p_imp": imp_min_param,
             **{f"loss/{t.name}": v for t, v in zip(recon_terms, term_losses, strict=True)},
             **grad_norm_metrics,

--- a/param_decomp_lab/experiments/lm/gpt2-xl.yaml
+++ b/param_decomp_lab/experiments/lm/gpt2-xl.yaml
@@ -44,7 +44,9 @@ pd:
   - type: ImportanceMinimalityLoss
     coeff: 0.00001
     pnorm: 2.0
-    beta: 0.5
+    frequency:
+      coeff: 5.0e-06
+      reference_token_count: 32768
     p_anneal_start_frac: 0.0
     p_anneal_final_p: 0.4
     p_anneal_end_frac: 1.0

--- a/param_decomp_lab/experiments/lm/gpt2_config.yaml
+++ b/param_decomp_lab/experiments/lm/gpt2_config.yaml
@@ -29,7 +29,6 @@ pd:
     - type: ImportanceMinimalityLoss
       coeff: 0.0003
       pnorm: 2.0
-      beta: 0
       p_anneal_start_frac: 0.0
       p_anneal_final_p: 0.3
       p_anneal_end_frac: 1.0

--- a/param_decomp_lab/experiments/lm/llama-3.1-8b.yaml
+++ b/param_decomp_lab/experiments/lm/llama-3.1-8b.yaml
@@ -50,7 +50,9 @@ pd:
   - type: ImportanceMinimalityLoss
     coeff: 0.000001
     pnorm: 2.0
-    beta: 0.5
+    frequency:
+      coeff: 5.0e-07
+      reference_token_count: 32768
     p_anneal_start_frac: 0.0
     p_anneal_final_p: 0.4
     p_anneal_end_frac: 1.0

--- a/param_decomp_lab/experiments/lm/pile_llama_simple_mlp-12L.yaml
+++ b/param_decomp_lab/experiments/lm/pile_llama_simple_mlp-12L.yaml
@@ -48,7 +48,9 @@ pd:
     - type: ImportanceMinimalityLoss
       coeff: 0.0001
       pnorm: 2.0
-      beta: 0.5
+      frequency:
+        coeff: 5.0e-05
+        reference_token_count: 32768
       p_anneal_start_frac: 0.0
       p_anneal_final_p: 0.4
       p_anneal_end_frac: 1.0

--- a/param_decomp_lab/experiments/lm/pile_llama_simple_mlp-4L.yaml
+++ b/param_decomp_lab/experiments/lm/pile_llama_simple_mlp-4L.yaml
@@ -48,7 +48,9 @@ pd:
     - type: ImportanceMinimalityLoss
       coeff: 0.0002
       pnorm: 2.0
-      beta: 0.5
+      frequency:
+        coeff: 1.0e-04
+        reference_token_count: 32768
       p_anneal_start_frac: 0.0
       p_anneal_final_p: 0.4
       p_anneal_end_frac: 1.0

--- a/param_decomp_lab/experiments/lm/pile_llama_simple_mlp-4L_layerwise.yaml
+++ b/param_decomp_lab/experiments/lm/pile_llama_simple_mlp-4L_layerwise.yaml
@@ -48,7 +48,9 @@ pd:
   - type: ImportanceMinimalityLoss
     coeff: 0.0001
     pnorm: 2.0
-    beta: 0.5
+    frequency:
+      coeff: 5.0e-05
+      reference_token_count: 32768
     p_anneal_start_frac: 0.0
     p_anneal_final_p: 0.4
     p_anneal_end_frac: 1.0

--- a/param_decomp_lab/experiments/lm/ss_llama_simple_mlp-2L.yaml
+++ b/param_decomp_lab/experiments/lm/ss_llama_simple_mlp-2L.yaml
@@ -48,7 +48,9 @@ pd:
     - type: ImportanceMinimalityLoss
       coeff: 0.001
       pnorm: 2.0
-      beta: 0.5
+      frequency:
+        coeff: 5.0e-04
+        reference_token_count: 32768
       p_anneal_start_frac: 0.0
       p_anneal_final_p: 0.4
       p_anneal_end_frac: 1.0

--- a/param_decomp_lab/experiments/resid_mlp/configs/resid_mlp_1l.yaml
+++ b/param_decomp_lab/experiments/resid_mlp/configs/resid_mlp_1l.yaml
@@ -20,7 +20,6 @@ pd:
   - type: ImportanceMinimalityLoss
     coeff: 1e-5
     pnorm: 2.0
-    beta: 0.0
     p_anneal_start_frac: 0.0
     p_anneal_final_p: 2.0
     p_anneal_end_frac: 1.0

--- a/param_decomp_lab/experiments/resid_mlp/configs/resid_mlp_1l_SMOKE.yaml
+++ b/param_decomp_lab/experiments/resid_mlp/configs/resid_mlp_1l_SMOKE.yaml
@@ -20,7 +20,6 @@ pd:
   - type: ImportanceMinimalityLoss
     coeff: 3e-3
     pnorm: 1.0
-    beta: 0.0
     p_anneal_start_frac: 0.0
     p_anneal_final_p: 1.0
     p_anneal_end_frac: 1.0

--- a/param_decomp_lab/experiments/resid_mlp/configs/resid_mlp_1l_global.yaml
+++ b/param_decomp_lab/experiments/resid_mlp/configs/resid_mlp_1l_global.yaml
@@ -23,7 +23,6 @@ pd:
   - type: ImportanceMinimalityLoss
     coeff: 1e-5
     pnorm: 2.0
-    beta: 0.0
     p_anneal_start_frac: 0.0
     p_anneal_final_p: 2.0
     p_anneal_end_frac: 1.0

--- a/param_decomp_lab/experiments/resid_mlp/configs/resid_mlp_2l.yaml
+++ b/param_decomp_lab/experiments/resid_mlp/configs/resid_mlp_2l.yaml
@@ -23,7 +23,6 @@ pd:
   - type: ImportanceMinimalityLoss
     coeff: 1e-4
     pnorm: 2.0
-    beta: 0.0
     p_anneal_start_frac: 0.0
     p_anneal_final_p: 2.0
     p_anneal_end_frac: 1.0

--- a/param_decomp_lab/experiments/resid_mlp/configs/resid_mlp_3l.yaml
+++ b/param_decomp_lab/experiments/resid_mlp/configs/resid_mlp_3l.yaml
@@ -27,7 +27,6 @@ pd:
   - type: ImportanceMinimalityLoss
     coeff: 1e-4
     pnorm: 2.0
-    beta: 0.0
     p_anneal_start_frac: 0.0
     p_anneal_final_p: 2.0
     p_anneal_end_frac: 1.0

--- a/param_decomp_lab/experiments/resid_mlp/test_resid_mlp.py
+++ b/param_decomp_lab/experiments/resid_mlp/test_resid_mlp.py
@@ -231,7 +231,6 @@ def _loss_metrics():
         ImportanceMinimalityLossConfig(
             coeff=3e-3,
             pnorm=1.0,
-            beta=0.0,
             p_anneal_start_frac=0.0,
             p_anneal_final_p=1.0,
             p_anneal_end_frac=1.0,
@@ -334,7 +333,6 @@ def _recovery_loss_metrics():
         ImportanceMinimalityLossConfig(
             coeff=3e-3,
             pnorm=1.0,
-            beta=0.0,
             p_anneal_start_frac=0.0,
             p_anneal_final_p=1.0,
             p_anneal_end_frac=1.0,

--- a/param_decomp_lab/experiments/tms/configs/tms_40-10-id.yaml
+++ b/param_decomp_lab/experiments/tms/configs/tms_40-10-id.yaml
@@ -21,7 +21,6 @@ pd:
   - type: ImportanceMinimalityLoss
     coeff: 1e-4
     pnorm: 2.0
-    beta: 0.0
     p_anneal_start_frac: 0.0
     p_anneal_final_p: 1.0
     p_anneal_end_frac: 1.0

--- a/param_decomp_lab/experiments/tms/configs/tms_40-10.yaml
+++ b/param_decomp_lab/experiments/tms/configs/tms_40-10.yaml
@@ -20,7 +20,6 @@ pd:
   - type: ImportanceMinimalityLoss
     coeff: 1e-4
     pnorm: 2.0
-    beta: 0.0
     p_anneal_start_frac: 0.0
     p_anneal_final_p: 1.0
     p_anneal_end_frac: 1.0

--- a/param_decomp_lab/experiments/tms/configs/tms_5-2-id.yaml
+++ b/param_decomp_lab/experiments/tms/configs/tms_5-2-id.yaml
@@ -21,7 +21,6 @@ pd:
   - type: ImportanceMinimalityLoss
     coeff: 3e-3
     pnorm: 1.0
-    beta: 0.0
     p_anneal_start_frac: 0.0
     p_anneal_final_p: 1.0
     p_anneal_end_frac: 1.0

--- a/param_decomp_lab/experiments/tms/configs/tms_5-2.yaml
+++ b/param_decomp_lab/experiments/tms/configs/tms_5-2.yaml
@@ -24,7 +24,6 @@ pd:
   - type: ImportanceMinimalityLoss
     coeff: 3e-3
     pnorm: 1.0
-    beta: 0.0
     p_anneal_start_frac: 0.0
     p_anneal_final_p: 1.0
     p_anneal_end_frac: 1.0

--- a/param_decomp_lab/experiments/tms/configs/tms_5-5_SMOKE.yaml
+++ b/param_decomp_lab/experiments/tms/configs/tms_5-5_SMOKE.yaml
@@ -18,7 +18,6 @@ pd:
   - type: ImportanceMinimalityLoss
     coeff: 3e-3
     pnorm: 1.0
-    beta: 0.0
     p_anneal_start_frac: 0.0
     p_anneal_final_p: 1.0
     p_anneal_end_frac: 1.0

--- a/param_decomp_lab/experiments/tms/test_tms.py
+++ b/param_decomp_lab/experiments/tms/test_tms.py
@@ -181,7 +181,6 @@ def _loss_metrics():
         ImportanceMinimalityLossConfig(
             coeff=3e-3,
             pnorm=1.0,
-            beta=0.0,
             p_anneal_start_frac=0.0,
             p_anneal_final_p=1.0,
             p_anneal_end_frac=1.0,
@@ -276,7 +275,6 @@ def _recovery_loss_metrics():
         ImportanceMinimalityLossConfig(
             coeff=3e-3,
             pnorm=1.0,
-            beta=0.0,
             p_anneal_start_frac=0.0,
             p_anneal_final_p=1.0,
             p_anneal_end_frac=1.0,


### PR DESCRIPTION
## Description

Ports #543 (torch) to the JAX trainer: splits the frequency-weighted `log2` term out of the rolled importance-minimality loss into a standalone, **batch-invariant** frequency penalty. Per component `c`, with `f_c` the per-token firing frequency over the **global** batch (`f_c = Σ_{B·T tokens}(ci_c+eps)^p / B·T`):

- **importance-minimality** → the bare mean: `L_imp = Σ_c f_c`
- **frequency-minimality** (split out) → `L_freq = Σ_c f_c · log2(1 + a'·f_c)`, where `a' = reference_token_count`

The old rolled form was `Σ_c f_c·(1 + beta·log2(1 + B·T·f_c))` — the `B·T` was *implicit inside the `log2`*, so the penalty's curvature drifted with batch size. Making the normalizer the explicit `a'` knob decouples the two sparsity pressures and removes the batch coupling. `total = imp_coeff·L_imp + freq_coeff·L_freq` with **independent** coefficients.

This is the deferred "token-count reparameterization" of imp-min (see the imp-min scaling notes): the old `beta`/entropy term's `log2(N)` coupling was a per-token-batch artifact; `reference_token_count` removes it.

### Tied form (single config, two outputs)

Unlike the torch PR's two separate `Metric` classes, the JAX trainer computes both terms from **one** `(c+eps)^p` pass. So `beta` is replaced by a nested, optional `frequency: (coeff, reference_token_count) | None` on **both** imp-min configs (`ImportanceMinimalityLoss` + `SmoothL0ImportanceMinimalityLoss`), reusing the shared per-component sums. A separate flat `LossTerm` was rejected: a standalone frequency term has no penalty `ψ` of its own and would either refetch the sums (a second full pass over CI at 8B) or reach into the imp term's intermediates, breaking the self-contained-term model that replaced `LossSpec`.

```yaml
- type: ImportanceMinimalityLoss     # (or SmoothL0ImportanceMinimalityLoss)
  coeff: 5.0e-06
  pnorm: 2.0
  p_anneal_final_p: 0.4
  eps: 1.0e-06
  frequency:                         # replaces `beta: 0.2`; omit entirely for old beta:0
    coeff: 1.0e-06                    # = old imp.coeff * beta
    reference_token_count: 65536      # global B*T  → reproduces the old behavior exactly
```

### Coefficient translation (for migrated configs)

`freq.coeff = old imp.coeff · old beta`, `imp.coeff` unchanged, `reference_token_count = global B·T = pd.batch_size · max_seq_len`. `beta: 0` configs just drop `beta` (no `frequency` block).

## Motivation and Context

The implicit-`B·T` coupling meant frequency-penalty strength silently rescaled with batch size. Splitting + normalizing makes the two sparsity pressures independently tunable and batch-invariant.

## How Has This Been Tested?

- `make type` clean.
- Full non-slow suite: **449 passed, 5 skipped, 11 xfailed, 0 failures**.
- New `param_decomp/tests/test_frequency_minimality.py`: closed-form, batch-invariance, `f=0 → 0`, `a'=B·T` reproduces the old rolled value, `lp` independent of `a'`, dispatch (frequency `None` → `freq=0`).
- **Equivalence goldens preserved WITHOUT regen**: `a' = n_positions` reproduces the old `entropy` bit-for-bit, so `test_imp_min_bf16_seam` / `test_imp_min_global_reduction` / the `tests/equivalence/` harness just pass `reference_token_count = n_positions`. The smooth-L0 + global-reduction tests also pass under the 4-device sim.
- All 23 in-repo YAMLs validated through the pydantic config union.

## Code changes

- **Core**: `losses.py` (`_imp_min_terms → (lp, freq)` with `reference_token_count`; `importance_minimality_terms` / `smooth_l0_importance_minimality_terms` / `imp_min_terms` signatures), `configs.py` (`FrequencyMinimalityConfig`, `beta` dropped from both imp configs), `train.py` (`imp_coeff·lp + freq_coeff·freq`; new `freq` metric), `run.py` (`train/loss/FrequencyMinimalityLoss`).
- **SPEC.md**: amended S7/S8 + new **S8′**, rewrote the imp-min pseudocode (`imp_min_terms`), the config example, and the `L_freq` rationale. *(Per the repo's "one rule," the SPEC change wants @ocg-goodfire's deliberate sign-off.)*
- **Migrations**: all in-repo run/experiment YAMLs + Python test/experiment config constructions. `invariance_check` keeps `frequency` active (it guards the global-reduction / Jensen path under the device-count invariance check); structural smoke tests (checkpoint, llama8b, simple-mlp, io, no-bake) migrate to `frequency=None`.

## Notes / decisions made under ambiguity

- **Base branch**: targets `feature/jax-full32L-port` (the merge of `feature/jax` into the full-32L work, which carries the flat-`LossTerm` refactor + the smooth-L0 penalty this builds on). Not `feature/jax`, so the diff stays imp-min-only.
- **Duplicated `frequency` field** on both imp configs mirrors how they already duplicated `beta`; a shared base would dedupe it but the existing code chose duplication — left consistent.
- An independent `pnorm`/`gamma`/`eps` for the frequency term is intentionally **not** offered: the two terms share one pass, so it's optionality that doesn't exist in practice. A future second-pass variant could add it if ever wanted.

## Does this PR introduce a breaking change?

Yes — `ImportanceMinimalityLoss` / `SmoothL0ImportanceMinimalityLoss` no longer accept `beta`. No legacy fallback (house style); all in-repo configs are migrated here. Stored/snapshotted configs of running runs are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
