### PR TITLE
test(recon): confirm PGDReconLayerwiseLoss fresh-PGD per-site independence (#918 item 6)

### DIFF
--- a/param_decomp/tests/test_recon_log_keys.py
+++ b/param_decomp/tests/test_recon_log_keys.py
@@ -33,7 +33,7 @@ from param_decomp.configs import (
     StochasticReconSubsetLossConfig,
     UnmaskedReconLossConfig,
 )
-from param_decomp.recon import ReconLossTerm, build_loss_terms
+from param_decomp.recon import FreshPGDSources, ReconLossTerm, build_loss_terms
 from param_decomp.schedule import ScheduleConfig
 
 SITE_NAMES = ("h.0.mlp.c_fc", "h.0.mlp.down_proj")
@@ -92,6 +92,30 @@ def test_recon_term_name_honors_name_override():
     cfg = StochasticReconLossConfig(coeff=1.0, name="StochasticReconLoss_probe")
     (term,) = _recon_terms((cfg,))
     assert term.name == "StochasticReconLoss_probe"
+
+
+def test_pgd_layerwise_plan_is_independent_per_site():
+    """#918 item 6 / SPEC S24: `PGDReconLayerwiseLoss` factors into ONE fresh-PGD entry
+    per site, each living on exactly its own single site in canonical site order.
+    Combined with the step's per-entry key derivation (`fold_in(term_key, entry_idx)` in
+    `train.py`, which splits into `init_key`/`routing_key`), this is what draws an
+    INDEPENDENT fresh adversarial source per site — the JAX counterpart of torch
+    `PGDReconLayerwiseLoss.update`'s loop, where each layer calls
+    `pgd_masked_recon_loss_update` (fresh `_init_adv_sources`) under a `LayerRouter`
+    routing only that layer."""
+    cfg = PGDReconLayerwiseLossConfig(
+        coeff=1.0, init="random", step_size=0.1, n_steps=1, mask_scope="bsc"
+    )
+    (term,) = _recon_terms((cfg,))
+    assert tuple(entry.live_sites for entry in term.plan) == tuple((s,) for s in SITE_NAMES)
+    for entry in term.plan:
+        assert isinstance(entry.sources, FreshPGDSources)
+        assert (entry.sources.init, entry.sources.n_steps, entry.sources.step_size) == (
+            "random",
+            1,
+            0.1,
+        )
+        assert entry.sources.scope == "bsc"
 
 
 def test_fixed_scalar_loss_keys_use_torch_class_names():


### PR DESCRIPTION
## What

Closes **item 6** of the Stage-4 adversary/source parity tracker (#918): _"Confirm `PGDReconLayerwiseLoss` fresh-PGD per-site path by line-by-line read"_ — previously marked done but **inferred** from LOSS_PARITY_DESIGN, not read line-by-line vs torch.

Adds one pure-structure test pinning that `PGDReconLayerwiseLoss` factors into **one fresh-PGD entry per site**, each on exactly its own single site in canonical order.

## Line-by-line confirmation (torch-oracle vs JAX)

**Torch** (`PGDReconLayerwiseLoss.update` → `pgd_masked_recon_loss_update` → `_init_adv_sources` / `_run_pgd_loop`, git tag `torch-oracle`):
- Loops over every `target_module_paths` layer; per layer calls `pgd_masked_recon_loss_update` with a fresh `LayerRouter(layer_name=layer)`.
- `_init_adv_sources` **freshly** initializes sources per call → independent per layer.
- `LayerRouter.get_masks` = all-ones for that one layer, all-zeros elsewhere → only that layer decomposed-masked; others take the frozen path.
- `_run_pgd_loop`: `n_steps` of `add_(step_size * grad.sign())` then `clamp_(0,1)`; routing fixed across steps.
- Aggregation: `Σ_layer sum_loss / Σ_layer n` = mean over (layer, example).

**JAX** (`recon.py` `PGDReconLayerwiseLossConfig` case + `train.py` fresh-PGD block + `adversary.init_fresh_pgd_sources`):
- `make_plan(per_site(site_names), AllRoutingConfig(), FreshPGDSources(...), n_samples=1)` → one `ReconForward` per site, `live_sites=(s,)`.
- `train.py`: `term_key = fold_in(key, 1+term_idx)`; per entry `routing_key, init_key = split(fold_in(term_key, entry_idx))`. **Distinct `entry_idx` per site ⇒ distinct `init_key` ⇒ independent fresh source.**
- `sign_ascend_body`: `clip(sources + step_size*sign(grad), 0, 1)`, scanned `n_steps` — matches torch.
- Routing drawn once per entry, shared by ascents + main forward (SPEC S24); `AllRoutingConfig` over the single live site == torch `LayerRouter` all-ones on that one layer.
- Aggregation: `Σ_entry recon / n_entries` (n_draws=1) = mean over sites. Equivalent to torch (equal per-entry n).

**Structural note (equivalent, not a divergence):** torch inits fresh sources for *all* modules per layer but routes only one (non-routed sources contribute nothing to the forward/gradient → no-op); JAX inits only the one live site. Loss value + ascent gradient identical; only RNG *consumption* differs — and torch (global RNG) vs JAX (split keys) already differ, so numeric goldens use deterministic init.

## Fixture decision

No numeric torch golden exists for the fresh-PGD layerwise path (the equivalence suite covers faith/imp/stoch/ppgd only; fresh-PGD as a whole isn't in the goldens). The layerwise path shares byte-identical fresh-PGD ascent machinery with `PGDReconLoss`/`PGDReconSubsetLoss`, differing **only** in chunking (`per_site` vs `one_chunk`); per-entry independence is the generic plan-entry keying. Per the item's acceptance clause, I took the **confirm + document** branch (a torch golden would need the deprecated torch-oracle regen flow) and pinned the plan-side invariant with a pure-JAX structural test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)