### PR TITLE
feat(optim): bf16 Adam m/v storage for the V/U + CI-fn optimizers (moments_dtype)

### DIFF
--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -573,6 +573,13 @@ class OptimizerConfig(BaseConfig):
         default=None,
         description="If set, clip the grad norm of this group's parameters to this value",
     )
+    moments_dtype: Literal["float32", "bfloat16"] = "float32"
+    """Storage dtype for the Adam moments (`m`/`v`); the fp32 masters are untouched (SPEC
+    N1) and the moment-update arithmetic still promotes to fp32 — `bfloat16` is storage
+    rounding only. `float32` (default) is the oracle-parity path; `bfloat16` halves the
+    resident moment footprint (m+v = 2/3 of the 3x-master optimizer block; ~-6 GiB/GPU on
+    full32L b128). bf16 keeps fp32's exponent range, so `v = grad^2` cannot underflow any
+    earlier than fp32 (validated on the PPGD source Adam, `source_dtype`)."""
 
 
 AnyLossMetricConfig = Annotated[

--- a/param_decomp/configs/llama8b_full32L_b128_dp32_momdtype_memprobe_bf16.yaml
+++ b/param_decomp/configs/llama8b_full32L_b128_dp32_momdtype_memprobe_bf16.yaml
@@ -1,0 +1,597 @@
+# bf16-Adam-moments MEMPROBE (bf16-treatment arm) — full32L b128/dp32 mem_profile-and-exit
+# (static memory_analysis + runtime memory_stats, then os._exit). Derived from
+# llama8b_full32L_HSDP_b128_dp32.yaml; the ONLY treatment diff is `moments_dtype:
+# bfloat16` on BOTH pd optimizers (expected ~-5.8 GiB resident: m+v are 2/3 of the
+# 3x-fp32-master optimizer block). Bridge task: lp-bf16-adam-moments-vu.
+run_name: jax-full32L-b128-momdtype-memprobe-bf16
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 1000
+  train_log_every: 25
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/fineweb_llama_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: meta-llama/Llama-3.1-8B
+  train_split: train
+eval:
+  batch_size: 32
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups: null
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: c
+    n_steps: 20
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 100000
+  slow_on_first_step: false
+pd:
+  batch_size: 128
+  ci_config:
+    type: chunkwise_transformer
+    blocks_per_chunk: 1
+    d_model: 4096
+    n_blocks: 4
+    n_heads: 64
+    mlp_hidden: 16384
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.83e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+    moments_dtype: bfloat16
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.83e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+    moments_dtype: bfloat16
+  decomposition_targets:
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.0.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.1.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.2.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.3.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.4.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.5.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.6.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.7.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.8.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.9.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.10.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.11.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.12.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.13.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.14.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.15.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.16.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.17.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.18.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.19.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.20.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.21.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.22.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.23.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.24.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.25.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.26.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.27.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.28.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.29.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.30.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.31.mlp.down_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 0
+  faithfulness_warmup_weight_decay: 0.0
+  identity_decomposition_targets: null
+  loss_metrics:
+  - frequency:
+      coeff: 1.0e-06
+      reference_token_count: 65536
+    coeff: 5.0e-06
+    eps: 1.0e-06
+    pnorm:
+      start_val: 2.0
+      fn_type: linear
+      final_val_frac: 0.2
+    type: ImportanceMinimalityLoss
+  - coeff: 2.0
+    n_samples: 1
+    routing:
+      type: uniform_k_subset
+    sites_per_chunk: 56
+    type: ChunkwiseSubsetReconLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.01
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: bsc
+    type: PersistentPGDReconLoss
+  - coeff: 1000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 50000
+runtime:
+  dp: 32
+  tp: 1
+  remat_recon_forwards: true
+  remat_ci_fn: true
+  launch_env:
+    profile:
+      mem_profile: true
+      no_checkpoint: true
+target:
+  output_extract: logits
+  weights_dtype: bfloat16
+  spec:
+    kind: hf
+    model_class: transformers.LlamaForCausalLM
+    model_name: meta-llama/Llama-3.1-8B
+wandb:
+  entity: null
+  project: param-decomp-llama
+  group: full32L
+  tags:
+  - full-model
+  - 32L
+  - allmat
+  - dp128
+  - seq512

--- a/param_decomp/configs/llama8b_full32L_b128_dp32_momdtype_memprobe_fp32.yaml
+++ b/param_decomp/configs/llama8b_full32L_b128_dp32_momdtype_memprobe_fp32.yaml
@@ -1,0 +1,595 @@
+# bf16-Adam-moments MEMPROBE (fp32-control arm) — full32L b128/dp32 mem_profile-and-exit
+# (static memory_analysis + runtime memory_stats, then os._exit). Derived from
+# llama8b_full32L_HSDP_b128_dp32.yaml; the ONLY treatment diff is `moments_dtype:
+# bfloat16` on BOTH pd optimizers (expected ~-5.8 GiB resident: m+v are 2/3 of the
+# 3x-fp32-master optimizer block). Bridge task: lp-bf16-adam-moments-vu.
+run_name: jax-full32L-b128-momdtype-memprobe-fp32
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 1000
+  train_log_every: 25
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/fineweb_llama_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: meta-llama/Llama-3.1-8B
+  train_split: train
+eval:
+  batch_size: 32
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups: null
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: c
+    n_steps: 20
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 100000
+  slow_on_first_step: false
+pd:
+  batch_size: 128
+  ci_config:
+    type: chunkwise_transformer
+    blocks_per_chunk: 1
+    d_model: 4096
+    n_blocks: 4
+    n_heads: 64
+    mlp_hidden: 16384
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.83e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.83e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.0.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.1.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.2.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.3.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.4.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.5.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.6.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.7.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.8.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.9.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.10.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.11.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.12.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.13.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.14.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.15.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.16.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.17.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.18.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.19.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.20.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.21.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.22.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.23.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.24.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.25.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.26.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.27.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.28.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.29.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.30.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.31.mlp.down_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 0
+  faithfulness_warmup_weight_decay: 0.0
+  identity_decomposition_targets: null
+  loss_metrics:
+  - frequency:
+      coeff: 1.0e-06
+      reference_token_count: 65536
+    coeff: 5.0e-06
+    eps: 1.0e-06
+    pnorm:
+      start_val: 2.0
+      fn_type: linear
+      final_val_frac: 0.2
+    type: ImportanceMinimalityLoss
+  - coeff: 2.0
+    n_samples: 1
+    routing:
+      type: uniform_k_subset
+    sites_per_chunk: 56
+    type: ChunkwiseSubsetReconLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.01
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: bsc
+    type: PersistentPGDReconLoss
+  - coeff: 1000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 50000
+runtime:
+  dp: 32
+  tp: 1
+  remat_recon_forwards: true
+  remat_ci_fn: true
+  launch_env:
+    profile:
+      mem_profile: true
+      no_checkpoint: true
+target:
+  output_extract: logits
+  weights_dtype: bfloat16
+  spec:
+    kind: hf
+    model_class: transformers.LlamaForCausalLM
+    model_name: meta-llama/Llama-3.1-8B
+wandb:
+  entity: null
+  project: param-decomp-llama
+  group: full32L
+  tags:
+  - full-model
+  - 32L
+  - allmat
+  - dp128
+  - seq512

--- a/param_decomp/configs/pile_ppgd_bsc_momdtype_ab_bf16.yaml
+++ b/param_decomp/configs/pile_ppgd_bsc_momdtype_ab_bf16.yaml
@@ -1,0 +1,157 @@
+# bf16-Adam-moments A/B (bf16-treatment arm) — same-seed 10k-step quality gate for storing the
+# V/U + CI-fn optimizers' Adam m/v in bf16 (fp32 masters untouched). Derived from
+# pile_ppgd_bsc.yaml (the pile-4L PPGD-bsc lineage): steps 400k->10k, dp 16->8 (1 node),
+# slow_every 10000->2000 so the fresh-PGD 20-step eval traces at 0/2k/../10k. The ONLY
+# treatment diff is `moments_dtype: bfloat16` on BOTH pd optimizers. Same seed (0), same
+# data order. Bridge task: lp-bf16-adam-moments-vu (harness shape from lp-bf16-source-ab).
+run_name: ai-jax-pile4l-ppgd-bsc-momdtype-bf16
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 5000
+  train_log_every: 200
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/pile_neox_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: EleutherAI/gpt-neox-20b
+  train_split: train
+eval:
+  batch_size: 128
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups:
+      layer_0:
+      - h.0.*
+      layer_1:
+      - h.1.*
+      layer_2:
+      - h.2.*
+      layer_3:
+      - h.3.*
+      total:
+      - '*'
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: c
+    n_steps: 20
+    name: PGDReconLoss_20step
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 2000
+  slow_on_first_step: true
+pd:
+  batch_size: 64
+  ci_config:
+    type: chunkwise_transformer
+    blocks_per_chunk: 1
+    d_model: 2048
+    n_blocks: 8
+    n_heads: 16
+    mlp_hidden: 8192
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    moments_dtype: bfloat16
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    moments_dtype: bfloat16
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 3072
+    module_pattern: h.*.mlp.c_fc
+  - C: 3584
+    module_pattern: h.*.mlp.down_proj
+  - C: 512
+    module_pattern: h.*.attn.q_proj
+  - C: 512
+    module_pattern: h.*.attn.k_proj
+  - C: 1024
+    module_pattern: h.*.attn.v_proj
+  - C: 1024
+    module_pattern: h.*.attn.o_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 400
+  faithfulness_warmup_weight_decay: 0.0
+  loss_metrics:
+  - frequency:
+      coeff: 1.0e-04
+      reference_token_count: 65536
+    coeff: 0.0002
+    eps: 1.0e-12
+    pnorm:
+      start_val: 2.0
+      fn_type: linear
+      final_val_frac: 0.2
+    type: ImportanceMinimalityLoss
+  - coeff: 0.5
+    routing:
+      type: uniform_k_subset
+    type: StochasticReconSubsetLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.5
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: bsc
+    type: PersistentPGDReconLoss
+  - coeff: 10000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 10000
+runtime:
+  remat_recon_forwards: false
+  dp: 8
+target:
+  output_extract: 0
+  weights_dtype: bfloat16
+  spec:
+    kind: pretrained
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
+    run_path: goodfire/spd/runs/t-9d2b8f02
+wandb:
+  entity: null
+  project: param-decomp

--- a/param_decomp/configs/pile_ppgd_bsc_momdtype_ab_fp32.yaml
+++ b/param_decomp/configs/pile_ppgd_bsc_momdtype_ab_fp32.yaml
@@ -1,0 +1,155 @@
+# bf16-Adam-moments A/B (fp32-control arm) — same-seed 10k-step quality gate for storing the
+# V/U + CI-fn optimizers' Adam m/v in bf16 (fp32 masters untouched). Derived from
+# pile_ppgd_bsc.yaml (the pile-4L PPGD-bsc lineage): steps 400k->10k, dp 16->8 (1 node),
+# slow_every 10000->2000 so the fresh-PGD 20-step eval traces at 0/2k/../10k. The ONLY
+# treatment diff is `moments_dtype: bfloat16` on BOTH pd optimizers. Same seed (0), same
+# data order. Bridge task: lp-bf16-adam-moments-vu (harness shape from lp-bf16-source-ab).
+run_name: ai-jax-pile4l-ppgd-bsc-momdtype-fp32
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 5000
+  train_log_every: 200
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/pile_neox_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: EleutherAI/gpt-neox-20b
+  train_split: train
+eval:
+  batch_size: 128
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups:
+      layer_0:
+      - h.0.*
+      layer_1:
+      - h.1.*
+      layer_2:
+      - h.2.*
+      layer_3:
+      - h.3.*
+      total:
+      - '*'
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: c
+    n_steps: 20
+    name: PGDReconLoss_20step
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 2000
+  slow_on_first_step: true
+pd:
+  batch_size: 64
+  ci_config:
+    type: chunkwise_transformer
+    blocks_per_chunk: 1
+    d_model: 2048
+    n_blocks: 8
+    n_heads: 16
+    mlp_hidden: 8192
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 5.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 3072
+    module_pattern: h.*.mlp.c_fc
+  - C: 3584
+    module_pattern: h.*.mlp.down_proj
+  - C: 512
+    module_pattern: h.*.attn.q_proj
+  - C: 512
+    module_pattern: h.*.attn.k_proj
+  - C: 1024
+    module_pattern: h.*.attn.v_proj
+  - C: 1024
+    module_pattern: h.*.attn.o_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 400
+  faithfulness_warmup_weight_decay: 0.0
+  loss_metrics:
+  - frequency:
+      coeff: 1.0e-04
+      reference_token_count: 65536
+    coeff: 0.0002
+    eps: 1.0e-12
+    pnorm:
+      start_val: 2.0
+      fn_type: linear
+      final_val_frac: 0.2
+    type: ImportanceMinimalityLoss
+  - coeff: 0.5
+    routing:
+      type: uniform_k_subset
+    type: StochasticReconSubsetLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.5
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: bsc
+    type: PersistentPGDReconLoss
+  - coeff: 10000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 10000
+runtime:
+  remat_recon_forwards: false
+  dp: 8
+target:
+  output_extract: 0
+  weights_dtype: bfloat16
+  spec:
+    kind: pretrained
+    model_class: param_decomp_lab.experiments.lm.pretrain.models.llama_simple_mlp.LlamaSimpleMLP
+    run_path: goodfire/spd/runs/t-9d2b8f02
+wandb:
+  entity: null
+  project: param-decomp

--- a/param_decomp/run_state.py
+++ b/param_decomp/run_state.py
@@ -71,13 +71,42 @@ def clip_by_global_norm_with_eps(max_norm: float, eps: float) -> optax.GradientT
     return optax.GradientTransformation(init, update)
 
 
+def _with_nu_dtype(
+    adamw: optax.GradientTransformation, dtype: jnp.dtype
+) -> optax.GradientTransformation:
+    """Pin the SECOND Adam moment's storage dtype (optax exposes only `mu_dtype`). optax's
+    `scale_by_adam` update ends with `nu = cast_like(nu, state.nu)`, so nu keeps whatever
+    dtype it was INITIALIZED with — overriding the init is sufficient, and the moment
+    arithmetic still promotes to fp32 in-update (storage rounding only)."""
+
+    def init(params: optax.Params) -> tuple[optax.OptState, ...]:
+        states = adamw.init(params)
+        assert isinstance(states, tuple)
+        adam_state, *rest = states
+        assert isinstance(adam_state, optax.ScaleByAdamState)
+        nu = jax.tree.map(lambda v: v.astype(dtype), adam_state.nu)
+        return (adam_state._replace(nu=nu), *rest)
+
+    return optax.GradientTransformation(init, adamw.update)
+
+
 def _adamw_with_clip(opt: OptimizerConfig, schedule: Callable[[ArrayLike], Array]):
     """AdamW (fp32 master, optax wd default overridden to the config's — torch's is 0)
     over `schedule`, optionally preceded by torch-parity global-norm clip (SPEC S19/N1).
-    Adam eps is the torch/optax default 1e-8 (not exposed on `OptimizerConfig`)."""
+    Adam eps is the torch/optax default 1e-8 (not exposed on `OptimizerConfig`). The Adam
+    m/v STORAGE dtype is `opt.moments_dtype` (fp32 masters regardless; see the config
+    field's docstring)."""
+    moments_dtype = jnp.dtype(opt.moments_dtype)
     adamw = optax.adamw(
-        schedule, b1=opt.betas[0], b2=opt.betas[1], eps=1e-8, weight_decay=opt.weight_decay
+        schedule,
+        b1=opt.betas[0],
+        b2=opt.betas[1],
+        eps=1e-8,
+        weight_decay=opt.weight_decay,
+        mu_dtype=moments_dtype,
     )
+    if moments_dtype != jnp.float32:
+        adamw = _with_nu_dtype(adamw, moments_dtype)
     if opt.grad_clip_norm is None:
         return adamw
     return optax.chain(clip_by_global_norm_with_eps(opt.grad_clip_norm, eps=1e-6), adamw)

--- a/param_decomp/tests/test_optim_torch_parity.py
+++ b/param_decomp/tests/test_optim_torch_parity.py
@@ -6,6 +6,8 @@
   optax's eps-free `clip_by_global_norm`.
 """
 
+from typing import Literal
+
 import jax
 import jax.numpy as jnp
 import optax
@@ -13,7 +15,8 @@ import pytest
 from jax.typing import ArrayLike
 from jaxtyping import Array
 
-from param_decomp.run_state import clip_by_global_norm_with_eps, optax_schedule
+from param_decomp.configs import OptimizerConfig
+from param_decomp.run_state import _adamw_with_clip, clip_by_global_norm_with_eps, optax_schedule
 from param_decomp.schedule import ScheduleConfig
 
 
@@ -96,3 +99,56 @@ def test_grad_clip_noop_below_threshold():
     out = _clip(clip, grads)
     assert float(out["a"][0]) == pytest.approx(3.0)
     assert float(out["a"][1]) == pytest.approx(4.0)
+
+
+def _adamw(moments_dtype: Literal["float32", "bfloat16"]) -> optax.GradientTransformation:
+    opt = OptimizerConfig(
+        lr_schedule=ScheduleConfig(start_val=1e-3, fn_type="constant"),
+        moments_dtype=moments_dtype,
+    )
+    return _adamw_with_clip(opt, optax_schedule(opt.lr_schedule, total_steps=100))
+
+
+def _run_steps(
+    optimizer: optax.GradientTransformation, n_steps: int, key: Array
+) -> tuple[dict[str, Array], optax.OptState]:
+    params = {"w": jnp.ones((4, 8), jnp.float32)}
+    state = optimizer.init(params)
+    for step in range(n_steps):
+        grads = {"w": jax.random.normal(jax.random.fold_in(key, step), (4, 8)) * 1e-3}
+        updates, state = optimizer.update(grads, state, params)
+        new_params, treedef = jax.tree.flatten(optax.apply_updates(params, updates))
+        params = jax.tree.unflatten(treedef, new_params)
+    return params, state
+
+
+def test_bf16_moments_dtype_persists_across_updates():
+    _, state = _run_steps(_adamw("bfloat16"), n_steps=3, key=jax.random.key(0))
+    assert isinstance(state, tuple)
+    adam_state = state[0]
+    assert isinstance(adam_state, optax.ScaleByAdamState)
+    assert all(m.dtype == jnp.bfloat16 for m in jax.tree.leaves(adam_state.mu))
+    assert all(v.dtype == jnp.bfloat16 for v in jax.tree.leaves(adam_state.nu))
+    assert all(bool(jnp.any(v != 0)) for v in jax.tree.leaves(adam_state.nu))
+
+
+def test_bf16_moments_track_fp32_trajectory():
+    key = jax.random.key(1)
+    params_f32, _ = _run_steps(_adamw("float32"), n_steps=20, key=key)
+    params_bf16, _ = _run_steps(_adamw("bfloat16"), n_steps=20, key=key)
+    divergence = jnp.max(jnp.abs(params_f32["w"] - params_bf16["w"]))
+    total_movement = jnp.max(jnp.abs(params_f32["w"] - 1.0))
+    assert float(divergence) < 0.02 * float(total_movement)
+    assert bool(jnp.any(params_f32["w"] != params_bf16["w"]))
+
+
+def test_fp32_moments_default_matches_plain_optax_adamw():
+    opt = OptimizerConfig(lr_schedule=ScheduleConfig(start_val=1e-3, fn_type="constant"))
+    assert opt.moments_dtype == "float32"
+    schedule = optax_schedule(opt.lr_schedule, total_steps=100)
+    ours = _adamw_with_clip(opt, schedule)
+    plain = optax.adamw(schedule, b1=0.9, b2=0.999, eps=1e-8, weight_decay=0.0)
+    key = jax.random.key(2)
+    params_ours, _ = _run_steps(ours, n_steps=5, key=key)
+    params_plain, _ = _run_steps(plain, n_steps=5, key=key)
+    assert bool(jnp.all(params_ours["w"] == params_plain["w"]))


### PR DESCRIPTION
## What

New `OptimizerConfig.moments_dtype: float32 | bfloat16` (default `float32` — bit-unchanged, pinned by a new test): `bfloat16` stores BOTH Adam moments of the components (V/U) and CI-fn optimizers in bf16 while the fp32 masters stay untouched (SPEC N1). Item #5 of the lower-precision roadmap (bridge task `lp-bf16-adam-moments-vu`; follows `lp-bf16-source-ab` / #938 which validated the same technique on the PPGD source Adam).

Implementation is deliberately tiny: optax's `mu_dtype` covers the first moment natively, and its `scale_by_adam` update ends with `nu = cast_like(nu, state.nu)` — so the second moment's storage dtype is whatever it was *initialized* with. `_with_nu_dtype` wraps only the init. Update arithmetic still promotes to fp32; bf16 is storage rounding only. m/v inherit the masters' ZeRO-1 ÷N sharding via `zeros_like`/`astype`; the #927 fsdp-major reconstruct gathers masters only, so sharding/layout is untouched (confirmed by the memprobe: temp identical, 96.9 GiB both arms).

## Validation

**Memory (full32L b128/dp32 memprobes, 4 scavenge nodes each):**
- resident argument 49.50 → 43.70 GiB = **−5.80 GiB/GPU** (exactly m+v = ⅓ of the 3×-fp32-master optimizer block)
- runtime peak 146.45 → 140.38 GiB (limit 164.08); runs p-841cc252 (fp32) / p-f9ddec8a (bf16), jobs 170794/170795

**Quality (same-seed 10k-step pile-4L PPGD-bsc A/B, runs p-6a9bc1ce fp32 / p-4731b0d9 bf16):**
- adversary effectiveness (train PPGD recon): within ±5%, no drift/collapse
- fresh-PGD 20-step eval: bf16 equal or better at every point (−2..−9% pre-spike)
- masked CE/KL (ci/rounded/stoch): ±5%, no systematic degradation; CI-L0 within +3% through step 8k
- faithfulness: converges to identical (+0.0% from step 2600 on)
- both arms share the known end-of-run p-anneal spike (same artifact as the #938 A/B; bf16 degrades *less* on eval at the spike)
- ckpt moment probe: v==0 fraction **0.000% in both arms** (medians 1e-11..1e-14 ≫ the exponent floor, which bf16 shares with fp32); bf16 arm ckpts store m/v as bfloat16 end-to-end
- live memory corroboration on the 4L arms: −0.90 GB/rank peak

**Tests:** new tests pin (a) bf16 m/v dtype persists across updates, (b) bf16 trajectory tracks fp32 within storage-rounding scale, (c) fp32 default is bit-identical to plain `optax.adamw`. Optim-parity/checkpoint/equivalence/stacked-parity suites green at default + 4 sim devices.

The A/B + memprobe config pairs are included (derived from `pile_ppgd_bsc.yaml` / `llama8b_full32L_HSDP_b128_dp32.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbD62cDit2QPQBHUT3fzkk