### PR TITLE
fix(toys): pd-tms/pd-resid-mlp eval crash — missing remat kwarg

### DIFF
--- a/param_decomp_lab/experiments/resid_mlp/model.py
+++ b/param_decomp_lab/experiments/resid_mlp/model.py
@@ -743,8 +743,8 @@ def single_feature_ci(
     lm: ResidMLPDecomposedModel,
     ci_fn: "CIFnCallable",
     n_features: int,
-) -> dict[str, Array]:
-    """Feed the single-feature probe (embedded through `W_E`) and read the `lower_leaky`
-    CI per site, `{site: [n_features, C]}`."""
+) -> CI:
+    """Feed the single-feature probe (embedded through `W_E`) and return the CI per site,
+    `{site: [n_features, C]}` under each squashing."""
     resid = single_feature_probe(n_features) @ lm.target.W_E
-    return ci_fn(lm.read_activations(resid, ci_fn.input_names), remat=False).lower
+    return ci_fn(lm.read_activations(resid, ci_fn.input_names), remat=False)

--- a/param_decomp_lab/experiments/resid_mlp/run.py
+++ b/param_decomp_lab/experiments/resid_mlp/run.py
@@ -21,6 +21,7 @@ from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 
 from param_decomp.built_run import LAUNCH_CONFIG_FILENAME, BuiltRun
+from param_decomp.ci_fn import CI
 from param_decomp.components import SiteC
 from param_decomp.log import setup_logger
 from param_decomp.recon import build_loss_terms
