### PR TITLE
perf(compile): 13x faster V/U init compile + compile-time findings

### DIFF
--- a/param_decomp/CLAUDE.md
+++ b/param_decomp/CLAUDE.md
@@ -285,6 +285,10 @@ shared FS, which `$PARAM_DECOMP_OUT_DIR` already is.
   `xla_gpu_autotune_level` 0/2/4 measured flat (~71s jit_step at the 8L probe), and jax
   ≥0.10 already persists the per-fusion autotune cache alongside the compilation cache
   (`jax_persistent_cache_enable_xla_caches` default) — don't re-chase these levers.
+- **`jax_persistent_cache_enable_xla_caches='all'` (XLA kernel cache + parallel LLVM
+  codegen) CRASHES on this stack** (jax 0.10.1 / B200): jit_step dies at runtime with
+  `CUDA_ERROR_NOT_FOUND: named symbol not found` (probe arm F, 2026-07-03). Leave it at
+  the default.
 - **`init_decomp_vu_placed` compiles stacked** (vmap per V/U shape, then a slice jit) —
   bit-identical to the per-site init but ~10× cheaper to compile at 224 sites. Keep new
   seeded inits few-outputs-under-jit; a sharded jit returning 2×n_sites outputs was a

--- a/param_decomp/CLAUDE.md
+++ b/param_decomp/CLAUDE.md
@@ -272,6 +272,31 @@ write cache entries from the first process … contention for writes on some fil
 so all ranks read but only rank 0 writes — no shared-FS race. Requires the cache dir on a
 shared FS, which `$PARAM_DECOMP_OUT_DIR` already is.
 
+### Compile time (measured 2026-07-03, compile-probe arms A–F)
+
+- **The executable cache only hits on an IDENTICAL module** — any structural config change
+  (C, sites, batch, seq, chunking, a compiler flag) is a full recompile. Swept SCALARS also
+  miss: coeffs/LRs/step-sizes are baked into HLO as constants, so a run differing only in a
+  coefficient recompiles everything. **Keep smoke configs byte-identical to the production
+  arm in everything but cadence** — then the production launch reuses the smoke's cached
+  executables. (`steps` feeds schedules, which ARE baked — a changed `steps` is a cache
+  miss; smoke the exact production config when you want to prewarm.)
+- **Autotuning is NOT where compile time goes** (with `triton_gemm` off):
+  `xla_gpu_autotune_level` 0/2/4 measured flat (~71s jit_step at the 8L probe), and jax
+  ≥0.10 already persists the per-fusion autotune cache alongside the compilation cache
+  (`jax_persistent_cache_enable_xla_caches` default) — don't re-chase these levers.
+- **`init_decomp_vu_placed` compiles stacked** (vmap per V/U shape, then a slice jit) —
+  bit-identical to the per-site init but ~10× cheaper to compile at 224 sites. Keep new
+  seeded inits few-outputs-under-jit; a sharded jit returning 2×n_sites outputs was a
+  multi-minute SPMD pass.
+- The remaining big jit_step-compile lever is structural: the recon plan unrolls its chunks
+  python-side, so the production step module contains n_chunks full-model masked
+  forwards+backwards. Scanning over uniform chunks would shrink the module ~n_chunks×.
+- The compile-probe harness lives in `param_decomp/configs/compile_probe/` (arm-isolated
+  caches via `PARAM_DECOMP_OUT_DIR` in `launch_env.env`); compile-structure A/Bs also
+  reproduce cheaply on CPU via `XLA_FLAGS=--xla_force_host_platform_device_count=8` + AOT
+  `.lower().compile()`.
+
 ## Gotchas
 
 - **`init_distributed(dp)` is config-driven, NEVER SLURM-sniffing** (`sharding.py`):

--- a/param_decomp/components.py
+++ b/param_decomp/components.py
@@ -121,6 +121,49 @@ def init_decomp_vu(sites: tuple[SiteSpec, ...], key: Array) -> DecompVU:
     return DecompVU(vu=vu)
 
 
