### PR TITLE
chore(configs): drop dead identity_decomposition_targets keys

### DIFF
--- a/param_decomp/configs/compile_probe/gen_probe_config.py
+++ b/param_decomp/configs/compile_probe/gen_probe_config.py
@@ -105,7 +105,6 @@ def main(n_layers: int, dp: int, out_path: str, seq: int = 256, batch: int | Non
             "faithfulness_warmup_lr": 0.001,
             "faithfulness_warmup_steps": 2,
             "faithfulness_warmup_weight_decay": 0.0,
-            "identity_decomposition_targets": None,
             "loss_metrics": [
                 {
                     "beta": 0.2,

--- a/param_decomp/configs/llama8b_full32L_1node_b8_dp8_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_1node_b8_dp8_PROFILE.yaml
@@ -525,7 +525,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 0
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32.yaml
@@ -550,7 +550,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 0
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32_PROFILE.yaml
@@ -525,7 +525,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 0
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32_SAVESMOKE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32_SAVESMOKE.yaml
@@ -550,7 +550,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 0
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_HSDP_b32_dp32.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b32_dp32.yaml
@@ -550,7 +550,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 0
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_HSDP_b32_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b32_dp32_PROFILE.yaml
@@ -550,7 +550,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 0
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_HSDP_b32_dp32_SAVESMOKE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b32_dp32_SAVESMOKE.yaml
@@ -550,7 +550,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 0
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_HSDP_b64_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b64_dp32_PROFILE.yaml
@@ -525,7 +525,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 0
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_HSDP_b96_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b96_dp32_PROFILE.yaml
@@ -525,7 +525,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 0
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_cifn4chunk_b32_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_cifn4chunk_b32_dp32_PROFILE.yaml
@@ -525,7 +525,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 0
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_noPGD_b32_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_noPGD_b32_dp32_PROFILE.yaml
@@ -525,7 +525,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 0
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_noPGD_b64_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_noPGD_b64_dp32_PROFILE.yaml
@@ -525,7 +525,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 0
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_nw0_b32_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_nw0_b32_dp32_PROFILE.yaml
@@ -525,7 +525,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 0
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_nw1_b32_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_nw1_b32_dp32_PROFILE.yaml
@@ -525,7 +525,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 0
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_seq512_b128_dp128.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b128_dp128.yaml
@@ -550,7 +550,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 400
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_seq512_b128_dp128_bf16src.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b128_dp128_bf16src.yaml
@@ -550,7 +550,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 400
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_seq512_b128_dp64.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b128_dp64.yaml
@@ -550,7 +550,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 400
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_seq512_b256_dp128.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b256_dp128.yaml
@@ -550,7 +550,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 400
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_seq512_b32_dp128_tp4.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b32_dp128_tp4.yaml
@@ -552,7 +552,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 400
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_seq512_b64_dp128_tp2.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b64_dp128_tp2.yaml
@@ -550,7 +550,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 400
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp1.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp1.yaml
@@ -550,7 +550,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 400
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp2.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp2.yaml
@@ -550,7 +550,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 400
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp4.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp4.yaml
@@ -550,7 +550,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 400
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp8.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp8.yaml
@@ -550,7 +550,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 400
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06

--- a/param_decomp/configs/llama8b_l18only_doubleC_b128_dp32.yaml
+++ b/param_decomp/configs/llama8b_l18only_doubleC_b128_dp32.yaml
@@ -95,7 +95,6 @@ pd:
   faithfulness_warmup_lr: 0.001
   faithfulness_warmup_steps: 0
   faithfulness_warmup_weight_decay: 0.0
-  identity_decomposition_targets: null
   loss_metrics:
   - frequency:
       coeff: 1.0e-06


### PR DESCRIPTION
## What

Deletes the last authorable surfaces still carrying the removed `identity_decomposition_targets` key:

- `identity_decomposition_targets: null` lines in 25 run YAMLs under `param_decomp/configs/` (the only removed-field key these YAMLs still carried — the others were already scrubbed)
- the `"identity_decomposition_targets": None` entry `gen_probe_config.py` still emitted into generated probe configs

## Why

The identity-insertion feature (torch-era `insert_identity_operations_` / `Identity` pre-hook shim, so the identity op itself could be decomposed) was deleted with the torch trainer (#876) and is deliberately not in the JAX trainer. The provenance strip-shim in `param_decomp/configs.py` (`_strip_removed_jax_unsupported_fields`, c6369ad56) pops the key from stored run configs and asserts it was never non-empty — that shim **stays** (stored `launch_config.yaml`s of historical runs still carry the key). This PR just stops the repo itself from re-authoring the dead key.

Part of the bridge task `identity-targets-clarity` (full archaeology in the task log).

## Validation

- `load_config` over 3 representative edited YAMLs (llama8b HSDP, l18 C49k, pile_pgd1) — all load
- shim behavior verified intact: null key stripped, non-empty key rejected loudly
- `pytest param_decomp/tests -k config` (20 passed), `param_decomp_lab/tests/test_launch.py` (8 passed)
- pre-existing, unrelated: `gen_probe_config.py` output no longer validates against the current schema (`ci_config` discriminator is now `type` not `fn_type`; `ImportanceMinimalityLoss.beta` removed) — bitrot that predates this change, not addressed here

🤖 Generated with [Claude Code](https://claude.com/claude-code)