### PR TITLE
config(pile-4l): add jose-ish, a runnable migrated baseline

### DIFF
--- a/param_decomp_lab/experiments/lm/jose-ish.yaml
+++ b/param_decomp_lab/experiments/lm/jose-ish.yaml
@@ -1,0 +1,131 @@
+run_name: jose-ish
+pd:
+  seed: 0
+  ci_config:
+    type: chunkwise_transformer
+    blocks_per_chunk: 4
+    d_model: 2048
+    n_blocks: 8
+    n_heads: 16
+    mlp_hidden: 8192
+  decomposition_targets:
+  - module_pattern: h.*.mlp.c_fc
+    C: 3072
+  - module_pattern: h.*.mlp.down_proj
+    C: 3584
+  - module_pattern: h.*.attn.q_proj
+    C: 512
+  - module_pattern: h.*.attn.k_proj
+    C: 512
+  - module_pattern: h.*.attn.v_proj
+    C: 1024
+  - module_pattern: h.*.attn.o_proj
+    C: 1024
+  components_optimizer:
+    lr_schedule:
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+      final_val_frac: 0.1
+      fn_type: cosine
+    grad_clip_norm: 0.01
+  ci_fn_optimizer:
+    lr_schedule:
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+      final_val_frac: 0.1
+      fn_type: cosine
+  steps: 400000
+  batch_size: 64
+  faithfulness_warmup_steps: 400
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_weight_decay: 0.0
+  loss_metrics:
+    - type: ImportanceMinimalityLoss
+      coeff: 0.0002
+      pnorm: 2.0
+      frequency:
+        coeff: 1.0e-04
+        reference_token_count: 32768
+      p_anneal_start_frac: 0.0
+      p_anneal_final_p: 0.4
+      p_anneal_end_frac: 1.0
+      eps: 1.0e-12
+    - type: StochasticReconSubsetLoss
+      coeff: 0.5
+      routing:
+        type: uniform_k_subset
+    - type: PersistentPGDReconLoss
+      coeff: 0.5
+      optimizer:
+        type: adam
+        beta1: 0.5
+        beta2: 0.99
+        eps: 1.0e-08
+        lr_schedule:
+          start_val: 0.01
+          warmup_pct: 0.025
+          final_val_frac: 1.0
+          fn_type: constant
+      scope:
+        type: bsc
+      n_warmup_steps: 2
+    - type: FaithfulnessLoss
+      coeff: 10000000.0
+cadence:
+  train_log_every: 200
+  save_every: 5000
+  keep_last_n_checkpoints: 2
+eval:
+  n_steps: 1
+  batch_size: 128
+  every: 1000
+  slow_every: 100000000
+  slow_on_first_step: false
+  metrics:
+    - type: CIHistograms
+      n_batches_accum: 1
+    - type: ComponentActivationDensity
+    - type: CI_L0
+      groups:
+        layer_0:
+        - h.0.*
+        layer_1:
+        - h.1.*
+        layer_2:
+        - h.2.*
+        layer_3:
+        - h.3.*
+        total:
+        - '*'
+    - type: CEandKLLosses
+      rounding_threshold: 0.0
+    - type: CIMeanPerComponent
+    - type: StochasticHiddenActsReconLoss
+    - type: CIHiddenActsReconLoss
+    - type: PGDReconLoss
+      init: random
+      step_size: 0.1
+      n_steps: 20
+      mask_scope: c
+target:
+  weights_dtype: bfloat16
+  spec:
+    kind: pretrained
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
+    run_path: goodfire/spd/runs/t-9d2b8f02
+data:
+  tokenizer_name: EleutherAI/gpt-neox-20b
+  max_seq_len: 512
+  buffer_size: 1000
+  dataset_name: parquet
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/pile_neox_tok_512/*.parquet
+  train_split: train
+  eval_split: train
+  shuffle_each_epoch: true
+  is_tokenized: true
+  streaming: false
+runtime:
+  dp: 8
+wandb:
+  project: param-decomp

--- a/param_decomp_lab/experiments/lm/jose-ish.yaml
+++ b/param_decomp_lab/experiments/lm/jose-ish.yaml
@@ -1,3 +1,14 @@
+# jose-ish: the flagship jose.yaml (José's paper 4L-pile PPGD-bsc decomposition,
+# torch run p-20f9fc15) migrated to the current JAX schema — "-ish" = a close-but-not-
+# identical baseline, runnable today. Deliberate deviations from José's exact run
+# (Oli, 2026-07-14):
+#   - imp-min eps 1e-12 -> 1e-6 (the #976 endgame-recon-ramp fix; matches pile_ppgd_bsc)
+#   - slow/plot eval enabled every 2k steps (was effectively off)
+#   - runtime.dp: 8 (1 node)
+#   - pnorm anneal expressed as the unified ScheduleConfig (#939); same anneal
+#     (p: 2.0 -> 0.4 linear over the full run)
+# Kept from José: blocks_per_chunk 4, frequency reference_token_count 32768, all
+# losses/coeffs/optimizers/C. Launch: pd-lm <this file>.
 run_name: jose-ish
 pd:
   seed: 0
@@ -42,14 +53,14 @@ pd:
   loss_metrics:
     - type: ImportanceMinimalityLoss
       coeff: 0.0002
-      pnorm: 2.0
+      pnorm:
+        start_val: 2.0
+        fn_type: linear
+        final_val_frac: 0.2
       frequency:
         coeff: 1.0e-04
         reference_token_count: 32768
-      p_anneal_start_frac: 0.0
-      p_anneal_final_p: 0.4
-      p_anneal_end_frac: 1.0
-      eps: 1.0e-12
+      eps: 1.0e-06
     - type: StochasticReconSubsetLoss
       coeff: 0.5
       routing:
@@ -79,8 +90,8 @@ eval:
   n_steps: 1
   batch_size: 128
   every: 1000
-  slow_every: 100000000
-  slow_on_first_step: false
+  slow_every: 2000
+  slow_on_first_step: true
   metrics:
     - type: CIHistograms
       n_batches_accum: 1


### PR DESCRIPTION
Migrates `jose-ish.yaml` — José's paper 4L-pile PPGD-bsc decomposition (torch p-20f9fc15) as a runnable baseline — to the current JAX schema, per Oli's spec (bridge task `component-norm-optimizer` context):

- **pnorm anneal as the unified `ScheduleConfig`** (#939): same 2.0 → 0.4 linear anneal over the full run
- **imp-min eps 1e-12 → 1e-6** (the #976 endgame-recon-ramp fix, matching `pile_ppgd_bsc`)
- **slow/plot eval every 2k** (was effectively disabled)
- **`runtime.dp: 8`** (1 node)

Kept from José: `blocks_per_chunk: 4`, frequency `reference_token_count: 32768`, all losses/coeffs/optimizers/C, 400k steps.

Validated at feature/jax tip: `load_config` + `assert_canonical_algorithm_config` + `build_optimizers` all pass.

Bridge thread: component-norm-optimizer

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SwEM9ZetQw9W4yjH8okwaH