### PR TITLE
feat(adversary): optional global-norm grad clip on PPGD source ascent + src-grad-norm metric

### DIFF
--- a/param_decomp/SPEC.md
+++ b/param_decomp/SPEC.md
@@ -311,7 +311,7 @@ faithfulness, sources/PPGD, the squashings (S5/S6), the imp-min reduction, the g
 | `RECON_TERMS` | any static tuple of coefficiented terms, each a static plan of `(live_sites, SAMPLE_ROUTING, MASK_SOURCE)` entries: `subset_chunk_plan` · `per_site_plan` (the torch "layerwise" shape) · `all_sites_plan` · custom subset families (pairs, covers, …); built from the shared torch loss configs by `build_loss_terms` | ★ stochastic subset term + persistent-PGD term |
 | `MASK_SOURCE` | `stochastic` (fresh U[0,1]/Bernoulli per draw) · `constant(v)` (`v=0` CI-masked, `v=1` unmasked; no delta path) · `fresh_pgd(init, n_steps, step_size, scope)` · `persistent(state_key)` | ★ stochastic + persistent |
 | `SAMPLE_ROUTING` | `(key, [B,T]) → tuple of routing draws`, statically sized; draws may be jointly sampled (independent repeats, antithetic/complementary subsets, per-step covers) | ★ uniform_k_routing(·, 1) |
-| `SRC_STEP` | `adam(β₁,β₂,ε)` with bias correction; `sign` (`sources += lr·sign(grad)`) | ★ adam(.5, .99, 1e-8) |
+| `SRC_STEP` | `adam(β₁,β₂,ε)` with bias correction, optionally preceded by a global-norm clip on the source grad (`grad_clip_norm`, whole bundle, all sites jointly — experimental, default off = oracle parity); `sign` (`sources += lr·sign(grad)`) | ★ adam(.5, .99, 1e-8), no clip |
 | `PROJ` / `EFFECTIVE` | **clamp**: PROJ = clamp[0,1], EFFECTIVE = identity, init U[0,1] · **sigmoid**: PROJ = identity (unbounded raw), EFFECTIVE = sigmoid, init N(0,1) | ★ clamp |
 | `SCOPE` | persistent: `c (1,1)` · `sc (1,T)` · `nsc (n,T), n|B` · `bsc (B,T)` (jax: `sc` + `bsc` today) — fresh-PGD: `c` · `bc` · `bsc` | ★ sc |
 | stoch sampling | `continuous U[0,1]` · `binomial {0,1}` | ★ continuous |

--- a/param_decomp/adversary.py
+++ b/param_decomp/adversary.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 import equinox as eqx
 import jax
 import jax.numpy as jnp
+import optax
 from jax import random
 from jax.typing import DTypeLike
 from jaxtyping import Array, Float, PRNGKeyArray
