### PR TITLE
perf(train): per-entry recon fwd/bwd sequencing (+ save_gathered_weights, both default-off)

### DIFF
--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -796,6 +796,18 @@ class RuntimeConfig(BaseConfig):
             "losses, forwards, and RNG; grad accumulation reassociates. Compute substrate."
         ),
     )
+    save_gathered_weights: bool = Field(
+        default=False,
+        description=(
+            "Save the LIVE segment's gathered per-layer V/U/W as checkpoint residuals across "
+            "fwd→bwd (`checkpoint_name` + a `save_only_these_names`-augmented remat policy), "
+            "so the rematerialized backward reuses them instead of re-gathering — the "
+            "dominant exposed-collective phase at full32L. Numerics-identical (pure "
+            "recompute-vs-store). Costs the live segment's gathered stacks resident fwd→bwd "
+            "(~11 GB per 8-layer chunk at full32L C) — AOT-probe memory before a big run. "
+            "llama8b target only. Compute substrate."
+        ),
+    )
     compiler_options: dict[str, bool | int | str] = Field(
         default_factory=lambda: {
             "xla_gpu_enable_latency_hiding_scheduler": True,
@@ -839,6 +851,9 @@ class RuntimeConfig(BaseConfig):
     def validate_gather_reshape(self) -> Self:
         assert not (self.ascend_replicate and self.gather_fp8), (
             "ascend_replicate and gather_fp8 both re-pin the compute-weight gather — pick one"
+        )
+        assert not (self.save_gathered_weights and self.gather_fp8), (
+            "save_gathered_weights and gather_fp8 both re-pin the compute-weight gather — pick one"
         )
         return self
 

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -785,6 +785,17 @@ class RuntimeConfig(BaseConfig):
             "the full V/U resident during the ascend phase for the eliminated re-gathers."
         ),
     )
