### PR TITLE
refactor(eval): drop unused ce_unrecovered wandb metrics

### DIFF
--- a/param_decomp/eval.py
+++ b/param_decomp/eval.py
@@ -28,11 +28,6 @@ arise here, because no emitted key wraps the cross-batch axis in a nonlinearity:
 - `ce_kl/ce_difference_<variant>` = `ce_v - ce_target`: torch averages this per-batch
   DIFFERENCE (computed inside `_calc_ce_and_kl_losses`), not a difference of grand means.
   Linear, so uniform-average parity holds.
-- `ce_kl/ce_unrecovered_<variant>` = `(ce_v - ce_target) / (ce_zero - ce_target)`: the
-  potential Jensen term. But torch forms this RATIO per-batch too, then averages the
-  per-batch ratios — it never divides grand-mean numerator by grand-mean denominator. So
-  averaging JAX's per-batch ratios matches torch exactly; no global-sum-before-divide is
-  needed.
 - `l0/<threshold>_<site|group>`: torch `CI_L0` collects per-batch L0 and averages them
   uniformly (`sum / count`); group L0 is a per-batch sum of member L0s. Linear.
 - `loss/PGDReconLoss`: torch `PGDReconLoss` accumulates `kl * n` over batches and divides
@@ -207,10 +202,6 @@ def make_eval_step(
         difference_variants = tuple(v for v in variant_masks if v != "zero_masked")
         for variant in difference_variants:
             out[f"ce_kl/ce_difference_{variant}"] = ce[variant] - target_ce
-        for variant in difference_variants:
-            out[f"ce_kl/ce_unrecovered_{variant}"] = (ce[variant] - target_ce) / (
-                ce["zero_masked"] - target_ce
-            )
         site_l0 = {
             site: (ci_lower[site] > ci_alive_threshold).astype(jnp.float32).sum(-1).mean()
             for site in site_names

--- a/param_decomp/tests/test_eval.py
+++ b/param_decomp/tests/test_eval.py
@@ -175,7 +175,6 @@ def test_eval_step_keys_identities_and_determinism():
     expected_keys = (
         {f"ce_kl/kl_{v}" for v in (*variants, "zero_masked")}
         | {f"ce_kl/ce_difference_{v}" for v in variants}
-        | {f"ce_kl/ce_unrecovered_{v}" for v in variants}
         | {f"l0/-1.0_{site}" for site in lm.site_names}
     )
     assert set(out) == expected_keys

--- a/param_decomp/tests/test_eval_averaging_parity.py
+++ b/param_decomp/tests/test_eval_averaging_parity.py
@@ -13,10 +13,6 @@ checks the averaging math directly (the per-batch step itself is covered by
   PRODUCTION FAST SET — all exact under `sum/n_steps`, all per-position means:
     - `ce_kl/kl_<variant>`            mean per-position KL  (mean)
     - `ce_kl/ce_difference_<variant>` mean CE minus target mean CE (affine in means -> mean)
-    - `ce_kl/ce_unrecovered_<variant>` per-BATCH ratio, then averaged across batches
-        in BOTH impls -> they agree, but the averaged quantity is itself non-mean
-        (ratio of two batch means); the per-batch-then-average convention is what makes
-        torch==JAX. See `test_ce_unrecovered_is_per_batch_ratio_then_averaged`.
     - `l0/<thr>_<site>` / `l0/<thr>_<group>` mean L0 per example (group = per-batch
         sum of member means, then averaged) (mean)
     - `loss/PGDReconLoss`             mean per-position KL at the final source (mean)
@@ -73,31 +69,6 @@ def test_mean_metric_averaging_diverges_under_ragged_bt():
     assert not math.isclose(jax_avg, torch_avg, rel_tol=1e-3)
 
 
-def test_ce_unrecovered_is_per_batch_ratio_then_averaged():
-    """`ce_unrecovered` is a ratio (non-mean), but torch (`_calc_ce_and_kl_losses`) and
-    JAX (`eval.py`) BOTH form the ratio per batch and then average it. So they agree
-    under fixed (B,T) via the mean-metric path above — the per-batch-then-average
-    convention is the parity. This contrasts with accumulating numerator and
-    denominator separately, which would Jensen-diverge from it."""
-    rng = np.random.default_rng(1)
-    n_steps = 5
-    ce = rng.uniform(1.0, 2.0, size=n_steps)
-    target_ce = rng.uniform(0.2, 0.5, size=n_steps)
-    zero_ce = rng.uniform(3.0, 4.0, size=n_steps)
-
-    per_batch_ratio = ((ce - target_ce) / (zero_ce - target_ce)).tolist()
-    fixed_positions = [4 * 16] * n_steps
-    jax_avg = _jax_average(per_batch_ratio, n_steps)
-    torch_avg = _torch_position_weighted_average(per_batch_ratio, fixed_positions)
-    assert math.isclose(jax_avg, torch_avg, rel_tol=1e-12)
-
-    ratio_of_summed = float((ce - target_ce).sum() / (zero_ce - target_ce).sum())
-    assert not math.isclose(jax_avg, ratio_of_summed, rel_tol=1e-3), (
-        "ratio-of-means != mean-of-ratios; the per-batch-then-average convention is the "
-        "one both impls use, and must stay so"
-    )
-
-
 def test_nonmean_metric_is_jensen_divergent():
     """A metric that is a nonlinear fn of a GLOBAL accumulated sum (the S8-class caveat,
     e.g. `log2(Σ_batches L0)`) is NOT exact under `sum/n_steps`. Exhibits the gap so a
@@ -115,7 +86,6 @@ def test_nonmean_metric_is_jensen_divergent():
     [
         ("ce_kl/kl_ci_masked", "mean"),
         ("ce_kl/ce_difference_ci_masked", "mean"),
-        ("ce_kl/ce_unrecovered_ci_masked", "per_batch_ratio_then_mean"),
         ("l0/0.0_site", "mean"),
         ("l0/0.0_group", "mean"),
         ("loss/PGDReconLoss", "mean"),
@@ -123,10 +93,7 @@ def test_nonmean_metric_is_jensen_divergent():
 )
 def test_production_fast_set_classification(metric_key: str, kind: str):
     """The recorded verdict: every production in-loop fast metric is mean (exact under
-    `sum/n_steps`) or per-batch-ratio-then-mean (exact because BOTH impls average the
-    per-batch ratio). None is a nonlinear fn of a global accumulated sum, so all are
-    exact under fixed (B,T). This list is the closing artifact for #715 — adding a
-    metric here that is `nonmean` must accompany an accumulate-then-compute impl."""
-    assert kind in ("mean", "per_batch_ratio_then_mean"), (
-        f"{metric_key}: production fast metrics must be exact under sum/n_steps"
-    )
+    `sum/n_steps`). None is a nonlinear fn of a global accumulated sum, so all are exact
+    under fixed (B,T). This list is the closing artifact for #715 — adding a metric here
+    that is `nonmean` must accompany an accumulate-then-compute impl."""
+    assert kind == "mean", f"{metric_key}: production fast metrics must be exact under sum/n_steps"

--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -359,7 +359,7 @@ def _make_lm_eval_fn(
         if is_main:
             headline = {
                 k: eval_record[f"eval/{k}"]
-                for k in ("ce_kl/kl_ci_masked", "ce_kl/ce_unrecovered_ci_masked")
+                for k in ("ce_kl/kl_ci_masked", "ce_kl/ce_difference_ci_masked")
             }
             print(f"[eval @ {now_step}] {headline}", flush=True)
         return eval_record


### PR DESCRIPTION
## Description
Removes the `ce_kl/ce_unrecovered_<variant>` metrics from the in-loop eval pass. These were `(ce_v - ce_target) / (ce_zero - ce_target)` ratios logged per masking variant.

Touched:
- `param_decomp/eval.py` — drop the `ce_unrecovered` computation and its docstring bullet. The `zero_masked` variant stays (still emits `ce_kl/kl_zero_masked`).
- `param_decomp_lab/experiments/lm/run.py` — the eval headline print now uses `ce_kl/ce_difference_ci_masked` instead of `ce_kl/ce_unrecovered_ci_masked`.
- `param_decomp/tests/test_eval.py` — drop `ce_unrecovered` from the expected eval-key set.
- `param_decomp/tests/test_eval_averaging_parity.py` — remove the `ce_unrecovered` ratio-parity test and its classification entry; all production fast metrics are now `mean`.

## Motivation and Context
We don't use the `ce_unrecovered` metrics in wandb anymore.

## How Has This Been Tested?
- `pytest param_decomp/tests/test_eval.py param_decomp/tests/test_eval_averaging_parity.py` — 14 passed.
- `make type` — clean.
- `make format` — clean.

## Does this PR introduce a breaking change?
No. Only removes wandb metric keys that are no longer consumed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)