### PR TITLE
Remove inert n_samples from PersistentPGDReconLoss

### DIFF
--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -390,14 +390,20 @@ class PersistentPGDReconLossConfig(LossMetricConfig):
 
     @model_validator(mode="before")
     @classmethod
-    def _strip_removed_use_sigmoid_parameterization(cls, data: object) -> object:
-        # Shared-storage shim: stored run configs carry `use_sigmoid_parameterization`
-        # (always False — clamp was the only implemented path). The field is removed; strip
-        # it so those configs still load. A True value was never supported -> reject.
-        if isinstance(data, dict) and "use_sigmoid_parameterization" in data:
-            assert not data.pop("use_sigmoid_parameterization"), (
-                "use_sigmoid_parameterization was removed (clamp-only)"
-            )
+    def _strip_removed_fields(cls, data: object) -> object:
+        # Shared-storage shim: stored run configs carry removed fields whose only
+        # supported value was inlined. Strip them so those configs still load; any
+        # other value never had an implementation -> reject.
+        if isinstance(data, dict):
+            if "use_sigmoid_parameterization" in data:
+                assert not data.pop("use_sigmoid_parameterization"), (
+                    "use_sigmoid_parameterization was removed (clamp-only)"
+                )
+            if "n_samples" in data:
+                assert data.pop("n_samples") == 1, (
+                    "n_samples was removed (route-all + one persistent source bundle make"
+                    " every draw identical, so only 1 was ever meaningful)"
+                )
         return data
 
     type: Literal["PersistentPGDReconLoss"] = "PersistentPGDReconLoss"
@@ -417,7 +423,6 @@ class PersistentPGDReconLossConfig(LossMetricConfig):
             " computation."
         ),
     )
-    n_samples: PositiveInt = 1
 
 
 # ---------------------------------------------------------------------------

