### PR TITLE
feat(adversary): stateless sign-ascent SRC_STEP for persistent-PGD sources (SPEC §6)

### DIFF
--- a/param_decomp/adversary.py
+++ b/param_decomp/adversary.py
@@ -4,10 +4,11 @@ Two semantically distinct adversaries share the source/mask machinery but nothin
 else (SPEC §3):
 
 - **Persistent PGD (PPGD)** — `PersistentPGDReconLossConfig`. Per-site sources + their
-  Adam moments live in `TrainState` across steps; `sc` scope is `(1, T, C+1)` (shared
-  across batch), `bsc` is `(B, T, C+1)` (independent per batch element, batch-sharded).
-  Each step runs `n_warmup_steps` supplemental Adam ascents plus one final ascent from
-  the main backward (SPEC S13/S14), projecting to [0,1] after every update (S15).
+  `SRC_STEP` optimizer state (Adam `m`/`v`; nothing for the stateless `sign` variant)
+  live in `TrainState` across steps; `sc` scope is `(1, T, C+1)` (shared across batch),
+  `bsc` is `(B, T, C+1)` (independent per batch element, batch-sharded). Each step runs
+  `n_warmup_steps` supplemental ascents plus one final ascent from the main backward
+  (SPEC S13/S14), projecting to [0,1] after every update (S15).
 - **Fresh PGD** — `PGDReconLossConfig` (torch `PGDReconLoss` as a TRAINING loss).
   Sources are re-initialized every step, ascended `n_steps` times by
   `step_size * sign(grad)` with clamp to [0,1], and carry NO state across steps —
@@ -25,7 +26,12 @@ from jax.typing import DTypeLike
 from jaxtyping import Array, Float, PRNGKeyArray
 
 from param_decomp.components import SiteSpec
-from param_decomp.configs import AdamPGDConfig, MaskScopeLiteral, PGDInitStrategy
+from param_decomp.configs import (
+    AdamPGDConfig,
+    MaskScopeLiteral,
+    PGDInitStrategy,
+    SignPGDConfig,
+)
 from param_decomp.losses import scheduled_value_traced
 
 
@@ -101,6 +107,34 @@ def init_sources_adam_state(sources: dict[str, Array]) -> SourcesAdamState:
     )
 
 
