### PR TITLE
fix(runs): pin run config as launch_config.yaml, not config.yaml

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,7 @@ Every artifact for a decomposition lives under one dir per run:
 
 ```
 PARAM_DECOMP_OUT_DIR/runs/<run_id>/
-  config.yaml                # the single self-contained run config (the trainer reads it; resume byte-compares)
+  launch_config.yaml         # the single self-contained run config (the trainer reads it; resume byte-compares). NOT config.yaml: that basename collides with wandb's reserved run-config file, which wandb.save would symlink onto and clobber
   ckpts/<step>/...           # orbax sharded checkpoints (JAX trainer)
   metrics.jsonl              # local logs
   harvest/h-*/...            # pd-harvest output

--- a/param_decomp/CLAUDE.md
+++ b/param_decomp/CLAUDE.md
@@ -240,7 +240,7 @@ onto the fresh reference and keeps ONLY the components + ci_fn; the optimizer st
 persistent sources, and `step` are FRESH (`step = 0`, no faith warmup) so the new LR /
 p-anneal schedule recomputes over the new `cfg.steps` from 0. A subsequent SLURM requeue
 (own `ckpts/` now non-empty) resumes from the run's own dir and ignores provenance.
-`run.py::assert_finetune_structural_compat` reads the parent's pinned `config.yaml` and
+`run.py::assert_finetune_structural_compat` reads the parent's pinned `launch_config.yaml` and
 asserts matching sites (names + C) + ci-fn arch before the restore. Provenance flows into
 `config.yaml` + `wandb.config`. Launch as usual via `pd-lm <config.yaml>`.
 

--- a/param_decomp/built_run.py
+++ b/param_decomp/built_run.py
@@ -21,9 +21,8 @@ from param_decomp.components import SiteC
 from param_decomp.configs import Cadence, PDConfig, ResumeProvenance, RuntimeConfig, WandbConfig
 
 LAUNCH_CONFIG_FILENAME = "launch_config.yaml"
-"""The self-contained run config pinned into each run dir. NOT `config.yaml`: that basename
-collides with wandb's reserved run-config file, so `wandb.save`-ing it symlinks wandb's own
-writer onto the pinned copy and clobbers it with a `_wandb:` value dump."""
+"""The self-contained run config pinned into each run dir. Not `config.yaml` — that basename
+clashes with wandb's own run-config file, which `wandb.save` would clobber via symlink."""
 
 
 class TargetSites(Protocol):

--- a/param_decomp/built_run.py
+++ b/param_decomp/built_run.py
@@ -20,6 +20,11 @@ from param_decomp.ci_fn import CIFnArch
 from param_decomp.components import SiteC
 from param_decomp.configs import Cadence, PDConfig, ResumeProvenance, RuntimeConfig, WandbConfig
 
+LAUNCH_CONFIG_FILENAME = "launch_config.yaml"
+"""The self-contained run config pinned into each run dir. NOT `config.yaml`: that basename
+collides with wandb's reserved run-config file, so `wandb.save`-ing it symlinks wandb's own
+writer onto the pinned copy and clobbers it with a `_wandb:` value dump."""
+
 
 class TargetSites(Protocol):
     """The only thing the generic engine needs from a target config: its decomposed

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -596,7 +596,7 @@ AnyLossMetricConfig = Annotated[
 class ProfileConfig(BaseConfig):
     """Profiling/instrumentation toggles the trainer (`run.py`) reads DIRECTLY off the config.
 
-    A profiling run is a CONFIG, not an env hack: the trainer parses its `config.yaml` and
+    A profiling run is a CONFIG, not an env hack: the trainer parses its `launch_config.yaml` and
     reads these fields, so the pinned config records exactly which hooks ran. All hooks are
     DEFAULT-OFF; the empty `ProfileConfig()` enables nothing.
 
@@ -626,7 +626,7 @@ class ProfileConfig(BaseConfig):
 class LaunchEnv(BaseConfig):
     """The process-environment surface a SLURM-launched rank runs with — the XLA *client*
     knobs (mem fraction / allocator / host-memory limit), NCCL/glibc tuning, and a free-form
-    env escape hatch — lifted into the run config so a run's `config.yaml` fully captures its
+    env escape hatch — lifted into the run config so a run's `launch_config.yaml` fully captures its
     environment (tracking + repro), and A/B-ing a knob is a config edit, not a launcher edit.
 
     XLA *compiler* flags are NOT here — they go through `RuntimeConfig.compiler_options`
@@ -1008,14 +1008,14 @@ class ResumeProvenance(BaseConfig):
     """Fine-tune lineage: a fresh run initialized from a PARENT decomposition. Lives on
     `ExperimentConfig`.
 
-    A fine-tune run gets its own `run_id` / `config.yaml` / `ckpts/`; this records the
+    A fine-tune run gets its own `run_id` / `launch_config.yaml` / `ckpts/`; this records the
     parent it forked from. The JAX trainer (SPEC S33) loads the parent checkpoint's
     V/U + ci_fn onto a fresh reference state and trains a clean schedule from step 0
     (fresh optimizer / sources) under the new config — only when the run's own `ckpts/`
     is empty (a subsequent SLURM requeue resumes from the run's own dir, ignoring
     provenance). The structure (sites / C / ci-fn arch) must match the parent; only
     LR / coeffs / eps / seq / batch / steps may change. Provenance flows into
-    `config.yaml` and `wandb.config` so the lineage is visible in the wandb UI. A run with
+    `launch_config.yaml` and `wandb.config` so the lineage is visible in the wandb UI. A run with
     `resume_provenance is None` is a fresh-from-init run.
     """
 

--- a/param_decomp/run.py
+++ b/param_decomp/run.py
@@ -44,7 +44,7 @@ from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jaxtyping import PRNGKeyArray
 
-from param_decomp.built_run import DataConfig, RunInstance
+from param_decomp.built_run import LAUNCH_CONFIG_FILENAME, DataConfig, RunInstance
 from param_decomp.checkpoint import (
     init_from_parent,
     make_checkpoint_manager,
@@ -190,12 +190,11 @@ class MetricsSink:
             resume="allow",
             config=wandb_config,
         )
-        # Persist the run's pinned config.yaml as a downloadable wandb run file
-        # (parity with the torch trainer's init_pd_run -> wandb.save), not just the
-        # flattened wandb.config dict. Pinned to run_dir before train() / wandb.init.
-        config_yaml = run.run_dir / "config.yaml"
-        assert config_yaml.exists(), config_yaml
-        wandb.save(str(config_yaml), base_path=str(run.run_dir), policy="now")
+        # Save the pinned launch config as a downloadable wandb run file, alongside (not
+        # in place of) the flattened wandb.config dict; it exists from before wandb.init.
+        launch_config = run.run_dir / LAUNCH_CONFIG_FILENAME
+        assert launch_config.exists(), launch_config
+        wandb.save(str(launch_config), base_path=str(run.run_dir), policy="now")
         # The in-loop slow tier (`SlowEvalRenderer`) logs `slow_eval/*` on the live
         # `_step` axis at the eval step (SPEC S28/S29), so NO dedicated `slow_eval/step`
         # metric is defined here. Slow eval is in-loop only (no offline CLI).

--- a/param_decomp/slow_eval.py
+++ b/param_decomp/slow_eval.py
@@ -58,6 +58,7 @@ from jaxtyping import Array, Float
 from matplotlib import pyplot as plt
 from matplotlib.figure import Figure
 
+from param_decomp.built_run import LAUNCH_CONFIG_FILENAME
 from param_decomp.ci_fn import lower_leaky_hard_sigmoid, upper_leaky_hard_sigmoid
 from param_decomp.configs import (
     DenseCITargetSpec,
@@ -690,7 +691,7 @@ def compute_hidden_acts_metrics(
 
 
 def eval_metrics_from_run_dir(run_dir: Path) -> list[Any]:
-    """The typed `eval.metrics` configs from the run's `config.yaml`. The trainer's
+    """The typed `eval.metrics` configs from the run's pinned launch config. The trainer's
     `EvalConfig` keeps only scalar-tier fields, so the plot/permutation metric configs are
     re-validated here from the raw block. The in-loop slow tier (`run.py`) reads the metric
     list this way to resolve the config-gated permutation/UV/identity metrics."""
@@ -699,7 +700,7 @@ def eval_metrics_from_run_dir(run_dir: Path) -> list[Any]:
 
     from param_decomp.configs import AnyEvalMetricConfig
 
-    raw = yaml.safe_load((run_dir / "config.yaml").read_text())
+    raw = yaml.safe_load((run_dir / LAUNCH_CONFIG_FILENAME).read_text())
     adapter = TypeAdapter(AnyEvalMetricConfig)
     return [adapter.validate_python(m) for m in raw["eval"]["metrics"]]
 

--- a/param_decomp/tests/test_config.py
+++ b/param_decomp/tests/test_config.py
@@ -10,7 +10,7 @@ import pytest
 import yaml
 from pydantic import ValidationError
 
-from param_decomp.built_run import DataConfig
+from param_decomp.built_run import LAUNCH_CONFIG_FILENAME, DataConfig
 from param_decomp.components import SiteC
 from param_decomp.configs import (
     ImportanceMinimalityLossConfig,
@@ -373,13 +373,13 @@ def test_fp32_frozen_target_is_refused():
 
 def test_load_run_dir_config_rebuilds_runs(tmp_path: Path):
     """Tools read run dirs via `load_run_dir_config`; runs pin the single self-contained
-    config as `config.yaml` (run.py's `_pin_config_copy`), and the rebuilt config must
+    config as `launch_config.yaml` (run.py's `_pin_config_copy`), and the rebuilt config must
     equal the launch-time conversion. The run id is the run-dir name."""
     config = CONFIGS / "llama8b_l18_C49k_200k.yaml"
     expected, _ = load_config(config, RUN_ID)
     run_dir = tmp_path / RUN_ID
     run_dir.mkdir()
-    (run_dir / "config.yaml").write_text(config.read_text())
+    (run_dir / LAUNCH_CONFIG_FILENAME).write_text(config.read_text())
     assert load_run_dir_config(run_dir) == expected
 
 

--- a/param_decomp/tests/test_finetune_resume.py
+++ b/param_decomp/tests/test_finetune_resume.py
@@ -13,6 +13,7 @@ import jax.numpy as jnp
 import pytest
 import yaml
 
+from param_decomp.built_run import LAUNCH_CONFIG_FILENAME
 from param_decomp.checkpoint import init_from_parent, make_checkpoint_manager, save_state
 from param_decomp.configs import ResumeProvenance
 from param_decomp.tests.test_checkpoint import _build
@@ -83,7 +84,7 @@ def test_init_from_parent_rejects_missing_step(tmp_path: Path):
 
 def _stamp(raw: dict[str, object], run_dir: Path) -> Path:
     run_dir.mkdir(parents=True, exist_ok=True)
-    (run_dir / "config.yaml").write_text(yaml.safe_dump(raw))
+    (run_dir / LAUNCH_CONFIG_FILENAME).write_text(yaml.safe_dump(raw))
     return run_dir
 
 

--- a/param_decomp_lab/adapters/__init__.py
+++ b/param_decomp_lab/adapters/__init__.py
@@ -10,7 +10,7 @@ from param_decomp_lab.harvest.config import ParamDecompHarvestConfig
 
 def adapter_from_config(method_config: ParamDecompHarvestConfig) -> PDAdapter:
     assert is_jax_run(method_config.wandb_path), (
-        f"{method_config.wandb_path}: not a loadable PD run (missing config.yaml or orbax ckpts/)."
+        f"{method_config.wandb_path}: not a loadable PD run (missing launch_config.yaml or orbax ckpts/)."
     )
     return PDAdapter(method_config.wandb_path)
 

--- a/param_decomp_lab/adapters/pd.py
+++ b/param_decomp_lab/adapters/pd.py
@@ -1,26 +1,25 @@
 from functools import cached_property
 from pathlib import Path
 
+from param_decomp.built_run import LAUNCH_CONFIG_FILENAME
 from param_decomp_lab.autointerp.schemas import ModelMetadata
 from param_decomp_lab.experiments.lm.config import LMExperimentConfig
 from param_decomp_lab.experiments.lm.load_run import RunMetadata, run_metadata
 from param_decomp_lab.harvest.schemas import get_harvest_dir
 from param_decomp_lab.topology.path_schemas import path_schema_for_model_type
 
-JAX_RUN_CONFIG_FILENAME = "config.yaml"
-
 
 def is_jax_run(decomposition_id: str) -> bool:
     """A JAX single-pool run dir pins its single self-contained run config as
-    `config.yaml` and checkpoints with orbax under `ckpts/`; a torch run instead has
+    `launch_config.yaml` and checkpoints with orbax under `ckpts/`; a torch run instead has
     `model_*.pth` and no orbax `ckpts/`. The orbax `ckpts/` dir is the explicit marker."""
     run_dir = get_harvest_dir(decomposition_id).parent
-    return (run_dir / JAX_RUN_CONFIG_FILENAME).exists() and (run_dir / "ckpts").is_dir()
+    return (run_dir / LAUNCH_CONFIG_FILENAME).exists() and (run_dir / "ckpts").is_dir()
 
 
 class PDAdapter:
     """Autointerp/clustering adapter for a JAX single-pool run, read torch-free from its
-    pinned config. Autointerp consumes harvest output plus run metadata only — no trained
+    pinned launch config. Autointerp consumes harvest output plus run metadata only — no trained
     components — so the target topology (`n_blocks`, vocab, per-site `(name, C)`) comes
     from `param_decomp_lab.experiments.lm.load_run.run_metadata` (config + pretrain-cache `model_config`,
     no orbax restore); canonical layer descriptions render via the torch-free path schema."""
@@ -34,7 +33,7 @@ class PDAdapter:
 
     @cached_property
     def cfg(self) -> LMExperimentConfig:
-        config_path = self._run_dir / JAX_RUN_CONFIG_FILENAME
+        config_path = self._run_dir / LAUNCH_CONFIG_FILENAME
         assert config_path.exists(), f"config not found: {config_path}"
         return LMExperimentConfig.from_file(config_path)
 

--- a/param_decomp_lab/experiments/lm/config.py
+++ b/param_decomp_lab/experiments/lm/config.py
@@ -17,6 +17,7 @@ from pydantic import Discriminator, Field, PositiveInt, model_validator
 
 from param_decomp.base_config import BaseConfig
 from param_decomp.built_run import (
+    LAUNCH_CONFIG_FILENAME,
     AttnPatternsEvalConfig,
     BuiltRun,
     DataConfig,
@@ -451,8 +452,8 @@ def load_config(config_path: Path, run_id: str) -> tuple[BuiltRun, dict[str, Any
 
 
 def load_run_dir_config(run_dir: Path) -> BuiltRun:
-    """Rebuild a run's `BuiltRun` bundle from its single pinned `config.yaml`
+    """Rebuild a run's `BuiltRun` bundle from its single pinned launch config
     (for tools that read finished/live run dirs, e.g. harvest / fine-tune compat). The
     run id is the run-dir name."""
-    schema_raw = yaml.safe_load((run_dir / "config.yaml").read_text())
+    schema_raw = yaml.safe_load((run_dir / LAUNCH_CONFIG_FILENAME).read_text())
     return build_from_schema(schema_raw, run_dir.name)

--- a/param_decomp_lab/experiments/lm/launch.py
+++ b/param_decomp_lab/experiments/lm/launch.py
@@ -14,7 +14,7 @@ immutable workspace.
 
 The rank env (XLA flags, NCCL/host-memory knobs, `PD_*` profiling toggles) is rendered from
 the config's `runtime.launch_env` (single source of truth, defaults in `LaunchEnv`), plus a
-submit-time-computed `LD_LIBRARY_PATH`. So a run's `config.yaml` fully captures the
+submit-time-computed `LD_LIBRARY_PATH`. So a run's `launch_config.yaml` fully captures the
 environment it ran with, and A/B-ing a flag is a config edit, not a launcher edit.
 """
 
@@ -113,7 +113,7 @@ def main(
         comment: SLURM `--comment`; defaults to the wandb run URL (or run id).
 
     The rank env (XLA flags, NCCL/host-memory knobs, profiling toggles) is config-driven
-    via `runtime.launch_env` — set it in the YAML, not here (so `config.yaml` records it).
+    via `runtime.launch_env` — set it in the YAML, not here (so `launch_config.yaml` records it).
     """
     config_rel = _config_path_relative_to_repo(config_path)
     cfg, run_name = _validate_config(REPO_ROOT / config_rel)

--- a/param_decomp_lab/experiments/lm/load_run.py
+++ b/param_decomp_lab/experiments/lm/load_run.py
@@ -2,7 +2,7 @@
 consumers that follow it: clustering, autointerp, slow-eval, app).
 
 This is the reusable "load a JAX run" pattern. It reads a run dir
-(`runs/<p-id>/{config.yaml, ckpts/}`), rebuilds the frozen
+(`runs/<p-id>/{launch_config.yaml, ckpts/}`), rebuilds the frozen
 target + `DecomposedModel` from the pinned config, restores the orbax checkpoint onto a
 reference `TrainState`, and exposes the pure forward a consumer needs:
 

--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -43,7 +43,7 @@ from param_decomp.attn_patterns_eval import (
     make_ci_attn_patterns_step,
     make_stochastic_attn_patterns_step,
 )
-from param_decomp.built_run import BuiltRun, DataConfig
+from param_decomp.built_run import LAUNCH_CONFIG_FILENAME, BuiltRun, DataConfig
 from param_decomp.configs import ResumeProvenance
 from param_decomp.data import BatchSchedule, ShardServer, scan_shards
 from param_decomp.eval import make_eval_step
@@ -125,7 +125,7 @@ def assert_finetune_structural_compat(built: BuiltRun, prov: ResumeProvenance) -
     same sites (names + C) and same ci-fn arch. A changed C / layers / target / ci-fn is a
     different-shaped decomposition and is NOT a fine-tune (the parent's V/U + ci_fn would
     not load onto the new reference). Only LR / coeffs / eps / seq / batch / steps may
-    change. Read from the parent's pinned `config.yaml` so the failure is a readable config
+    change. Read from the parent's pinned launch config so the failure is a readable config
     diff, not an opaque orbax tree mismatch."""
     parent = load_run_dir_config(prov.parent_run_dir)
     parent_sites = tuple((s.name, s.C) for s in parent.target.sites)
@@ -252,8 +252,8 @@ def _make_lm_eval_fn(
     slow_eval_step = make_slow_eval_step(lm, eval.density_ci_alive_threshold, co)
     slow_renderer = SlowEvalRenderer(is_main)
     # The CI-heatmap / permutation / UV / identity-error metrics read off the run's typed
-    # `eval.metrics` (re-validated from the pinned config.yaml: the trainer's `EvalConfig`
-    # drops the raw metric list). config.yaml is pinned before train().
+    # `eval.metrics` (re-validated from the pinned launch config: the trainer's `EvalConfig`
+    # drops the raw metric list). The launch config is pinned before train().
     run_eval_metrics = eval_metrics_from_run_dir(built.run.run_dir)
     perm_spec = resolve_permutation_metrics(lm.site_names, run_eval_metrics)
     hidden_acts_n_mask_samples = stochastic_hidden_acts_n_mask_samples(run_eval_metrics)
@@ -400,7 +400,7 @@ def main(config: Path, run_id: str) -> None:
         cache_dir.mkdir(parents=True, exist_ok=True)
         built.run.run_dir.mkdir(parents=True, exist_ok=True)
         setup_logger(built.run.run_dir / "logs.log")
-        _pin_config_copy(built.run.run_dir, "config.yaml", config)
+        _pin_config_copy(built.run.run_dir, LAUNCH_CONFIG_FILENAME, config)
         print(f"persistent XLA compilation cache: {cache_dir}", flush=True)
         site_kind_counts: dict[str, int] = {}
         for s in built.target.sites:

--- a/param_decomp_lab/experiments/resid_mlp/run.py
+++ b/param_decomp_lab/experiments/resid_mlp/run.py
@@ -20,7 +20,7 @@ from jax import random
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 
-from param_decomp.built_run import BuiltRun
+from param_decomp.built_run import LAUNCH_CONFIG_FILENAME, BuiltRun
 from param_decomp.components import SiteC
 from param_decomp.log import setup_logger
 from param_decomp.recon import build_loss_terms
@@ -200,7 +200,9 @@ def main(config: str, group: str | None = None, tags: str | None = None) -> None
     built = build_resid_mlp_built_run(ResidMLPExperimentConfig(**schema_raw), run_id)
     built.run.run_dir.mkdir(parents=True, exist_ok=True)
     setup_logger(built.run.run_dir / "logs.log")
-    (built.run.run_dir / "config.yaml").write_text(yaml.safe_dump(schema_raw, sort_keys=False))
+    (built.run.run_dir / LAUNCH_CONFIG_FILENAME).write_text(
+        yaml.safe_dump(schema_raw, sort_keys=False)
+    )
     mesh = hsdp_mesh()
     run_resid_mlp_decomposition(built, schema_raw, mesh)
 

--- a/param_decomp_lab/experiments/tms/run.py
+++ b/param_decomp_lab/experiments/tms/run.py
@@ -22,7 +22,7 @@ from jax import random
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 
-from param_decomp.built_run import BuiltRun
+from param_decomp.built_run import LAUNCH_CONFIG_FILENAME, BuiltRun
 from param_decomp.components import SiteC
 from param_decomp.log import setup_logger
 from param_decomp.recon import build_loss_terms
@@ -183,7 +183,9 @@ def main(config: str, group: str | None = None, tags: str | None = None) -> None
     built = build_tms_built_run(TMSExperimentConfig(**schema_raw), run_id)
     built.run.run_dir.mkdir(parents=True, exist_ok=True)
     setup_logger(built.run.run_dir / "logs.log")
-    (built.run.run_dir / "config.yaml").write_text(yaml.safe_dump(schema_raw, sort_keys=False))
+    (built.run.run_dir / LAUNCH_CONFIG_FILENAME).write_text(
+        yaml.safe_dump(schema_raw, sort_keys=False)
+    )
     mesh = hsdp_mesh()
     run_tms_decomposition(built, schema_raw, mesh)
 

--- a/param_decomp_lab/tests/autointerp/test_adapter_routing.py
+++ b/param_decomp_lab/tests/autointerp/test_adapter_routing.py
@@ -1,10 +1,11 @@
 """`is_jax_run` validates a loadable PD run dir: orbax `ckpts/` plus a single
-self-contained `config.yaml`. A dir missing either is not a loadable run."""
+self-contained `launch_config.yaml`. A dir missing either is not a loadable run."""
 
 from pathlib import Path
 
 import pytest
 
+from param_decomp.built_run import LAUNCH_CONFIG_FILENAME
 from param_decomp_lab.adapters import pd
 from param_decomp_lab.adapters.pd import is_jax_run
 
@@ -19,7 +20,7 @@ def _make_run(runs_root: Path, run_id: str, *, config_yaml: str | None, ckpts: b
     run_dir = runs_root / run_id
     run_dir.mkdir(parents=True)
     if config_yaml is not None:
-        (run_dir / "config.yaml").write_text(config_yaml)
+        (run_dir / LAUNCH_CONFIG_FILENAME).write_text(config_yaml)
     if ckpts:
         (run_dir / "ckpts").mkdir()
 


### PR DESCRIPTION
## Description

Renames the pinned per-run config file from `runs/<id>/config.yaml` to `runs/<id>/launch_config.yaml`, routed through a single shared `LAUNCH_CONFIG_FILENAME` constant in `param_decomp/built_run.py` and used by every writer (LM + TMS + ResidMLP trainers) and reader.

## Motivation and Context

`config.yaml` is a **reserved filename in wandb's own run-files directory**. The trainer pins each run's self-contained config to `run_dir/config.yaml` (`_pin_config_copy`), then `MetricsSink.for_run` calls `wandb.save(run_dir/"config.yaml", base_path=run_dir, policy="now")`. That symlinks wandb's `files/config.yaml → run_dir/config.yaml`, and wandb writes its *own* run config through the symlink — clobbering the pinned launch config with a `_wandb:`/`<config>:` value dump.

Confirmed live on a finished run (cw-rno2, `p-1e7e8e36`): the run-dir `config.yaml` is a wandb dump, and `wandb/run-*/files/config.yaml` is a symlink back into the run dir.

In-loop readers survive (they read the config before `wandb.init`), but every **off-loop** consumer of a finished run's config reads the clobbered dump and fails:
- `load_run_dir_config` → `open_jax_run` / `run_metadata` / harvest / autointerp
- fine-tune structural-compat (`assert_finetune_structural_compat`)
- slow-eval metric re-validation (`eval_metrics_from_run_dir`)

A non-reserved basename removes the collision, so the pinned config stays clean and off-loop consumers work directly (no more "use the source config" workaround).

## How Has This Been Tested?

- `make type` — 0 errors
- `make format` / pre-commit — clean
- `pytest param_decomp/tests/test_config.py::test_load_run_dir_config_rebuilds_runs param_decomp/tests/test_finetune_resume.py param_decomp_lab/tests/autointerp/test_adapter_routing.py` — 8 passed
- grep confirms no lingering run-dir `config.yaml` reader/writer (autointerp *subrun* `config.yaml` is a different file, untouched)

## Does this PR introduce a breaking change?

Behavioral, for **old** runs only, and no shim is added (per repo policy). New runs write `launch_config.yaml` (clean). Existing finished runs only have the corrupted `config.yaml` dump — which the consumers already couldn't parse — so they now report as not-loadable rather than crashing mid-parse. To reopen a specific old run, drop its source YAML in as `launch_config.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)