--- a/param_decomp/configs/compile_probe/gen_probe_config.py
+++ b/param_decomp/configs/compile_probe/gen_probe_config.py
@@ -126,7 +126,6 @@ def main(n_layers: int, dp: int, out_path: str, seq: int = 256, batch: int | Non
                 },
                 {
                     "coeff": 0.5,
-                    "n_samples": 1,
                     "n_warmup_steps": 2,
                     "optimizer": {
                         "beta1": 0.01,

--- a/param_decomp/configs/llama8b_full32L_1node_b8_dp8_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_1node_b8_dp8_PROFILE.yaml
@@ -544,7 +544,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32.yaml
@@ -569,7 +569,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32_PROFILE.yaml
@@ -544,7 +544,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32_SAVESMOKE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32_SAVESMOKE.yaml
@@ -569,7 +569,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_HSDP_b32_dp32.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b32_dp32.yaml
@@ -569,7 +569,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_HSDP_b32_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b32_dp32_PROFILE.yaml
@@ -569,7 +569,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_HSDP_b32_dp32_SAVESMOKE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b32_dp32_SAVESMOKE.yaml
@@ -569,7 +569,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_HSDP_b64_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b64_dp32_PROFILE.yaml
@@ -544,7 +544,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_HSDP_b96_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b96_dp32_PROFILE.yaml
@@ -544,7 +544,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_cifn4chunk_b32_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_cifn4chunk_b32_dp32_PROFILE.yaml
@@ -544,7 +544,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_nw0_b32_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_nw0_b32_dp32_PROFILE.yaml
@@ -544,7 +544,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 0
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_nw1_b32_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_nw1_b32_dp32_PROFILE.yaml
@@ -544,7 +544,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 1
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_seq512_b128_dp128.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b128_dp128.yaml
@@ -569,7 +569,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_seq512_b128_dp128_bf16src.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b128_dp128_bf16src.yaml
@@ -569,7 +569,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_seq512_b128_dp64.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b128_dp64.yaml
@@ -569,7 +569,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_seq512_b256_dp128.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b256_dp128.yaml
@@ -569,7 +569,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_seq512_b32_dp128_tp4.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b32_dp128_tp4.yaml
@@ -571,7 +571,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_seq512_b64_dp128_tp2.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b64_dp128_tp2.yaml
@@ -569,7 +569,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp1.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp1.yaml
@@ -569,7 +569,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp2.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp2.yaml
@@ -569,7 +569,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp4.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp4.yaml
@@ -569,7 +569,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp8.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp8.yaml
@@ -569,7 +569,6 @@ pd:
     sites_per_chunk: 56
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/llama8b_l18-26_9layer_chunkwise.yaml
+++ b/param_decomp/configs/llama8b_l18-26_9layer_chunkwise.yaml
@@ -186,7 +186,6 @@ pd:
     sites_per_chunk: 9
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.5

--- a/param_decomp/configs/llama8b_l18_C49k_200k.yaml
+++ b/param_decomp/configs/llama8b_l18_C49k_200k.yaml
@@ -123,7 +123,6 @@ pd:
       type: uniform_k_subset
     type: StochasticReconSubsetLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.5

--- a/param_decomp/configs/llama8b_l18_b128_cmp32.yaml
+++ b/param_decomp/configs/llama8b_l18_b128_cmp32.yaml
@@ -73,7 +73,6 @@ pd:
       type: uniform_k_subset
   - type: PersistentPGDReconLoss
     coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       type: adam

--- a/param_decomp/configs/llama8b_l18only_doubleC_b128_dp32.yaml
+++ b/param_decomp/configs/llama8b_l18only_doubleC_b128_dp32.yaml
@@ -114,7 +114,6 @@ pd:
     sites_per_chunk: 7
     type: ChunkwiseSubsetReconLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.01

--- a/param_decomp/configs/pile_ppgd_bsc.yaml
+++ b/param_decomp/configs/pile_ppgd_bsc.yaml
@@ -141,7 +141,6 @@ pd:
       type: uniform_k_subset
     type: StochasticReconSubsetLoss
   - coeff: 0.5
-    n_samples: 1
     n_warmup_steps: 2
     optimizer:
       beta1: 0.5

--- a/param_decomp/recon.py
+++ b/param_decomp/recon.py
@@ -429,7 +429,7 @@ def build_loss_terms(
                     one_chunk(site_names),
                     AllRoutingConfig(),
                     PersistentSources(state_key=key, cfg=cfg),
-                    cfg.n_samples,
+                    n_samples=1,
                 )
                 recon_terms.append(recon(cfg, plan))
             case _:

--- a/param_decomp/tests/test_config.py
+++ b/param_decomp/tests/test_config.py
@@ -163,22 +163,25 @@ def test_unsupported_settings_refuse():
     with pytest.raises(AssertionError, match="unsupported training loss"):
         build_experiment_config(LMExperimentConfig(**hidden_acts_training_loss), RUN_ID)
 
-    sigmoid_ppgd = dict(
-        raw,
-        pd=dict(
-            raw["pd"],
-            loss_metrics=[
-                dict(m, use_sigmoid_parameterization=True)
-                if m["type"] == "PersistentPGDReconLoss"
-                else m
-                for m in raw["pd"]["loss_metrics"]
-            ],
-        ),
-    )
-    # use_sigmoid_parameterization was removed (clamp-only); the strip-on-load shim
-    # accepts False (stored configs) but rejects True at config construction.
-    with pytest.raises(ValidationError):
-        LMExperimentConfig(**sigmoid_ppgd)
+    def with_ppgd_fields(**fields: object):
+        return dict(
+            raw,
+            pd=dict(
+                raw["pd"],
+                loss_metrics=[
+                    dict(m, **fields) if m["type"] == "PersistentPGDReconLoss" else m
+                    for m in raw["pd"]["loss_metrics"]
+                ],
+            ),
+        )
+
+    # Removed PPGD fields (use_sigmoid_parameterization: clamp-only; n_samples: route-all +
+    # one persistent source bundle make every draw identical): the strip-on-load shim
+    # accepts the only-ever-supported value (stored configs) and rejects anything else.
+    LMExperimentConfig(**with_ppgd_fields(use_sigmoid_parameterization=False, n_samples=1))
+    for bad_field in ({"use_sigmoid_parameterization": True}, {"n_samples": 2}):
+        with pytest.raises(ValidationError):
+            LMExperimentConfig(**with_ppgd_fields(**bad_field))
 
     non_site_target = dict(
         raw,


### PR DESCRIPTION
## Description

Removes the `n_samples` field from `PersistentPGDReconLossConfig` and pins the PPGD plan to `n_samples=1` in `build_loss_terms`. Stored run configs carrying `n_samples: 1` still load via the removed-field strip shim already on the class (the `use_sigmoid_parameterization` pattern); any other value is rejected at validation. The checked-in run yamls and the compile-probe generator drop the key.

## Motivation and Context

The PPGD term builds its plan with route-all routing and one persistent source bundle, so all `n_samples` routing draws produce byte-identical forwards — `n_samples > 1` just multiplied recon compute and averaged n identical losses. Sitting next to the stochastic losses where the same field genuinely means independent draws, it read as a variance-reduction knob and invited a silently wasteful sweep. It was `1` in every config; no setting of it was ever meaningful. (`LOSS_PARITY_DESIGN.md` had parked `n_samples>1` as an undecided composition-only variation point; this decides it. Plan construction is unchanged — SPEC S11/S24 untouched.)

## How Has This Been Tested?

- `make check` clean (ruff + basedpyright, whole workspace).
- `pytest param_decomp/tests -m "not slow"`: all pass except the `test_slow_eval.py` renderer tests, which fail identically on unmodified `feature/jax` (known flaky render-bound family).
- Extended `test_unsupported_settings_refuse`: stored-config `n_samples: 1` strips and loads; `n_samples: 2` rejects (same for both removed PPGD fields).
- Every tracked yaml in `param_decomp/configs/` validates through `LMExperimentConfig`.

## Does this PR introduce a breaking change?

A hand-authored config setting `n_samples != 1` on the PPGD term now fails validation — previously it silently burned compute. Stored run configs are unaffected (strip shim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KiMmzVhKUWbxbEz4R3Lkqm