### PR TITLE
fix(slow-eval): run the CI-fn readout in training precision (bf16), not fp32

### DIFF
--- a/param_decomp/slow_eval.py
+++ b/param_decomp/slow_eval.py
@@ -54,6 +54,7 @@ import equinox as eqx
 import jax.numpy as jnp
 import numpy as np
 from jax import random
+from jax.experimental import multihost_utils
 from jaxtyping import Array, Float
 from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
@@ -73,6 +74,7 @@ from param_decomp.hidden_acts_eval import (
     make_stochastic_hidden_acts_step,
 )
 from param_decomp.lm import DecomposedModel
+from param_decomp.train import COMPUTE_DT, cast_floating
 
 IDENTITY_CI_ERROR_TOLERANCE = 0.1
 """Torch `IdentityCIPattern.distance_from` / `compute_target_metrics` default tolerance —
@@ -116,14 +118,16 @@ def make_slow_eval_step(lm: DecomposedModel, ci_alive_threshold: float) -> SlowE
     def slow_eval_step(
         model: DecomposedModel, ci_fn: Any, residual: Float[Array, "*leading d"]
     ) -> tuple[dict[str, Array], dict[str, Array], Array, dict[str, Array], dict[str, Array]]:
-        # CI fn stays fp32 (its master dtype): torch offline-eval keeps V/U + CI fn fp32,
-        # casting only the frozen target to bf16. The slow plot metrics are a
-        # fp32-CI-fn readout, so we don't take eval.py's bf16-compute path here.
+        # Read the CI fn in TRAINING precision (bf16), matching train.py / eval.py and the
+        # hidden-acts + attn-pattern tiers: the readout reflects the deployed (bf16) model,
+        # and cuDNN flash attention (which rejects fp32) is used. Reductions/returns are
+        # upcast to fp32 so the host accumulation is unchanged.
+        ci_fn = cast_floating(ci_fn, COMPUTE_DT)
         taps = {
-            k: x.astype(jnp.float32)
+            k: x.astype(COMPUTE_DT)
             for k, x in model.read_activations(residual, ci_fn.input_names).items()
         }
-        logits = ci_fn(taps).logits
+        logits = {s: v.astype(jnp.float32) for s, v in ci_fn(taps).logits.items()}
         lower = {s: lower_leaky_hard_sigmoid(logits[s]) for s in site_names}
 
         density_counts = {
@@ -168,8 +172,17 @@ def accumulate_site_reductions(
             density[site] = counts if batch_idx == 0 else density[site] + counts
             sums[site] = ci_sum if batch_idx == 0 else sums[site] + ci_sum
             if keep_sample:
-                lower_chunks.setdefault(site, []).append(np.asarray(flat_lower[site]))
-                logits_chunks.setdefault(site, []).append(np.asarray(flat_logits[site]))
+                # flat_lower/flat_logits keep the dp-sharded batch axis, so on >1 process
+                # they span non-addressable devices and a bare `np.asarray` raises. Gather
+                # the global sample across processes (counts/sums above are already
+                # all-reduced, hence addressable). `tiled=True` concatenates the per-process
+                # shards along axis 0 (order is irrelevant for the histogram sample).
+                lower_chunks.setdefault(site, []).append(
+                    np.asarray(multihost_utils.process_allgather(flat_lower[site], tiled=True))
+                )
+                logits_chunks.setdefault(site, []).append(
+                    np.asarray(multihost_utils.process_allgather(flat_logits[site], tiled=True))
+                )
 
     return {
         site: SiteReduction(
@@ -203,11 +216,13 @@ def make_position_ci_step(lm: DecomposedModel) -> PositionCIStep:
     def position_ci_step(
         model: DecomposedModel, ci_fn: Any, residual: Float[Array, "*leading d"]
     ) -> tuple[dict[str, Array], dict[str, Array], Array]:
+        # Training precision (bf16) readout — see make_slow_eval_step; logits upcast to fp32.
+        ci_fn = cast_floating(ci_fn, COMPUTE_DT)
         taps = {
-            k: x.astype(jnp.float32)
+            k: x.astype(COMPUTE_DT)
             for k, x in model.read_activations(residual, ci_fn.input_names).items()
         }
-        logits = ci_fn(taps).logits
+        logits = {s: v.astype(jnp.float32) for s, v in ci_fn(taps).logits.items()}
         lower = {s: lower_leaky_hard_sigmoid(logits[s]) for s in site_names}
         upper = {s: upper_leaky_hard_sigmoid(logits[s]) for s in site_names}
         first = lower[site_names[0]]

--- a/param_decomp/slow_eval.py
+++ b/param_decomp/slow_eval.py
@@ -118,10 +118,8 @@ def make_slow_eval_step(lm: DecomposedModel, ci_alive_threshold: float) -> SlowE
     def slow_eval_step(
         model: DecomposedModel, ci_fn: Any, residual: Float[Array, "*leading d"]
     ) -> tuple[dict[str, Array], dict[str, Array], Array, dict[str, Array], dict[str, Array]]:
-        # Read the CI fn in TRAINING precision (bf16), matching train.py / eval.py and the
-        # hidden-acts + attn-pattern tiers: the readout reflects the deployed (bf16) model,
-        # and cuDNN flash attention (which rejects fp32) is used. Reductions/returns are
-        # upcast to fp32 so the host accumulation is unchanged.
+        # Read the CI fn in training precision (bf16), like train.py / eval.py: the readout
+        # reflects the deployed model, and cuDNN flash attention rejects fp32.
         ci_fn = cast_floating(ci_fn, COMPUTE_DT)
         taps = {
             k: x.astype(COMPUTE_DT)
@@ -172,11 +170,8 @@ def accumulate_site_reductions(
             density[site] = counts if batch_idx == 0 else density[site] + counts
             sums[site] = ci_sum if batch_idx == 0 else sums[site] + ci_sum
             if keep_sample:
-                # flat_lower/flat_logits keep the dp-sharded batch axis, so on >1 process
-                # they span non-addressable devices and a bare `np.asarray` raises. Gather
-                # the global sample across processes (counts/sums above are already
-                # all-reduced, hence addressable). `tiled=True` concatenates the per-process
-                # shards along axis 0 (order is irrelevant for the histogram sample).
+                # The sample keeps the dp-sharded batch axis; on >1 process a bare np.asarray
+                # spans non-addressable devices, so gather it (counts/sums are already reduced).
                 lower_chunks.setdefault(site, []).append(
                     np.asarray(multihost_utils.process_allgather(flat_lower[site], tiled=True))
                 )

--- a/param_decomp/tests/test_slow_eval.py
+++ b/param_decomp/tests/test_slow_eval.py
@@ -54,6 +54,7 @@ from param_decomp.tests.test_llama8b import (
     _tiny_cfg,
     _tiny_decomposed_lm,
 )
+from param_decomp.train import COMPUTE_DT, cast_floating
 
 
 def _build_ci_fn(lm: DecomposedModel, n_embd: int, key: jax.Array) -> CIFn:
@@ -89,8 +90,12 @@ def test_reductions_match_hand_rolled_per_component():
 
     reductions = accumulate_site_reductions(step, lm, ci_fn, [residual], n_batches_accum=None)
 
-    taps = lm.read_activations(residual, ci_fn.input_names)
-    logits = ci_fn(taps).logits
+    # Mirror slow_eval_step's training-precision (bf16) readout.
+    ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
+    taps = {
+        k: x.astype(COMPUTE_DT) for k, x in lm.read_activations(residual, ci_fn.input_names).items()
+    }
+    logits = {s: v.astype("float32") for s, v in ci_fn_bf16(taps).logits.items()}
     lower = {s: lower_leaky_hard_sigmoid(logits[s]) for s in lm.site_names}
     for site in lm.site_names:
         flat = np.asarray(lower[site]).reshape(-1, C).astype(np.float32)


### PR DESCRIPTION
## Description
The slow/plot eval tier (`make_slow_eval_step`, `make_position_ci_step`) deliberately read the CI fn out in **fp32**. But the CI transformer's attention routes to cuDNN flash, which only accepts fp16/bf16/fp8 — so the slow tier crashed at the first slow eval on GPU:
```
NotImplementedError: Q must be fp16/bf16/fp8_e4m3fn/fp8_e5m2, got float32
```
This hit **every** run (including bf16-only ones; surfaced while validating the fp8 work, but unrelated to it).

Fix: run the CI-fn readout in **training precision (bf16)** — matching `train.py` / `eval.py` and the hidden-acts + attn-pattern slow tiers, which already cast to `COMPUTE_DT`. Reductions and returns are upcast to fp32, so the host-side accumulation is byte-unchanged. The two affected tiers were the only slow-eval compute paths still pinned to fp32.

Also incorporates the precision-independent multihost fix from #885: the per-position histogram sample keeps the dp-sharded batch axis, so a bare `np.asarray` on >1 process spans non-addressable devices — gathered via `process_allgather(tiled=True)`.

## Related Issue
Related to #885. **Supersedes** #885's `ci_fn.py` fp32-attention routing (no fp32 attention path is needed once the slow tier is bf16); **incorporates** #885's `slow_eval.py` multihost gather fix. #885 can be closed if this lands.

## Motivation and Context
We shouldn't run the slow eval in fp32: the deployed model runs bf16, so a bf16 readout is the faithful one, it keeps cuDNN flash (faster, avoids the XLA `(B,H,T,T)` materialize the fp32 path needs), and it removes the GPU crash without a special-case attention impl.

## How Has This Been Tested?
- `make type` clean; `make format` clean.
- `param_decomp/tests/test_slow_eval.py` — 26 passed (the hand-rolled reduction reference now mirrors the bf16 readout).
- Found while debugging an fp8 parity ladder whose runs (incl. the bf16 baseline) all crashed here; disabling slow eval unblocked them, confirming this is the cause.

## Does this PR introduce a breaking change?
No. Slow-eval metric *values* shift by bf16-rounding (e.g. a CI value near the alive threshold may flip), which is the intended, more-faithful behavior. Host APIs and log keys are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019uMvZPo7hyAFgGbhDdLrEL