@@ -145,27 +146,25 @@ def run_resid_mlp_decomposition(built: BuiltRun, raw_cfg: dict[str, Any], mesh: 
 
     # `model` is the filter_jit ARG (frozen weights traced, not baked).
     @eqx.filter_jit
-    def single_feature_ci(
-        model: resid_mlp.ResidMLPDecomposedModel, ci_fn: Any
-    ) -> tuple[dict[str, jax.Array], dict[str, jax.Array]]:
-        resid = resid_mlp.single_feature_probe(target_cfg.n_features) @ model.target.W_E
-        ci = ci_fn(model.read_activations(resid, ci_fn.input_names))
-        return ci.lower, ci.upper
+    def single_feature_ci_jit(model: resid_mlp.ResidMLPDecomposedModel, ci_fn: Any) -> CI:
+        return resid_mlp.single_feature_ci(model, ci_fn, target_cfg.n_features)
 
     uv_spec = toy_uv_eval.toy_uv_spec(lm, raw_cfg)
 
     def eval_fn(state: TrainState, now_step: int) -> dict[str, float]:
-        ci_lower, ci_upper = single_feature_ci(lm, state.ci_fn)
+        ci = single_feature_ci_jit(lm, state.ci_fn)
         toy_uv_eval.log_uv_figure(
             uv_spec,
             state.components.vu,
-            ci_upper,
+            ci.upper,
             now_step,
             wandb_active=built.run.wandb is not None,
         )
         return {
-            f"eval/identity_ci_error/{site}": float(resid_mlp.identity_ci_error(ci, tolerance=0.1))
-            for site, ci in ci_lower.items()
+            f"eval/identity_ci_error/{site}": float(
+                resid_mlp.identity_ci_error(site_ci, tolerance=0.1)
+            )
+            for site, site_ci in ci.lower.items()
         }
 
     run_decomposition_training(

--- a/param_decomp_lab/experiments/resid_mlp/test_resid_mlp.py
+++ b/param_decomp_lab/experiments/resid_mlp/test_resid_mlp.py
@@ -408,7 +408,7 @@ def test_end_to_end_pretrain_decompose_recovers_identity():
         totals.append(float(m["total"]))
     assert totals[-1] < totals[0], (totals[0], totals[-1])
 
-    ci_lower = single_feature_ci(lm, state.ci_fn, n_features=5)
+    ci_lower = single_feature_ci(lm, state.ci_fn, n_features=5).lower
     err = identity_ci_error(ci_lower["layers.0.mlp_in"], tolerance=0.2)
     assert err == 0, (
         f"mlp_in did not recover identity (err={err}):\n{jnp.round(ci_lower['layers.0.mlp_in'], 2)}"

--- a/param_decomp_lab/experiments/tms/model.py
+++ b/param_decomp_lab/experiments/tms/model.py
@@ -609,11 +609,11 @@ def single_feature_ci(
     lm: TMSDecomposedModel,
     ci_fn: "CIFnCallable",
     n_features: int,
-) -> dict[str, Array]:
-    """Feed the single-feature probe and read the `lower_leaky` CI per site,
-    `{site: [n_features, C]}`."""
+) -> CI:
+    """Feed the single-feature probe and return the CI per site, `{site: [n_features, C]}`
+    under each squashing."""
     probe = single_feature_probe(n_features)
-    return ci_fn(lm.read_activations(probe, ci_fn.input_names), remat=False).lower
+    return ci_fn(lm.read_activations(probe, ci_fn.input_names), remat=False)
 
 
 # ----------------------------- visualizations -----------------------------

--- a/param_decomp_lab/experiments/tms/run.py
+++ b/param_decomp_lab/experiments/tms/run.py
@@ -23,6 +23,7 @@ from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 
 from param_decomp.built_run import LAUNCH_CONFIG_FILENAME, BuiltRun
+from param_decomp.ci_fn import CI
 from param_decomp.components import SiteC
 from param_decomp.log import setup_logger
 from param_decomp.recon import build_loss_terms
@@ -128,27 +129,23 @@ def run_tms_decomposition(built: BuiltRun, raw_cfg: dict[str, Any], mesh: Mesh) 
     # `model` is the filter_jit ARG (frozen TMS weights traced, not baked) — closing over an
     # array-bearing eqx model would bake its weights into the HLO.
     @eqx.filter_jit
-    def single_feature_ci(
-        model: tms.TMSDecomposedModel, ci_fn: Any
-    ) -> tuple[dict[str, jax.Array], dict[str, jax.Array]]:
-        probe = tms.single_feature_probe(target_cfg.n_features)
-        ci = ci_fn(model.read_activations(probe, ci_fn.input_names))
-        return ci.lower, ci.upper
+    def single_feature_ci_jit(model: tms.TMSDecomposedModel, ci_fn: Any) -> CI:
+        return tms.single_feature_ci(model, ci_fn, target_cfg.n_features)
 
     uv_spec = toy_uv_eval.toy_uv_spec(lm, raw_cfg)
 
     def eval_fn(state: TrainState, now_step: int) -> dict[str, float]:
-        ci_lower, ci_upper = single_feature_ci(lm, state.ci_fn)
+        ci = single_feature_ci_jit(lm, state.ci_fn)
         toy_uv_eval.log_uv_figure(
             uv_spec,
             state.components.vu,
-            ci_upper,
+            ci.upper,
             now_step,
             wandb_active=built.run.wandb is not None,
         )
         return {
-            f"eval/identity_ci_error/{site}": float(tms.identity_ci_error(ci, tolerance=0.1))
-            for site, ci in ci_lower.items()
+            f"eval/identity_ci_error/{site}": float(tms.identity_ci_error(site_ci, tolerance=0.1))
+            for site, site_ci in ci.lower.items()
         }
 
     run_decomposition_training(

--- a/param_decomp_lab/experiments/tms/test_tms.py
+++ b/param_decomp_lab/experiments/tms/test_tms.py
@@ -350,7 +350,7 @@ def test_end_to_end_pretrain_decompose_recovers_identity():
         totals.append(float(m["total"]))
     assert totals[-1] < totals[0], (totals[0], totals[-1])
 
-    ci_lower = single_feature_ci(lm, state.ci_fn, n_features=5)
+    ci_lower = single_feature_ci(lm, state.ci_fn, n_features=5).lower
     err1 = identity_ci_error(ci_lower["linear1"], tolerance=0.2)
     err2 = identity_ci_error(ci_lower["linear2"], tolerance=0.2)
     assert err1 == 0, (


### PR DESCRIPTION
## What

`CIFn.__call__` grew a keyword-only `remat: bool`, but the toy composition roots' eval closures were never updated — both `pd-tms` and `pd-resid-mlp` crashed at the first eval step:

```
TypeError: LayerwiseMLPCIFn.__call__() missing 1 required keyword-only argument: 'remat'
```

Reproduced with stock `tms_5-5_SMOKE.yaml` on `f423233fb`. (Found by bridge crew-try-muon while using the TMS smoke as a muon testbed.)

## Why the tests didn't catch it

Each `run.py` carried a near-duplicate of its domain's `model.single_feature_ci` helper. The tests exercise the helper (which passes `remat=False` correctly); the run.py duplicate rotted unseen.

## Fix

Deduplicate rather than patch: `model.single_feature_ci` now returns the full `CI` bundle (run.py needs `upper` for the UV figure, tests take `.lower`), and each run.py jit-wraps the helper instead of re-implementing it. The `remat=False` decision now lives in exactly one place per domain, on the code path the tests cover. `remat` is a no-op for the MLP CI fns, so `remat=False` is semantics-neutral.

## Verification

- Crash reproduced verbatim on unfixed tree, gone after fix
- `pd-tms --config tms_5-5_SMOKE.yaml` and `pd-resid-mlp --config resid_mlp_1l_SMOKE.yaml` run end-to-end on CPU; `eval/identity_ci_error/*` metrics identical between the minimal kwarg-only fix and the dedup version
- Toy suites: 42 passed + 2 slow passed (`--runslow`)
- basedpyright + ruff clean

## Remaining gap (not addressed here)

The toy composition roots (`run.py`: YAML→BuiltRun→engine + eval_fn wiring) still have no automated coverage — the SMOKE configs are run manually. A ~10s `--runslow` test invoking the SMOKE config with a tmpdir `PARAM_DECOMP_OUT_DIR` would close this class of rot entirely; left out to keep this PR minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)