### PR TITLE
bf16 PPGD source: quality A/B + full32L memory cash-in configs (lp-bf16-source-ab)

### DIFF
--- a/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32_bf16src_MEMPROBE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32_bf16src_MEMPROBE.yaml
@@ -1,0 +1,595 @@
+# bf16-PPGD-source memory probe, b128/dp32 (bridge task lp-bf16-source-ab).
+# llama8b_full32L_HSDP_b128_dp32.yaml + source_dtype bfloat16 + mem_profile
+# (prints compiled.memory_analysis() + runtime peak, then exits; no checkpoints).
+# b128 arm: confirm the -14.25 GiB vs the fp32 canon (argument 49.5 / peak 148.2 GiB).
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 1000
+  train_log_every: 25
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/fineweb_llama_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: meta-llama/Llama-3.1-8B
+  train_split: train
+eval:
+  batch_size: 32
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups: null
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: shared_across_batch
+    n_steps: 20
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 100000
+  slow_on_first_step: false
+pd:
+  batch_size: 128
+  ci_config:
+    blocks_per_chunk: 1
+    d_model: 4096
+    mlp_hidden: 16384
+    n_blocks: 4
+    n_heads: 64
+    type: chunkwise_transformer
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.83e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.83e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.0.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.1.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.2.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.3.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.4.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.5.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.6.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.7.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.8.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.9.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.10.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.11.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.12.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.13.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.14.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.15.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.16.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.17.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.18.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.19.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.20.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.21.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.22.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.23.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.24.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.25.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.26.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.27.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.28.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.29.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.30.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.31.mlp.down_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 0
+  faithfulness_warmup_weight_decay: 0.0
+  identity_decomposition_targets: null
+  loss_metrics:
+  - coeff: 5.0e-06
+    eps: 1.0e-06
+    frequency:
+      coeff: 1.0e-06
+      reference_token_count: 65536
+    p_anneal_end_frac: 1.0
+    p_anneal_final_p: 0.4
+    p_anneal_start_frac: 0.0
+    pnorm: 2.0
+    type: ImportanceMinimalityLoss
+  - coeff: 2.0
+    n_samples: 1
+    routing:
+      type: uniform_k_subset
+    sites_per_chunk: 56
+    type: ChunkwiseSubsetReconLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.01
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: per_batch_per_position
+    source_dtype: bfloat16
+    type: PersistentPGDReconLoss
+  - coeff: 1000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 50000
+run_name: jax-full32L-HSDP-b128-dp32-bf16src-MEMPROBE
+runtime:
+  dp: 32
+  launch_env:
+    profile:
+      mem_profile: true
+      no_checkpoint: true
+  remat_ci_fn: true
+  remat_recon_forwards: true
+  tp: 1
+target:
+  output_extract: logits
+  spec:
+    kind: hf
+    model_class: transformers.LlamaForCausalLM
+    model_name: meta-llama/Llama-3.1-8B
+  weights_dtype: bfloat16
+wandb:
+  entity: null
+  group: full32L
+  project: param-decomp-llama
+  tags:
+  - full-model
+  - 32L
+  - allmat
+  - dp128
+  - seq512

