### PR TITLE
fix(invariance_check): feed int tokens, not a float residual batch (SPEC D4)

### DIFF
--- a/param_decomp/experiments/invariance_check.py
+++ b/param_decomp/experiments/invariance_check.py
@@ -77,11 +77,11 @@ def _run(steps: int, sharded: bool) -> list[dict[str, float]]:
     src = init_persistent_sources(
         lm.site_names, tuple(s.C for s in lm.sites), (1, seq), jnp.float32, random.PRNGKey(3)
     )
-    resid = random.normal(random.PRNGKey(4), (gbatch, seq, cfg.n_embd)) * 0.5
+    tokens = random.randint(random.PRNGKey(4), (gbatch, seq), 0, cfg.vocab_size)
 
     mesh = hsdp_mesh() if sharded else None
     if mesh is not None:
-        resid = shard_batch(resid, mesh, batch_axis=0)
+        tokens = shard_batch(tokens, mesh, batch_axis=0)
 
     ppgd_cfg = PersistentPGDReconLossConfig(
         coeff=0.5,
@@ -132,7 +132,7 @@ def _run(steps: int, sharded: bool) -> list[dict[str, float]]:
 
     out = []
     for i in range(steps):
-        state, m = step(lm, state, resid, random.PRNGKey(100 + i))
+        state, m = step(lm, state, tokens, random.PRNGKey(100 + i))
         out.append({k: float(v) for k, v in m.items()})
     return out
 


### PR DESCRIPTION
## Summary
`python -m param_decomp.experiments.invariance_check` (step 3 of the validation stack, SPEC D4) crashed on clean `feature/jax` with `TypeError: Indexer must have integer or boolean type, got indexer with type float32` — the check still built a float32 residual batch from before the S18 amendment made the model input token ids, so `clean_output` hit `embed_tokens` indexing with floats. Same failure family as the slow-eval `hidden_acts` crash fixed by #919.

Fix: draw random int tokens (`random.randint(..., 0, cfg.vocab_size)`, matching the `test_llama8b.py` batch builders) and rename `resid` → `tokens`.

## Verification
`XLA_FLAGS=--xla_force_host_platform_device_count=4 python -m param_decomp.experiments.invariance_check`:
```
devices: 4
OK: 3-step trajectory matches 1-layout vs 4-device GSPMD (worst rel 1.02e-04; tol rel 1e-04 + abs 1e-07; reassociation-only)
```
`make check` clean on the touched file (basedpyright 0 errors, ruff pass).

Found while validating PR #939 (not caused by it). Bridge task: `fix-invariance-check-float-tokens`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)