### PR TITLE
fix(llama8b): default HF weight loading to the shared cluster cache

### DIFF
--- a/param_decomp/targets/llama8b.py
+++ b/param_decomp/targets/llama8b.py
@@ -894,9 +894,18 @@ class LlamaDecomposedModel(eqx.Module):
 
 
 def _hf_snapshot_dir(model_name: str) -> Path:
+    """Newest local snapshot of `model_name`. `HF_HUB_CACHE` overrides; otherwise on
+    cluster (`DATA_MOUNT` set) the shared world-readable cache is the source — a home
+    `~/.cache` hub is silently mutable, and a wiped entry strands running jobs that
+    reload weights on requeue."""
     import os
 
-    cache = Path(os.environ.get("HF_HUB_CACHE", str(Path.home() / ".cache/huggingface/hub")))
+    default_cache = (
+        f"{os.environ['DATA_MOUNT']}/artifacts/hf_cache/hub"
+        if "DATA_MOUNT" in os.environ
+        else str(Path.home() / ".cache/huggingface/hub")
+    )
+    cache = Path(os.environ.get("HF_HUB_CACHE", default_cache))
     repo = "models--" + model_name.replace("/", "--")
     snaps = sorted((cache / repo / "snapshots").iterdir())
     assert snaps, f"no snapshot for {model_name} under {cache}"


### PR DESCRIPTION
## What

`_hf_snapshot_dir` (param_decomp/targets/llama8b.py) defaulted to `~/.cache/huggingface/hub`. On cluster (`DATA_MOUNT` set) it now defaults to the shared, world-readable `$DATA_MOUNT/artifacts/hf_cache/hub`. An explicit `HF_HUB_CACHE` still overrides, and off-cluster (no `DATA_MOUNT`) the standard home cache remains.

## Why

Oli's home hub cache was wiped on 2026-07-03 (cause unidentified), deleting `models--meta-llama--Llama-3.1-8B`. Any running llama8b run that requeues (preemption / node failure) reloads the weights from the default cache path and crashes on FileNotFoundError — the live 16-node run 170473 is currently exposed exactly this way. A shared immutable weights source beats a silently-mutable per-user home dir; this mirrors the `PARAM_DECOMP_OUT_DIR` on/off-cluster convention in `param_decomp_lab/infra/settings.py`.

Verified on cluster: with `HF_HUB_CACHE` unset, the function resolves `/mnt/data/artifacts/hf_cache/hub/models--meta-llama--Llama-3.1-8B/snapshots/d04e592…` and the safetensors shards are readable.

Note: this fixes future launches and consumers (`load_run`/harvest build the target through the same path). It does NOT fix run 170473, whose workspace is an immutable snapshot — that needs the home-cache symlink restored (see bridge thread).

bridge thread: restore-home-hf-cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hqiv1W5DVbk17JJ3rxES1