--- a/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32_fp32src_TPUT.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b128_dp32_fp32src_TPUT.yaml
@@ -1,0 +1,593 @@
+# b128 fp32-source throughput CONTROL for the b160 bf16src probe (bridge task
+# lp-bf16-source-ab): same code, same 60-step protocol, incumbent config. Isolates
+# the b160 batch gain from the perf work that landed since the 2026-06-28 canon
+# (12.7 s/step was measured pre-#927).
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 1000
+  train_log_every: 5
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/fineweb_llama_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: meta-llama/Llama-3.1-8B
+  train_split: train
+eval:
+  batch_size: 32
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups: null
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: shared_across_batch
+    n_steps: 20
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 100000
+  slow_on_first_step: false
+pd:
+  batch_size: 128
+  ci_config:
+    blocks_per_chunk: 1
+    d_model: 4096
+    mlp_hidden: 16384
+    n_blocks: 4
+    n_heads: 64
+    type: chunkwise_transformer
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.83e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.83e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.0.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.1.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.2.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.3.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.4.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.5.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.6.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.7.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.8.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.9.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.10.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.11.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.12.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.13.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.14.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.15.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.16.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.17.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.18.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.19.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.20.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.21.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.22.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.23.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.24.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.25.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.26.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.27.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.28.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.29.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.30.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.31.mlp.down_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 0
+  faithfulness_warmup_weight_decay: 0.0
+  identity_decomposition_targets: null
+  loss_metrics:
+  - coeff: 5.0e-06
+    eps: 1.0e-06
+    frequency:
+      coeff: 1.0e-06
+      reference_token_count: 65536
+    p_anneal_end_frac: 1.0
+    p_anneal_final_p: 0.4
+    p_anneal_start_frac: 0.0
+    pnorm: 2.0
+    type: ImportanceMinimalityLoss
+  - coeff: 2.0
+    n_samples: 1
+    routing:
+      type: uniform_k_subset
+    sites_per_chunk: 56
+    type: ChunkwiseSubsetReconLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.01
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: per_batch_per_position
+    type: PersistentPGDReconLoss
+  - coeff: 1000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 60
+run_name: jax-full32L-HSDP-b128-dp32-fp32src-TPUT
+runtime:
+  dp: 32
+  launch_env:
+    profile:
+      no_checkpoint: true
+  remat_ci_fn: true
+  remat_recon_forwards: true
+  tp: 1
+target:
+  output_extract: logits
+  spec:
+    kind: hf
+    model_class: transformers.LlamaForCausalLM
+    model_name: meta-llama/Llama-3.1-8B
+  weights_dtype: bfloat16
+wandb:
+  entity: null
+  group: full32L
+  project: param-decomp-llama
+  tags:
+  - full-model
+  - 32L
+  - allmat
+  - dp128
+  - seq512

--- a/param_decomp/configs/llama8b_full32L_HSDP_b160_dp32_bf16src_MEMPROBE.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b160_dp32_bf16src_MEMPROBE.yaml
@@ -1,0 +1,595 @@
+# bf16-PPGD-source memory probe, b160/dp32 (bridge task lp-bf16-source-ab).
+# llama8b_full32L_HSDP_b128_dp32.yaml + source_dtype bfloat16 + mem_profile
+# (prints compiled.memory_analysis() + runtime peak, then exits; no checkpoints).
+# b160 arm: 5 seq/GPU, previously OOM ~172 vs 164 GiB wall at fp32 sources.
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 1000
+  train_log_every: 25
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/fineweb_llama_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: meta-llama/Llama-3.1-8B
+  train_split: train
+eval:
+  batch_size: 32
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups: null
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: shared_across_batch
+    n_steps: 20
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 100000
+  slow_on_first_step: false
+pd:
+  batch_size: 160
+  ci_config:
+    blocks_per_chunk: 1
+    d_model: 4096
+    mlp_hidden: 16384
+    n_blocks: 4
+    n_heads: 64
+    type: chunkwise_transformer
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.83e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.83e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.0.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.1.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.2.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.3.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.4.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.5.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.6.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.7.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.8.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.9.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.10.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.11.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.12.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.13.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.14.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.15.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.16.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.17.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.18.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.19.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.20.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.21.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.22.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.23.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.24.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.25.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.26.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.27.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.28.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.29.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.30.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.31.mlp.down_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 0
+  faithfulness_warmup_weight_decay: 0.0
+  identity_decomposition_targets: null
+  loss_metrics:
+  - coeff: 5.0e-06
+    eps: 1.0e-06
+    frequency:
+      coeff: 1.0e-06
+      reference_token_count: 65536
+    p_anneal_end_frac: 1.0
+    p_anneal_final_p: 0.4
+    p_anneal_start_frac: 0.0
+    pnorm: 2.0
+    type: ImportanceMinimalityLoss
+  - coeff: 2.0
+    n_samples: 1
+    routing:
+      type: uniform_k_subset
+    sites_per_chunk: 56
+    type: ChunkwiseSubsetReconLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.01
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: per_batch_per_position
+    source_dtype: bfloat16
+    type: PersistentPGDReconLoss
+  - coeff: 1000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 50000
+run_name: jax-full32L-HSDP-b160-dp32-bf16src-MEMPROBE
+runtime:
+  dp: 32
+  launch_env:
+    profile:
+      mem_profile: true
+      no_checkpoint: true
+  remat_ci_fn: true
+  remat_recon_forwards: true
+  tp: 1
+target:
+  output_extract: logits
+  spec:
+    kind: hf
+    model_class: transformers.LlamaForCausalLM
+    model_name: meta-llama/Llama-3.1-8B
+  weights_dtype: bfloat16
+wandb:
+  entity: null
+  group: full32L
+  project: param-decomp-llama
+  tags:
+  - full-model
+  - 32L
+  - allmat
+  - dp128
+  - seq512

