### PR TITLE
feat(logging): producer-declared window reductions for train metrics

### DIFF
--- a/param_decomp/experiments/invariance_check.py
+++ b/param_decomp/experiments/invariance_check.py
@@ -122,7 +122,7 @@ def _run(steps: int, sharded: bool) -> list[dict[str, float]]:
         ),
         lm.site_names,
     )  # fmt: skip
-    step = make_train_step(
+    step, _ = make_train_step(
         lm=lm,
         losses=loss_terms,
         components_optimizer=opt_vu, ci_fn_optimizer=opt_ci,

--- a/param_decomp/run.py
+++ b/param_decomp/run.py
@@ -63,7 +63,12 @@ from param_decomp.slow_eval import (
     render_permutation_figures,
     render_slow_eval_figures,
 )
-from param_decomp.train import TrainState, make_faith_warmup_step, make_train_step
+from param_decomp.train import (
+    TrainState,
+    WindowReduction,
+    make_faith_warmup_step,
+    make_train_step,
+)
 
 _sigterm_received = False
 
@@ -156,22 +161,33 @@ def _is_verbose_grad_norm(key: str) -> bool:
     return key.startswith("train/grad_norms/") and not key.startswith("train/grad_norms/summary/")
 
 
-def _grad_norm_summary_window_stats(window: list[dict[str, jax.Array]]) -> dict[str, float]:
-    """Window min/max/median for each `grad_norms/summary/*` scalar over every step since the
-    last log. The per-step values are accumulated as device handles (appending one is async),
-    so the whole window reduces in a single host transfer here — the loop stays unsynced
-    between logs rather than subsampling grad norms at the log step."""
-    assert window, "grad-norm summary window is empty at a log boundary"
+_REDUCTION_OPS: dict[WindowReduction, tuple[tuple[str, Callable[..., jax.Array]], ...]] = {
+    WindowReduction.MEAN: (("", jnp.mean),),  # empty suffix: replaces the point value in place
+    WindowReduction.SPREAD: (("/min", jnp.min), ("/max", jnp.max), ("/median", jnp.median)),
+}
+"""How each declared reduction is computed over the window: (output-key suffix, jnp op)."""
+
+
+def _reduce_metric_window(
+    window: list[dict[str, jax.Array]], reductions: dict[str, WindowReduction]
+) -> dict[str, float]:
+    """Apply each windowed metric's declared reduction over the steps since the last log. The
+    policy (`reductions`) is supplied by the metric producer (`make_train_step`), never inferred
+    from key strings here. Per-step values accumulate as device handles (appending one is async),
+    so the loop stays unsynced between logs and the whole window reduces here — one host transfer
+    per distinct reduction op."""
+    assert window, "metric window is empty at a log boundary"
     keys = list(window[0].keys())
     stacked = jnp.stack([jnp.stack([snap[k] for snap in window]) for k in keys])  # [keys, steps]
-    mins = np.asarray(jnp.min(stacked, axis=1))
-    maxs = np.asarray(jnp.max(stacked, axis=1))
-    medians = np.asarray(jnp.median(stacked, axis=1))
-    out: dict[str, float] = {}
+    keys_by_op: dict[tuple[str, Callable[..., jax.Array]], list[int]] = {}
     for i, key in enumerate(keys):
-        out[f"{key}/min"] = float(mins[i])
-        out[f"{key}/max"] = float(maxs[i])
-        out[f"{key}/median"] = float(medians[i])
+        for op in _REDUCTION_OPS[reductions[key]]:
+            keys_by_op.setdefault(op, []).append(i)
+    out: dict[str, float] = {}
+    for (suffix, reduce), idxs in keys_by_op.items():
+        vals = np.asarray(reduce(stacked[jnp.asarray(idxs)], axis=1))
+        for j, i in enumerate(idxs):
+            out[f"{keys[i]}{suffix}"] = float(vals[j])
     return out
 
 
@@ -501,7 +517,7 @@ def run_decomposition_training(
         return  # SIGTERM mid-warmup: clean exit for requeue
     state, start_step = init
 
-    step_fn = make_train_step(
+    step_fn, metric_reductions = make_train_step(
         lm=lm,
         losses=build_loss_terms(pd.loss_metrics, lm.site_names),
         components_optimizer=opt_vu,
@@ -532,7 +548,7 @@ def run_decomposition_training(
     sink = MetricsSink.for_run(run, wandb_config, is_main)
     window_t0 = loop_t0 = time.time()
     last_logged = start_step
-    grad_norm_summary_window: list[dict[str, jax.Array]] = []
+    metric_window: list[dict[str, jax.Array]] = []
 
     # SCRATCH PROFILER HOOK (revertable): env-gated jax.profiler.trace over a window of
     # steady-state steps + per-step block_until_ready wall-clock. PD_PROFILE_TRACE=1 enables;
@@ -690,9 +706,7 @@ def run_decomposition_training(
             batch = sample_batch(step)
             state, metrics = step_fn(lm, state, batch, random.fold_in(run_key, step))
 
-        grad_norm_summary_window.append(
-            {k: v for k, v in metrics.items() if k.startswith("grad_norms/summary/")}
-        )
+        metric_window.append({k: v for k, v in metrics.items() if k in metric_reductions})
 
         if _profiling:
             jax.block_until_ready((state, metrics["total"]))
@@ -721,11 +735,9 @@ def run_decomposition_training(
             dt = time.time() - window_t0
             per_step = dt / max(now_step - last_logged, 1)
             last_logged = now_step
-            record = {
-                k: float(v) for k, v in metrics.items() if not k.startswith("grad_norms/summary/")
-            }
-            record.update(_grad_norm_summary_window_stats(grad_norm_summary_window))
-            grad_norm_summary_window.clear()
+            record = {k: float(v) for k, v in metrics.items() if k not in metric_reductions}
+            record.update(_reduce_metric_window(metric_window, metric_reductions))
+            metric_window.clear()
             for loss_name in ("total", *(k for k in record if k.startswith("loss/"))):
                 assert math.isfinite(record[loss_name]), (
                     f"non-finite loss {loss_name!r} at step {now_step}: {record[loss_name]}"

--- a/param_decomp/tests/stacked_parity/gen_stacked_fixtures.py
+++ b/param_decomp/tests/stacked_parity/gen_stacked_fixtures.py
@@ -169,7 +169,7 @@ def main() -> None:
         sources=sources, sources_adam_state=init_sources_adam_state(sources),
         step=jax.numpy.zeros((), jax.numpy.int32),
     )  # fmt: skip
-    step_fn = make_train_step(
+    step_fn, _ = make_train_step(
         lm=lm,
         faith_coeff=1e5,
         stoch_coeff=0.5,

--- a/param_decomp/tests/stacked_parity/test_stacked_parity.py
+++ b/param_decomp/tests/stacked_parity/test_stacked_parity.py
@@ -281,7 +281,7 @@ def test_train_trajectory_matches():
         ),
         lm.site_names,
     )
-    step_fn = make_train_step(
+    step_fn, _ = make_train_step(
         lm=lm,
         losses=loss_terms,
         components_optimizer=opt_vu,

--- a/param_decomp/tests/test_checkpoint.py
+++ b/param_decomp/tests/test_checkpoint.py
@@ -130,7 +130,7 @@ def _build(seed: int):
         ),
         lm.site_names,
     )  # fmt: skip
-    step = make_train_step(
+    step, _ = make_train_step(
         lm=lm,
         losses=loss_terms,
         components_optimizer=opt_vu, ci_fn_optimizer=opt_ci,

--- a/param_decomp/tests/test_checkpoint_production_topology.py
+++ b/param_decomp/tests/test_checkpoint_production_topology.py
@@ -159,7 +159,7 @@ def _build_sharded(seed: int):
     )  # fmt: skip
     assert tuple(persistent_configs(loss_terms.recon)) == PERSISTENT_TERMS, loss_terms
 
-    step = make_train_step(
+    step, _ = make_train_step(
         lm=lm,
         losses=loss_terms,
         components_optimizer=opt_vu, ci_fn_optimizer=opt_ci,

--- a/param_decomp/tests/test_generic_model_io.py
+++ b/param_decomp/tests/test_generic_model_io.py
@@ -260,7 +260,7 @@ def test_train_step_runs_through_generic_target():
         ),
         lm.site_names,
     )
-    step_fn = make_train_step(
+    step_fn, _ = make_train_step(
         lm=lm,
         losses=loss_terms,
         components_optimizer=opt_vu,

--- a/param_decomp/tests/test_llama8b.py
+++ b/param_decomp/tests/test_llama8b.py
@@ -389,7 +389,7 @@ def test_step_trains_and_has_vpd_signature(site_cs: tuple[SiteC, ...]):
         ),
         lm.site_names,
     )
-    step = make_train_step(
+    step, _ = make_train_step(
         lm=lm,
         losses=loss_terms,
         components_optimizer=opt_vu,
@@ -513,7 +513,7 @@ def test_fresh_pgd_adversary_step():
             ),
             lm.site_names,
         )
-        step = make_train_step(
+        step, _ = make_train_step(
             lm=lm,
             losses=loss_terms,
             components_optimizer=opt_vu,

--- a/param_decomp/tests/test_llama_simple_mlp.py
+++ b/param_decomp/tests/test_llama_simple_mlp.py
@@ -407,7 +407,7 @@ def test_step_trains_and_has_vpd_signature():
         ),
         lm.site_names,
     )
-    step = make_train_step(
+    step, _ = make_train_step(
         lm=lm,
         losses=loss_terms,
         components_optimizer=opt_vu,

--- a/param_decomp/tests/test_no_bake_invariant.py
+++ b/param_decomp/tests/test_no_bake_invariant.py
@@ -73,7 +73,7 @@ def _build_step_and_args():
         ),
         lm.site_names,
     )
-    step_fn = make_train_step(
+    step_fn, _ = make_train_step(
         lm=lm,
         losses=loss_terms,
         components_optimizer=opt_vu,

--- a/param_decomp/train.py
+++ b/param_decomp/train.py
@@ -16,6 +16,7 @@ Per-term RNG: term i draws from `fold_in(step_key, 1 + i)` in config-list order
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from enum import Enum, auto
 from typing import Any
 
 import equinox as eqx
@@ -75,24 +76,44 @@ class TrainState:
     step: Array
 
 
+class WindowReduction(Enum):
+    """How a train-step metric collapses the window of steps since the last log. A metric
+    absent from the step's reduction map is SUBSAMPLED (logged at the log-step value) — the
+    default. The producer (`make_train_step`) declares this so the logger never re-infers a
+    metric's intent from its key string."""
+
+    MEAN = auto()
+    SPREAD = auto()
+
+
+_GRAD_NORM_FAMILIES = ("components", "ci_fns")
+GRAD_NORM_SUMMARY_KEYS = tuple(
+    f"grad_norms/summary/{family}" for family in (*_GRAD_NORM_FAMILIES, "total")
+)
+"""The aggregate grad-norm keys `_grad_norm_metrics` emits (per-family + total) — the ones
+that carry a window SPREAD reduction; the per-leaf norms are subsampled."""
+
+
 def _grad_norm_metrics(components_grad: DecompVU, ci_fn_grad: Any) -> dict[str, Array]:
     """Pre-clip gradient L2 norms, matching the torch `component_grad_norms` families:
     per-leaf `grad_norms/components<path>` / `grad_norms/ci_fns<path>` (paths are this
     pytree's own — e.g. `.vu['layers.18.mlp.gate_proj'][0]` for the per-site Llama
-    layout, vs torch's per-site names) and the overlay-critical
-    `grad_norms/summary/{components,ci_fns,total}`."""
+    layout, vs torch's per-site names) and the overlay-critical `GRAD_NORM_SUMMARY_KEYS`."""
+    grads_by_family = {"components": components_grad, "ci_fns": ci_fn_grad}
     out: dict[str, Array] = {}
 
-    def family(grad_tree: Any, prefix: str) -> Array:
+    def family_sum_sq(family: str) -> Array:
         sum_sq = jnp.zeros((), jnp.float32)
-        for path, leaf in jax.tree_util.tree_flatten_with_path(grad_tree)[0]:
+        for path, leaf in jax.tree_util.tree_flatten_with_path(grads_by_family[family])[0]:
             leaf_sum_sq = jnp.sum(leaf.astype(jnp.float32) ** 2)
-            out[f"grad_norms/{prefix}{jax.tree_util.keystr(path)}"] = jnp.sqrt(leaf_sum_sq)
+            out[f"grad_norms/{family}{jax.tree_util.keystr(path)}"] = jnp.sqrt(leaf_sum_sq)
             sum_sq = sum_sq + leaf_sum_sq
-        out[f"grad_norms/summary/{prefix}"] = jnp.sqrt(sum_sq)
+        out[f"grad_norms/summary/{family}"] = jnp.sqrt(sum_sq)
         return sum_sq
 
-    total_sq = family(components_grad, "components") + family(ci_fn_grad, "ci_fns")
+    total_sq = jnp.zeros((), jnp.float32)
+    for family in _GRAD_NORM_FAMILIES:
+        total_sq = total_sq + family_sum_sq(family)
     out["grad_norms/summary/total"] = jnp.sqrt(total_sq)
     return out
 
@@ -527,7 +548,21 @@ def make_train_step(
             metrics |= {f"schedules/lr/src/{k}": v for k, v in source_lrs.items()}
         return new_state, metrics
 
-    return filter_jit(step, donate="all-except-first", compiler_options=compiler_options)
+    # The producer declares each metric's window reduction (the logger applies it, never
+    # re-inferring from key strings): losses -> MEAN over the window, grad-norm summaries ->
+    # SPREAD (min/max/median). Keys absent here (imp_min_param, per-leaf grad norms) subsample.
+    metric_reductions: dict[str, WindowReduction] = {
+        "total": WindowReduction.MEAN,
+        "faith": WindowReduction.MEAN,
+        imp_loss_key: WindowReduction.MEAN,
+        "freq": WindowReduction.MEAN,
+        **{f"loss/{term.name}": WindowReduction.MEAN for term in recon_terms},
+        **{key: WindowReduction.SPREAD for key in GRAD_NORM_SUMMARY_KEYS},
+    }
+    return (
+        filter_jit(step, donate="all-except-first", compiler_options=compiler_options),
+        metric_reductions,
+    )
 
 
 # ───────────────────────────── faithfulness warmup (SPEC S21) ─────────────────────────────

--- a/param_decomp_lab/experiments/resid_mlp/test_resid_mlp.py
+++ b/param_decomp_lab/experiments/resid_mlp/test_resid_mlp.py
@@ -255,7 +255,7 @@ def _make_state_and_step(
         adversaries={}, step=jnp.zeros((), jnp.int32),
     )  # fmt: skip
     loss_terms = build_loss_terms(_loss_metrics(), lm.site_names)
-    step = make_train_step(
+    step, _ = make_train_step(
         lm=lm, losses=loss_terms, components_optimizer=opt_vu, ci_fn_optimizer=opt_ci,
         total_steps=total_steps, remat_recon_forwards=False, remat_ci_fn=False, mesh=None,
     )  # fmt: skip
@@ -364,7 +364,7 @@ def _faith_warmed_state(
         adversaries={}, step=jnp.zeros((), jnp.int32),
     )  # fmt: skip
     loss_terms = build_loss_terms(_recovery_loss_metrics(), lm.site_names)
-    step = make_train_step(
+    step, _ = make_train_step(
         lm=lm, losses=loss_terms, components_optimizer=opt_vu, ci_fn_optimizer=opt_ci,
         total_steps=total_steps, remat_recon_forwards=False, remat_ci_fn=False, mesh=None,
     )  # fmt: skip

--- a/param_decomp_lab/experiments/tms/test_tms.py
+++ b/param_decomp_lab/experiments/tms/test_tms.py
@@ -205,7 +205,7 @@ def _make_state_and_step(
         adversaries={}, step=jnp.zeros((), jnp.int32),
     )  # fmt: skip
     loss_terms = build_loss_terms(_loss_metrics(), lm.site_names)
-    step = make_train_step(
+    step, _ = make_train_step(
         lm=lm, losses=loss_terms, components_optimizer=opt_vu, ci_fn_optimizer=opt_ci,
         total_steps=total_steps, remat_recon_forwards=False, remat_ci_fn=False, mesh=None,
     )  # fmt: skip
@@ -308,7 +308,7 @@ def _faith_warmed_state(
         adversaries={}, step=jnp.zeros((), jnp.int32),
     )  # fmt: skip
     loss_terms = build_loss_terms(_recovery_loss_metrics(), lm.site_names)
-    step = make_train_step(
+    step, _ = make_train_step(
         lm=lm, losses=loss_terms, components_optimizer=opt_vu, ci_fn_optimizer=opt_ci,
         total_steps=total_steps, remat_recon_forwards=False, remat_ci_fn=False, mesh=None,
     )  # fmt: skip


### PR DESCRIPTION
**Stacked on #914** (base branch is that PR's branch; review/merge #914 first).

## What

Extends window reduction beyond grad-norm summaries to the **loss terms**, and — per review feedback — **inverts control** so the choice of reduction is owned by the metric *producer* (`make_train_step`), not re-inferred from key strings in the logger.

The prior form classified metrics in `run.py` with `startswith("loss/")` and a `_LOSS_METRIC_KEYS` frozenset derived by grepping the sink's rename-table *values* for `train/loss/`. That's the consumer re-guessing intent the producer already knows. Gone.

## How

- `WindowReduction` enum in `train.py`: `MEAN` / `SPREAD`. Absence from the policy = subsample (the default).
- `make_train_step` now returns `(step_fn, metric_reductions)`. It declares the policy right where it builds the metrics dict, from the actual term objects:
  - losses (`total`, `faith`, `imp`/`imp_smooth_l0`, `freq`, `loss/<term.name>`) → `MEAN`
  - grad-norm summaries (`GRAD_NORM_SUMMARY_KEYS`) → `SPREAD` (min/max/median)
  - `imp_min_param` (`gamma_imp`/`p_imp`) and per-leaf grad norms are simply absent → subsampled
- `run.py` applies the injected policy and nothing else: accumulates the windowed keys as device handles, then reduces via a small `_REDUCTION_OPS` table (`WindowReduction` → `(suffix, jnp op)`) at the log boundary. **No key-string classification remains in the consumer.**
- `GRAD_NORM_SUMMARY_KEYS` single-sources the summary key names shared by `_grad_norm_metrics` and the policy (the `_grad_norm_metrics` refactor is bit-identical).

Result: losses log the window **mean** under their existing keys (dashboard-stable, batch-noise averaged); grad-norm summaries keep min/max/median. Same async property as #914 — appending per-step handles doesn't sync, so the loop stays unsynced between logs; the window reduces in one host transfer per op at the log step.

All ~14 `make_train_step` callers updated to unpack the tuple (test churn is fine — it shouldn't shape the code).

## Testing

- `make type` (full workspace basedpyright) clean; ruff + pre-commit green.
- `test_generic_model_io` + `test_no_bake_invariant` (drive the real `make_train_step`) pass; `test_stacked_parity` passes (grad-norm summary keys still emitted by the step, unchanged); TMS toy suite passes.
- Policy-driven reduction hand-verified: `total`/`loss/*` → window mean under same key; grad summary → min/max/median.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GjuHowooGKrpNaGCXmiztg