+def sources_ascend_project(
+    sources: dict[str, Array],
+    sources_grad: dict[str, Array],
+    opt_state: SourcesAdamState | None,
+    lr: Array,
+    optimizer: AdamPGDConfig | SignPGDConfig,
+) -> tuple[dict[str, Array], SourcesAdamState | None]:
+    """One `SRC_STEP` ASCENT on the persistent sources, then project to [0,1]
+    (SPEC S13/S15). The variation point `SRC_STEP` (SPEC §6): `adam` carries persistent
+    `m`/`v` moments (`opt_state`); `sign` is stateless (`opt_state is None`) — same
+    projection contract."""
+    match optimizer:
+        case AdamPGDConfig():
+            assert opt_state is not None
+            return sources_adam_ascend_project(sources, sources_grad, opt_state, lr, optimizer)
+        case SignPGDConfig():
+            assert opt_state is None
+            new_sources = {
+                s: jnp.clip(
+                    sources[s] + (lr * jnp.sign(sources_grad[s])).astype(sources[s].dtype),
+                    0.0,
+                    1.0,
+                )
+                for s in sources
+            }
+            return new_sources, None
+
+
 def sources_adam_ascend_project(
     sources: dict[str, Array],
     sources_grad: dict[str, Array],
@@ -108,10 +142,6 @@ def sources_adam_ascend_project(
     lr: Array,
     adam: AdamPGDConfig,
 ) -> tuple[dict[str, Array], SourcesAdamState]:
-    """One Adam ASCENT on the persistent sources, then project to [0,1] (SPEC S13/S15).
-
-    The variation point `SRC_STEP` (SPEC §6): a `sign` variant would replace the Adam
-    update with `lr * sign(grad)` (stateless) — same projection contract."""
     step_count = adam_state.step_count + 1.0
     # `sources_grad` arrives in the masked-forward compute dtype (bf16); cast to the moment
     # dtype so the persistent `m`/`v` keep their declared storage dtype across steps.
@@ -151,9 +181,11 @@ def source_masks(
 
 
 class PersistentAdversary(eqx.Module):
-    """One persistent-PGD adversary (SPEC §3): the per-site sources + their Adam moments
-    that persist across steps, plus the lifecycle the trainer drives around the shared
-    backward. `sources` / `opt_state` are dynamic state; the rest is static config.
+    """One persistent-PGD adversary (SPEC §3): the per-site sources + their `SRC_STEP`
+    optimizer state that persist across steps, plus the lifecycle the trainer drives
+    around the shared backward. `sources` / `opt_state` are dynamic state (`opt_state`
+    is None iff the optimizer is the stateless `sign` variant); the rest is static
+    config.
 
     Per step: `warmup_ascend` (n_warmup supplemental ascents vs a scoring forward, params
     + CI detached) → the warmed sources enter the main `value_and_grad` as leaves →
@@ -161,14 +193,14 @@ class PersistentAdversary(eqx.Module):
     term's `coeff` — exact since one source bundle feeds exactly one term, SPEC S23)."""
 
     sources: dict[str, Array]  # site -> source in [0,1], `(*scope_leading, C+1)`
-    opt_state: SourcesAdamState
+    opt_state: SourcesAdamState | None
     state_key: str = eqx.field(static=True)
     coeff: float = eqx.field(static=True)
-    adam: AdamPGDConfig = eqx.field(static=True)
+    optimizer: AdamPGDConfig | SignPGDConfig = eqx.field(static=True)
     n_warmup: int = eqx.field(static=True)
 
     def source_lr(self, step_f32: Array, total_steps: int) -> Array:
-        return scheduled_value_traced(step_f32, total_steps, self.adam.lr_schedule)
+        return scheduled_value_traced(step_f32, total_steps, self.optimizer.lr_schedule)
 
     def warmup_ascend(
         self, scoring_loss: Callable[[dict[str, Array]], Array], step_f32: Array, total_steps: int
@@ -180,11 +212,11 @@ class PersistentAdversary(eqx.Module):
         lr = self.source_lr(step_f32, total_steps)
 
         def body(
-            carry: tuple[dict[str, Array], SourcesAdamState], _: None
-        ) -> tuple[tuple[dict[str, Array], SourcesAdamState], None]:
+            carry: tuple[dict[str, Array], SourcesAdamState | None], _: None
+        ) -> tuple[tuple[dict[str, Array], SourcesAdamState | None], None]:
             sources, opt = carry
             grad = jax.grad(scoring_loss)(sources)
-            return sources_adam_ascend_project(sources, grad, opt, lr, self.adam), None
+            return sources_ascend_project(sources, grad, opt, lr, self.optimizer), None
 
         (warmed, warmed_opt), _ = jax.lax.scan(
             body, (self.sources, self.opt_state), None, length=self.n_warmup
@@ -201,7 +233,7 @@ class PersistentAdversary(eqx.Module):
         `L_term` itself (exact: each source bundle feeds exactly one term, SPEC S23)."""
         lr = self.source_lr(step_f32, total_steps)
         grad = {s: g / self.coeff for s, g in source_grad_scaled.items()}
-        ascended, ascended_opt = sources_adam_ascend_project(
-            self.sources, grad, self.opt_state, lr, self.adam
+        ascended, ascended_opt = sources_ascend_project(
+            self.sources, grad, self.opt_state, lr, self.optimizer
         )
         return eqx.tree_at(lambda a: (a.sources, a.opt_state), self, (ascended, ascended_opt))

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -325,13 +325,26 @@ class PGDReconSubsetLossConfig(PGDConfig):
 
 
 class AdamPGDConfig(BaseConfig):
-    """Adam-style PGD optimizer config — the only implemented persistent-PGD optimizer."""
+    """Adam-style persistent-PGD source optimizer (SPEC §6 SRC_STEP `adam`, the ★
+    production choice); keeps fp32 `m`/`v` moments per source (SPEC N1)."""
 
     type: Literal["adam"] = "adam"
     beta1: Probability = Field(default=0.9, description="Adam beta1 for masks")
     beta2: Probability = Field(default=0.999, description="Adam beta2 for masks")
     eps: NonNegativeFloat = Field(default=1e-8, description="Adam epsilon for masks")
     lr_schedule: ScheduleConfig
+
+
+class SignPGDConfig(BaseConfig):
+    """Stateless sign-ascent persistent-PGD source optimizer (SPEC §6 SRC_STEP `sign`):
+    `sources += lr·sign(grad)`, no moments — kills the Adam `m`/`v` resident footprint
+    (source-bundle-sized ×2)."""
+
+    type: Literal["sign"] = "sign"
+    lr_schedule: ScheduleConfig
+
+
+PersistentPGDOptimizerConfig = Annotated[AdamPGDConfig | SignPGDConfig, Field(discriminator="type")]
 
 
 class SCScope(BaseConfig):
@@ -401,7 +414,7 @@ class PersistentPGDReconLossConfig(LossMetricConfig):
         return data
 
     type: Literal["PersistentPGDReconLoss"] = "PersistentPGDReconLoss"
-    optimizer: AdamPGDConfig
+    optimizer: PersistentPGDOptimizerConfig
     scope: PersistentPGDSourceScope
     source_dtype: Literal["float32", "bfloat16"] = "float32"
     """Storage dtype for the persistent PPGD source tensors AND their Adam moments

--- a/param_decomp/configs/pile_ppgd_bsc_srcstep_ab_adam.yaml
+++ b/param_decomp/configs/pile_ppgd_bsc_srcstep_ab_adam.yaml
@@ -1,0 +1,155 @@
+# SRC_STEP sign-ascent Tier-1 quality A/B, adam control (bridge task lp-sign-ascent-source).
+# Derived from pile_ppgd_bsc.yaml (pile-4L PPGD-bsc lineage): steps 400k -> 10k,
+# dp 16 -> 8 (1 node), slow_every 10000 -> 2000 (PGD_20step every 2k steps).
+# Control: SRC_STEP adam(0.5, 0.99), lr const 0.01 w/ 2.5% warmup (production ★).
+# Same seed all arms; judge on adv recon-loss trajectory, PGD_20step eval,
+# faith, CI-L0, masked CE/KL. All arms fp32 source (isolate the update rule).
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 5000
+  train_log_every: 200
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/pile_neox_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: EleutherAI/gpt-neox-20b
+  train_split: train
+eval:
+  batch_size: 128
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups:
+      layer_0:
+      - h.0.*
+      layer_1:
+      - h.1.*
+      layer_2:
+      - h.2.*
+      layer_3:
+      - h.3.*
+      total:
+      - '*'
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: c
+    n_steps: 20
+    name: PGDReconLoss_20step
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 2000
+  slow_on_first_step: true
+pd:
+  batch_size: 64
+  ci_config:
+    blocks_per_chunk: 1
+    d_model: 2048
+    mlp_hidden: 8192
+    n_blocks: 8
+    n_heads: 16
+    type: chunkwise_transformer
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 3072
+    module_pattern: h.*.mlp.c_fc
+  - C: 3584
+    module_pattern: h.*.mlp.down_proj
+  - C: 512
+    module_pattern: h.*.attn.q_proj
+  - C: 512
+    module_pattern: h.*.attn.k_proj
+  - C: 1024
+    module_pattern: h.*.attn.v_proj
+  - C: 1024
+    module_pattern: h.*.attn.o_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 400
+  faithfulness_warmup_weight_decay: 0.0
+  loss_metrics:
+  - coeff: 0.0002
+    eps: 1.0e-12
+    frequency:
+      coeff: 0.0001
+      reference_token_count: 65536
+    pnorm:
+      final_val_frac: 0.2
+      fn_type: linear
+      start_val: 2.0
+    type: ImportanceMinimalityLoss
+  - coeff: 0.5
+    routing:
+      type: uniform_k_subset
+    type: StochasticReconSubsetLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.5
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: bsc
+    type: PersistentPGDReconLoss
+  - coeff: 10000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 10000
+run_name: jax-pile4l-ppgd-bsc-srcstep-ab-adam
+runtime:
+  dp: 8
+  remat_recon_forwards: false
+target:
+  output_extract: 0
+  spec:
+    kind: pretrained
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
+    run_path: goodfire/spd/runs/t-9d2b8f02
+  weights_dtype: bfloat16
+wandb:
+  entity: null
+  project: param-decomp

--- a/param_decomp/configs/pile_ppgd_bsc_srcstep_ab_sign_lr003.yaml
+++ b/param_decomp/configs/pile_ppgd_bsc_srcstep_ab_sign_lr003.yaml
@@ -1,0 +1,152 @@
+# SRC_STEP sign-ascent Tier-1 quality A/B, sign lr=0.003 (bridge task lp-sign-ascent-source).
+# Derived from pile_ppgd_bsc.yaml (pile-4L PPGD-bsc lineage): steps 400k -> 10k,
+# dp 16 -> 8 (1 node), slow_every 10000 -> 2000 (PGD_20step every 2k steps).
+# Treatment: SRC_STEP sign (stateless, no m/v), lr const 0.003 w/ 2.5% warmup.
+# Same seed all arms; judge on adv recon-loss trajectory, PGD_20step eval,
+# faith, CI-L0, masked CE/KL. All arms fp32 source (isolate the update rule).
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 5000
+  train_log_every: 200
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/pile_neox_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: EleutherAI/gpt-neox-20b
+  train_split: train
+eval:
+  batch_size: 128
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups:
+      layer_0:
+      - h.0.*
+      layer_1:
+      - h.1.*
+      layer_2:
+      - h.2.*
+      layer_3:
+      - h.3.*
+      total:
+      - '*'
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: c
+    n_steps: 20
+    name: PGDReconLoss_20step
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 2000
+  slow_on_first_step: true
+pd:
+  batch_size: 64
+  ci_config:
+    blocks_per_chunk: 1
+    d_model: 2048
+    mlp_hidden: 8192
+    n_blocks: 8
+    n_heads: 16
+    type: chunkwise_transformer
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 3072
+    module_pattern: h.*.mlp.c_fc
+  - C: 3584
+    module_pattern: h.*.mlp.down_proj
+  - C: 512
+    module_pattern: h.*.attn.q_proj
+  - C: 512
+    module_pattern: h.*.attn.k_proj
+  - C: 1024
+    module_pattern: h.*.attn.v_proj
+  - C: 1024
+    module_pattern: h.*.attn.o_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 400
+  faithfulness_warmup_weight_decay: 0.0
+  loss_metrics:
+  - coeff: 0.0002
+    eps: 1.0e-12
+    frequency:
+      coeff: 0.0001
+      reference_token_count: 65536
+    pnorm:
+      final_val_frac: 0.2
+      fn_type: linear
+      start_val: 2.0
+    type: ImportanceMinimalityLoss
+  - coeff: 0.5
+    routing:
+      type: uniform_k_subset
+    type: StochasticReconSubsetLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.003
+        warmup_pct: 0.025
+      type: sign
+    scope:
+      type: bsc
+    type: PersistentPGDReconLoss
+  - coeff: 10000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 10000
+run_name: jax-pile4l-ppgd-bsc-srcstep-ab-sign_lr003
+runtime:
+  dp: 8
+  remat_recon_forwards: false
+target:
+  output_extract: 0
+  spec:
+    kind: pretrained
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
+    run_path: goodfire/spd/runs/t-9d2b8f02
+  weights_dtype: bfloat16
+wandb:
+  entity: null
+  project: param-decomp

--- a/param_decomp/configs/pile_ppgd_bsc_srcstep_ab_sign_lr01.yaml
+++ b/param_decomp/configs/pile_ppgd_bsc_srcstep_ab_sign_lr01.yaml
@@ -1,0 +1,152 @@
+# SRC_STEP sign-ascent Tier-1 quality A/B, sign lr=0.01 (bridge task lp-sign-ascent-source).
+# Derived from pile_ppgd_bsc.yaml (pile-4L PPGD-bsc lineage): steps 400k -> 10k,
+# dp 16 -> 8 (1 node), slow_every 10000 -> 2000 (PGD_20step every 2k steps).
+# Treatment: SRC_STEP sign (stateless, no m/v), lr const 0.01 w/ 2.5% warmup.
+# Same seed all arms; judge on adv recon-loss trajectory, PGD_20step eval,
+# faith, CI-L0, masked CE/KL. All arms fp32 source (isolate the update rule).
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 5000
+  train_log_every: 200
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/pile_neox_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: EleutherAI/gpt-neox-20b
+  train_split: train
+eval:
+  batch_size: 128
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups:
+      layer_0:
+      - h.0.*
+      layer_1:
+      - h.1.*
+      layer_2:
+      - h.2.*
+      layer_3:
+      - h.3.*
+      total:
+      - '*'
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: c
+    n_steps: 20
+    name: PGDReconLoss_20step
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 2000
+  slow_on_first_step: true
+pd:
+  batch_size: 64
+  ci_config:
+    blocks_per_chunk: 1
+    d_model: 2048
+    mlp_hidden: 8192
+    n_blocks: 8
+    n_heads: 16
+    type: chunkwise_transformer
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 3072
+    module_pattern: h.*.mlp.c_fc
+  - C: 3584
+    module_pattern: h.*.mlp.down_proj
+  - C: 512
+    module_pattern: h.*.attn.q_proj
+  - C: 512
+    module_pattern: h.*.attn.k_proj
+  - C: 1024
+    module_pattern: h.*.attn.v_proj
+  - C: 1024
+    module_pattern: h.*.attn.o_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 400
+  faithfulness_warmup_weight_decay: 0.0
+  loss_metrics:
+  - coeff: 0.0002
+    eps: 1.0e-12
+    frequency:
+      coeff: 0.0001
+      reference_token_count: 65536
+    pnorm:
+      final_val_frac: 0.2
+      fn_type: linear
+      start_val: 2.0
+    type: ImportanceMinimalityLoss
+  - coeff: 0.5
+    routing:
+      type: uniform_k_subset
+    type: StochasticReconSubsetLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: sign
+    scope:
+      type: bsc
+    type: PersistentPGDReconLoss
+  - coeff: 10000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 10000
+run_name: jax-pile4l-ppgd-bsc-srcstep-ab-sign_lr01
+runtime:
+  dp: 8
+  remat_recon_forwards: false
+target:
+  output_extract: 0
+  spec:
+    kind: pretrained
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
+    run_path: goodfire/spd/runs/t-9d2b8f02
+  weights_dtype: bfloat16
+wandb:
+  entity: null
+  project: param-decomp

--- a/param_decomp/configs/pile_ppgd_bsc_srcstep_ab_sign_lr03.yaml
+++ b/param_decomp/configs/pile_ppgd_bsc_srcstep_ab_sign_lr03.yaml
@@ -1,0 +1,152 @@
+# SRC_STEP sign-ascent Tier-1 quality A/B, sign lr=0.03 (bridge task lp-sign-ascent-source).
+# Derived from pile_ppgd_bsc.yaml (pile-4L PPGD-bsc lineage): steps 400k -> 10k,
+# dp 16 -> 8 (1 node), slow_every 10000 -> 2000 (PGD_20step every 2k steps).
+# Treatment: SRC_STEP sign (stateless, no m/v), lr const 0.03 w/ 2.5% warmup.
+# Same seed all arms; judge on adv recon-loss trajectory, PGD_20step eval,
+# faith, CI-L0, masked CE/KL. All arms fp32 source (isolate the update rule).
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 5000
+  train_log_every: 200
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/pile_neox_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: EleutherAI/gpt-neox-20b
+  train_split: train
+eval:
+  batch_size: 128
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups:
+      layer_0:
+      - h.0.*
+      layer_1:
+      - h.1.*
+      layer_2:
+      - h.2.*
+      layer_3:
+      - h.3.*
+      total:
+      - '*'
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: c
+    n_steps: 20
+    name: PGDReconLoss_20step
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 2000
+  slow_on_first_step: true
+pd:
+  batch_size: 64
+  ci_config:
+    blocks_per_chunk: 1
+    d_model: 2048
+    mlp_hidden: 8192
+    n_blocks: 8
+    n_heads: 16
+    type: chunkwise_transformer
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 3072
+    module_pattern: h.*.mlp.c_fc
+  - C: 3584
+    module_pattern: h.*.mlp.down_proj
+  - C: 512
+    module_pattern: h.*.attn.q_proj
+  - C: 512
+    module_pattern: h.*.attn.k_proj
+  - C: 1024
+    module_pattern: h.*.attn.v_proj
+  - C: 1024
+    module_pattern: h.*.attn.o_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 400
+  faithfulness_warmup_weight_decay: 0.0
+  loss_metrics:
+  - coeff: 0.0002
+    eps: 1.0e-12
+    frequency:
+      coeff: 0.0001
+      reference_token_count: 65536
+    pnorm:
+      final_val_frac: 0.2
+      fn_type: linear
+      start_val: 2.0
+    type: ImportanceMinimalityLoss
+  - coeff: 0.5
+    routing:
+      type: uniform_k_subset
+    type: StochasticReconSubsetLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.03
+        warmup_pct: 0.025
+      type: sign
+    scope:
+      type: bsc
+    type: PersistentPGDReconLoss
+  - coeff: 10000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 10000
+run_name: jax-pile4l-ppgd-bsc-srcstep-ab-sign_lr03
+runtime:
+  dp: 8
+  remat_recon_forwards: false
+target:
+  output_extract: 0
+  spec:
+    kind: pretrained
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
+    run_path: goodfire/spd/runs/t-9d2b8f02
+  weights_dtype: bfloat16
+wandb:
+  entity: null
+  project: param-decomp

--- a/param_decomp/experiments/invariance_check.py
+++ b/param_decomp/experiments/invariance_check.py
@@ -103,7 +103,7 @@ def _run(steps: int, sharded: bool) -> list[dict[str, float]]:
                 opt_state=init_sources_adam_state(src),
                 state_key=ppgd_cfg.type,
                 coeff=ppgd_cfg.coeff,
-                adam=ppgd_cfg.optimizer,
+                optimizer=ppgd_cfg.optimizer,
                 n_warmup=ppgd_cfg.n_warmup_steps,
             )
         },

--- a/param_decomp/run_state.py
+++ b/param_decomp/run_state.py
@@ -134,7 +134,6 @@ def init_train_state(
         )
         for term_idx, state_key in enumerate(persistent):
             cfg = persistent[state_key]
-            assert isinstance(cfg.optimizer, AdamPGDConfig)
             sources = init_sources_sharded(
                 lm.site_names,
                 tuple(s.C for s in lm.sites),
@@ -147,10 +146,12 @@ def init_train_state(
             )
             adversaries[state_key] = PersistentAdversary(
                 sources=sources,
-                opt_state=init_sources_adam_state(sources),
+                opt_state=init_sources_adam_state(sources)
+                if isinstance(cfg.optimizer, AdamPGDConfig)
+                else None,
                 state_key=state_key,
                 coeff=term_coeff_by_state_key[state_key],
-                adam=cfg.optimizer,
+                optimizer=cfg.optimizer,
                 n_warmup=cfg.n_warmup_steps,
             )
     return TrainState(

--- a/param_decomp/tests/stacked_parity/test_stacked_parity.py
+++ b/param_decomp/tests/stacked_parity/test_stacked_parity.py
@@ -257,7 +257,7 @@ def test_train_trajectory_matches():
                 opt_state=init_sources_adam_state(sources),
                 state_key=ppgd_cfg.type,
                 coeff=ppgd_cfg.coeff,
-                adam=ppgd_cfg.optimizer,
+                optimizer=ppgd_cfg.optimizer,
                 n_warmup=ppgd_cfg.n_warmup_steps,
             )
         },

--- a/param_decomp/tests/test_checkpoint.py
+++ b/param_decomp/tests/test_checkpoint.py
@@ -74,7 +74,7 @@ def _adversary(src: dict[str, jax.Array], cfg: PersistentPGDReconLossConfig) -> 
         opt_state=init_sources_adam_state(src),
         state_key=cfg.type,
         coeff=cfg.coeff,
-        adam=cfg.optimizer,
+        optimizer=cfg.optimizer,
         n_warmup=cfg.n_warmup_steps,
     )
 