--- a/param_decomp/configs/llama8b_full32L_HSDP_b160_dp32_bf16src_TPUT.yaml
+++ b/param_decomp/configs/llama8b_full32L_HSDP_b160_dp32_bf16src_TPUT.yaml
@@ -1,0 +1,595 @@
+# bf16-PPGD-source b160 throughput probe (bridge task lp-bf16-source-ab).
+# llama8b_full32L_HSDP_b128_dp32.yaml + batch 160 (5 seq/GPU, fits ONLY with
+# source_dtype bfloat16: runtime peak 144.8/164 GiB vs ~172 OOM at fp32) +
+# 60 steps, no checkpoints. Measures steady-state s/step vs the b128 canon
+# (12.7 s = 10.09 seq/s).
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 1000
+  train_log_every: 5
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/fineweb_llama_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: meta-llama/Llama-3.1-8B
+  train_split: train
+eval:
+  batch_size: 32
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups: null
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: shared_across_batch
+    n_steps: 20
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 100000
+  slow_on_first_step: false
+pd:
+  batch_size: 160
+  ci_config:
+    blocks_per_chunk: 1
+    d_model: 4096
+    mlp_hidden: 16384
+    n_blocks: 4
+    n_heads: 64
+    type: chunkwise_transformer
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.83e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.83e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.0.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.1.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.2.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.3.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.4.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.5.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.6.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.7.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.8.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.9.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.10.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.11.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.12.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.13.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.14.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.15.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.16.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.17.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.18.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.19.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.20.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.21.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.22.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.23.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.24.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.25.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.26.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.27.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.28.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.29.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.30.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.31.mlp.down_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 0
+  faithfulness_warmup_weight_decay: 0.0
+  identity_decomposition_targets: null
+  loss_metrics:
+  - coeff: 5.0e-06
+    eps: 1.0e-06
+    frequency:
+      coeff: 1.0e-06
+      reference_token_count: 65536
+    p_anneal_end_frac: 1.0
+    p_anneal_final_p: 0.4
+    p_anneal_start_frac: 0.0
+    pnorm: 2.0
+    type: ImportanceMinimalityLoss
+  - coeff: 2.0
+    n_samples: 1
+    routing:
+      type: uniform_k_subset
+    sites_per_chunk: 56
+    type: ChunkwiseSubsetReconLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.01
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: per_batch_per_position
+    source_dtype: bfloat16
+    type: PersistentPGDReconLoss
+  - coeff: 1000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 60
+run_name: jax-full32L-HSDP-b160-dp32-bf16src-TPUT
+runtime:
+  dp: 32
+  launch_env:
+    profile:
+      no_checkpoint: true
+  remat_ci_fn: true
+  remat_recon_forwards: true
+  tp: 1
+target:
+  output_extract: logits
+  spec:
+    kind: hf
+    model_class: transformers.LlamaForCausalLM
+    model_name: meta-llama/Llama-3.1-8B
+  weights_dtype: bfloat16
+wandb:
+  entity: null
+  group: full32L
+  project: param-decomp-llama
+  tags:
+  - full-model
+  - 32L
+  - allmat
+  - dp128
+  - seq512