+    sequence_recon_entries: bool = Field(
+        default=False,
+        description=(
+            "Decompose the main backward into per-recon-forward backwards chained by "
+            "`optimization_barrier`: forward i+1 data-depends on ALL of backward i, so XLA "
+            "frees each recon forward's saved stack before the next begins instead of "
+            "keeping every forward's co-resident (~5x peak at the production 4-chunk + PPGD "
+            "plan). Trades cross-entry fwd/bwd overlap for peak activation memory. Same "
+            "losses, forwards, and RNG; grad accumulation reassociates. Compute substrate."
+        ),
+    )
     compiler_options: dict[str, bool | int | str] = Field(
         default_factory=lambda: {
             "xla_gpu_enable_latency_hiding_scheduler": True,

--- a/param_decomp/configs/jax_full32L_seqOFF_b128_dp32_MEMPROBE.yaml
+++ b/param_decomp/configs/jax_full32L_seqOFF_b128_dp32_MEMPROBE.yaml
@@ -1,0 +1,590 @@
+run_name: jax-full32L-seqOFF-b128-dp32-MEMPROBE
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 5000
+  train_log_every: 1
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/fineweb_llama_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: meta-llama/Llama-3.1-8B
+  train_split: train
+eval:
+  batch_size: 32
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups: null
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: c
+    n_steps: 20
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 100000
+  slow_on_first_step: false
+pd:
+  batch_size: 128
+  ci_config:
+    type: chunkwise_transformer
+    blocks_per_chunk: 1
+    d_model: 4096
+    n_blocks: 4
+    n_heads: 64
+    mlp_hidden: 16384
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.0.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.1.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.2.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.3.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.4.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.5.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.6.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.7.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.8.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.9.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.10.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.11.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.12.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.13.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.14.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.15.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.16.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.17.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.18.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.19.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.20.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.21.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.22.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.23.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.24.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.25.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.26.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.27.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.28.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.29.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.30.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.31.mlp.down_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 0
+  faithfulness_warmup_weight_decay: 0.0
+  identity_decomposition_targets: null
+  loss_metrics:
+  - frequency:
+      coeff: 1.0e-06
+      reference_token_count: 65536
+    coeff: 5.0e-06
+    eps: 1.0e-06
+    pnorm:
+      start_val: 2.0
+      fn_type: linear
+      final_val_frac: 0.2
+    type: ImportanceMinimalityLoss
+  - coeff: 2.0
+    n_samples: 1
+    routing:
+      type: uniform_k_subset
+    sites_per_chunk: 56
+    type: ChunkwiseSubsetReconLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.01
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: bsc
+    type: PersistentPGDReconLoss
+  - coeff: 1000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 12
+runtime:
+  dp: 32
+  tp: 1
+  remat_recon_forwards: true
+  remat_ci_fn: true
+  launch_env:
+    profile:
+      mem_profile: true
+      no_checkpoint: true
+target:
+  output_extract: logits
+  weights_dtype: bfloat16
+  spec:
+    kind: hf
+    model_class: transformers.LlamaForCausalLM
+    model_name: meta-llama/Llama-3.1-8B
+wandb:
+  entity: null
+  project: param-decomp-llama
+  group: full32L
+  tags:
+  - full-model
+  - 32L
+  - allmat
+  - dp128
+  - seq512

--- a/param_decomp/configs/jax_full32L_seqOFF_b128_dp32_TRACE.yaml
+++ b/param_decomp/configs/jax_full32L_seqOFF_b128_dp32_TRACE.yaml
@@ -1,0 +1,592 @@
+run_name: jax-full32L-seqOFF-b128-dp32-TRACE
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 5000
+  train_log_every: 1
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/fineweb_llama_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: meta-llama/Llama-3.1-8B
+  train_split: train
+eval:
+  batch_size: 32
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups: null
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: c
+    n_steps: 20
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 100000
+  slow_on_first_step: false
+pd:
+  batch_size: 128
+  ci_config:
+    type: chunkwise_transformer
+    blocks_per_chunk: 1
+    d_model: 4096
+    n_blocks: 4
+    n_heads: 64
+    mlp_hidden: 16384
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.0.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.1.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.2.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.3.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.4.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.5.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.6.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.7.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.8.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.9.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.10.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.11.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.12.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.13.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.14.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.15.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.16.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.17.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.18.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.19.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.20.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.21.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.22.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.23.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.24.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.25.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.26.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.27.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.28.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.29.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.30.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.31.mlp.down_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 0
+  faithfulness_warmup_weight_decay: 0.0
+  identity_decomposition_targets: null
+  loss_metrics:
+  - frequency:
+      coeff: 1.0e-06
+      reference_token_count: 65536
+    coeff: 5.0e-06
+    eps: 1.0e-06
+    pnorm:
+      start_val: 2.0
+      fn_type: linear
+      final_val_frac: 0.2
+    type: ImportanceMinimalityLoss
+  - coeff: 2.0
+    n_samples: 1
+    routing:
+      type: uniform_k_subset
+    sites_per_chunk: 56
+    type: ChunkwiseSubsetReconLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.01
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: bsc
+    type: PersistentPGDReconLoss
+  - coeff: 1000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 12
+runtime:
+  dp: 32
+  tp: 1
+  remat_recon_forwards: true
+  remat_ci_fn: true
+  launch_env:
+    profile:
+      trace: true
+      trace_steps: 1
+      no_checkpoint: true
+      profile_max_events: 3000000
+target:
+  output_extract: logits
+  weights_dtype: bfloat16
+  spec:
+    kind: hf
+    model_class: transformers.LlamaForCausalLM
+    model_name: meta-llama/Llama-3.1-8B
+wandb:
+  entity: null
+  project: param-decomp-llama
+  group: full32L
+  tags:
+  - full-model
+  - 32L
+  - allmat
+  - dp128
+  - seq512

--- a/param_decomp/configs/jax_full32L_seqON_b128_dp32_MEMPROBE.yaml
+++ b/param_decomp/configs/jax_full32L_seqON_b128_dp32_MEMPROBE.yaml
@@ -1,0 +1,591 @@
+run_name: jax-full32L-seqON-b128-dp32-MEMPROBE
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 5000
+  train_log_every: 1
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/fineweb_llama_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: meta-llama/Llama-3.1-8B
+  train_split: train
+eval:
+  batch_size: 32
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups: null
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: c
+    n_steps: 20
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 100000
+  slow_on_first_step: false
+pd:
+  batch_size: 128
+  ci_config:
+    type: chunkwise_transformer
+    blocks_per_chunk: 1
+    d_model: 4096
+    n_blocks: 4
+    n_heads: 64
+    mlp_hidden: 16384
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.0.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.1.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.2.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.3.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.4.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.5.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.6.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.7.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.8.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.9.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.10.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.11.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.12.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.13.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.14.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.15.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.16.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.17.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.18.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.19.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.20.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.21.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.22.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.23.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.24.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.25.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.26.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.27.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.28.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.29.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.30.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.31.mlp.down_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 0
+  faithfulness_warmup_weight_decay: 0.0
+  identity_decomposition_targets: null
+  loss_metrics:
+  - frequency:
+      coeff: 1.0e-06
+      reference_token_count: 65536
+    coeff: 5.0e-06
+    eps: 1.0e-06
+    pnorm:
+      start_val: 2.0
+      fn_type: linear
+      final_val_frac: 0.2
+    type: ImportanceMinimalityLoss
+  - coeff: 2.0
+    n_samples: 1
+    routing:
+      type: uniform_k_subset
+    sites_per_chunk: 56
+    type: ChunkwiseSubsetReconLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.01
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: bsc
+    type: PersistentPGDReconLoss
+  - coeff: 1000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 12
+runtime:
+  dp: 32
+  tp: 1
+  remat_recon_forwards: true
+  remat_ci_fn: true
+  launch_env:
+    profile:
+      mem_profile: true
+      no_checkpoint: true
+  sequence_recon_entries: true
+target:
+  output_extract: logits
+  weights_dtype: bfloat16
+  spec:
+    kind: hf
+    model_class: transformers.LlamaForCausalLM
+    model_name: meta-llama/Llama-3.1-8B
+wandb:
+  entity: null
+  project: param-decomp-llama
+  group: full32L
+  tags:
+  - full-model
+  - 32L
+  - allmat
+  - dp128
+  - seq512

--- a/param_decomp/configs/jax_full32L_seqON_b128_dp32_TRACE.yaml
+++ b/param_decomp/configs/jax_full32L_seqON_b128_dp32_TRACE.yaml
@@ -1,0 +1,593 @@
+run_name: jax-full32L-seqON-b128-dp32-TRACE
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 5000
+  train_log_every: 1
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/fineweb_llama_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: meta-llama/Llama-3.1-8B
+  train_split: train
+eval:
+  batch_size: 32
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups: null
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: c
+    n_steps: 20
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 100000
+  slow_on_first_step: false
+pd:
+  batch_size: 128
+  ci_config:
+    type: chunkwise_transformer
+    blocks_per_chunk: 1
+    d_model: 4096
+    n_blocks: 4
+    n_heads: 64
+    mlp_hidden: 16384
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.0.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.1.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.2.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.3.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.4.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.5.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.6.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.7.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.8.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.9.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.10.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.11.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.12.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.13.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.14.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.15.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.16.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.17.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.18.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.19.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.20.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.21.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.22.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.23.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.24.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.25.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.26.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.27.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.28.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.29.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.30.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.31.mlp.down_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 0
+  faithfulness_warmup_weight_decay: 0.0
+  identity_decomposition_targets: null
+  loss_metrics:
+  - frequency:
+      coeff: 1.0e-06
+      reference_token_count: 65536
+    coeff: 5.0e-06
+    eps: 1.0e-06
+    pnorm:
+      start_val: 2.0
+      fn_type: linear
+      final_val_frac: 0.2
+    type: ImportanceMinimalityLoss
+  - coeff: 2.0
+    n_samples: 1
+    routing:
+      type: uniform_k_subset
+    sites_per_chunk: 56
+    type: ChunkwiseSubsetReconLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.01
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: bsc
+    type: PersistentPGDReconLoss
+  - coeff: 1000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 12
+runtime:
+  dp: 32
+  tp: 1
+  remat_recon_forwards: true
+  remat_ci_fn: true
+  launch_env:
+    profile:
+      trace: true
+      trace_steps: 1
+      no_checkpoint: true
+      profile_max_events: 3000000
+  sequence_recon_entries: true
+target:
+  output_extract: logits
+  weights_dtype: bfloat16
+  spec:
+    kind: hf
+    model_class: transformers.LlamaForCausalLM
+    model_name: meta-llama/Llama-3.1-8B
+wandb:
+  entity: null
+  project: param-decomp-llama
+  group: full32L
+  tags:
+  - full-model
+  - 32L
+  - allmat
+  - dp128
+  - seq512

--- a/param_decomp/configs/jax_full32L_seqON_sgwON_b128_dp32_MEMPROBE.yaml
+++ b/param_decomp/configs/jax_full32L_seqON_sgwON_b128_dp32_MEMPROBE.yaml
@@ -1,0 +1,592 @@
+run_name: jax-full32L-seqON-sgwON-b128-dp32-MEMPROBE
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 5000
+  train_log_every: 1
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/fineweb_llama_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: meta-llama/Llama-3.1-8B
+  train_split: train
+eval:
+  batch_size: 32
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups: null
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: c
+    n_steps: 20
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 100000
+  slow_on_first_step: false
+pd:
+  batch_size: 128
+  ci_config:
+    type: chunkwise_transformer
+    blocks_per_chunk: 1
+    d_model: 4096
+    n_blocks: 4
+    n_heads: 64
+    mlp_hidden: 16384
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.0.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.1.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.2.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.3.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.4.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.5.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.6.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.7.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.8.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.9.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.10.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.11.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.12.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.13.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.14.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.15.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.16.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.17.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.18.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.19.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.20.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.21.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.22.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.23.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.24.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.25.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.26.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.27.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.28.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.29.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.30.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.31.mlp.down_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 0
+  faithfulness_warmup_weight_decay: 0.0
+  identity_decomposition_targets: null
+  loss_metrics:
+  - frequency:
+      coeff: 1.0e-06
+      reference_token_count: 65536
+    coeff: 5.0e-06
+    eps: 1.0e-06
+    pnorm:
+      start_val: 2.0
+      fn_type: linear
+      final_val_frac: 0.2
+    type: ImportanceMinimalityLoss
+  - coeff: 2.0
+    n_samples: 1
+    routing:
+      type: uniform_k_subset
+    sites_per_chunk: 56
+    type: ChunkwiseSubsetReconLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.01
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: bsc
+    type: PersistentPGDReconLoss
+  - coeff: 1000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 12
+runtime:
+  dp: 32
+  tp: 1
+  remat_recon_forwards: true
+  remat_ci_fn: true
+  launch_env:
+    profile:
+      mem_profile: true
+      no_checkpoint: true
+  sequence_recon_entries: true
+  save_gathered_weights: true
+target:
+  output_extract: logits
+  weights_dtype: bfloat16
+  spec:
+    kind: hf
+    model_class: transformers.LlamaForCausalLM
+    model_name: meta-llama/Llama-3.1-8B
+wandb:
+  entity: null
+  project: param-decomp-llama
+  group: full32L
+  tags:
+  - full-model
+  - 32L
+  - allmat
+  - dp128
+  - seq512

--- a/param_decomp/configs/jax_full32L_seqON_sgwON_b128_dp32_TRACE.yaml
+++ b/param_decomp/configs/jax_full32L_seqON_sgwON_b128_dp32_TRACE.yaml
@@ -1,0 +1,594 @@
+run_name: jax-full32L-seqON-sgwON-b128-dp32-TRACE
+cadence:
+  keep_last_n_checkpoints: 2
+  save_every: 5000
+  train_log_every: 1
+data:
+  buffer_size: 1000
+  column_name: input_ids
+  data_files: /mnt/data/artifacts/mechanisms/param-decomp/datasets/fineweb_llama_tok_512/*.parquet
+  dataset_name: parquet
+  eval_split: train
+  is_tokenized: true
+  max_seq_len: 512
+  revision: null
+  shuffle_each_epoch: true
+  streaming: false
+  tokenizer_name: meta-llama/Llama-3.1-8B
+  train_split: train
+eval:
+  batch_size: 32
+  every: 1000
+  metrics:
+  - n_batches_accum: 1
+    type: CIHistograms
+  - ci_alive_threshold: 0.0
+    type: ComponentActivationDensity
+  - ci_alive_threshold: 0.0
+    groups: null
+    type: CI_L0
+  - rounding_threshold: 0.0
+    type: CEandKLLosses
+  - type: CIMeanPerComponent
+  - coeff: null
+    type: StochasticHiddenActsReconLoss
+  - type: CIHiddenActsReconLoss
+  - coeff: null
+    init: random
+    mask_scope: c
+    n_steps: 20
+    step_size: 0.1
+    type: PGDReconLoss
+  n_steps: 1
+  slow_every: 100000
+  slow_on_first_step: false
+pd:
+  batch_size: 128
+  ci_config:
+    type: chunkwise_transformer
+    blocks_per_chunk: 1
+    d_model: 4096
+    n_blocks: 4
+    n_heads: 64
+    mlp_hidden: 16384
+  ci_fn_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: null
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  components_optimizer:
+    betas:
+    - 0.9
+    - 0.999
+    grad_clip_norm: 0.01
+    lr_schedule:
+      final_val_frac: 0.1
+      fn_type: cosine
+      start_val: 2.0e-05
+      warmup_pct: 0.0
+    weight_decay: 0.0
+  decomposition_targets:
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.0.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.0.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.0.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.0.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.1.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.1.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.1.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.1.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.2.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.2.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.2.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.2.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.3.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.3.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.3.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.3.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.4.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.4.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.4.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.4.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.5.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.5.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.5.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.5.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.6.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.6.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.6.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.6.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.7.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.7.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.7.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.7.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.8.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.8.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.8.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.8.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.9.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.9.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.9.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.9.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.10.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.10.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.10.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.10.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.11.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.11.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.11.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.11.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.12.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.12.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.12.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.12.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.13.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.13.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.13.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.13.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.14.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.14.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.14.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.14.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.15.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.15.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.15.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.15.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.16.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.16.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.16.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.16.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.17.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.17.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.17.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.17.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.18.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.18.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.18.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.18.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.19.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.19.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.19.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.19.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.20.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.20.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.20.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.20.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.21.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.21.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.21.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.21.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.22.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.22.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.22.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.22.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.23.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.23.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.23.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.23.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.24.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.24.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.24.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.24.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.25.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.25.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.25.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.25.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.26.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.26.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.26.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.26.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.27.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.27.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.27.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.27.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.28.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.28.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.28.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.28.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.29.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.29.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.29.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.29.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.30.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.30.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.30.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.30.mlp.down_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.q_proj
+  - C: 2048
+    module_pattern: model.layers.31.self_attn.k_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.v_proj
+  - C: 4096
+    module_pattern: model.layers.31.self_attn.o_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.gate_proj
+  - C: 8192
+    module_pattern: model.layers.31.mlp.up_proj
+  - C: 10240
+    module_pattern: model.layers.31.mlp.down_proj
+  faithfulness_warmup_lr: 0.001
+  faithfulness_warmup_steps: 0
+  faithfulness_warmup_weight_decay: 0.0
+  identity_decomposition_targets: null
+  loss_metrics:
+  - frequency:
+      coeff: 1.0e-06
+      reference_token_count: 65536
+    coeff: 5.0e-06
+    eps: 1.0e-06
+    pnorm:
+      start_val: 2.0
+      fn_type: linear
+      final_val_frac: 0.2
+    type: ImportanceMinimalityLoss
+  - coeff: 2.0
+    n_samples: 1
+    routing:
+      type: uniform_k_subset
+    sites_per_chunk: 56
+    type: ChunkwiseSubsetReconLoss
+  - coeff: 0.5
+    n_warmup_steps: 2
+    optimizer:
+      beta1: 0.01
+      beta2: 0.99
+      eps: 1.0e-08
+      lr_schedule:
+        final_val_frac: 1.0
+        fn_type: constant
+        start_val: 0.01
+        warmup_pct: 0.025
+      type: adam
+    scope:
+      type: bsc
+    type: PersistentPGDReconLoss
+  - coeff: 1000000.0
+    type: FaithfulnessLoss
+  seed: 0
+  steps: 12
+runtime:
+  dp: 32
+  tp: 1
+  remat_recon_forwards: true
+  remat_ci_fn: true
+  launch_env:
+    profile:
+      trace: true
+      trace_steps: 1
+      no_checkpoint: true
+      profile_max_events: 3000000
+  sequence_recon_entries: true
+  save_gathered_weights: true
+target:
+  output_extract: logits
+  weights_dtype: bfloat16
+  spec:
+    kind: hf
+    model_class: transformers.LlamaForCausalLM
+    model_name: meta-llama/Llama-3.1-8B
+wandb:
+  entity: null
+  project: param-decomp-llama
+  group: full32L
+  tags:
+  - full-model
+  - 32L
+  - allmat
+  - dp128
+  - seq512

--- a/param_decomp/run.py
+++ b/param_decomp/run.py
@@ -437,6 +437,7 @@ def run_decomposition_training(
     remat_recon_forwards: bool,
     remat_ci_fn: bool,
     ascend_replicate: bool,
+    sequence_recon_entries: bool,
     compiler_options: dict[str, bool | int | str],
     profile: ProfileConfig,
     sample_batch: Callable[[int], Any],
@@ -506,6 +507,7 @@ def run_decomposition_training(
         remat_recon_forwards=remat_recon_forwards,
         remat_ci_fn=remat_ci_fn,
         ascend_replicate=ascend_replicate,
+        sequence_recon_entries=sequence_recon_entries,
         compiler_options=compiler_options,
         mesh=mesh,
     )
@@ -520,6 +522,7 @@ def run_decomposition_training(
                 "n_processes": jax.process_count(),
                 "remat_recon_forwards": remat_recon_forwards,
                 "remat_ci_fn": remat_ci_fn,
+                "sequence_recon_entries": sequence_recon_entries,
                 "run_id": run.run_id,
                 "run_dir": str(run.run_dir),
             },

--- a/param_decomp/targets/llama8b.py
+++ b/param_decomp/targets/llama8b.py
@@ -23,6 +23,7 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
+from jax.ad_checkpoint import checkpoint_name
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, Float, Int
@@ -272,6 +273,10 @@ def _frozen_site_weight(layer: LlamaLayer, kind: str) -> Array:
 
 
 # ----------------------------- forwards -----------------------------
+
+
+_GATHERED_WEIGHTS_NAME = "gathered_compute_weights"
+"""`checkpoint_name` tag on the live block's post-gather V/U/W (`save_gathered_weights`)."""
 
 
 def _clean_mlp_out(layer: LlamaLayer, mlp_in: Array) -> Array:
@@ -528,6 +533,9 @@ class LlamaDecomposedModel(eqx.Module):
     plain per-layer scan."""
     gather_fp8: bool = eqx.field(static=True, default=False)
     """Quantized all-gather of the ÷fsdp compute V/U (`RuntimeConfig.gather_fp8`)."""
+    save_gathered_weights: bool = eqx.field(static=True, default=False)
+    """Save the live segment's gathered per-layer V/U/W across fwd→bwd
+    (`RuntimeConfig.save_gathered_weights`)."""
 
     @property
     def site_names(self) -> tuple[str, ...]:
@@ -681,8 +689,22 @@ class LlamaDecomposedModel(eqx.Module):
         else:
             first_live = last_live = 0
 
+        def saved_gathered(w: Array, gathered: P) -> Array:
+            """Pin `w` to its post-gather (full) layout and NAME it, so the checkpoint policy
+            SAVES the gathered value across fwd→bwd — the rematerialized backward then reuses
+            it instead of re-running the ÷fsdp→full gather (the dominant exposed-collective
+            phase). Identity unless `save_gathered_weights`; the constraint is a no-op
+            off-mesh (CPU tests still exercise the name + policy path)."""
+            if not self.save_gathered_weights:
+                return w
+            if not jax.sharding.get_abstract_mesh().empty:
+                w = jax.lax.with_sharding_constraint(w, gathered)
+            return checkpoint_name(w, _GATHERED_WEIGHTS_NAME)
+
         def decomp_site(x_in: Array, W: Array, e: dict[str, Array]) -> Array:
             v, u = e["V"], e["U"]
+            v = saved_gathered(v, P(None, "tp"))  # [d_in FULL (was ÷fsdp), C ÷tp]
+            u = saved_gathered(u, P("tp", None))  # [C ÷tp, d_out FULL (was ÷fsdp)]
             if "V_scale" in e:  # fp8 QAG: gather the fp8 ÷fsdp weight to full d (½ bytes on the
                 # wire), THEN dequant to bf16 — the barrier keeps the convert after the gather so
                 # the collective moves fp8, not bf16.
@@ -717,9 +739,10 @@ class LlamaDecomposedModel(eqx.Module):
         ) -> tuple[Array, Array | None]:
             # LIVE block only: every decomposed kind decomps (static — no cond); a kind absent
             # from the decomposition stays frozen.
+            W_full = saved_gathered(W, P(None, None))
             if kind not in decomposed_kinds:
-                return x_in @ W.T, None
-            out = decomp_site(x_in, W, pk[kind])
+                return x_in @ W_full.T, None
+            out = decomp_site(x_in, W_full, pk[kind])
             return out, (out if want_collect else None)
 
         def live_block(
@@ -767,6 +790,11 @@ class LlamaDecomposedModel(eqx.Module):
         #   remat=False → dots_saveable: SAVE the activation matmuls (no batch dims here → they
         #     qualify) but still recompute the gather + cheap elementwise. Pure recompute either
         #     way; zero numerics change.
+        # `save_gathered_weights` augments either mode with `save_only_these_names`: the live
+        # block's named gathered V/U/W (see `saved_gathered`) become saved residuals — the scan
+        # stacks them `[live_layers, …]` resident across fwd→bwd, and the backward's remat
+        # re-execution reuses them instead of re-gathering. Frozen segments name nothing, so
+        # the policy is uniform across segments.
         # `scan_unroll` (native `lax.scan(unroll=k)`) emits k iterations straight-line so XLA can
         # prefetch gather(L+1) under matmul(L) — the overlap a 1-layer while-body denies.
         policy = (
@@ -774,6 +802,13 @@ class LlamaDecomposedModel(eqx.Module):
             if remat
             else jax.checkpoint_policies.dots_saveable
         )
+        if self.save_gathered_weights:
+            saved_names = jax.checkpoint_policies.save_only_these_names(_GATHERED_WEIGHTS_NAME)
+            policy = (
+                saved_names
+                if remat
+                else jax.checkpoint_policies.save_from_both_policies(policy, saved_names)
+            )
 
         def run_scan(body: Any, carry: Array, xs: Any) -> tuple[Array, Any]:
             return jax.lax.scan(
@@ -958,10 +993,12 @@ def build_decomposed_lm(
     sites: tuple[SiteSpec, ...],
     scan_unroll: int = 1,
     gather_fp8: bool = False,
+    save_gathered_weights: bool = False,
 ) -> LlamaDecomposedModel:
     """Assemble a `LlamaDecomposedModel` from the frozen full-model arrays + decomposition
     config. `sites` must be canonical-ordered with dims matching `cfg`. `scan_unroll` /
-    `gather_fp8` are the `RuntimeConfig` compute knobs (1 / off = the default forward)."""
+    `gather_fp8` / `save_gathered_weights` are the `RuntimeConfig` compute knobs
+    (1 / off / off = the default forward)."""
     site_cs = tuple(SiteC(s.name, s.C) for s in sites)
     assert sites == llama_site_specs(cfg, canonical_site_cs(site_cs)), (
         f"sites are not the canonical specs for this config: {sites}"
@@ -978,6 +1015,7 @@ def build_decomposed_lm(
         eps=cfg.rms_norm_eps,
         scan_unroll=scan_unroll,
         gather_fp8=gather_fp8,
+        save_gathered_weights=save_gathered_weights,
     )
 
 
@@ -987,11 +1025,12 @@ def load_decomposed_lm_from_hf(
     sites: tuple[SiteSpec, ...],
     scan_unroll: int = 1,
     gather_fp8: bool = False,
+    save_gathered_weights: bool = False,
 ) -> LlamaDecomposedModel:
     """Load the Llama-8B `DecomposedModel`: the full frozen model (embedding, all blocks,
     final norm, lm_head) as fields plus the static decomposition config (`sites`). Blocks
-    without a decomposed site run the plain frozen path. `scan_unroll` / `gather_fp8` are the
-    `RuntimeConfig` compute knobs."""
+    without a decomposed site run the plain frozen path. `scan_unroll` / `gather_fp8` /
+    `save_gathered_weights` are the `RuntimeConfig` compute knobs."""
     w = _HFWeights(_hf_snapshot_dir(model_name))
     return build_decomposed_lm(
         embed=w.get("model.embed_tokens.weight"),
@@ -1003,4 +1042,5 @@ def load_decomposed_lm_from_hf(
         sites=sites,
         scan_unroll=scan_unroll,
         gather_fp8=gather_fp8,
+        save_gathered_weights=save_gathered_weights,
     )

--- a/param_decomp/tests/equivalence/test_equivalence.py
+++ b/param_decomp/tests/equivalence/test_equivalence.py
@@ -104,7 +104,7 @@ def test_structure_stoch_is_per_chunk() -> None:
     assert "for entry_idx, entry in enumerate(term.plan)" in src, (
         "each recon term must loop its plan's entries"
     )
-    assert "/ n_forwards" in src, "each term must average over ALL forwards (every draw)"
+    assert "/ len(draws)" in src, "each term must average over ALL forwards (every draw)"
 
 
 def test_structure_recon_is_kl_not_mse() -> None:

--- a/param_decomp/tests/test_llama8b.py
+++ b/param_decomp/tests/test_llama8b.py
@@ -27,6 +27,7 @@ from param_decomp.components import DecompVU, SiteC, SiteSpec, init_decomp_vu
 from param_decomp.configs import (
     AdamPGDConfig,
     ChunkwiseSubsetReconLossConfig,
+    CIMaskedReconLossConfig,
     FaithfulnessLossConfig,
     ImportanceMinimalityLossConfig,
     PersistentPGDReconLossConfig,
@@ -453,6 +454,118 @@ def test_decomp_vu_shapes_fp32():
     assert V_d.shape == (di, 8) and U_d.shape == (8, d)
     assert isinstance(vu, DecompVU)
     assert all(a.dtype == jnp.float32 for pair in vu.vu.values() for a in pair)
+
+
+@pytest.mark.parametrize("remat", [True, False])
+def test_sequence_recon_entries_matches_fused_backward(remat: bool):
+    """`sequence_recon_entries` only reorders scheduling: same forwards, same RNG, same
+    losses; grads differ only by float reassociation in the shared-leaf accumulation.
+    One full step per arm from bit-identical states, over the production term shapes
+    (chunkwise-stochastic multi-entry + PPGD all-sites) plus a constant-sources term."""
+    cfg = _tiny_cfg()
+    seq = 16
+    site_cs = mlp_family_site_cs(2, 5, 8)
+    sites = llama_site_specs(cfg, site_cs)
+    lm = _tiny_decomposed_lm(cfg, sites, jax.random.PRNGKey(0))
+    opt_vu = optax.chain(optax.clip_by_global_norm(0.01), optax.adamw(1e-3, weight_decay=0.0))
+    opt_ci = optax.adamw(1e-3, weight_decay=0.0)
+    ppgd_cfg = PersistentPGDReconLossConfig(
+        coeff=0.5,
+        scope=SCScope(),
+        optimizer=AdamPGDConfig(
+            beta1=0.5,
+            beta2=0.99,
+            lr_schedule=ScheduleConfig(start_val=0.01, warmup_pct=0.025),
+        ),
+        n_warmup_steps=2,
+    )
+    assert ppgd_cfg.coeff is not None
+    loss_terms = build_loss_terms(
+        (
+            FaithfulnessLossConfig(coeff=1e5),
+            ImportanceMinimalityLossConfig(
+                coeff=5e-6,
+                pnorm=ScheduleConfig(start_val=2.0, fn_type="linear", final_val_frac=0.2),
+            ),
+            ChunkwiseSubsetReconLossConfig(
+                routing=UniformKSubsetRoutingConfig(), coeff=0.5, sites_per_chunk=3, n_samples=2
+            ),
+            CIMaskedReconLossConfig(coeff=0.25),
+            ppgd_cfg,
+        ),
+        lm.site_names,
+    )
+
+    def make_state() -> TrainState:
+        # Fresh buffers per arm: `step` donates the state. Deterministic keys keep the two
+        # arms' inits bit-identical.
+        vu = init_decomp_vu(sites, jax.random.PRNGKey(1))
+        ci_fn = _build_chunkwise_ci_fn(lm, jax.random.PRNGKey(2), n_blocks=2)
+        src = init_persistent_sources(
+            lm.site_names,
+            tuple(s.C for s in lm.sites),
+            (1, seq),
+            jnp.float32,
+            jax.random.PRNGKey(3),
+        )
+        assert ppgd_cfg.coeff is not None
+        return TrainState(
+            components=vu, ci_fn=ci_fn,
+            components_opt_state=opt_vu.init(eqx.filter(vu, eqx.is_array)),
+            ci_fn_opt_state=opt_ci.init(eqx.filter(ci_fn, eqx.is_array)),
+            adversaries={
+                ppgd_cfg.type: PersistentAdversary(
+                    sources=src,
+                    opt_state=init_sources_adam_state(src),
+                    state_key=ppgd_cfg.type,
+                    coeff=ppgd_cfg.coeff,
+                    adam=ppgd_cfg.optimizer,
+                    n_warmup=ppgd_cfg.n_warmup_steps,
+                )
+            },
+            step=jnp.zeros((), jnp.int32),
+        )  # fmt: skip
+
+    def run_arm(sequence_recon_entries: bool) -> tuple[TrainState, dict[str, jax.Array]]:
+        step = make_train_step(
+            lm=lm,
+            losses=loss_terms,
+            components_optimizer=opt_vu,
+            ci_fn_optimizer=opt_ci,
+            total_steps=100,
+            remat_recon_forwards=remat,
+            remat_ci_fn=False,
+            mesh=None,
+            sequence_recon_entries=sequence_recon_entries,
+        )
+        tokens = jax.random.randint(jax.random.PRNGKey(4), (2, seq), 0, cfg.vocab_size)
+        return step(lm, make_state(), tokens, jax.random.PRNGKey(100))
+
+    state_fused, metrics_fused = run_arm(False)
+    state_seq, metrics_seq = run_arm(True)
+
+    # Same forwards + RNG → the loss VALUES are identical (only the backward is restructured).
+    assert set(metrics_fused) == set(metrics_seq)
+    for k in ("total", "faith", "imp", "freq") + tuple(
+        k for k in metrics_fused if k.startswith("loss/")
+    ):
+        assert jnp.array_equal(metrics_fused[k], metrics_seq[k]), (
+            k, metrics_fused[k], metrics_seq[k],
+        )  # fmt: skip
+
+    # Grads (→ updated state) match up to reassociation of the per-forward accumulation.
+    def leaves(tree: object) -> list[jax.Array]:
+        return [leaf for leaf in jax.tree.leaves(tree) if eqx.is_array(leaf)]
+
+    for name, fused, seq_ in (
+        ("components", state_fused.components, state_seq.components),
+        ("ci_fn", state_fused.ci_fn, state_seq.ci_fn),
+        ("adversaries", state_fused.adversaries, state_seq.adversaries),
+    ):
+        for leaf_fused, leaf_seq in zip(leaves(fused), leaves(seq_), strict=True):
+            assert jnp.allclose(
+                leaf_fused.astype(jnp.float32), leaf_seq.astype(jnp.float32), atol=1e-6, rtol=1e-5
+            ), (name, jnp.abs(leaf_fused - leaf_seq).max())
 
 
 def test_fresh_pgd_adversary_step():

--- a/param_decomp/tests/test_llama8b.py
+++ b/param_decomp/tests/test_llama8b.py
@@ -72,7 +72,10 @@ def _tiny_cfg() -> LlamaConfig:
 
 
 def _tiny_decomposed_lm(
-    cfg: LlamaConfig, sites: tuple[SiteSpec, ...], key: jax.Array
+    cfg: LlamaConfig,
+    sites: tuple[SiteSpec, ...],
+    key: jax.Array,
+    save_gathered_weights: bool = False,
 ) -> LlamaDecomposedModel:
     """A tiny random `LlamaDecomposedModel` (random embedding + full frozen layer stack
     plus the decomposition `sites`) — the CPU-test analog of `load_decomposed_lm_from_hf`."""
@@ -102,6 +105,7 @@ def _tiny_decomposed_lm(
         inv_freq=llama3_inv_freq(cfg),
         cfg=cfg,
         sites=sites,
+        save_gathered_weights=save_gathered_weights,
     )
 
 
@@ -185,6 +189,38 @@ def test_llama_site_specs_dims():
     assert dims(by_name["layers.2.mlp.down_proj"]) == (cfg.n_intermediate, cfg.n_embd, 4)
     with pytest.raises(AssertionError, match="canonical"):
         llama_site_specs(cfg, tuple(reversed(mlp_family_site_cs(2, 2, 4))))
+
+
+@pytest.mark.parametrize("remat", [True, False])
+def test_save_gathered_weights_is_numerics_identical(remat: bool):
+    """`save_gathered_weights` is a pure store-vs-recompute trade: outputs AND grads (wrt
+    V/U and masks, through the checkpointed live-block scan) must match the default path."""
+    cfg = _tiny_cfg()
+    C = 8
+    sites = _mlp_sites(cfg, 3, 5, C)
+    key = jax.random.PRNGKey(0)
+    lm_off = _tiny_decomposed_lm(cfg, sites, key)
+    lm_on = _tiny_decomposed_lm(cfg, sites, key, save_gathered_weights=True)
+    vu = init_decomp_vu(sites, jax.random.PRNGKey(1))
+    b, t = 2, 16
+    tokens = jax.random.randint(jax.random.PRNGKey(2), (b, t), 0, cfg.vocab_size)
+    names = lm_off.site_names
+    masks = {
+        s: jax.random.uniform(jax.random.fold_in(jax.random.PRNGKey(3), i), (b, t, C))
+        for i, s in enumerate(names)
+    }
+
+    def loss(lm: LlamaDecomposedModel, vu_: DecompVU, masks_: dict[str, jax.Array]) -> jax.Array:
+        out = lm.masked_output(
+            lm.prepare_compute_weights(vu_), tokens, masks_, {}, None, names, False, remat=remat
+        )
+        return jnp.sum(out.astype(jnp.float32) ** 2)
+
+    (l_off, g_off) = jax.value_and_grad(lambda v, m: loss(lm_off, v, m), argnums=(0, 1))(vu, masks)
+    (l_on, g_on) = jax.value_and_grad(lambda v, m: loss(lm_on, v, m), argnums=(0, 1))(vu, masks)
+    assert jnp.array_equal(l_off, l_on), (l_off, l_on)
+    for leaf_off, leaf_on in zip(jax.tree.leaves(g_off), jax.tree.leaves(g_on), strict=True):
+        assert jnp.array_equal(leaf_off, leaf_on)
 
 
 @pytest.mark.parametrize("first,last", [(4, 4), (3, 6)])

--- a/param_decomp/train.py
+++ b/param_decomp/train.py
@@ -49,6 +49,7 @@ from param_decomp.recon import (
     LossSurface,
     PersistentSources,
     ReconForward,
+    ReconLossTerm,
     Routes,
     StochasticSources,
 )
@@ -111,6 +112,7 @@ def make_train_step(
     remat_ci_fn: bool,
     mesh: Mesh | None,
     ascend_replicate: bool = False,
+    sequence_recon_entries: bool = False,
     compiler_options: dict[str, bool | int | str] | None = None,
 ):
     """Build the `eqx.filter_jit`'d `step(model, state, batch, key) -> (state, metrics)`.
@@ -369,106 +371,210 @@ def make_train_step(
         # the graph so their gradient comes from the SAME backward (SPEC S14'); they
         # are NOT detached here, but components/ci grads through them are what torch
         # gets too (sources are leaves). ──
+        warmed_sources = {k: a.sources for k, a in warmed_advs.items()}
+
+        def draw_recon_loss(
+            prepared: Any,
+            ci_lower: dict[str, Array],
+            persistent_sources: dict[str, dict[str, Array]],
+            ci_stacked: dict[str, Array] | None,
+            term_idx: int,
+            entry_idx: int,
+            entry: ReconForward,
+            draw_key: PRNGKeyArray,
+            routes: Routes,
+        ) -> Array:
+            """One recon forward's KL: dispatch on the entry's mask-source strategy, run the
+            masked forward, compare against the clean output (SPEC S10')."""
+            with jax.named_scope("pd_recon_masked_fwd"):
+                match entry.sources:
+                    case StochasticSources():
+                        # Stochastic recon builds its masks INSIDE the target's
+                        # `masked_output_stochastic` from the shared `ci_stacked` — a scan
+                        # target recomputes them in its checkpointed block (mask never held,
+                        # the memory win); others build masks then `masked_output`. Either way
+                        # the engine holds no per-forward mask stacks.
+                        assert ci_stacked is not None
+                        masked = batch_sharded(
+                            model.masked_output_stochastic(
+                                prepared,
+                                batch,
+                                ci_stacked,
+                                draw_key,
+                                routes,
+                                entry.live_sites,
+                                entry.has_delta,
+                                remat=remat_recon_forwards,
+                            )
+                        )
+                    case ConstantSources() as strategy:
+                        masks, delta_masks = constant_entry_masks(
+                            strategy, ci_lower, entry.live_sites
+                        )
+                        masked = masked_forward(
+                            model, prepared, batch, masks, delta_masks,
+                            routes, entry.live_sites, entry.has_delta,
+                        )  # fmt: skip
+                    case FreshPGDSources():
+                        masks, delta_masks = source_masks(
+                            ci_lower, fresh_sources[(term_idx, entry_idx)], entry.live_sites
+                        )
+                        masked = masked_forward(
+                            model, prepared, batch, masks, delta_masks,
+                            routes, entry.live_sites, entry.has_delta,
+                        )  # fmt: skip
+                    case PersistentSources(state_key=state_key):
+                        masks, delta_masks = source_masks(
+                            ci_lower, persistent_sources[state_key], entry.live_sites
+                        )
+                        masked = masked_forward(
+                            model, prepared, batch, masks, delta_masks,
+                            routes, entry.live_sites, entry.has_delta,
+                        )  # fmt: skip
+            return recon_loss_fn(masked, clean_output)
+
+        def term_draws(
+            term_idx: int, term: ReconLossTerm
+        ) -> list[tuple[int, ReconForward, PRNGKeyArray, Routes]]:
+            """The term's flat `(entry_idx, entry, draw_key, routes)` forwards. Key derivation
+            reproduces the pre-unification production trace exactly (SPEC R1); fresh-PGD
+            entries reuse the ascent phase's fixed routes (SPEC S24)."""
+            term_key = random.fold_in(key, 1 + term_idx)
+            draws: list[tuple[int, ReconForward, PRNGKeyArray, Routes]] = []
+            for entry_idx, entry in enumerate(term.plan):
+                entry_key, routing_key = random.split(random.fold_in(term_key, entry_idx))
+                match entry.sources:
+                    case FreshPGDSources():
+                        routes_per_draw = fixed_routes[(term_idx, entry_idx)]
+                    case _:
+                        routes_per_draw = entry.sample_routing(routing_key, leading)
+                draws.extend(
+                    (entry_idx, entry, random.fold_in(entry_key, draw_idx), routes)
+                    for draw_idx, routes in enumerate(routes_per_draw)
+                )
+            assert draws, f"term {term.name!r} produced no forwards"
+            return draws
+
+        per_term_draws = [term_draws(term_idx, term) for term_idx, term in enumerate(recon_terms)]
+
         def loss_fn(
             trainable: tuple[Any, DecompVU, CI, dict[str, dict[str, Array]]],
         ) -> tuple[Array, tuple[Array, Array, Array, tuple[Array, ...]]]:
             prepared, components, ci, persistent_sources = trainable
-            # Stochastic recon builds its masks INSIDE the target's `masked_output_stochastic`
-            # from this once-per-step shared CI form — a scan target recomputes them in its
-            # checkpointed block (mask never held, the memory win); others fall back to building
-            # masks then `masked_output`. Either way the engine holds no per-forward mask stacks.
             ci_stacked = model.stack_ci(ci.lower)
             faith_loss = faithfulness_loss(model.weight_deltas(components))
             imp_lp, imp_freq = imp_min_terms(ci.upper, imp_min, imp_min_param)
 
             term_losses: list[Array] = []
-            for term_idx, term in enumerate(recon_terms):
-                term_key = random.fold_in(key, 1 + term_idx)
+            for term_idx, draws in enumerate(per_term_draws):
                 total = jnp.zeros((), jnp.float32)
-                n_forwards = 0
-                for entry_idx, entry in enumerate(term.plan):
-                    entry_key, routing_key = random.split(random.fold_in(term_key, entry_idx))
-                    match entry.sources:
-                        case FreshPGDSources():
-                            routes_per_draw = fixed_routes[(term_idx, entry_idx)]
-                        case _:
-                            routes_per_draw = entry.sample_routing(routing_key, leading)
-                    for draw_idx, routes in enumerate(routes_per_draw):
-                        draw_key = random.fold_in(entry_key, draw_idx)
-
-                        def pre_built_fwd(
-                            mds: tuple[dict[str, Array], dict[str, Array]],
-                            routes: Routes = routes,
-                            entry: ReconForward = entry,
-                        ) -> Any:
-                            return masked_forward(
-                                model,
-                                prepared,
-                                batch,
-                                mds[0],
-                                mds[1],
-                                routes,
-                                entry.live_sites,
-                                entry.has_delta,
-                            )
-
-                        with jax.named_scope("pd_recon_masked_fwd"):
-                            match entry.sources:
-                                case StochasticSources():  # masks built inside the target
-                                    masked = batch_sharded(
-                                        model.masked_output_stochastic(
-                                            prepared,
-                                            batch,
-                                            ci_stacked,
-                                            draw_key,
-                                            routes,
-                                            entry.live_sites,
-                                            entry.has_delta,
-                                            remat=remat_recon_forwards,
-                                        )
-                                    )
-                                case ConstantSources() as strategy:
-                                    masked = pre_built_fwd(
-                                        constant_entry_masks(strategy, ci.lower, entry.live_sites)
-                                    )
-                                case FreshPGDSources():
-                                    masked = pre_built_fwd(
-                                        source_masks(
-                                            ci.lower,
-                                            fresh_sources[(term_idx, entry_idx)],
-                                            entry.live_sites,
-                                        )
-                                    )
-                                case PersistentSources(state_key=state_key):
-                                    masked = pre_built_fwd(
-                                        source_masks(
-                                            ci.lower,
-                                            persistent_sources[state_key],
-                                            entry.live_sites,
-                                        )
-                                    )
-                        total = total + recon_loss_fn(masked, clean_output)
-                        n_forwards += 1
-                assert n_forwards > 0, f"term {term.name!r} produced no forwards"
-                term_loss = total / n_forwards
-                term_losses.append(term_loss)
+                for entry_idx, entry, draw_key, routes in draws:
+                    total = total + draw_recon_loss(
+                        prepared, ci.lower, persistent_sources, ci_stacked,
+                        term_idx, entry_idx, entry, draw_key, routes,
+                    )  # fmt: skip
+                term_losses.append(total / len(draws))
 
             total_loss = faith_coeff * faith_loss + imp_coeff * imp_lp + freq_coeff * imp_freq
             for term, term_loss in zip(recon_terms, term_losses, strict=True):
                 total_loss = total_loss + term.coeff * term_loss
             return total_loss, (faith_loss, imp_lp, imp_freq, tuple(term_losses))
 
-        with jax.named_scope("pd_value_and_grad"):
-            (total_loss, (faith_loss, imp_lp, imp_freq, term_losses)), grads = (
-                eqx.filter_value_and_grad(loss_fn, has_aux=True)(
-                    (
-                        prepared,
-                        state.components,
-                        ci,
-                        {k: a.sources for k, a in warmed_advs.items()},
-                    )
+        def sequenced_value_and_grad() -> tuple[
+            tuple[Array, tuple[Array, Array, Array, tuple[Array, ...]]],
+            tuple[Any, DecompVU, CI, dict[str, dict[str, Array]]],
+        ]:
+            """`loss_fn`'s backward, decomposed per recon forward and CHAINED: each forward's
+            `value_and_grad` is tied to its predecessor's grads through
+            `jax.lax.optimization_barrier`, so fwd_{i+1} cannot be scheduled before bwd_i and
+            XLA frees each forward's saved stack before the next begins. The fused backward
+            keeps every recon forward's saved residuals co-resident instead (~5x peak at the
+            production 4-chunk + PPGD plan). Σ per-forward grads = the fused grads up to float
+            reassociation in the shared-leaf accumulation; losses, forwards, and RNG are
+            identical. Recon touches only `(prepared, ci.lower, sources)`, so only those thread
+            through the chain — faith + imp-min get their own small backward."""
+
+            def faith_imp_loss(
+                components_and_upper: tuple[DecompVU, dict[str, Array]],
+            ) -> tuple[Array, tuple[Array, Array, Array]]:
+                components, ci_upper = components_and_upper
+                faith_loss = faithfulness_loss(model.weight_deltas(components))
+                imp_lp, imp_freq = imp_min_terms(ci_upper, imp_min, imp_min_param)
+                loss = faith_coeff * faith_loss + imp_coeff * imp_lp + freq_coeff * imp_freq
+                return loss, (faith_loss, imp_lp, imp_freq)
+
+            (_, (faith_loss, imp_lp, imp_freq)), (components_grad_faith, upper_grad) = (
+                eqx.filter_value_and_grad(faith_imp_loss, has_aux=True)(
+                    (state.components, ci.upper)
                 )
             )
+
+            # The initial barrier also ties the warmed persistent sources to the recon
+            # inputs, so the PPGD warmup ascents complete before the first recon forward
+            # (ascent-phase overlap is part of the measured co-residency).
+            recon_primals = jax.lax.optimization_barrier((prepared, ci.lower, warmed_sources))
+            acc: tuple[Any, dict[str, Array], dict[str, dict[str, Array]]] | None = None
+            term_losses: list[Array] = []
+            for term_idx, draws in enumerate(per_term_draws):
+                coeff_per_draw = recon_terms[term_idx].coeff / len(draws)
+                term_total = jnp.zeros((), jnp.float32)
+                for entry_idx, entry, draw_key, routes in draws:
+
+                    def scaled_draw_loss(
+                        primals: tuple[Any, dict[str, Array], dict[str, dict[str, Array]]],
+                        term_idx: int = term_idx,
+                        entry_idx: int = entry_idx,
+                        entry: ReconForward = entry,
+                        draw_key: PRNGKeyArray = draw_key,
+                        routes: Routes = routes,
+                        coeff_per_draw: float = coeff_per_draw,
+                    ) -> tuple[Array, Array]:
+                        prepared_, ci_lower_, persistent_sources_ = primals
+                        ci_stacked = (
+                            model.stack_ci(ci_lower_)
+                            if isinstance(entry.sources, StochasticSources)
+                            else None
+                        )
+                        draw_loss = draw_recon_loss(
+                            prepared_, ci_lower_, persistent_sources_, ci_stacked,
+                            term_idx, entry_idx, entry, draw_key, routes,
+                        )  # fmt: skip
+                        return coeff_per_draw * draw_loss, draw_loss
+
+                    (_, draw_loss), draw_grads = eqx.filter_value_and_grad(
+                        scaled_draw_loss, has_aux=True
+                    )(recon_primals)
+                    term_total = term_total + draw_loss
+                    acc = draw_grads if acc is None else jax.tree.map(jnp.add, acc, draw_grads)
+                    acc, recon_primals = jax.lax.optimization_barrier((acc, recon_primals))
+                term_losses.append(term_total / len(draws))
+            assert acc is not None
+            prepared_grad, lower_grad, persistent_grads_scaled = acc
+
+            total_loss = faith_coeff * faith_loss + imp_coeff * imp_lp + freq_coeff * imp_freq
+            for term, term_loss in zip(recon_terms, term_losses, strict=True):
+                total_loss = total_loss + term.coeff * term_loss
+            # `ci_vjp` wants the full CI cotangent; the logits view is unused in the step, so
+            # its cotangent is zero (as in the fused backward, where it falls out of AD).
+            ci_grad = CI(
+                logits=jax.tree.map(jnp.zeros_like, ci.logits),
+                lower=lower_grad,
+                upper=upper_grad,
+            )
+            grads = (prepared_grad, components_grad_faith, ci_grad, persistent_grads_scaled)
+            return (total_loss, (faith_loss, imp_lp, imp_freq, tuple(term_losses))), grads
+
+        with jax.named_scope("pd_value_and_grad"):
+            if sequence_recon_entries:
+                (total_loss, (faith_loss, imp_lp, imp_freq, term_losses)), grads = (
+                    sequenced_value_and_grad()
+                )
+            else:
+                (total_loss, (faith_loss, imp_lp, imp_freq, term_losses)), grads = (
+                    eqx.filter_value_and_grad(loss_fn, has_aux=True)(
+                        (prepared, state.components, ci, warmed_sources)
+                    )
+                )
         prepared_grad, components_grad_faith, ci_grad, persistent_grads_scaled = grads
         components_grad_recon = recon_vjp(prepared_grad)[0]
         ci_fn_grad = ci_vjp(ci_grad)[0]

--- a/param_decomp_lab/experiments/lm/load_run.py
+++ b/param_decomp_lab/experiments/lm/load_run.py
@@ -74,6 +74,9 @@ def build_target(cfg: BuiltRun, mesh: jax.sharding.Mesh) -> tuple[DecomposedMode
     validate via their in-loop target-CI metric in the lab provider, not this path."""
     match cfg.target:
         case LlamaSimpleMLPTargetConfig():
+            assert not cfg.runtime.save_gathered_weights, (
+                "save_gathered_weights is wired for the llama8b target only"
+            )
             cache_dir = llama_simple_mlp.pretrain_cache_dir(cfg.target.pretrain_run_path)
             simple_cfg = llama_simple_mlp.load_model_config(cache_dir)
             sites = llama_simple_mlp.site_specs(simple_cfg, cfg.target.sites)
@@ -92,6 +95,7 @@ def build_target(cfg: BuiltRun, mesh: jax.sharding.Mesh) -> tuple[DecomposedMode
                     sites,
                     scan_unroll=cfg.runtime.scan_unroll,
                     gather_fp8=cfg.runtime.gather_fp8,
+                    save_gathered_weights=cfg.runtime.save_gathered_weights,
                 ),
                 mesh,
             )

--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -195,6 +195,7 @@ def train(
         remat_recon_forwards=built.runtime.remat_recon_forwards,
         remat_ci_fn=built.runtime.remat_ci_fn,
         ascend_replicate=built.runtime.ascend_replicate,
+        sequence_recon_entries=built.runtime.sequence_recon_entries,
         compiler_options=built.runtime.compiler_options,
         profile=built.runtime.launch_env.profile,
         sample_batch=sample_batch,

--- a/param_decomp_lab/experiments/resid_mlp/run.py
+++ b/param_decomp_lab/experiments/resid_mlp/run.py
@@ -178,6 +178,7 @@ def run_resid_mlp_decomposition(built: BuiltRun, raw_cfg: dict[str, Any], mesh: 
         remat_recon_forwards=built.runtime.remat_recon_forwards,
         remat_ci_fn=built.runtime.remat_ci_fn,
         ascend_replicate=built.runtime.ascend_replicate,
+        sequence_recon_entries=built.runtime.sequence_recon_entries,
         compiler_options=built.runtime.compiler_options,
         profile=built.runtime.launch_env.profile,
         sample_batch=sample_batch,

--- a/param_decomp_lab/experiments/tms/run.py
+++ b/param_decomp_lab/experiments/tms/run.py
@@ -161,6 +161,7 @@ def run_tms_decomposition(built: BuiltRun, raw_cfg: dict[str, Any], mesh: Mesh) 
         remat_recon_forwards=built.runtime.remat_recon_forwards,
         remat_ci_fn=built.runtime.remat_ci_fn,
         ascend_replicate=built.runtime.ascend_replicate,
+        sequence_recon_entries=built.runtime.sequence_recon_entries,
         compiler_options=built.runtime.compiler_options,
         profile=built.runtime.launch_env.profile,
         sample_batch=sample_batch,


### PR DESCRIPTION
## What

Two default-off `RuntimeConfig` compute-substrate flags, measured together at production full32L b128/dp32:

- **`sequence_recon_entries`**: decomposes the main backward into per-recon-forward `value_and_grad`s chained by `jax.lax.optimization_barrier`, so fwd_{i+1} data-depends on ALL of bwd_i and XLA frees each forward's saved stack before the next begins. The fused backward instead keeps every recon forward's saved residuals co-resident (~5x at the production 4-chunk + PPGD plan). The fused path is refactored onto the same per-draw dispatch (`draw_recon_loss` / `term_draws`) with identical RNG key derivation (SPEC R1/S10').
- **`save_gathered_weights`** (cherry-pick of a58a908f9 from `bridge/task-tensor-parallel-remat-gather-residency`, full V/U/W scope): keep the live block's gathered weight stacks across fwd→bwd so the rematerialized backward stops re-gathering.

## Measured (b128 dp32, 4 nodes, PROFILE shape; MEMPROBE + TRACE configs included)

Memory (per-rank GiB, limit 164.08):

| arm | static temp | runtime peak |
|---|---|---|
| fused control (p-5700cd4a) | 96.98 | 146.49 |
| sgw alone (prior, p-8ac48747) | 159.31 | **OOM at allocation** |
| seq (p-ae4a5f6f) | 84.59 | **134.09 (−12.4)** |
| seq+sgw full V/U/W (p-a975640e) | 113.37 | **162.88 — fits** (1.2 headroom) |

Step time (xplane_attr full-step window, 2 hosts/arm):

| arm | window | compute | exposed AllGather | AG kernels |
|---|---|---|---|---|
| fused control (p-42cb7fe0) | 5.652/5.624s | 2.71s | 1.50/1.45s | 888 |
| seq (p-f8c3a3d8) | 5.929/5.970s (+5.5%) | 2.95s | 1.61/1.56s | 890 |
| seq+sgw (p-e11ee40c) | 5.789/5.861s (+2.4–4.2%) | 3.40s | 1.00/0.96s | 603 |

**Verdict**: sequencing is a strong memory lever (−12.4 GiB baseline peak; unlocks full-scope sgw at b128, which was 5x-co-resident-OOM without it) and the sgw comms mechanism cashes exactly proportionally (−285 AG kernels, −0.54s exposed comms) — but sequencing costs ~+0.3s window (compute union +0.24s from lost cross-entry overlap/fusion), so **neither flag is a net speed win at b128 yet**. Both stay default-off: enable `sequence_recon_entries` when a run needs the memory (bigger batch/C at fixed topology). Speed follow-ons (not in this PR): attribute the sequencing compute tax per-op, partial sequencing (barrier every K entries), sgw scope trims.

## Numerics

- Losses bitwise-identical to the fused backward (asserted in the new step-level test, both remat modes); grads differ only by shared-leaf accumulation reassociation (≤4e-7 over a full step at the tiny config).
- seq+sgw composed vs fused+no-sgw: losses bitwise-equal, state ≤4e-7 (ad-hoc, logged on the bridge task).
- Full CPU suite green (280 passed) + `test_llama8b` at 4 sim devices; `make check` green.
- SPEC: no invariant changes — S10' term structure, R1 key derivation, S13'/S14'/S23 persistent-source lifecycle all preserved (the persistent term's source grad now comes from its own entry's backward, which is the same gradient since each source bundle feeds exactly one term, S23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHFLYWzHGitvdfpTWvdkTm