### PR TITLE
fix(checkpoint): make orbax-restored TrainState donatable — solve the resume OOM (S22)

### DIFF
--- a/param_decomp/checkpoint.py
+++ b/param_decomp/checkpoint.py
@@ -50,17 +50,23 @@ def save_state(mgr: ocp.CheckpointManager, step: int, state: TrainState) -> None
 
 def restore_step(mgr: ocp.CheckpointManager, reference: TrainState, step: int) -> TrainState:
     """Restore checkpoint `step` onto `reference`'s shapes/dtypes/shardings
-    (a freshly-initialised, correctly-placed `TrainState`)."""
+    (a freshly-initialised, correctly-placed `TrainState`).
+
+    The restored tree is re-materialised as JIT OUTPUTS on the reference's exact format
+    (layout + sharding) before it is returned. Orbax-restored arrays — composed per shard
+    by `device_put` + `make_array_from_single_device_arrays` — are not reliably donatable
+    to the jitted train step (jax#18617): the step's baked-in input→output aliasing then
+    silently falls back to copying, and the first resumed step peaks one full `TrainState`
+    above any fresh step (the resume OOM; lore
+    2026-07-03--resume-oom-is-buffer-donation-asymmetry). An identity jit's outputs are
+    indistinguishable from fresh-init state, at a transient 2×-state cost that restore
+    already paid while `reference` and the restored tree coexisted. Deliberately NOT
+    donating into the identity jit: a plain copy cannot hard-fail at dispatch the way a
+    blocked donation can, and the buffer reuse it would buy is off the step's peak."""
     abstract = jax.tree.map(ocp.utils.to_shape_dtype_struct, reference)
     restored = mgr.restore(step, args=ocp.args.StandardRestore(abstract))
-    # Coerce the restored tree onto the reference's exact FORMAT (layout + sharding), not just its
-    # sharding. StandardRestore already honors the sharding SPEC (verified), so a device_put onto
-    # sharding alone is a no-op — but orbax-restored arrays carry a default memory LAYOUT that
-    # differs from what the jitted step was compiled for. The reference is a fresh-init state built
-    # by the same XLA layout assignment as the step, so its `.format` IS the step's expected input
-    # layout; matching it avoids a ÷1-scale entry relayout on the first resumed step (the resume OOM).
-    restored = jax.device_put(restored, jax.tree.map(lambda r: r.format, reference))
-    return cast(TrainState, restored)
+    rematerialize = jax.jit(lambda t: t, out_shardings=jax.tree.map(lambda r: r.format, reference))
+    return cast(TrainState, rematerialize(restored))
 
 
 def restore_latest(

--- a/param_decomp/configs/pile_pgd1_RESUMESMOKE_dp8.yaml
+++ b/param_decomp/configs/pile_pgd1_RESUMESMOKE_dp8.yaml
@@ -1,0 +1,141 @@
+# Save->resume smoke for the resume-OOM donation fix (bridge task solve-resumption-oom).
+# pile_pgd1.yaml shrunk to dp=8 / 40 steps / save_every=10 / warmup=5 / evals+wandb off.
+# Procedure: pd-lm launch -> scancel after the step-20 save -> pd-lm --run_id resubmit ->
+# expect 'resumed from checkpoint step 20', NO 'DONATION FAILED' line, observe ~20 resumed steps, scancel, rm the run dir.
+run_name: jax-pile4l-resume-smoke
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 10
+  train_log_every: 5
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/pile_neox_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: EleutherAI/gpt-neox-20b
+  train_split: train
+eval:
+  batch_size: 128
+  every: 100000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups:
+      layer_0:
+      - h.0.*
+      layer_1:
+      - h.1.*
+      layer_2:
+      - h.2.*
+      layer_3:
+      - h.3.*
+      total:
+      - '*'
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: shared_across_batch
+    n_steps: 20
+    name: PGDReconLoss_20step
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 100000
+  slow_on_first_step: false
+pd:
+  batch_size: 64
+  ci_config:
+    type: chunkwise_transformer
+    blocks_per_chunk: 1
+    d_model: 2048
+    n_blocks: 8
+    n_heads: 16
+    mlp_hidden: 8192
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 3072
+    module_pattern: h.*.mlp.c_fc
+  - C: 3584
+    module_pattern: h.*.mlp.down_proj
+  - C: 512
+    module_pattern: h.*.attn.q_proj
+  - C: 512
+    module_pattern: h.*.attn.k_proj
+  - C: 1024
+    module_pattern: h.*.attn.v_proj
+  - C: 1024
+    module_pattern: h.*.attn.o_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 5
+  faithfulness_warmup_weight_decay: 0.0
+  loss_metrics:
+  - frequency:
+      coeff: 0.0001
+      reference_token_count: 65536
+    coeff: 0.0002
+    eps: 1.0e-12
+    p_anneal_end_frac: 1.0
+    p_anneal_final_p: 0.4
+    p_anneal_start_frac: 0.0
+    pnorm: 2.0
+    type: ImportanceMinimalityLoss
+  - coeff: 0.5
+    routing:
+      type: uniform_k_subset
+    type: StochasticReconSubsetLoss
+  - coeff: 0.5
+    init: random
+    mask_scope: unique_per_datapoint
+    n_steps: 1
+    step_size: 1.0
+    type: PGDReconLoss
+  - coeff: 10000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 100000
+runtime:
+  remat_recon_forwards: false
+  dp: 8
+target:
+  output_extract: 0
+  weights_dtype: bfloat16
+  spec:
+    kind: pretrained
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
+    run_path: goodfire/spd/runs/t-9d2b8f02

--- a/param_decomp/experiments/invariance_check.py
+++ b/param_decomp/experiments/invariance_check.py
@@ -77,11 +77,11 @@ def _run(steps: int, sharded: bool) -> list[dict[str, float]]:
     src = init_persistent_sources(
         lm.site_names, tuple(s.C for s in lm.sites), (1, seq), jnp.float32, random.PRNGKey(3)
     )
-    resid = random.normal(random.PRNGKey(4), (gbatch, seq, cfg.n_embd)) * 0.5
+    tokens = random.randint(random.PRNGKey(4), (gbatch, seq), 0, cfg.vocab_size)
 
     mesh = hsdp_mesh() if sharded else None
     if mesh is not None:
-        resid = shard_batch(resid, mesh, batch_axis=0)
+        tokens = shard_batch(tokens, mesh, batch_axis=0)
 
     ppgd_cfg = PersistentPGDReconLossConfig(
         coeff=0.5,
@@ -132,7 +132,7 @@ def _run(steps: int, sharded: bool) -> list[dict[str, float]]:
 
     out = []
     for i in range(steps):
-        state, m = step(lm, state, resid, random.PRNGKey(100 + i))
+        state, m = step(lm, state, tokens, random.PRNGKey(100 + i))
         out.append({k: float(v) for k, v in m.items()})
     return out
 

--- a/param_decomp/run.py
+++ b/param_decomp/run.py
@@ -104,6 +104,42 @@ def _log_wandb_safe(wandb_module: "ModuleType", payload: "LogRecord", step: int,
         print(f"wandb communication error, skipping {what}: {e}", flush=True)
 
 
+def _state_buffer_bytes_by_ptr(state: object) -> dict[int, int]:
+    """Device-buffer pointer -> shard nbytes over every addressable shard of `state`.
+
+    Transient probe for the first-resumed-step donation guard: holds no array
+    references (the per-shard views die with the comprehension), so it cannot itself
+    block donation."""
+    return {
+        shard.data.unsafe_buffer_pointer(): shard.data.nbytes
+        for leaf in jax.tree.leaves(state)
+        for shard in leaf.addressable_shards
+    }
+
+
+def _warn_if_first_resumed_step_did_not_donate(
+    in_buffers: dict[int, int], out_state: object
+) -> None:
+    """The jitted step donates the state (input→output aliasing baked into the
+    executable), but dispatch-time donation can fail SILENTLY (no warning, the runtime
+    copies) — peaking one full `TrainState` above steady state, which is exactly the
+    resume OOM. Aliasing is checked by buffer-pointer reuse, bytes-weighted; XLA may
+    cross-match same-aval leaves (Adam m/v), so compare pointer SETS, not positions."""
+    total = sum(in_buffers.values())
+    reused = sum(
+        nbytes for ptr, nbytes in _state_buffer_bytes_by_ptr(out_state).items()
+        if ptr in in_buffers and in_buffers[ptr] == nbytes
+    )  # fmt: skip
+    if reused < 0.95 * total:
+        print(
+            f"[rank {jax.process_index()}] DONATION FAILED on the first resumed step: "
+            f"only {reused / 2**30:.2f}/{total / 2**30:.2f} GiB of state buffers were "
+            "reused; this step peaked ~one TrainState above steady state "
+            "(lore 2026-07-03--resume-oom-is-buffer-donation-asymmetry)",
+            flush=True,
+        )
+
+
 def _ensure_global[T](tree: T, mesh: Mesh) -> T:
     """Re-materialize the NON-mesh array leaves (eagerly created scalars: step
     counters, Adam counts) as well-formed GLOBAL replicated arrays via an identity
@@ -633,6 +669,8 @@ def run_decomposition_training(
             print(f"PD_MEM: resident device-memory profile -> {_prof_path}", flush=True)
         os._exit(0)  # profiling-only path; donation has consumed `state`, so don't enter the loop
 
+    resumed_state_buffers = _state_buffer_bytes_by_ptr(state) if start_step > 0 else None
+
     for step in range(start_step, pd.steps):
         if _profile_on and step == _profile_start:
             jax.block_until_ready(state)
@@ -684,6 +722,10 @@ def run_decomposition_training(
         else:
             batch = sample_batch(step)
             state, metrics = step_fn(lm, state, batch, random.fold_in(run_key, step))
+
+        if resumed_state_buffers is not None:
+            _warn_if_first_resumed_step_did_not_donate(resumed_state_buffers, state)
+            resumed_state_buffers = None
 
         grad_norm_summary_window.append(
             {k: v for k, v in metrics.items() if k.startswith("grad_norms/summary/")}

--- a/param_decomp/tests/test_checkpoint.py
+++ b/param_decomp/tests/test_checkpoint.py
@@ -39,6 +39,7 @@ from param_decomp.configs import (
 )
 from param_decomp.lm import DecomposedModel
 from param_decomp.recon import build_loss_terms
+from param_decomp.run import _ensure_global
 from param_decomp.schedule import ScheduleConfig
 from param_decomp.sharding import hsdp_mesh
 from param_decomp.targets.llama8b import (
@@ -265,7 +266,11 @@ def _build_sharded(seed: int, mesh: Mesh):
         adversaries={ppgd_cfg.type: _adversary(src, ppgd_cfg)},
         step=jnp.asarray(7, jnp.int32),
     )  # fmt: skip
-    return state
+    # Production references pass through `run._ensure_global` before restore: the eager
+    # scalar stragglers (step, Adam counts) become global replicated arrays. `restore_step`
+    # relies on that contract — it re-materialises the restored tree through ONE jit,
+    # which needs every reference leaf on a single device set.
+    return _ensure_global(state, mesh)
 
 
 def test_sharded_roundtrip_bit_equal(tmp_path: Path):
@@ -300,3 +305,36 @@ def test_sharded_roundtrip_bit_equal(tmp_path: Path):
     for saved, got, ref in zip(state_leaves, loaded_leaves, ref_leaves, strict=True):
         assert jnp.array_equal(jnp.asarray(saved), jnp.asarray(got))
         assert got.sharding == ref.sharding
+
+
+def _shard_buffer_ptrs(tree: TrainState) -> set[int]:
+    return {
+        shard.data.unsafe_buffer_pointer()
+        for leaf in jax.tree.leaves(tree)
+        for shard in leaf.addressable_shards
+    }
+
+
+def test_restored_state_is_donatable(tmp_path: Path):
+    """The restore-side half of the resume-OOM fix (lore
+    2026-07-03--resume-oom-is-buffer-donation-asymmetry): `restore_step` must return a
+    state whose buffers the donating train step actually REUSES. Raw orbax-restored
+    arrays are not reliably donatable (jax#18617) and dispatch-time donation failure is
+    silent — this pins that the re-materialised state aliases through a donating jit
+    exactly like fresh-init state does (checked by buffer-pointer reuse, which works on
+    the CPU backend too: its silent-copy fallback still yields fresh pointers)."""
+    mesh = hsdp_mesh()
+    state = _build_sharded(seed=1, mesh=mesh)
+    mgr = make_checkpoint_manager(tmp_path / "ckpts", keep_last=2)
+    save_state(mgr, 3, state)
+
+    reference = _build_sharded(seed=7, mesh=mesh)
+    loaded = restore_step(mgr, reference, 3)
+    del reference, state
+
+    in_ptrs = _shard_buffer_ptrs(loaded)
+    out = jax.jit(lambda t: t, donate_argnums=0)(loaded)
+    out_ptrs = _shard_buffer_ptrs(out)
+    assert out_ptrs == in_ptrs, (
+        f"donation silently copied {len(out_ptrs - in_ptrs)}/{len(in_ptrs)} buffers"
+    )


### PR DESCRIPTION
## Description
Three commits:

1. **`restore_step` re-materialises the restored tree as jit outputs** (non-donating identity jit pinned to `reference.format` via `out_shardings`), replacing the `device_put(format)` coercion. Orbax-restored arrays (per-shard `device_put` + `make_array_from_single_device_arrays`) are not reliably donatable to the jitted train step ([jax#18617](https://github.com/jax-ml/jax/issues/18617), never fixed upstream). When dispatch-time donation fails it is **silent** (the `Some donated buffers were not usable` warning is lowering-time only — `jax/_src/interpreters/mlir.py`), and the first resumed step peaks ~one full `TrainState` above any fresh step: the full32L resume OOM (lore `2026-07-03--resume-oom-is-buffer-donation-asymmetry`). Jit outputs are indistinguishable from fresh-init state; the transient 2×-state cost equals the peak restore already paid while `reference` and the restored tree coexisted. Non-donating deliberately: a plain copy cannot hard-fail at dispatch (GPU errors loudly on donation of externally-referenced buffers), and the reuse donation would buy is off the step's peak. Covers the fine-tune path too (`init_from_parent` → `restore_step`).
   Plus a **bytes-weighted buffer-reuse guard** after the first resumed step (`run.py`): if <95% of state bytes were reused, each affected rank prints `DONATION FAILED …` — the silent failure mode is silent no more.

2. **`invariance_check.py` fed float residuals** where the target now takes token ids (same fallout class as #919) — validation-stack item 3 was unrunnable. Now feeds `randint` tokens.

3. **dp8 save→resume smoke config** documenting the scancel-after-save → `pd-lm --run_id` resubmit procedure.

## Related Issue
Bridge task `solve-resumption-oom`; upstream [jax#18617](https://github.com/jax-ml/jax/issues/18617).

## Motivation and Context
Large-state donating runs can train fresh but die on any preemption/requeue: full32L resumes OOM'd at the default mem fraction, and for `p-8e2380e2` (attn C=4096) the mem-fraction band-aid is unusable in both directions (0.97 starves NCCL clique init; even max fraction cannot fit fresh-peak + one state). The restored state must donate.

## How Has This Been Tested?
- **Repro harness** (task workspace `repro/repro_donation.py`): orbax StandardSave/Restore + donating jitted step, donation observed directly via per-shard `unsafe_buffer_pointer` aliasing + `memory_stats`. On CPU, raw restored state flakily fails donation on a random subset of leaves — exclusively the *sharded* ones; the identity-jit re-materialisation fixes it deterministically. (GPU 1-dev and 8-proc×1-GPU multi-controller runs did not reproduce the raw failure at small scale — 48/48 rank×mode combos aliased — so CPU + the at-scale diag logs are the only places the failure is visible; the fix makes the restored arrays *constructively* equivalent to fresh-init ones rather than relying on that.)
- `test_checkpoint.py::test_restored_state_is_donatable` pins the contract (pointer aliasing through a donating jit); ran 3× stable at 4 sim devices.
- Full `param_decomp/tests/` green at default device count AND `--xla_force_host_platform_device_count=4`; `make type` clean; `invariance_check.py` passes at 4 sim devices (worst rel 1.02e-04).
- **End-to-end dp8 trainer smoke** (LlamaSimpleMLP pile, scavenge jobs 170727/170729): fresh run → scancel → SIGTERM save at step 70 → `pd-lm --run_id` resubmit → `resumed from checkpoint step 70`, first resumed step trains, **no DONATION FAILED line from any rank**, losses continue the trajectory, per-rank peak identical (18.22 GB). Run + workspaces deleted after.
- NOT yet validated at 128-proc scale (the original OOM artifact `p-05101e15` was GC'd; `p-8e2380e2` is live). The guard turns any residual at-scale failure loud on the next real resume.

## Does this PR introduce a breaking change?
No. `restore_step` now requires the reference on a single device set (one jit over the tree) — production references already are (`_ensure_global`); the sharded test fixture was aligned to that contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)