### PR TITLE
fix(hidden-acts-eval): derive waist leading from CI output, not token inputs (S31)

### DIFF
--- a/param_decomp/hidden_acts_eval.py
+++ b/param_decomp/hidden_acts_eval.py
@@ -29,7 +29,7 @@ from typing import Any
 import jax.numpy as jnp
 import numpy as np
 from jax import random
-from jaxtyping import Array, Float, PRNGKeyArray
+from jaxtyping import Array, PRNGKeyArray
 
 from param_decomp.components import DecompVU
 from param_decomp.jit_util import filter_jit
@@ -57,13 +57,21 @@ def _per_site_sum_mse(
 
 
 HiddenActsStep = Callable[
-    [DecomposedModel, Any, Any, Float[Array, "*leading d"], PRNGKeyArray],
+    [DecomposedModel, Any, Any, Any, PRNGKeyArray],
     tuple[dict[str, Array], dict[str, int]],
 ]
-"""`(model, components, ci_fn, residual, key) -> ({site: sum_mse}, {site: n_elements})`
+"""`(model, components, ci_fn, inputs, key) -> ({site: sum_mse}, {site: n_elements})`
 — one batch's per-site summed MSE (fp32) and element counts (the host folds these into
-`SiteMSEReduction`s). `key` is unused by the deterministic CI step. `model`
-(frozen-weight-bearing) is the jit ARG."""
+`SiteMSEReduction`s). `inputs` is the model's target-specific input (an LM's `[batch, seq]`
+token ids), exactly as `read_activations` / `masked_site_outputs` take it. `key` is unused
+by the deterministic CI step. `model` (frozen-weight-bearing) is the jit ARG."""
+
+
+def _waist_leading(ci_lower: dict[str, Array], site_names: tuple[str, ...]) -> tuple[int, ...]:
+    """The waist's `*leading` (batch + position axes), read off the CI output
+    `[*leading, C]` — the model `inputs` can't provide it (target-specific; an LM's token
+    ids carry no feature axis to strip)."""
+    return ci_lower[site_names[0]].shape[:-1]
 
 
 def make_ci_hidden_acts_step(
@@ -76,24 +84,24 @@ def make_ci_hidden_acts_step(
         model: DecomposedModel,
         components: DecompVU,
         ci_fn: Any,
-        residual: Float[Array, "*leading d"],
+        inputs: Any,
         _key: PRNGKeyArray,
     ) -> tuple[dict[str, Array], dict[str, int]]:
-        taps = model.read_activations(residual, ci_fn.input_names)
+        taps = model.read_activations(inputs, ci_fn.input_names)
         components_bf16 = cast_floating(components, COMPUTE_DT)
         prepared = model.prepare_compute_weights(components_bf16)
         ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
         ci_lower = ci_fn_bf16(taps, remat=False).lower
 
-        leading = residual.shape[:-1]
+        leading = _waist_leading(ci_lower, site_names)
         zeros_delta = {s: jnp.zeros(leading, COMPUTE_DT) for s in site_names}
         clean = model.masked_site_outputs(
-            prepared, residual,
+            prepared, inputs,
             {s: jnp.ones_like(ci_lower[s]) for s in site_names}, zeros_delta,
             all_false_routes(site_names, leading), site_names, False,
         )  # fmt: skip
         masked = model.masked_site_outputs(
-            prepared, residual, ci_lower, zeros_delta, None, site_names, False
+            prepared, inputs, ci_lower, zeros_delta, None, site_names, False
         )
         sum_mse = _per_site_sum_mse(masked, clean, site_names)
         n_elements = {s: clean[s].size for s in site_names}
@@ -117,18 +125,18 @@ def make_stochastic_hidden_acts_step(
         model: DecomposedModel,
         components: DecompVU,
         ci_fn: Any,
-        residual: Float[Array, "*leading d"],
+        inputs: Any,
         key: PRNGKeyArray,
     ) -> tuple[dict[str, Array], dict[str, int]]:
-        taps = model.read_activations(residual, ci_fn.input_names)
+        taps = model.read_activations(inputs, ci_fn.input_names)
         components_bf16 = cast_floating(components, COMPUTE_DT)
         prepared = model.prepare_compute_weights(components_bf16)
         ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
         ci_lower = ci_fn_bf16(taps, remat=False).lower
 
-        leading = residual.shape[:-1]
+        leading = _waist_leading(ci_lower, site_names)
         clean = model.masked_site_outputs(
-            prepared, residual,
+            prepared, inputs,
             {s: jnp.ones_like(ci_lower[s]) for s in site_names},
             {s: jnp.zeros(leading, COMPUTE_DT) for s in site_names},
             all_false_routes(site_names, leading), site_names, False,
@@ -148,7 +156,7 @@ def make_stochastic_hidden_acts_step(
                     random.fold_in(delta_key, site_idx), leading, COMPUTE_DT
                 )
             masked = model.masked_site_outputs(
-                prepared, residual, masks, delta_masks, None, site_names, True
+                prepared, inputs, masks, delta_masks, None, site_names, True
             )
             draw_sum = _per_site_sum_mse(masked, clean, site_names)
             sum_mse = {s: sum_mse[s] + draw_sum[s] for s in site_names}
@@ -164,18 +172,18 @@ def accumulate_hidden_acts(
     model: DecomposedModel,
     components: DecompVU,
     ci_fn: Any,
-    residual_batches: list[Float[Array, "*leading d"]],
+    input_batches: list[Any],
     base_key: PRNGKeyArray,
 ) -> dict[str, SiteMSEReduction]:
     """Drive `step` over the eval batches, host-accumulating `(Σ sum_mse, Σ n)` per site
     (token-weighted, exact under micro-batching — same pattern as the density/mean
     accumulators). Per-batch RNG is `fold_in(base_key, batch_idx)`."""
-    assert residual_batches, "hidden-acts eval needs at least one batch"
+    assert input_batches, "hidden-acts eval needs at least one batch"
     sums: dict[str, float] = {}
     counts: dict[str, int] = {}
-    for batch_idx, residual in enumerate(residual_batches):
+    for batch_idx, inputs in enumerate(input_batches):
         batch_sum, batch_n = step(
-            model, components, ci_fn, residual, random.fold_in(base_key, batch_idx)
+            model, components, ci_fn, inputs, random.fold_in(base_key, batch_idx)
         )
         for site in batch_sum:
             sums[site] = sums.get(site, 0.0) + float(np.asarray(batch_sum[site]))

--- a/param_decomp/slow_eval.py
+++ b/param_decomp/slow_eval.py
@@ -799,22 +799,23 @@ def render_slow_eval_figures(
 def compute_hidden_acts_metrics(
     model: DecomposedModel,
     state: Any,
-    residual_batches: list[Float[Array, "*leading d"]],
+    input_batches: list[Any],
     n_mask_samples: int,
     base_key: Array,
     compiler_options: dict[str, bool | int | str] | None = None,
 ) -> dict[str, float]:
-    """Both hidden-acts recon eval metrics over the eval batches, keyed by the torch
+    """Both hidden-acts recon eval metrics over the eval batches (`input_batches` holds
+    the model's target-specific inputs — an LM's token ids), keyed by the torch
     `<ClassName>[/<site>]` log keys. `state.components`/`state.ci_fn` are the restored
     trajectory; `base_key` seeds the stochastic variant's per-batch draws."""
     ci_key, stoch_key = random.split(base_key)
     ci_step = make_ci_hidden_acts_step(model, compiler_options)
     ci_reductions = accumulate_hidden_acts(
-        ci_step, model, state.components, state.ci_fn, residual_batches, ci_key
+        ci_step, model, state.components, state.ci_fn, input_batches, ci_key
     )
     stoch_step = make_stochastic_hidden_acts_step(model, n_mask_samples, compiler_options)
     stoch_reductions = accumulate_hidden_acts(
-        stoch_step, model, state.components, state.ci_fn, residual_batches, stoch_key
+        stoch_step, model, state.components, state.ci_fn, input_batches, stoch_key
     )
     return {
         **hidden_acts_log_entries("CIHiddenActsReconLoss", ci_reductions),

--- a/param_decomp/tests/test_hidden_acts_eval.py
+++ b/param_decomp/tests/test_hidden_acts_eval.py
@@ -1,0 +1,115 @@
+"""CPU tests for the in-loop hidden-acts recon eval metrics (SPEC S31).
+
+Pins the per-site MSE shape/count bookkeeping on both steps and the host-side
+token-weighted accumulation. Batch != seq throughout: the steps must derive the waist
+`*leading` from the CI output, not from the token inputs (whose `shape[:-1]` drops the
+sequence axis — the regression that crashed the stochastic step's delta/route broadcast).
+"""
+
+import jax
+import numpy as np
+
+from param_decomp.ci_fn import Chunk, ChunkwiseTransformerCIArch, CIFn, build_ci_fn
+from param_decomp.components import SiteC, init_decomp_vu
+from param_decomp.hidden_acts_eval import (
+    accumulate_hidden_acts,
+    hidden_acts_log_entries,
+    make_ci_hidden_acts_step,
+    make_stochastic_hidden_acts_step,
+)
+from param_decomp.lm import DecomposedModel
+from param_decomp.targets.llama_simple_mlp import (
+    canonical_site_cs,
+    parse_site_name,
+    site_specs,
+)
+from param_decomp.tests.test_llama_simple_mlp import (
+    _tiny_cfg,
+    _tiny_decomposed_model,
+)
+
+_BATCH, _SEQ = 2, 12
+
+
+def _build_ci_fn(lm: DecomposedModel, n_embd: int, key: jax.Array) -> CIFn:
+    site_names = lm.site_names
+    first_block = min(parse_site_name(n)[0] for n in site_names)
+    arch = ChunkwiseTransformerCIArch(
+        chunks=(Chunk(input_taps=(f"resid.{first_block}",), output_sites=site_names),),
+        input_dim=n_embd,
+        d_model=16,
+        n_blocks=1,
+        n_heads=2,
+        mlp_hidden=32,
+    )
+    return build_ci_fn(arch, lm.sites, key)
+
+
+def _setup():
+    cfg = _tiny_cfg()
+    site_cs = canonical_site_cs(
+        (
+            SiteC("h.2.attn.q_proj", 8),
+            SiteC("h.2.attn.v_proj", 12),
+            SiteC("h.2.mlp.c_fc", 8),
+            SiteC("h.3.mlp.down_proj", 16),
+        )
+    )
+    lm = _tiny_decomposed_model(cfg, site_specs(cfg, site_cs), jax.random.PRNGKey(0))
+    components = init_decomp_vu(lm.sites, jax.random.PRNGKey(1))
+    ci_fn = _build_ci_fn(lm, cfg.n_embd, jax.random.PRNGKey(2))
+    tokens = jax.random.randint(jax.random.PRNGKey(3), (_BATCH, _SEQ), 0, cfg.vocab_size)
+    site_d_out = {
+        "h.2.attn.q_proj": cfg.n_head * cfg.head_dim,
+        "h.2.attn.v_proj": cfg.n_kv_head * cfg.head_dim,
+        "h.2.mlp.c_fc": cfg.n_intermediate,
+        "h.3.mlp.down_proj": cfg.n_embd,
+    }
+    return lm, components, ci_fn, tokens, site_d_out
+
+
+def test_ci_step_per_site_sums_and_counts():
+    lm, components, ci_fn, tokens, site_d_out = _setup()
+    step = make_ci_hidden_acts_step(lm)
+
+    sum_mse, n_elements = step(lm, components, ci_fn, tokens, jax.random.PRNGKey(0))
+
+    assert set(sum_mse) == set(lm.site_names) == set(n_elements)
+    for site in lm.site_names:
+        assert int(n_elements[site]) == _BATCH * _SEQ * site_d_out[site]
+        assert np.isfinite(float(sum_mse[site]))
+        assert float(sum_mse[site]) >= 0.0
+
+
+def test_stochastic_step_per_site_sums_and_counts():
+    lm, components, ci_fn, tokens, site_d_out = _setup()
+    n_mask_samples = 3
+    step = make_stochastic_hidden_acts_step(lm, n_mask_samples)
+
+    sum_mse, n_elements = step(lm, components, ci_fn, tokens, jax.random.PRNGKey(0))
+
+    assert set(sum_mse) == set(lm.site_names) == set(n_elements)
+    for site in lm.site_names:
+        assert int(n_elements[site]) == _BATCH * _SEQ * site_d_out[site] * n_mask_samples
+        assert np.isfinite(float(sum_mse[site]))
+        assert float(sum_mse[site]) >= 0.0
+
+
+def test_accumulate_and_log_entries_token_weighted():
+    lm, components, ci_fn, tokens, _ = _setup()
+    step = make_ci_hidden_acts_step(lm)
+
+    one = accumulate_hidden_acts(step, lm, components, ci_fn, [tokens], jax.random.PRNGKey(0))
+    two = accumulate_hidden_acts(
+        step, lm, components, ci_fn, [tokens, tokens], jax.random.PRNGKey(0)
+    )
+
+    for site, r in two.items():
+        assert r.n_elements == 2 * one[site].n_elements
+        np.testing.assert_allclose(r.sum_mse, 2 * one[site].sum_mse, rtol=1e-6)
+
+    entries = hidden_acts_log_entries("CIHiddenActsReconLoss", two)
+    assert set(entries) == {"CIHiddenActsReconLoss"} | {f"CIHiddenActsReconLoss/{s}" for s in two}
+    total_sum = sum(r.sum_mse for r in two.values())
+    total_n = sum(r.n_elements for r in two.values())
+    np.testing.assert_allclose(entries["CIHiddenActsReconLoss"], total_sum / total_n)


### PR DESCRIPTION
## Description

Fixes the hidden-acts recon eval metrics (`CIHiddenActsReconLoss` / `StochasticHiddenActsReconLoss`, SPEC S31), which crashed with a broadcast `ValueError` the first time a run reached a slow eval with them enabled.

Both steps in `param_decomp/hidden_acts_eval.py` computed `leading = residual.shape[:-1]` on what is actually the model **inputs** — an LM's `[batch, seq]` token ids, not a `[batch, seq, d]` residual — yielding `(batch,)` instead of `(batch, seq)`. Every leading-shaped tensor (the stochastic delta masks, the zero deltas, and the clean forward's all-false routes) lost the sequence axis and failed `site_out`'s `route[..., None]` / `delta_mask[..., None]` broadcast. Note the **deterministic CI step crashes too** (via the clean forward's routes), not just the stochastic delta path.

The fix derives `leading` from the CI output `[*leading, C]` (`_waist_leading`), matching how the training path already draws delta masks (`lm.py::stochastic_site_masks` uses `ci.shape[:-1]`) and staying target-generic. The misnamed `residual` arg is renamed to `inputs: Any` per the `DecomposedModel` protocol — the misnomer is what invited the bug; the sibling `attn_patterns_eval.py` names the same thing `tokens` and got it right.

## Related Issue

None — surfaced by review of the S31 seam (no completed run had exercised these metrics in-loop yet).

## Motivation and Context

Any run with the hidden-acts metrics in `eval.metrics` dies at its first slow-eval pass. The seam is new (mid-June) so no production run has hit it yet; this unblocks enabling the metrics.

## How Has This Been Tested?

- New `param_decomp/tests/test_hidden_acts_eval.py` with `batch=2 ≠ seq=12` so the dropped axis can't hide: per-site sum/count bookkeeping on both steps + the token-weighted accumulation and log-entry math. Verified it **fails on the pre-fix code** (both steps crash with the broadcast error) and passes now, at the default device count and `--xla_force_host_platform_device_count=4`.
- `test_attn_patterns_eval.py` + `test_eval.py` pass (17 total).
- `make type` / ruff clean (pre-commit).

## Does this PR introduce a breaking change?

No. Eval-only; no training-path semantics touched. `compute_hidden_acts_metrics`' third parameter is renamed (`residual_batches` → `input_batches`); its one caller passes positionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016wiNqVkCMzQ8UQtkeEZ8eK