--- a/param_decomp/configs/pile_ppgd_bsc_srcdtype_ab_bf16.yaml
+++ b/param_decomp/configs/pile_ppgd_bsc_srcdtype_ab_bf16.yaml
@@ -1,0 +1,157 @@
+# bf16-PPGD-source Tier-1 quality A/B, bf16 arm (bridge task lp-bf16-source-ab).
+# Derived from pile_ppgd_bsc.yaml (pile-4L PPGD-bsc lineage): steps 400k -> 10k,
+# dp 16 -> 8 (1 node), slow_every 10000 -> 2500 (PGD_20step every 2k steps).
+# Treatment: source_dtype bfloat16 on the PersistentPGDReconLoss term (knob
+# a3ffa2a79: PPGD source + its Adam m/v stored in bf16).
+# Same seed both arms; judge on adv recon-loss trajectory, PGD_20step eval,
+# faith, CI-L0, masked CE/KL.
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 5000
+  train_log_every: 200
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/pile_neox_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: EleutherAI/gpt-neox-20b
+  train_split: train
+eval:
+  batch_size: 128
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups:
+      layer_0:
+      - h.0.*
+      layer_1:
+      - h.1.*
+      layer_2:
+      - h.2.*
+      layer_3:
+      - h.3.*
+      total:
+      - '*'
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: shared_across_batch
+    n_steps: 20
+    name: PGDReconLoss_20step
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 2000
+  slow_on_first_step: true
+pd:
+  batch_size: 64
+  ci_config:
+    blocks_per_chunk: 1
+    d_model: 2048
+    mlp_hidden: 8192
+    n_blocks: 8
+    n_heads: 16
+    type: chunkwise_transformer
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 3072
+    module_pattern: h.*.mlp.c_fc
+  - C: 3584
+    module_pattern: h.*.mlp.down_proj
+  - C: 512
+    module_pattern: h.*.attn.q_proj
+  - C: 512
+    module_pattern: h.*.attn.k_proj
+  - C: 1024
+    module_pattern: h.*.attn.v_proj
+  - C: 1024
+    module_pattern: h.*.attn.o_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 400
+  faithfulness_warmup_weight_decay: 0.0
+  loss_metrics:
+  - coeff: 0.0002
+    eps: 1.0e-12
+    frequency:
+      coeff: 0.0001
+      reference_token_count: 65536
+    p_anneal_end_frac: 1.0
+    p_anneal_final_p: 0.4
+    p_anneal_start_frac: 0.0
+    pnorm: 2.0
+    type: ImportanceMinimalityLoss
+  - coeff: 0.5
+    routing:
+      type: uniform_k_subset
+    type: StochasticReconSubsetLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.5
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: per_batch_per_position
+    source_dtype: bfloat16
+    type: PersistentPGDReconLoss
+  - coeff: 10000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 10000
+run_name: jax-pile4l-ppgd-bsc-srcdtype-ab-bf16
+runtime:
+  dp: 8
+  remat_recon_forwards: false
+target:
+  output_extract: 0
+  spec:
+    kind: pretrained
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
+    run_path: goodfire/spd/runs/t-9d2b8f02
+  weights_dtype: bfloat16
+wandb:
+  entity: null
+  project: param-decomp

