### PR TITLE
docs(pretrain): fix stale clean_suffix_logits reference missed by #923

### DIFF
--- a/param_decomp_lab/experiments/lm/pretrain/CLAUDE.md
+++ b/param_decomp_lab/experiments/lm/pretrain/CLAUDE.md
@@ -51,7 +51,7 @@ target:
 ```
 
 (`run_path` resolves to `pretrain_cache/<project>-<run_id>`.) The pretrain model's forward
-is bit-identical to the loader's `clean_suffix_logits` round-trip — pinned by
+is bit-identical to the loaded target's `clean_output` round-trip — pinned by
 `param_decomp/tests/test_pretrain.py`.
 
 ## Data


### PR DESCRIPTION
One-line fast-follow to #923's prefix/suffix terminology sweep.

`param_decomp_lab/experiments/lm/pretrain/CLAUDE.md` still claimed the pretrain forward is pinned bit-identical to the loader's `clean_suffix_logits` round-trip — that symbol died with the residual-start removal (3883362ff). The pinning test (`param_decomp/tests/test_pretrain.py::test_cache_round_trip_matches_decomposition_loader`) compares against `target.clean_output(idx)`; the prose now says so.

Verified this is the last dead-design straggler on `feature/jax`: a fresh grep of the tip finds only live meanings (chunkwise-scan frozen prefix/suffix in llama8b.py, string/module-name prefixes, `path.suffix`, linguistic "##ing suffix") plus the intentionally-left `tests/equivalence` + `stacked_parity` fixture prose, which belongs to the xfailed residual-fed goldens pending embed-internal regen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)