@@ -179,6 +179,7 @@ def test_persistent_adam_step_count_roundtrip_and_post_resume_bias_correction(tm
         state, _ = step(lm, state, resid, jax.random.PRNGKey(i))
 
     pre_save = state.adversaries[state_key].opt_state
+    assert pre_save is not None
     n_ascents = int(pre_save.step_count)
     # Each train step runs n_warmup_steps (1) supplemental ascents + 1 final ascent.
     assert n_ascents == 3 * (1 + 1)
@@ -191,6 +192,7 @@ def test_persistent_adam_step_count_roundtrip_and_post_resume_bias_correction(tm
     assert restored is not None
     loaded, _ = restored
     loaded_adam = loaded.adversaries[state_key].opt_state
+    assert loaded_adam is not None
 
     # (a) the step_count leaf survived the round-trip: present, fp32 scalar, value N.
     assert state_key in loaded.adversaries

--- a/param_decomp/tests/test_checkpoint_production_topology.py
+++ b/param_decomp/tests/test_checkpoint_production_topology.py
@@ -130,7 +130,7 @@ def _build_sharded(seed: int):
             opt_state=init_sources_adam_state(src),
             state_key=state_key,
             coeff=ppgd_cfg.coeff,
-            adam=ppgd_cfg.optimizer,
+            optimizer=ppgd_cfg.optimizer,
             n_warmup=ppgd_cfg.n_warmup_steps,
         )
     state = TrainState(

--- a/param_decomp/tests/test_llama8b.py
+++ b/param_decomp/tests/test_llama8b.py
@@ -366,7 +366,7 @@ def test_step_trains_and_has_vpd_signature(site_cs: tuple[SiteC, ...]):
                 opt_state=init_sources_adam_state(src),
                 state_key=ppgd_cfg.type,
                 coeff=ppgd_cfg.coeff,
-                adam=ppgd_cfg.optimizer,
+                optimizer=ppgd_cfg.optimizer,
                 n_warmup=ppgd_cfg.n_warmup_steps,
             )
         },
@@ -408,6 +408,7 @@ def test_step_trains_and_has_vpd_signature(site_cs: tuple[SiteC, ...]):
     assert int(state.step) == n_steps
     # SPEC S13: n_warmup + 1 source-Adam updates per training step, moments persist.
     ppgd_adv = state.adversaries["PersistentPGDReconLoss"]
+    assert ppgd_adv.opt_state is not None
     assert float(ppgd_adv.opt_state.step_count) == n_steps * (n_warmup + 1)
     # SPEC S15: sources stay projected to [0,1].
     for v in ppgd_adv.sources.values():

--- a/param_decomp/tests/test_llama_simple_mlp.py
+++ b/param_decomp/tests/test_llama_simple_mlp.py
@@ -32,6 +32,7 @@ from param_decomp.configs import (
     ImportanceMinimalityLossConfig,
     PersistentPGDReconLossConfig,
     SCScope,
+    SignPGDConfig,
     UniformKSubsetRoutingConfig,
 )
 from param_decomp.lm import DecomposedModel
@@ -384,7 +385,7 @@ def test_step_trains_and_has_vpd_signature():
                 opt_state=init_sources_adam_state(src),
                 state_key=ppgd_cfg.type,
                 coeff=ppgd_cfg.coeff,
-                adam=ppgd_cfg.optimizer,
+                optimizer=ppgd_cfg.optimizer,
                 n_warmup=ppgd_cfg.n_warmup_steps,
             )
         },
@@ -426,6 +427,7 @@ def test_step_trains_and_has_vpd_signature():
     assert int(state.step) == n_steps
     # SPEC S13: n_warmup + 1 source-Adam updates per training step, moments persist.
     ppgd_adv = state.adversaries["PersistentPGDReconLoss"]
+    assert ppgd_adv.opt_state is not None
     assert float(ppgd_adv.opt_state.step_count) == n_steps * (n_warmup + 1)
     # SPEC S15: sources stay projected to [0,1].
     for v in ppgd_adv.sources.values():
@@ -438,6 +440,85 @@ def test_step_trains_and_has_vpd_signature():
         assert V.dtype == jnp.float32 and U.dtype == jnp.float32
     assert isinstance(state.ci_fn, ChunkwiseTransformerCIFn)
     assert state.ci_fn.chunks.in_proj_w.dtype == jnp.float32
+
+
+def test_step_trains_with_sign_src_step():
+    """SRC_STEP `sign` (SPEC §6) through the full jitted step: stateless (`opt_state`
+    stays None — no moment buffers exist), sources move and stay projected (S15)."""
+    cfg = _tiny_cfg()
+    seq = 16
+    n_warmup = 2
+    sites = site_specs(cfg, _MIXED_SITE_CS)
+    lm = _tiny_decomposed_model(cfg, sites, jax.random.PRNGKey(0))
+    vu = init_decomp_vu(sites, jax.random.PRNGKey(1))
+    ci_fn = _build_chunkwise_ci_fn(lm, jax.random.PRNGKey(2))
+    opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
+    opt_ci = optax.adamw(1e-3, weight_decay=0.0)
+
+    src = init_persistent_sources(
+        lm.site_names, tuple(s.C for s in lm.sites), (1, seq), jnp.float32, jax.random.PRNGKey(3)
+    )
+    # The jitted step donates TrainState buffers; keep host copies to compare against.
+    src_before = jax.device_get(src)
+    ppgd_cfg = PersistentPGDReconLossConfig(
+        coeff=0.5,
+        scope=SCScope(),
+        optimizer=SignPGDConfig(lr_schedule=ScheduleConfig(start_val=0.01, warmup_pct=0.025)),
+        n_warmup_steps=n_warmup,
+    )
+    assert ppgd_cfg.coeff is not None
+    state = TrainState(
+        components=vu, ci_fn=ci_fn,
+        components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
+        ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
+        adversaries={
+            ppgd_cfg.type: PersistentAdversary(
+                sources=src,
+                opt_state=None,
+                state_key=ppgd_cfg.type,
+                coeff=ppgd_cfg.coeff,
+                optimizer=ppgd_cfg.optimizer,
+                n_warmup=ppgd_cfg.n_warmup_steps,
+            )
+        },
+        step=jnp.zeros((), jnp.int32),
+    )  # fmt: skip
+    loss_terms = build_loss_terms(
+        (
+            FaithfulnessLossConfig(coeff=1e5),
+            ImportanceMinimalityLossConfig(
+                coeff=5e-6,
+                pnorm=ScheduleConfig(start_val=2.0, fn_type="linear", final_val_frac=0.2),
+            ),
+            ppgd_cfg,
+        ),
+        lm.site_names,
+    )
+    step = make_train_step(
+        lm=lm,
+        losses=loss_terms,
+        components_optimizer=opt_vu,
+        ci_fn_optimizer=opt_ci,
+        total_steps=100,
+        remat_recon_forwards=True,
+        remat_ci_fn=False,
+        mesh=None,
+    )
+
+    tokens = jax.random.randint(jax.random.PRNGKey(4), (2, seq), 0, cfg.vocab_size)
+    n_steps = 4
+    losses = []
+    for i in range(n_steps):
+        state, m = step(lm, state, tokens, jax.random.PRNGKey(100 + i))
+        losses.append({k: float(v) for k, v in m.items()})
+
+    assert all(jnp.isfinite(jnp.array(list(m.values()))).all() for m in losses)
+    assert int(state.step) == n_steps
+    ppgd_adv = state.adversaries["PersistentPGDReconLoss"]
+    assert ppgd_adv.opt_state is None
+    for site, v in ppgd_adv.sources.items():
+        assert float(v.min()) >= 0.0 and float(v.max()) <= 1.0
+        assert not jnp.array_equal(v, src_before[site]), f"sources never moved for {site}"
 
 
 def test_faith_warmup_decreases_faith():

