### PR TITLE
config: finish the shape-literal scope migration in repo-authored content

### DIFF
--- a/nano_param_decomp/run.py
+++ b/nano_param_decomp/run.py
@@ -112,7 +112,7 @@ class Config:
     ci_mlp_hidden: int = 8192
     ci_rope_base: float = 10000.0
 
-    # Persistent PGD (per_batch_per_position scope, Adam)
+    # Persistent PGD (bsc scope: independent sources per batch element and position; Adam)
     ppgd_lr: float = 0.01
     ppgd_lr_final_frac: float = 1.0
     ppgd_warmup_pct: float = 0.025
@@ -509,7 +509,7 @@ def stochastic_recon_loss(
 class PersistentPGD:
     """Per-module adversarial sources that persist across training steps.
 
-    Scope is `per_batch_per_position`: sources have shape `[local_B, S, C + 1]` on each
+    Scope is `bsc` (batch, seq, C): sources have shape `[local_B, S, C + 1]` on each
     rank (+1 for the delta component's scalar mask), with no cross-rank sync. We maintain
     Adam state (m, v) alongside each source and a global step counter t.
 

--- a/param_decomp/SPEC.md
+++ b/param_decomp/SPEC.md
@@ -61,7 +61,7 @@ and the tables (§2, §3, §6). Prose between them is orientation only. Notation
 | coeffs | faith `1e5` · imp `5e-6` · stoch `0.5` · ppgd `0.5` |
 | imp-min | `eps 1e-12`, `p: 2.0 → 0.4` linear over `[0, 1]`-frac of training; `frequency` coeff `1e-6` (= imp `5e-6` · old beta `0.2`), `reference_token_count = B·T = 1048576` |
 | stoch | plan = sequential 3-site chunks × `uniform_k_routing(chunk, n_draws=1)` |
-| PPGD | scope `broadcast_across_batch`, `n_warmup 2`, clamp-parameterization, Adam(β₁ .5, β₂ .99, ε 1e-8), lr const `0.01` w/ 2.5% LR-warmup |
+| PPGD | scope `sc`, `n_warmup 2`, clamp-parameterization, Adam(β₁ .5, β₂ .99, ε 1e-8), lr const `0.01` w/ 2.5% LR-warmup |
 | components opt | AdamW(.9, .999, ε 1e-8, wd 0), lr `1.5e-4` cosine → `0.1×`, **grad-clip 0.01** |
 | CI opt | AdamW(.9, .999, ε 1e-8, wd 0), lr `5e-5` cosine → `0.1×`, no clip |
 | faith warmup | 400 steps, AdamW lr `1e-3`, wd 0 |
@@ -285,7 +285,7 @@ faithfulness, sources/PPGD, the squashings (S5/S6), the imp-min reduction, the g
 | S13′ | Per persistent term: source updates per training step = `n_warmup + 1`, all through THAT term's persistent SRC_STEP optimizer state; its source LR schedule advances once per training step. **`warmup_pct==0` edge (accepted seam):** at `warmup_pct==0` torch short-circuits to full LR at step 0 (`warmup_steps=0`), while JAX clamps `warmup_steps = max(floor(...), 1)` → source LR `=0` at step 0 (`losses.py:61`, `train.py:265`). A one-step divergence, only when `warmup_pct==0`; production uses 2.5% warmup and is unaffected. Accepted, not matched. |
 | S14′ | Each persistent term's final ascent gradient comes from the SAME graph as the main backward (pre-update components, live `ci_lower`), unscaled by THAT term's coeff. It is applied after backward; it must not use post-update params. |
 | S15 | Every source update ends with `PROJ` (★ clamp to `[0,1]`). Init: ★ `sources ~ U[0,1]` i.i.d. |
-| S16 | Shared-scope sources are identical on every data-parallel replica at every step (identical init, identical updates from the global-batch gradient). `per_batch_per_position` sources shard with the batch instead. (Implementation mapping in §8/§9.) |
+| S16 | Shared-scope sources are identical on every data-parallel replica at every step (identical init, identical updates from the global-batch gradient). `bsc` sources shard with the batch instead. (Implementation mapping in §8/§9.) |
 | S17 | `faithfulness_loss` is the global mean of squared delta entries over all sites' parameters (Σ‖Δ‖² / Σ numel), recomputed from live V/U each step. |
 | S18 | Each training step consumes a fresh token batch (a pure function of `(seed, step)` for O(1) resume); the model embeds it internally. **AMENDED 2026-06-24** (Oli-approved): removed the prefix harvest (residual-start) — there is no separate prefix forward; `clean_output` / `read_activations` / `masked_output` take the token batch directly. |
 | S19 | Components gradients are global-norm-clipped at `0.01`, before the optimizer step. CI fn is unclipped (production). The clip coefficient uses torch's eps convention: `clip_coef = min(1, max_norm / (total_norm + 1e-6))` (`torch.nn.utils.clip_grad_norm_`). This `+1e-6` is canonical and matched JAX-side (#643); plain `optax.clip_by_global_norm` divides by `max(total_norm, max_norm)` with NO eps, which at `clip=0.01` (clip fires almost every step) gives a ~1e-4 relative component-grad difference each step — a real per-step deviation the JAX clip must avoid by reproducing the `+1e-6`. |

--- a/param_decomp/configs/compile_probe/gen_probe_config.py
+++ b/param_decomp/configs/compile_probe/gen_probe_config.py
@@ -139,7 +139,7 @@ def main(n_layers: int, dp: int, out_path: str, seq: int = 256, batch: int | Non
                         },
                         "type": "adam",
                     },
-                    "scope": {"type": "per_batch_per_position"},
+                    "scope": {"type": "bsc"},
                     "type": "PersistentPGDReconLoss",
                 },
                 {"coeff": 1000000.0, "type": "FaithfulnessLoss"},

--- a/param_decomp/configs/llama8b_full32L_1node_b8_dp8_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_1node_b8_dp8_PROFILE.yaml
@@ -35,7 +35,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -556,7 +556,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32.yaml
@@ -60,7 +60,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -581,7 +581,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32_PROFILE.yaml
@@ -35,7 +35,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -556,7 +556,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32_SAVESMOKE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32_SAVESMOKE.yaml
@@ -60,7 +60,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -581,7 +581,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_HSDP_b32_dp32.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b32_dp32.yaml
@@ -60,7 +60,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -581,7 +581,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_HSDP_b32_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b32_dp32_PROFILE.yaml
@@ -60,7 +60,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -581,7 +581,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_HSDP_b32_dp32_SAVESMOKE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b32_dp32_SAVESMOKE.yaml
@@ -60,7 +60,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -581,7 +581,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_HSDP_b64_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b64_dp32_PROFILE.yaml
@@ -35,7 +35,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -556,7 +556,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_HSDP_b96_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b96_dp32_PROFILE.yaml
@@ -35,7 +35,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -556,7 +556,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_cifn4chunk_b32_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_cifn4chunk_b32_dp32_PROFILE.yaml
@@ -35,7 +35,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -556,7 +556,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_noPGD_b32_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_noPGD_b32_dp32_PROFILE.yaml
@@ -35,7 +35,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss

--- a/param_decomp/configs/llama8b_full32L_noPGD_b64_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_noPGD_b64_dp32_PROFILE.yaml
@@ -35,7 +35,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss

--- a/param_decomp/configs/llama8b_full32L_nw0_b32_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_nw0_b32_dp32_PROFILE.yaml
@@ -35,7 +35,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -556,7 +556,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_nw1_b32_dp32_PROFILE.yaml
+++ b/param_decomp/configs/llama8b_full32L_nw1_b32_dp32_PROFILE.yaml
@@ -35,7 +35,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -556,7 +556,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_seq512_b128_dp128.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b128_dp128.yaml
@@ -60,7 +60,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -581,7 +581,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_seq512_b128_dp128_bf16src.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b128_dp128_bf16src.yaml
@@ -60,7 +60,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -581,7 +581,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     source_dtype: bfloat16
     type: PersistentPGDReconLoss
   - coeff: 1000000.0

--- a/param_decomp/configs/llama8b_full32L_seq512_b128_dp64.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b128_dp64.yaml
@@ -60,7 +60,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -581,7 +581,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_seq512_b256_dp128.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b256_dp128.yaml
@@ -60,7 +60,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -581,7 +581,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_seq512_b32_dp128_tp4.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b32_dp128_tp4.yaml
@@ -62,7 +62,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -583,7 +583,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_seq512_b64_dp128_tp2.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b64_dp128_tp2.yaml
@@ -60,7 +60,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -581,7 +581,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp1.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp1.yaml
@@ -60,7 +60,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -581,7 +581,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp2.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp2.yaml
@@ -60,7 +60,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -581,7 +581,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp4.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp4.yaml
@@ -60,7 +60,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -581,7 +581,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp8.yaml
+++ b/param_decomp/configs/llama8b_full32L_seq512_b64_dp64_tp8.yaml
@@ -60,7 +60,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -581,7 +581,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_l18-26_9layer_chunkwise.yaml
+++ b/param_decomp/configs/llama8b_l18-26_9layer_chunkwise.yaml
@@ -33,7 +33,7 @@ run_name: jax-l18-26-9L-seq512-b128-40k
 #      batch-invariant vs the torch oracle).
 #   7. steps 200k -> 40k: short R&D horizon (won't converge; cosine + p-anneal recompute
 #      over 40k).
-# Everything else (PersistentPGDReconLoss one-chunk coeff 0.5 broadcast_across_batch,
+# Everything else (PersistentPGDReconLoss one-chunk coeff 0.5 scope sc,
 # FaithfulnessLoss 1e5, faith warmup, eval metric set, target.weights_dtype bfloat16) is
 # identical to the C49k base. remat is on (runtime.remat_recon_forwards: true).
 cadence:
@@ -72,7 +72,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -198,7 +198,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: broadcast_across_batch
+      type: sc
     type: PersistentPGDReconLoss
     use_sigmoid_parameterization: false
   - coeff: 100000.0

--- a/param_decomp/configs/llama8b_l18_C49k_200k.yaml
+++ b/param_decomp/configs/llama8b_l18_C49k_200k.yaml
@@ -9,8 +9,8 @@ run_name: jax-l18-C49k-200k
 #      (the JAX trainer reads the staged 2048 artifact; seq length is a REAL
 #      hyperparameter change, chosen deliberately — 4x tokens/step vs upstream).
 #   2. ci attn max_len: 512 -> 2048 (RoPE table must cover the longer seq).
-#   3. PersistentPGDReconLoss scope: per_batch_per_position -> broadcast_across_batch
-#      (the JAX trainer implements broadcast only; deliberate divergence).
+#   3. PersistentPGDReconLoss scope: per_batch_per_position -> sc (batch-shared
+#      sources; deliberate divergence — the JAX trainer implemented sc only at launch).
 #   4. cadence.save_every: 25000 -> 5000 (overnight crash costs <=40 min, not 3 h).
 #   5. C: 30000 -> 49152 per Oli (2x the b512 run's C=24576; also unlocks a 32-GPU
 #      mesh — 30000's gcd with batch 128 capped the mesh at 16).
@@ -59,7 +59,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -135,7 +135,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: broadcast_across_batch
+      type: sc
     type: PersistentPGDReconLoss
   - coeff: 100000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/llama8b_l18_b128_cmp32.yaml
+++ b/param_decomp/configs/llama8b_l18_b128_cmp32.yaml
@@ -85,7 +85,7 @@ pd:
         final_val_frac: 1.0
         fn_type: constant
     scope:
-      type: broadcast_across_batch
+      type: sc
 cadence:
   train_log_every: 20
   save_every: 1000

--- a/param_decomp/configs/llama8b_l18only_doubleC_b128_dp32.yaml
+++ b/param_decomp/configs/llama8b_l18only_doubleC_b128_dp32.yaml
@@ -39,7 +39,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     step_size: 0.1
     type: PGDReconLoss
@@ -126,7 +126,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 1000000.0
     type: FaithfulnessLoss

--- a/param_decomp/configs/pile_pgd1.yaml
+++ b/param_decomp/configs/pile_pgd1.yaml
@@ -63,7 +63,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     name: PGDReconLoss_20step
     step_size: 0.1
@@ -135,7 +135,7 @@ pd:
     type: StochasticReconSubsetLoss
   - coeff: 0.5
     init: random
-    mask_scope: unique_per_datapoint
+    mask_scope: bsc
     n_steps: 1
     step_size: 1.0
     type: PGDReconLoss

--- a/param_decomp/configs/pile_ppgd_bsc.yaml
+++ b/param_decomp/configs/pile_ppgd_bsc.yaml
@@ -70,7 +70,7 @@ eval:
   - type: CIHiddenActsReconLoss
   - coeff: null
     init: random
-    mask_scope: shared_across_batch
+    mask_scope: c
     n_steps: 20
     name: PGDReconLoss_20step
     step_size: 0.1
@@ -153,7 +153,7 @@ pd:
         warmup_pct: 0.025
       type: adam
     scope:
-      type: per_batch_per_position
+      type: bsc
     type: PersistentPGDReconLoss
   - coeff: 10000000.0
     type: FaithfulnessLoss


### PR DESCRIPTION
## Description

Migrates every repo-authored occurrence of the legacy verbose scope names to the canonical shape-spelled literals (fresh-PGD `mask_scope: c|bc|bsc`, PPGD scope `sc|bsc`, per SPEC §6 SCOPE):

- `param_decomp/configs/*.yaml` (30 files): `mask_scope: shared_across_batch → c`, `unique_per_datapoint → bsc`; `scope type: per_batch_per_position → bsc`, `broadcast_across_batch → sc`. Header comments naming a file's *own* settings updated; upstream-torch provenance mentions (e.g. "`per_batch_per_position` (-> bsc)" describing the torch snapshot a config was derived from) kept verbatim.
- `configs/compile_probe/gen_probe_config.py`: emitted scope type → `bsc`.
- `SPEC.md`: defaults-table PPGD scope → `sc`; S16 → `bsc`. Both now consistent with §6's canonical SCOPE row — text-only, no semantic change.
- `nano_param_decomp/run.py`: comment + docstring → `bsc` with a shape gloss for paper readers.

The `_LEGACY_*_ALIASES` BeforeValidators in `param_decomp/configs.py` are deliberately KEPT: 30 stored run configs under `PARAM_DECOMP_OUT_DIR/runs/` still carry the legacy names on disk. With this PR the repo no longer *authors* those names anywhere, so the aliases are now scoped purely to stored data and can be deleted the day stored runs are migrated (as their comment already says).

## Related Issue

None (bridge task `bsc-naming-conflict`).

## Motivation and Context

The shape literals were the settled convention since the c/sc/nsc/bsc renames, but the repo kept authoring the legacy names in its checked-in configs, SPEC, and the compile-probe generator — so the "delete once stored runs are migrated" aliases could never actually become dead, and readers met two names for the same concept depending on which file they opened.

## How Has This Been Tested?

- All 30 checked-in YAMLs parse through `param_decomp_lab.experiments.lm.config.load_config` and produce the intended scopes (spot-checked `bsc`/`sc` on the parsed configs).
- Stored legacy run configs (e.g. p-05101e15) still parse to the same scopes through the aliases.
- `make type` clean; `param_decomp/tests/test_config.py` + `test_recon_log_keys.py` green; pre-commit (ruff + basedpyright) passed.
- Full `make test` could not complete on the login node (session resource cap kills the heavy `test_llama8b` runs mid-suite, zero failures up to the kill both attempts); the diff touches no Python module any test imports, so suite behavior is unchanged by construction.

## Does this PR introduce a breaking change?

No. Values-only YAML edits validated equivalent through the schema; stored-run alias path untouched. Running jobs are unaffected (requeues re-enter their immutable workspace snapshots; resume byte-compares the run dir's own pinned launch_config.yaml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)