--- a/param_decomp/configs/pile_ppgd_bsc_srcdtype_ab_fp32.yaml
+++ b/param_decomp/configs/pile_ppgd_bsc_srcdtype_ab_fp32.yaml
@@ -1,0 +1,155 @@
+# bf16-PPGD-source Tier-1 quality A/B, fp32 arm (bridge task lp-bf16-source-ab).
+# Derived from pile_ppgd_bsc.yaml (pile-4L PPGD-bsc lineage): steps 400k -> 10k,
+# dp 16 -> 8 (1 node), slow_every 10000 -> 2500 (PGD_20step every 2k steps).
+# Control: source_dtype fp32 (default) — otherwise byte-identical to the bf16 arm.
+# Same seed both arms; judge on adv recon-loss trajectory, PGD_20step eval,
+# faith, CI-L0, masked CE/KL.
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 5000
+  train_log_every: 200
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/pile_neox_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: EleutherAI/gpt-neox-20b
+  train_split: train
+eval:
+  batch_size: 128
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups:
+      layer_0:
+      - h.0.*
+      layer_1:
+      - h.1.*
+      layer_2:
+      - h.2.*
+      layer_3:
+      - h.3.*
+      total:
+      - '*'
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: shared_across_batch
+    n_steps: 20
+    name: PGDReconLoss_20step
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 2000
+  slow_on_first_step: true
+pd:
+  batch_size: 64
+  ci_config:
+    blocks_per_chunk: 1
+    d_model: 2048
+    mlp_hidden: 8192
+    n_blocks: 8
+    n_heads: 16
+    type: chunkwise_transformer
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 3072
+    module_pattern: h.*.mlp.c_fc
+  - C: 3584
+    module_pattern: h.*.mlp.down_proj
+  - C: 512
+    module_pattern: h.*.attn.q_proj
+  - C: 512
+    module_pattern: h.*.attn.k_proj
+  - C: 1024
+    module_pattern: h.*.attn.v_proj
+  - C: 1024
+    module_pattern: h.*.attn.o_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 400
+  faithfulness_warmup_weight_decay: 0.0
+  loss_metrics:
+  - coeff: 0.0002
+    eps: 1.0e-12
+    frequency:
+      coeff: 0.0001
+      reference_token_count: 65536
+    p_anneal_end_frac: 1.0
+    p_anneal_final_p: 0.4
+    p_anneal_start_frac: 0.0
+    pnorm: 2.0
+    type: ImportanceMinimalityLoss
+  - coeff: 0.5
+    routing:
+      type: uniform_k_subset
+    type: StochasticReconSubsetLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.5
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: per_batch_per_position
+    type: PersistentPGDReconLoss
+  - coeff: 10000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 10000
+run_name: jax-pile4l-ppgd-bsc-srcdtype-ab-fp32
+runtime:
+  dp: 8
+  remat_recon_forwards: false
+target:
+  output_extract: 0
+  spec:
+    kind: pretrained
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
+    run_path: goodfire/spd/runs/t-9d2b8f02
+  weights_dtype: bfloat16
+wandb:
+  entity: null
+  project: param-decomp


### PR DESCRIPTION
Experiment configs for the bf16 PPGD source+moments investigation (bridge task `lp-bf16-source-ab`, items #1+#2 of the lower-precision roadmap). No code changes — the `source_dtype` knob (a3ffa2a79) is exercised as-is.

## What's in here
- `pile_ppgd_bsc_srcdtype_ab_{fp32,bf16}.yaml` — Tier-1 quality A/B on the pile-4L PPGD-bsc lineage (10k steps, dp8, same seed; only diff = `source_dtype: bfloat16`)
- `llama8b_full32L_HSDP_{b128,b160}_dp32_bf16src_MEMPROBE.yaml` — mem_profile-and-exit probes
- `llama8b_full32L_HSDP_b160_dp32_bf16src_TPUT.yaml` — 60-step b160 throughput probe

## Results
**Quality gate PASSED** (runs p-1b097fd2 fp32 / p-07ae1175 bf16): bf16 arm equal-or-better on every judge metric — persistent-adversary recon within ±2% from 5k steps, fresh-PGD-20step eval −1..−13%, masked CE/KL −2..−8%, CI-L0 ~8% sparser, faithfulness identical. Post-hoc ckpt probe: NO Adam v underflow (bf16 shares fp32's 8-bit exponent; the risk was mantissa swallowing, which didn't materialize — v/m stats match fp32).

**Memory confirmed** (p-910a7582): b128/dp32 resident 49.5 → **35.25 GiB (−14.25 GiB exactly)**, runtime peak 148.2 → 132.2 GiB.

**b160 / 5 seq/GPU now FITS** (p-03721a2f): runtime peak **144.8 / 164.1 GiB** (fp32 sources OOM'd at ~172). Throughput probe p-8dd01149 in flight.

Full trail: bridge task log `lp-bf16-source-ab`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)