--- a/param_decomp/tests/test_sign_src_step.py
+++ b/param_decomp/tests/test_sign_src_step.py
@@ -1,0 +1,45 @@
+"""SRC_STEP `sign` (SPEC §6): stateless `sources += lr·sign(grad)` with the S15 clamp
+projection, `opt_state is None` throughout — the moment buffers must not exist."""
+
+import jax.numpy as jnp
+
+from param_decomp.adversary import PersistentAdversary, sources_ascend_project
+from param_decomp.configs import SignPGDConfig
+from param_decomp.schedule import ScheduleConfig
+
+
+def _sign_cfg(lr: float) -> SignPGDConfig:
+    return SignPGDConfig(lr_schedule=ScheduleConfig(start_val=lr, warmup_pct=0.0))
+
+
+def test_sign_ascent_moves_by_lr_and_projects():
+    sources = {"site": jnp.asarray([0.5, 0.02, 0.99, 0.5])}
+    grad = {"site": jnp.asarray([2.7, -0.3, 1.0, 0.0])}
+    new_sources, opt_state = sources_ascend_project(
+        sources, grad, None, jnp.asarray(0.05), _sign_cfg(0.05)
+    )
+    assert opt_state is None
+    expected = jnp.asarray([0.55, 0.0, 1.0, 0.5])  # +lr, clamped at 0, clamped at 1, sign(0)=0
+    assert jnp.allclose(new_sources["site"], expected)
+
+
+def test_sign_ascent_preserves_source_dtype():
+    sources = {"site": jnp.full((3,), 0.5, jnp.bfloat16)}
+    grad = {"site": jnp.ones((3,), jnp.bfloat16)}
+    new_sources, _ = sources_ascend_project(sources, grad, None, jnp.asarray(0.01), _sign_cfg(0.01))
+    assert new_sources["site"].dtype == jnp.bfloat16
+
+
+def test_sign_adversary_final_ascend_stays_stateless():
+    adv = PersistentAdversary(
+        sources={"site": jnp.full((2, 3), 0.5)},
+        opt_state=None,
+        state_key="ppgd",
+        coeff=0.5,
+        optimizer=_sign_cfg(0.01),
+        n_warmup=0,
+    )
+    scaled_grad = {"site": jnp.full((2, 3), 0.5 * 3.0)}  # coeff-scaled, sign unaffected
+    ascended = adv.final_ascend(scaled_grad, jnp.asarray(100.0), 1000)
+    assert ascended.opt_state is None
+    assert jnp.allclose(ascended.sources["site"], 0.51)


### PR DESCRIPTION
## What

Implements the `sign` SRC_STEP variant already named as a valid instantiation in SPEC §6: `sources += lr·sign(grad)` with the same S15 clamp projection, selected via `optimizer: {type: sign, lr_schedule: ...}` (a discriminated union with `adam` on `PersistentPGDReconLossConfig.optimizer`).

The variant is **stateless**: `PersistentAdversary.opt_state` is now `SourcesAdamState | None` (None iff sign), so the source Adam `m`/`v` buffers never exist. On full32L that is **−19 GiB/GPU resident** (2× the 9.5 GiB source bundle); combined with the validated `source_dtype: bfloat16` (#938) the source bundle goes 28.5 → ~4.75 GiB.

## Invariants (SPEC IDs)

- **§6 SRC_STEP**: `sign` was already a named valid instantiation — no SPEC amendment. Production stays ★ `adam`.
- **S13'/S14'**: lifecycle unchanged — `n_warmup` supplemental ascents + one final ascent from the main backward, coeff-unscaled; `sources_ascend_project` dispatches on the optimizer config.
- **S15**: same clamp-to-[0,1] after every ascent.
- **N1** (fp32 SRC_STEP moments): vacuous for sign — no moments. The adam path (`sources_adam_ascend_project`) is bit-untouched.

## Configs

Four Tier-1 quality A/B arms (pile-4L PPGD-bsc, 10k steps, same seed, dp 8): adam control + sign at lr {0.003, 0.01, 0.03} — a step-size sweep since Adam's normalized per-update magnitude ≈ lr was tuned at 0.01, but sign steps are exactly lr. All arms fp32 source to isolate the update rule. Results will be logged on the bridge task (lp-sign-ascent-source).

## Validation

- `pytest param_decomp/tests/` green at default device count; adversary/checkpoint tests also green at `XLA_FLAGS=--xla_force_host_platform_device_count=4`.
- New: `test_sign_src_step.py` (unit: ±lr move, clamp, dtype, statelessness) + `test_step_trains_with_sign_src_step` (full jitted train step: losses finite, sources move and stay projected, `opt_state` stays None).
- `make check` clean (ruff + basedpyright 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ALaUCqhksKmWNbxjfmuMUi