@@ -116,6 +117,12 @@ def sources_adam_ascend_project(
     # `sources_grad` arrives in the masked-forward compute dtype (bf16); cast to the moment
     # dtype so the persistent `m`/`v` keep their declared storage dtype across steps.
     grad = {s: sources_grad[s].astype(adam_state.m[s].dtype) for s in sources}
+    if adam.grad_clip_norm is not None:
+        # Same clip semantics as the main optimizers (`run_state.clip_by_global_norm_with_eps`):
+        # one global norm over the whole source bundle, scale = min(max_norm/(norm+eps), 1).
+        global_norm = optax.global_norm(grad)
+        scale = jnp.minimum(adam.grad_clip_norm / (global_norm + 1e-6), 1.0)
+        grad = {s: g * scale for s, g in grad.items()}
     m = {s: adam.beta1 * adam_state.m[s] + (1 - adam.beta1) * grad[s] for s in sources}
     v = {s: adam.beta2 * adam_state.v[s] + (1 - adam.beta2) * grad[s] * grad[s] for s in sources}
     bias_correction1 = 1 - adam.beta1**step_count

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -337,6 +337,14 @@ class AdamPGDConfig(BaseConfig):
     beta1: Probability = Field(default=0.9, description="Adam beta1 for masks")
     beta2: Probability = Field(default=0.999, description="Adam beta2 for masks")
     eps: NonNegativeFloat = Field(default=1e-8, description="Adam epsilon for masks")
+    grad_clip_norm: PositiveFloat | None = Field(
+        default=None,
+        description=(
+            "Global-norm clip on the source gradient (whole per-adversary source bundle,"
+            " all sites jointly) before the Adam moments — the source-side analog of the"
+            " main optimizers' grad_clip_norm. None (default) is the oracle-parity path."
+        ),
+    )
     lr_schedule: ScheduleConfig
 
 

--- a/param_decomp/configs/adv_gradclip/pile4l_ppgd_40k_base.yaml
+++ b/param_decomp/configs/adv_gradclip/pile4l_ppgd_40k_base.yaml
@@ -1,0 +1,157 @@
+# PPGD source-grad-clip A/B — BASELINE arm (bridge task try-grad-clip-adv-recon).
+# Derived from pile_ppgd_bsc.yaml (the paper 4L pile PPGD config); documented edits:
+#   1. steps 400k -> 40k (short A/B; all fraction-based schedules auto-stretch)
+#   2. runtime.dp 16 -> 8 (1 node; same global batch 64 -> bl8)
+#   3. run_name
+# The adversary optimizer is UNCHANGED (grad_clip_norm unset = None): this arm exists to
+# (a) anchor the comparison and (b) read the grad_norms/summary/src/* scale off wandb to
+# size the clip arms' grad_clip_norm.
+run_name: jax-pile4l-ppgd-gradclip-base
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 5000
+  train_log_every: 200
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/pile_neox_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: EleutherAI/gpt-neox-20b
+  train_split: train
+eval:
+  batch_size: 128
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups:
+      layer_0:
+      - h.0.*
+      layer_1:
+      - h.1.*
+      layer_2:
+      - h.2.*
+      layer_3:
+      - h.3.*
+      total:
+      - '*'
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: shared_across_batch
+    n_steps: 20
+    name: PGDReconLoss_20step
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 10000
+  slow_on_first_step: true
+pd:
+  batch_size: 64
+  ci_config:
+    type: chunkwise_transformer
+    blocks_per_chunk: 1
+    d_model: 2048
+    n_blocks: 8
+    n_heads: 16
+    mlp_hidden: 8192
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 3072
+    module_pattern: h.*.mlp.c_fc
+  - C: 3584
+    module_pattern: h.*.mlp.down_proj
+  - C: 512
+    module_pattern: h.*.attn.q_proj
+  - C: 512
+    module_pattern: h.*.attn.k_proj
+  - C: 1024
+    module_pattern: h.*.attn.v_proj
+  - C: 1024
+    module_pattern: h.*.attn.o_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 400
+  faithfulness_warmup_weight_decay: 0.0
+  loss_metrics:
+  - frequency:
+      coeff: 0.0001
+      reference_token_count: 65536
+    coeff: 0.0002
+    eps: 1.0e-12
+    p_anneal_end_frac: 1.0
+    p_anneal_final_p: 0.4
+    p_anneal_start_frac: 0.0
+    pnorm: 2.0
+    type: ImportanceMinimalityLoss
+  - coeff: 0.5
+    routing:
+      type: uniform_k_subset
+    type: StochasticReconSubsetLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.5
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: per_batch_per_position
+    type: PersistentPGDReconLoss
+  - coeff: 10000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 40000
+runtime:
+  remat_recon_forwards: false
+  dp: 8
+target:
+  output_extract: 0
+  weights_dtype: bfloat16
+  spec:
+    kind: pretrained
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
+    run_path: goodfire/spd/runs/t-9d2b8f02
+wandb:
+  entity: null
+  project: param-decomp

--- a/param_decomp/configs/adv_gradclip/pile4l_ppgd_40k_clip0p01.yaml
+++ b/param_decomp/configs/adv_gradclip/pile4l_ppgd_40k_clip0p01.yaml
@@ -1,0 +1,154 @@
+# PPGD source-grad-clip A/B — CLIP arm (bridge task try-grad-clip-adv-recon).
+# Identical to pile4l_ppgd_40k_base.yaml except run_name and the PPGD adversary's
+# optimizer.grad_clip_norm: null -> 0.01 (sized off the baseline's measured
+# grad_norms/summary/src scale).
+run_name: jax-pile4l-ppgd-gradclip-0p01
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 5000
+  train_log_every: 200
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/pile_neox_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: EleutherAI/gpt-neox-20b
+  train_split: train
+eval:
+  batch_size: 128
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups:
+      layer_0:
+      - h.0.*
+      layer_1:
+      - h.1.*
+      layer_2:
+      - h.2.*
+      layer_3:
+      - h.3.*
+      total:
+      - '*'
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: shared_across_batch
+    n_steps: 20
+    name: PGDReconLoss_20step
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 10000
+  slow_on_first_step: true
+pd:
+  batch_size: 64
+  ci_config:
+    type: chunkwise_transformer
+    blocks_per_chunk: 1
+    d_model: 2048
+    n_blocks: 8
+    n_heads: 16
+    mlp_hidden: 8192
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 3072
+    module_pattern: h.*.mlp.c_fc
+  - C: 3584
+    module_pattern: h.*.mlp.down_proj
+  - C: 512
+    module_pattern: h.*.attn.q_proj
+  - C: 512
+    module_pattern: h.*.attn.k_proj
+  - C: 1024
+    module_pattern: h.*.attn.v_proj
+  - C: 1024
+    module_pattern: h.*.attn.o_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 400
+  faithfulness_warmup_weight_decay: 0.0
+  loss_metrics:
+  - frequency:
+      coeff: 0.0001
+      reference_token_count: 65536
+    coeff: 0.0002
+    eps: 1.0e-12
+    p_anneal_end_frac: 1.0
+    p_anneal_final_p: 0.4
+    p_anneal_start_frac: 0.0
+    pnorm: 2.0
+    type: ImportanceMinimalityLoss
+  - coeff: 0.5
+    routing:
+      type: uniform_k_subset
+    type: StochasticReconSubsetLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.5
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+      grad_clip_norm: 0.01
+    scope:
+      type: per_batch_per_position
+    type: PersistentPGDReconLoss
+  - coeff: 10000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 40000
+runtime:
+  remat_recon_forwards: false
+  dp: 8
+target:
+  output_extract: 0
+  weights_dtype: bfloat16
+  spec:
+    kind: pretrained
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
+    run_path: goodfire/spd/runs/t-9d2b8f02
+wandb:
+  entity: null
+  project: param-decomp

--- a/param_decomp/configs/adv_gradclip/pile4l_ppgd_40k_clip0p03.yaml
+++ b/param_decomp/configs/adv_gradclip/pile4l_ppgd_40k_clip0p03.yaml
@@ -1,0 +1,154 @@
+# PPGD source-grad-clip A/B — CLIP arm (bridge task try-grad-clip-adv-recon).
+# Identical to pile4l_ppgd_40k_base.yaml except run_name and the PPGD adversary's
+# optimizer.grad_clip_norm: null -> 0.03 (sized off the baseline's measured
+# grad_norms/summary/src scale).
+run_name: jax-pile4l-ppgd-gradclip-0p03
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 5000
+  train_log_every: 200
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/pile_neox_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: EleutherAI/gpt-neox-20b
+  train_split: train
+eval:
+  batch_size: 128
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups:
+      layer_0:
+      - h.0.*
+      layer_1:
+      - h.1.*
+      layer_2:
+      - h.2.*
+      layer_3:
+      - h.3.*
+      total:
+      - '*'
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: shared_across_batch
+    n_steps: 20
+    name: PGDReconLoss_20step
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 10000
+  slow_on_first_step: true
+pd:
+  batch_size: 64
+  ci_config:
+    type: chunkwise_transformer
+    blocks_per_chunk: 1
+    d_model: 2048
+    n_blocks: 8
+    n_heads: 16
+    mlp_hidden: 8192
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 3072
+    module_pattern: h.*.mlp.c_fc
+  - C: 3584
+    module_pattern: h.*.mlp.down_proj
+  - C: 512
+    module_pattern: h.*.attn.q_proj
+  - C: 512
+    module_pattern: h.*.attn.k_proj
+  - C: 1024
+    module_pattern: h.*.attn.v_proj
+  - C: 1024
+    module_pattern: h.*.attn.o_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 400
+  faithfulness_warmup_weight_decay: 0.0
+  loss_metrics:
+  - frequency:
+      coeff: 0.0001
+      reference_token_count: 65536
+    coeff: 0.0002
+    eps: 1.0e-12
+    p_anneal_end_frac: 1.0
+    p_anneal_final_p: 0.4
+    p_anneal_start_frac: 0.0
+    pnorm: 2.0
+    type: ImportanceMinimalityLoss
+  - coeff: 0.5
+    routing:
+      type: uniform_k_subset
+    type: StochasticReconSubsetLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.5
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+      grad_clip_norm: 0.03
+    scope:
+      type: per_batch_per_position
+    type: PersistentPGDReconLoss
+  - coeff: 10000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 40000
+runtime:
+  remat_recon_forwards: false
+  dp: 8
+target:
+  output_extract: 0
+  weights_dtype: bfloat16
+  spec:
+    kind: pretrained
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
+    run_path: goodfire/spd/runs/t-9d2b8f02
+wandb:
+  entity: null
+  project: param-decomp

--- a/param_decomp/train.py
+++ b/param_decomp/train.py
@@ -478,6 +478,13 @@ def make_train_step(
             components_grad_faith,
         )
         grad_norm_metrics = _grad_norm_metrics(components_grad, ci_fn_grad)
+        # Pre-clip source-grad norm per adversary, unscaled by the term's coeff — the same
+        # gradient `final_ascend`'s SRC_STEP sees (S14'). Logged to size `grad_clip_norm`.
+        grad_norm_metrics |= {
+            f"grad_norms/summary/src/{k}": optax.global_norm(persistent_grads_scaled[k])
+            / warmed_advs[k].coeff
+            for k in warmed_advs
+        }
 
         # ── each adversary's final ascent from the fused graph (SPEC S13'/S14'): the
         # backward saw coeff·L_term, so it ascends on L_term itself (unscaled by its coeff


### PR DESCRIPTION
## Description
- `AdamPGDConfig.grad_clip_norm: PositiveFloat | None = None` — global-norm clip over the whole per-adversary source bundle (all sites jointly, same `min(max_norm/(norm+eps), 1)` semantics as the main optimizers' `clip_by_global_norm_with_eps`), applied to the source grad before the Adam moments in `adversary.py::sources_adam_ascend_project`. Covers both warmup ascents and the final ascent (S13'/S14').
- New always-on train metric `grad_norms/summary/src/<state_key>`: the pre-clip final-ascend source-grad global norm, unscaled by the term's coeff — exactly the gradient SRC_STEP sees, for sizing clip thresholds and adversary-health visibility.
- SPEC §6 `SRC_STEP` row amended with the config-gated variation (default off = oracle parity, N1/S13 unchanged).
- Experiment configs `param_decomp/configs/adv_gradclip/` (pile 4L ppgd bsc, 40k, dp=8): base / clip 0.03 / clip 0.01.

## Related Issue
Bridge task `try-grad-clip-adv-recon`.

## Motivation and Context
Oli's ask: try grad clipping in the adversarial recon term. A/B result (lore `2026-07-03--ppgd-source-grad-clip-ab-no-effect-4l`): **no effect at 4L pile scale** — the source grad is already smooth (whole-bundle norm 0.01–0.07, spike-free through step 35k), so even a continuously-binding clip@0.01 leaves every metric within noise of base (runs p-4515d4dd / p-cddac242 / p-a3386426, wandb group `adv-gradclip`). Landing the knob anyway: zero cost when off (bit-identical default), and it's the ready lever if big-run adversary spikes recur; the norm metric is independently useful visibility.

## How Has This Been Tested?
- Full `param_decomp/tests/` at default AND 4 sim devices (SLURM jobs 167167 pre-rebase, 170708 post-rebase onto feature/jax): 230 passed ×2, equivalence goldens pass UNMODIFIED (default-None path bit-identical).
- Unit check: Adam moments scale exactly by the clip factor; None path unchanged.
- 3 full 40k-step training runs (above) exercising clip on/off end to end; clip step-time cost ≈ 0.
- ruff + basedpyright clean (`make type` green).

## Does this PR introduce a breaking change?
No. Default `grad_clip_norm: None` preserves existing trajectories bit-for-bit; existing configs unaffected. One new metric key family in train logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)