+VUShape = tuple[int, int, int]  # (d_in, d_out, C)
+
+
+def vu_shape_groups(sites: tuple[SiteSpec, ...]) -> dict[VUShape, tuple[SiteSpec, ...]]:
+    """Sites grouped by V/U shape, site order preserved within a group."""
+    groups: dict[VUShape, list[SiteSpec]] = {}
+    for spec in sites:
+        groups.setdefault((spec.d_in, spec.d_out, spec.C), []).append(spec)
+    return {shape: tuple(specs) for shape, specs in groups.items()}
+
+
+def init_decomp_vu_stacked(
+    sites: tuple[SiteSpec, ...], key: Array
+) -> dict[VUShape, tuple[Array, Array]]:
+    """`init_decomp_vu` computed as same-shape stacks: `{(d_in, d_out, C):
+    (V [n, d_in, C], U [n, C, d_out])}`, vmapped over the SAME per-site keys — so
+    `unstack_decomp_vu` recovers `init_decomp_vu`'s output BIT-IDENTICALLY (pinned by
+    `test_sharding`). Under jit the graph has 2×n_shapes sharded outputs instead of
+    2×n_sites, which cuts the production init compile ~10× (448 outputs → 14 at 32L)."""
+    keys = jax.random.split(key, 2 * len(sites))
+    site_index = {spec.name: idx for idx, spec in enumerate(sites)}
+    stacked: dict[VUShape, tuple[Array, Array]] = {}
+    for (d_in, d_out, c), specs in vu_shape_groups(sites).items():
+        idxs = jnp.array([site_index[spec.name] for spec in specs])
+        Vs = jax.vmap(lambda k, s=(d_in, c): jax.random.normal(k, s))(keys[2 * idxs])
+        Us = jax.vmap(lambda k, s=(c, d_out): jax.random.normal(k, s))(keys[2 * idxs + 1])
+        stacked[(d_in, d_out, c)] = (Vs * d_in**-0.5, Us * c**-0.5)
+    return stacked
+
+
+def unstack_decomp_vu(
+    sites: tuple[SiteSpec, ...], stacked: dict[VUShape, tuple[Array, Array]]
+) -> DecompVU:
+    """Slice `init_decomp_vu_stacked`'s per-shape stacks back into the per-site DecompVU."""
+    vu: dict[str, tuple[Array, Array]] = {}
+    for shape, specs in vu_shape_groups(sites).items():
+        Vs, Us = stacked[shape]
+        assert Vs.shape[0] == len(specs), (Vs.shape, len(specs))
+        for j, spec in enumerate(specs):
+            vu[spec.name] = (Vs[j], Us[j])
+    return DecompVU(vu={spec.name: vu[spec.name] for spec in sites})
+
+
 def site_out(
     x: Array,
     V: Array,

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -630,6 +630,10 @@ class ProfileConfig(BaseConfig):
     async_test: bool = False
     leaf_bench: bool = False
     no_checkpoint: bool = False
+    hlo_dump: bool = False
+    """Dump the step modules' optimized HLO + buffer assignment to `<run_dir>/hlo` on rank 0
+    (the buffer-assignment dump is how an exec-time OOM's blowing buffer gets named). Costs
+    compile time + ~100s of MB per run, so opt-in."""
 
 
 class LaunchEnv(BaseConfig):

--- a/param_decomp/configs/compile_probe/gen_probe_config.py
+++ b/param_decomp/configs/compile_probe/gen_probe_config.py
@@ -1,179 +1,92 @@
 """Generate a small full-model-faithful compile-probe config.
 
-Derived from llama8b_full32L_seq512_b128_dp128.yaml: SAME per-kind C structure
-(q/k 2048, v/o 4096, gate/up 8192, down 10240) so the masked forward takes the
-uniform-per-kind `lax.scan` path (the production compile path), SAME chunkwise-recon +
-persistent-PGD + faith + imp-min machinery, SAME CI-fn arch (4-block transformer). The
-only knobs scaled down are layer count (decompose the LAST `n_layers`, so the live
-decomposed span the scan walks is exactly `n_layers` long), batch, seq, and the
-warmup/step counts so we reach the real recon step fast for timing.
+DERIVED from the production 32L config (llama8b_full32L_seq512_b128_dp64.yaml) rather
+than hand-mirroring the schema — so it stays valid as the schema moves. Keeps the
+production algorithm (chunkwise-recon + persistent-PGD + faith + imp-min), CI-fn arch,
+per-kind C structure, and tp; scales down to the LAST `n_layers` (the live decomposed
+span the scan walks), one recon chunk, 10 steps, 2 faith-warmup steps, eval never fires.
 
-Usage: python gen_probe_config.py <n_layers> <dp> <out.yaml>
+Per-arm isolation: `PARAM_DECOMP_OUT_DIR` in the rank env points the run dir AND both
+persistent caches (xla_compilation_cache / xla_autotune_cache, siblings of runs/) at
+`compile_probe_scratch/<arm>`, so arms never share a cache. `JAX_LOG_COMPILES=1` prints
+per-jit compile durations into the slurm log.
+
+Usage:
+    python gen_probe_config.py <n_layers> <dp> <arm_name> <out.yaml> [k=v ...]
+
+Trailing `k=v` pairs are extra `runtime.compiler_options` (e.g.
+`xla_gpu_autotune_level=0`); specifying any restates the full default set (a yaml
+`compiler_options` block REPLACES the default dict).
 """
 
 import sys
+from pathlib import Path
 
 import yaml
 
-PER_KIND_C = {
-    "self_attn.q_proj": 2048,
-    "self_attn.k_proj": 2048,
-    "self_attn.v_proj": 4096,
-    "self_attn.o_proj": 4096,
-    "mlp.gate_proj": 8192,
-    "mlp.up_proj": 8192,
-    "mlp.down_proj": 10240,
-}
+BASE_CONFIG = Path(__file__).parent.parent / "llama8b_full32L_seq512_b128_dp64.yaml"
+SCRATCH = "/mnt/data/artifacts/mechanisms/param-decomp/compile_probe_scratch"
 N_TOTAL_LAYERS = 32
 
+# mirror of RuntimeConfig.compiler_options defaults, restated because a yaml
+# compiler_options block replaces the whole default dict
+DEFAULT_COMPILER_OPTIONS = {
+    "xla_gpu_enable_latency_hiding_scheduler": True,
+    "xla_gpu_enable_triton_gemm": False,
+    "xla_gpu_enable_command_buffer": "",
+    "xla_gpu_enable_highest_priority_async_stream": True,
+    "xla_gpu_all_reduce_combine_threshold_bytes": 1073741824,
+    "xla_gpu_all_gather_combine_threshold_bytes": 1073741824,
+    "xla_gpu_reduce_scatter_combine_threshold_bytes": 134217728,
+    "xla_gpu_enable_pipelined_all_gather": True,
+    "xla_gpu_enable_pipelined_reduce_scatter": True,
+    "xla_gpu_enable_pipelined_all_reduce": True,
+    "xla_gpu_enable_while_loop_double_buffering": True,
+    "xla_gpu_enable_all_gather_combine_by_dim": False,
+    "xla_gpu_enable_reduce_scatter_combine_by_dim": False,
+}
 
-def main(n_layers: int, dp: int, out_path: str, seq: int = 256, batch: int | None = None) -> None:
-    if batch is None:
-        batch = dp  # per-rank 1
-    first = N_TOTAL_LAYERS - n_layers
-    targets = []
-    for layer in range(first, N_TOTAL_LAYERS):
-        for mod, c in PER_KIND_C.items():
-            targets.append({"C": c, "module_pattern": f"model.layers.{layer}.{mod}"})
-    sites_per_chunk = len(targets)  # one chunk: minimise compile, still the chunkwise path
 
-    cfg = {
-        "run_name": f"compileprobe-{n_layers}L-dp{dp}-seq{seq}",
-        "cadence": {"keep_last_n_checkpoints": 1, "save_every": 100000, "train_log_every": 1},
-        "data": {
-            "buffer_size": 1000,
-            "column_name": "input_ids",
-            "data_files": "/mnt/data/artifacts/mechanisms/param-decomp/datasets/fineweb_llama_tok_512/*.parquet",
-            "dataset_name": "parquet",
-            "eval_split": "train",
-            "is_tokenized": True,
-            "max_seq_len": seq,
-            "revision": None,
-            "shuffle_each_epoch": True,
-            "streaming": False,
-            "tokenizer_name": "meta-llama/Llama-3.1-8B",
-            "train_split": "train",
-        },
-        # eval disabled-ish: large `every` so no eval compile interferes with timing
-        "eval": {
-            "batch_size": batch,
-            "every": 100000,
-            "metrics": [
-                {"ci_alive_threshold": 0.0, "groups": None, "type": "CI_L0"},
-                {"rounding_threshold": 0.0, "type": "CEandKLLosses"},
-            ],
-            "n_steps": 1,
-            "slow_every": 1000000,
-            "slow_on_first_step": False,
-        },
-        "pd": {
-            "batch_size": batch,
-            "ci_config": {
-                "fn_type": "global_shared_transformer",
-                "hidden_dims": None,
-                "mode": "global",
-                "simple_transformer_ci_cfg": {
-                    "attn_config": {"max_len": seq, "n_heads": 64, "rope_base": 10000.0},
-                    "d_model": 4096,
-                    "mlp_hidden_dim": [16384],
-                    "n_blocks": 4,
-                },
-            },
-            "ci_fn_optimizer": {
-                "betas": [0.9, 0.999],
-                "grad_clip_norm": None,
-                "lr_schedule": {
-                    "final_val_frac": 0.1,
-                    "fn_type": "cosine",
-                    "start_val": 2.0e-05,
-                    "warmup_pct": 0.0,
-                },
-                "weight_decay": 0.0,
-            },
-            "components_optimizer": {
-                "betas": [0.9, 0.999],
-                "grad_clip_norm": 0.01,
-                "lr_schedule": {
-                    "final_val_frac": 0.1,
-                    "fn_type": "cosine",
-                    "start_val": 2.0e-05,
-                    "warmup_pct": 0.0,
-                },
-                "weight_decay": 0.0,
-            },
-            "decomposition_targets": targets,
-            "faithfulness_warmup_lr": 0.001,
-            "faithfulness_warmup_steps": 2,
-            "faithfulness_warmup_weight_decay": 0.0,
-            "identity_decomposition_targets": None,
-            "loss_metrics": [
-                {
-                    "beta": 0.2,
-                    "coeff": 5.0e-06,
-                    "eps": 1.0e-06,
-                    "p_anneal_end_frac": 1.0,
-                    "p_anneal_final_p": 0.4,
-                    "p_anneal_start_frac": 0.0,
-                    "pnorm": 2.0,
-                    "type": "ImportanceMinimalityLoss",
-                },
-                {
-                    "coeff": 2.0,
-                    "n_samples": 1,
-                    "routing": {"type": "uniform_k_subset"},
-                    "sites_per_chunk": sites_per_chunk,
-                    "type": "ChunkwiseSubsetReconLoss",
-                },
-                {
-                    "coeff": 0.5,
-                    "n_warmup_steps": 2,
-                    "optimizer": {
-                        "beta1": 0.01,
-                        "beta2": 0.99,
-                        "eps": 1.0e-08,
-                        "lr_schedule": {
-                            "final_val_frac": 1.0,
-                            "fn_type": "constant",
-                            "start_val": 0.01,
-                            "warmup_pct": 0.025,
-                        },
-                        "type": "adam",
-                    },
-                    "scope": {"type": "per_batch_per_position"},
-                    "type": "PersistentPGDReconLoss",
-                },
-                {"coeff": 1000000.0, "type": "FaithfulnessLoss"},
-            ],
-            "n_mask_samples": 1,
-            "sampling": "continuous",
-            "seed": 0,
-            "steps": 10,
-        },
-        "runtime": {
-            "autocast_bf16": True,
-            "device": "cuda:0",
-            "dp": dp,
-            "remat_recon_forwards": True,
-        },
-        "target": {
-            "weights_dtype": "bfloat16",
-            "spec": {
-                "kind": "hf",
-                "model_class": "transformers.LlamaForCausalLM",
-                "model_name": "meta-llama/Llama-3.1-8B",
-            },
-        },
+def main(n_layers: int, dp: int, arm: str, out_path: str, extra_opts: dict[str, object]) -> None:
+    cfg = yaml.safe_load(BASE_CONFIG.read_text())
+    cfg["run_name"] = f"compileprobe-{arm}"
+    cfg.pop("wandb", None)
+
+    keep_layers = {str(i) for i in range(N_TOTAL_LAYERS - n_layers, N_TOTAL_LAYERS)}
+    targets = [
+        t
+        for t in cfg["pd"]["decomposition_targets"]
+        if t["module_pattern"].split(".")[2] in keep_layers
+    ]
+    assert len(targets) == 7 * n_layers, len(targets)
+    cfg["pd"]["decomposition_targets"] = targets
+    cfg["pd"]["steps"] = 10
+    cfg["pd"]["batch_size"] = dp
+    cfg["pd"]["faithfulness_warmup_steps"] = 2
+    for lm in cfg["pd"]["loss_metrics"]:
+        if lm["type"] == "ChunkwiseSubsetReconLoss":
+            lm["sites_per_chunk"] = 7 * n_layers
+
+    cfg["cadence"] = {"keep_last_n_checkpoints": 1, "save_every": 100000, "train_log_every": 1}
+    cfg["eval"]["batch_size"] = dp
+    cfg["eval"]["every"] = 100000
+    cfg["eval"]["slow_every"] = 1000000
+    cfg["eval"]["slow_on_first_step"] = False
+
+    cfg["runtime"]["dp"] = dp
+    if extra_opts:
+        cfg["runtime"]["compiler_options"] = DEFAULT_COMPILER_OPTIONS | extra_opts
+    cfg["runtime"]["launch_env"] = {
+        "env": {"JAX_LOG_COMPILES": "1", "PARAM_DECOMP_OUT_DIR": f"{SCRATCH}/{arm}"}
     }
-    with open(out_path, "w") as f:
-        yaml.safe_dump(cfg, f, sort_keys=False)
-    print(
-        f"wrote {out_path}: {n_layers}L (layers {first}..31), {len(targets)} sites, dp={dp}, batch={batch}, seq={seq}"
-    )
+
+    Path(out_path).write_text(yaml.safe_dump(cfg, sort_keys=False))
+    print(f"wrote {out_path}: arm={arm} {len(targets)} sites dp={dp} extra={extra_opts}")
 
 
 if __name__ == "__main__":
-    n_layers = int(sys.argv[1])
-    dp = int(sys.argv[2])
-    out_path = sys.argv[3]
-    seq = int(sys.argv[4]) if len(sys.argv) > 4 else 256
-    main(n_layers, dp, out_path, seq=seq)
+    extra = {}
+    for kv in sys.argv[5:]:
+        k, v = kv.split("=", 1)
+        extra[k] = int(v) if v.isdigit() else v
+    main(int(sys.argv[1]), int(sys.argv[2]), sys.argv[3], sys.argv[4], extra)

--- a/param_decomp/targets/llama8b_sharding.py
+++ b/param_decomp/targets/llama8b_sharding.py
@@ -51,7 +51,14 @@ from jaxtyping import Array, PRNGKeyArray
 
 from param_decomp.adversary import init_persistent_sources
 from param_decomp.ci_fn import CIFn, CIFnArch, build_ci_fn
-from param_decomp.components import DecompVU, SiteSpec, init_decomp_vu
+from param_decomp.components import (
+    DecompVU,
+    SiteSpec,
+    init_decomp_vu,
+    init_decomp_vu_stacked,
+    unstack_decomp_vu,
+    vu_shape_groups,
+)
 from param_decomp.configs import BSCScope, SCScope
 from param_decomp.sharding import hsdp_mesh, place_via_shardings
 from param_decomp.sharding import shard_batch as _generic_shard_batch
@@ -74,11 +81,27 @@ def place_target(tgt: LlamaDecomposedModel, mesh: Mesh) -> LlamaDecomposedModel:
 
 
 def init_decomp_vu_placed(sites: tuple[SiteSpec, ...], key: PRNGKeyArray, mesh: Mesh) -> DecompVU:
-    """Seeded per-site V/U init placed by `DecompVU.shardings` (pure HSDP: V d_in / U d_out
-    FSDP on `fsdp`, C replicated). Shardings computed on the abstract model, init under jit."""
-    init = partial(init_decomp_vu, sites)
-    out_shardings = eqx.filter_eval_shape(init, key).shardings(mesh)
-    return jax.jit(init, out_shardings=out_shardings)(key)
+    """Seeded per-site V/U init placed by `DecompVU.shardings`, bit-identical to
+    `init_decomp_vu` (pinned by `test_sharding`) but compiled in two cheap stages: the RNG
+    runs vmap-STACKED per V/U shape (2×n_shapes sharded outputs instead of 2×n_sites — the
+    SPMD/layout pass over a 448-output RNG graph was a multi-minute compile at 32L), then a
+    trivial slice jit fans the stacks out to the per-site layout. The stack axis is
+    unsharded (each trailing spec is the per-site spec behind a leading None); the stacked
+    input is donated so the transient stacked copy frees as the slices materialize."""
+    per_site_shardings = eqx.filter_eval_shape(partial(init_decomp_vu, sites), key).shardings(mesh)
+    stacked_shardings = {
+        shape: tuple(
+            NamedSharding(mesh, P(None, *per_site_shardings.vu[specs[0].name][i].spec))
+            for i in range(2)
+        )
+        for shape, specs in vu_shape_groups(sites).items()
+    }
+    stacked = jax.jit(partial(init_decomp_vu_stacked, sites), out_shardings=stacked_shardings)(key)
+    return jax.jit(
+        partial(unstack_decomp_vu, sites),
+        out_shardings=per_site_shardings,
+        donate_argnums=0,
+    )(stacked)
 
 
 def init_ci_fn_placed(

--- a/param_decomp/tests/test_sharding.py
+++ b/param_decomp/tests/test_sharding.py
@@ -101,8 +101,26 @@ def test_jitted_sharded_inits_match_eager_values():
         assert isinstance(V.sharding, NamedSharding) and isinstance(U.sharding, NamedSharding)
         assert V.sharding.spec == P(full, "tp"), (spec.name, V.sharding.spec)
         assert U.sharding.spec == P("tp", full), (spec.name, U.sharding.spec)
-    for got, want in zip(jax.tree.leaves(vu_placed), jax.tree.leaves(vu_eager), strict=True):
+    # The placed init runs vmap-stacked per shape group (compile-time optimization) and
+    # must be BIT-identical to the jitted per-site `init_decomp_vu` it replaced (vmap over
+    # the same per-site keys) — the trajectory anchor. The unjitted eager reference differs
+    # from EITHER jitted path by ~1 ULP (XLA fusion), so it only gets allclose.
+    from functools import partial
+
+    import equinox as eqx
+
+    per_site_shardings = eqx.filter_eval_shape(
+        partial(init_decomp_vu, sites), jax.random.PRNGKey(1)
+    ).shardings(mesh)
+    vu_jitted_per_site = jax.jit(partial(init_decomp_vu, sites), out_shardings=per_site_shardings)(
+        jax.random.PRNGKey(1)
+    )
+    for got, want in zip(
+        jax.tree.leaves(vu_placed), jax.tree.leaves(vu_jitted_per_site), strict=True
+    ):
         assert got.shape == want.shape and got.dtype == want.dtype
+        assert jnp.array_equal(jnp.asarray(got), jnp.asarray(want))
+    for got, want in zip(jax.tree.leaves(vu_placed), jax.tree.leaves(vu_eager), strict=True):
         assert jnp.allclose(jnp.asarray(got), want, rtol=1e-6, atol=0)
 
     # A declared ÷N shard dim that does NOT tile the device count is a loud crash inside

--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -96,6 +96,27 @@ def _enable_persistent_compilation_cache(out_dir: Path) -> Path:
     return cache_dir
 
 
+def _enable_persistent_autotune_cache(
+    out_dir: Path, compiler_options: dict[str, bool | int | str]
+) -> Path:
+    """Persist XLA's per-fusion GEMM-autotuning results to a shared-FS dir reused across
+    runs (sibling of the compilation cache). The executable cache above only hits on an
+    IDENTICAL module; any structural config change is a full recompile, but the matmul
+    shapes are usually unchanged — this cache lets that recompile skip re-benchmarking every
+    GEMM. Injected via `setdefault` so an explicit `runtime.compiler_options` in the config
+    wins; the same flags on every rank keep the compile-cache key rank-uniform (a per-rank
+    flag would fork the key and break the requeue fast path for rank != 0). All ranks write
+    (XLA's per-fusion files land via temp+rename, so concurrent writers are safe); the dir
+    path is deployment-constant, so it costs no compile-cache misses."""
+    autotune_dir = out_dir.parent / "xla_autotune_cache"
+    autotune_dir.mkdir(parents=True, exist_ok=True)
+    compiler_options.setdefault("xla_gpu_per_fusion_autotune_cache_dir", str(autotune_dir))
+    compiler_options.setdefault(
+        "xla_gpu_experimental_autotune_cache_mode", "AUTOTUNE_CACHE_MODE_UPDATE"
+    )
+    return autotune_dir
+
+
 def _enable_hlo_dump(run_dir: Path) -> None:
     """Dump the step modules' optimized HLO + buffer assignment to `<run_dir>/hlo` (rank 0).
 
@@ -385,7 +406,8 @@ def main(config: Path, run_id: str) -> None:
     built, _raw_cfg = load_config(config, run_id)
 
     install_sigterm_flag()
-    _enable_hlo_dump(built.run.run_dir)
+    if built.runtime.launch_env.profile.hlo_dump:
+        _enable_hlo_dump(built.run.run_dir)
     init_distributed(built.runtime.dp)
     # Harden the cold-cache HF weight load against the 8N-rank startup burst before any
     # per-rank Hub call (no-op when huggingface_hub is absent / cache is pre-warmed).
@@ -396,6 +418,9 @@ def main(config: Path, run_id: str) -> None:
         assert_finetune_structural_compat(built, built.run.resume_provenance)
 
     cache_dir = _enable_persistent_compilation_cache(built.run.out_dir)
+    autotune_dir = _enable_persistent_autotune_cache(
+        built.run.out_dir, built.runtime.compiler_options
+    )
 
     is_main = jax.process_index() == 0
     if is_main:
@@ -404,6 +429,7 @@ def main(config: Path, run_id: str) -> None:
         setup_logger(built.run.run_dir / "logs.log")
         _pin_config_copy(built.run.run_dir, LAUNCH_CONFIG_FILENAME, config)
         print(f"persistent XLA compilation cache: {cache_dir}", flush=True)
+        print(f"persistent XLA autotune cache: {autotune_dir}", flush=True)
         site_kind_counts: dict[str, int] = {}
         for s in built.target.sites:
             kind = s.name.rsplit(".", 1)[-1]

--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -88,33 +88,20 @@ def _enable_persistent_compilation_cache(out_dir: Path) -> Path:
     ranks point at the same shared-FS path. Only process 0 writes (jax gates the write on
     `process_id == 0` to avoid shared-FS write contention); every rank reads. Must run
     after `init_distributed` (the rank gate reads the distributed state) and before the
-    first compile."""
+    first compile.
+
+    Enabling this also auto-enables XLA's per-fusion autotune cache (jax default
+    `jax_persistent_cache_enable_xla_caches`), written under
+    `<cache_dir>/xla_gpu_per_fusion_autotune_cache_dir/` with UPDATE on rank 0 / READ
+    elsewhere — so a structural config change reuses GEMM autotuning even on a full
+    executable-cache miss. Measured 2026-07-03 (compile-probe arms A–D): with triton_gemm
+    off, autotuning is a negligible slice of the step compile anyway
+    (`xla_gpu_autotune_level` 0/2/4 all ~71s at the 8L probe)."""
     cache_dir = out_dir.parent / "xla_compilation_cache"
     jax.config.update("jax_compilation_cache_dir", str(cache_dir))
     jax.config.update("jax_persistent_cache_min_compile_time_secs", 60.0)
     jax.config.update("jax_persistent_cache_min_entry_size_bytes", 0)
     return cache_dir
-
-
-def _enable_persistent_autotune_cache(
-    out_dir: Path, compiler_options: dict[str, bool | int | str]
-) -> Path:
-    """Persist XLA's per-fusion GEMM-autotuning results to a shared-FS dir reused across
-    runs (sibling of the compilation cache). The executable cache above only hits on an
-    IDENTICAL module; any structural config change is a full recompile, but the matmul
-    shapes are usually unchanged — this cache lets that recompile skip re-benchmarking every
-    GEMM. Injected via `setdefault` so an explicit `runtime.compiler_options` in the config
-    wins; the same flags on every rank keep the compile-cache key rank-uniform (a per-rank
-    flag would fork the key and break the requeue fast path for rank != 0). All ranks write
-    (XLA's per-fusion files land via temp+rename, so concurrent writers are safe); the dir
-    path is deployment-constant, so it costs no compile-cache misses."""
-    autotune_dir = out_dir.parent / "xla_autotune_cache"
-    autotune_dir.mkdir(parents=True, exist_ok=True)
-    compiler_options.setdefault("xla_gpu_per_fusion_autotune_cache_dir", str(autotune_dir))
-    compiler_options.setdefault(
-        "xla_gpu_experimental_autotune_cache_mode", "AUTOTUNE_CACHE_MODE_UPDATE"
-    )
-    return autotune_dir
 
 
 def _enable_hlo_dump(run_dir: Path) -> None:
@@ -418,9 +405,6 @@ def main(config: Path, run_id: str) -> None:
         assert_finetune_structural_compat(built, built.run.resume_provenance)
 
     cache_dir = _enable_persistent_compilation_cache(built.run.out_dir)
-    autotune_dir = _enable_persistent_autotune_cache(
-        built.run.out_dir, built.runtime.compiler_options
-    )
 
     is_main = jax.process_index() == 0
     if is_main:
@@ -429,7 +413,6 @@ def main(config: Path, run_id: str) -> None:
         setup_logger(built.run.run_dir / "logs.log")
         _pin_config_copy(built.run.run_dir, LAUNCH_CONFIG_FILENAME, config)
         print(f"persistent XLA compilation cache: {cache_dir}", flush=True)
-        print(f"persistent XLA autotune cache: {autotune_dir}", flush=True)
         site_kind_counts: dict[str, int] = {}
         for s in built.target.sites:
             kind = s.name.rsplit(".", 1)[-1]

--- a/param_decomp_lab/infra/slurm.py
+++ b/param_decomp_lab/infra/slurm.py
@@ -9,6 +9,7 @@ It handles:
 - Job submission with script renaming and log file creation
 """
 
+import os
 import subprocess
 import tempfile
 from dataclasses import dataclass
@@ -348,10 +349,18 @@ def _case_block(commands: list[str]) -> str:
 def _submit_script(script_path: Path) -> str:
     """Submit script via sbatch and return job ID.
 
+    Submitting from INSIDE a SLURM allocation (agent sessions, dev pods) leaks the
+    caller's `SLURM_*` env into the new job — sbatch propagates it, and a mismatched
+    inherited `SLURM_CPUS_PER_TASK` makes the job's srun die instantly with
+    "cpus-per-task set by two different environment variables". Scrub `SLURM_*` (and
+    `SBATCH_*`) from the submission env so the new job's env comes only from its own
+    allocation.
+
     Raises RuntimeError if sbatch fails.
     """
+    clean_env = {k: v for k, v in os.environ.items() if not k.startswith(("SLURM_", "SBATCH_"))}
     result = subprocess.run(
-        ["sbatch", str(script_path)], capture_output=True, text=True, check=False
+        ["sbatch", str(script_path)], capture_output=True, text=True, check=False, env=clean_env
     )
     if result.returncode != 0:
         raise RuntimeError(f"Failed to submit SLURM job: {result.stderr}")


### PR DESCRIPTION
## Description

Compile-time pass for the full-model runs (bridge task `reduce-jax-compilation-time`). Every new-config launch of the 32L Llama-8B decomposition paid a 3m31s `jit_init_decomp_vu` compile plus ~24 min of `jit_step` compile; this PR kills the first, gates incidental compile costs, and pins down (with measurements) where the second does and does not go.

**Changes:**
- **Stacked V/U init — 210.5s → 16.3s (12.9×) measured on GPU at the full 224-site/32L shape set.** `init_decomp_vu_placed` now compiles two cheap stages: the RNG vmap-STACKED per V/U shape (2×n_shapes sharded jit outputs instead of 2×n_sites — the SPMD pass over a 448-output RNG graph was the multi-minute cost), then a trivial slice jit (stacked input donated) fans out to the per-site ZeRO-1 layout. **Bit-identical to the previous jitted per-site init** (vmap over the same per-site keys); `test_sharding` now pins exact equality against the jitted per-site reference. (Found in passing: the unjitted eager `init_decomp_vu` differs from ANY jitted init by ~1 ULP of XLA fusion — pre-existing, previously hidden by the test's `allclose`.)
- **HLO dump is now opt-in** (`ProfileConfig.hlo_dump`, default off) — it cost compile time + ~100s of MB on every rank-0 run.
- **`sbatch` submissions scrub `SLURM_*`/`SBATCH_*` from the env** — submitting from inside a SLURM allocation (agent sessions, dev pods) leaked `SLURM_CPUS_PER_TASK` into the new job, whose srun died instantly with "cpus-per-task set by two different environment variables" (the leak the btdr wrapper works around by hand).
- **Compile-probe generator regenerated** against the current schema (it had bit-rotted: pre-discriminator `ci_config`, removed `beta`) and now derives from the production 32L yaml with per-arm cache isolation.
- **Docs**: measured findings + smoke-config cache practice in `param_decomp/CLAUDE.md`.

**Measured nulls / negative results (probe arms A–F, 8L 1-node slices of the production config, per-arm isolated caches):**
- `xla_gpu_autotune_level` 0/2/4: jit_step compile flat (71.3/71.8/74.4s vs baseline 71.3s) — with `triton_gemm` off, autotuning is a negligible slice.
- Persistent autotune cache: **already on by default** — jax ≥0.10 auto-enables the XLA per-fusion autotune cache alongside the persistent compilation cache (arm A, baseline code, had 306 entries). A hand-wired duplicate was added and then reverted within this branch; the built-in also gates writes on rank 0 correctly.
- `jax_persistent_cache_enable_xla_caches='all'` (kernel cache + parallel LLVM codegen): **crashes at runtime** on jax 0.10.1/B200 (`CUDA_ERROR_NOT_FOUND: named symbol not found` in jit_step). Documented as do-not-use.

**Not addressed (the remaining ~24 min `jit_step` compile):** it is graph size (the recon plan unrolls n_chunks full-model masked forwards+backwards python-side) × topology, not autotuning. The structural lever is a `lax.scan` over uniform recon chunks — scoped as a follow-up board task, core-trainer change.

## Related Issue

Bridge task `reduce-jax-compilation-time` (see its log for the full probe data).

## Motivation and Context

20–30 min before step 0 on every new full-model config made iteration painful. The persistent executable cache only hits on identical HLO, so every real config change paid full price.

## How Has This Been Tested?

- `make test` (458 passed) + `make type` clean, `test_sharding` at 1 and 4 sim devices.
- Bit-identity of the new init vs the old jitted init pinned by test (exact `array_equal`, sharded + unsharded).
- GPU A/B at full production site count (224 sites, 1 node, tp8): old 210.5s vs new 16.3s.
- Probe arms A–D ran the production compile path end-to-end (10 steps, checkpoints, identical losses/step times across arms: 0.95–0.99 s/step, 119GB peak/rank).

## Does this PR introduce a breaking change?

No. Init values are bit-identical; HLO dump moves behind `runtime.launch_env.profile.hlo_dump: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CLGxUn9wtE3ce9XTbEJo9s