### PR TITLE
fix(harvest): per-worker local_batch_size; GPU assert + mem-fraction for 8B restores

### DIFF
--- a/param_decomp_lab/harvest/CLAUDE.md
+++ b/param_decomp_lab/harvest/CLAUDE.md
@@ -22,11 +22,11 @@ restore).
 ```bash
 # single process
 python -m param_decomp_lab.harvest.scripts.run_worker \
-    --run_dir runs/p-761bc061 --n_batches 50 --batch_size 16
+    --run_dir runs/p-761bc061 --n_batches 50 --local_batch_size 16
 
 # one rank of a sharded run (saves worker_states/worker_<rank>.npz; merge combines them)
 python -m param_decomp_lab.harvest.scripts.run_worker \
-    --run_dir runs/p-761bc061 --n_batches 50 --batch_size 16 \
+    --run_dir runs/p-761bc061 --n_batches 50 --local_batch_size 16 \
     --rank 0 --world_size 4 --subrun_id h-20260617_120000
 ```
 
@@ -73,13 +73,13 @@ The launcher:
 ```bash
 # Single process (auto-generates subrun ID)
 python -m param_decomp_lab.harvest.scripts.run_worker \
-    --run_dir runs/<run_id> --n_batches 1000 --batch_size 16
+    --run_dir runs/<run_id> --n_batches 1000 --local_batch_size 16
 
 # Multi-rank: all workers + merge must share the same --subrun_id
 SUBRUN="h-$(date +%Y%m%d_%H%M%S)"
 for r in 0 1 2 3; do
   python -m param_decomp_lab.harvest.scripts.run_worker \
-      --run_dir runs/<run_id> --n_batches 1000 --batch_size 16 \
+      --run_dir runs/<run_id> --n_batches 1000 --local_batch_size 16 \
       --rank $r --world_size 4 --subrun_id $SUBRUN &
 done
 wait
@@ -117,7 +117,7 @@ Entry point via `pd-harvest`. Submits array job + dependent merge job.
 The only worker. Opens a JAX run, runs its frozen forward, accumulates into the NumPy
 `Harvester`. Args:
 - `--run_dir`: the JAX run dir (`runs/<run_id>`) (required)
-- `--n_batches`, `--batch_size`, `--activation_threshold`
+- `--n_batches`, `--local_batch_size` (sequences per forward on each worker; global batch = local × world_size), `--activation_threshold`
 - `--rank R --world_size N`: serve `process_index=R`'s slice of every global batch; save
   to `worker_states/worker_<R>.npz`. Omit both for a single-process run that writes the
   final results directly.

--- a/param_decomp_lab/harvest/config.py
+++ b/param_decomp_lab/harvest/config.py
@@ -56,7 +56,10 @@ class IntruderSlurmConfig(BaseConfig):
 class HarvestConfig(BaseConfig):
     method_config: ParamDecompHarvestConfig
     n_batches: int | Literal["whole_dataset"] = 20_000
-    batch_size: int = 32
+    local_batch_size: int = 16
+    """Sequences per forward on EACH worker; a sharded run's global batch is
+    `local_batch_size * world_size`, so total sequences harvested =
+    `n_batches * local_batch_size * world_size`."""
     activation_examples_per_component: int = 400
     activation_context_tokens_per_side: int = 20
     pmi_token_top_k: int = 40

--- a/param_decomp_lab/harvest/scripts/run_slurm.py
+++ b/param_decomp_lab/harvest/scripts/run_slurm.py
@@ -114,7 +114,7 @@ def submit_harvest(
             "Sub-run ID": subrun_id,
             "N batches": config.config.n_batches,
             "N GPUs": n_gpus,
-            "Batch size": config.config.batch_size,
+            "Local batch size": config.config.local_batch_size,
             "Snapshot": f"{snapshot_ref} ({commit_hash[:8]})",
             "Array Job ID": array_result.job_id,
             "Merge Job ID": merge_result.job_id,

--- a/param_decomp_lab/harvest/scripts/run_worker.py
+++ b/param_decomp_lab/harvest/scripts/run_worker.py
@@ -2,7 +2,7 @@
 bridge.
 
     python -m param_decomp_lab.harvest.scripts.run_worker \
-        --run_dir runs/p-761bc061 --n_batches 50 --batch_size 16
+        --run_dir runs/p-761bc061 --n_batches 50 --local_batch_size 16
 
 The run is opened with `param_decomp_lab.experiments.lm.load_run.open_jax_run` (the reusable JAX
 "open a run for consumption" pattern); the frozen forward-only pass it exposes is
@@ -21,9 +21,11 @@ combines them. A single-process run (no `--rank`) writes the final results direc
 """
 
 import argparse
+import os
 from datetime import datetime
 from pathlib import Path
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 
@@ -68,7 +70,7 @@ def harvest_jax_run(
     data, seed = run.config.data, run.config.pd.seed
     assert isinstance(data, DataConfig), f"JAX harvest is LM-only, got {type(data).__name__}"
     rank, world_size = rank_world_size if rank_world_size is not None else (0, 1)
-    schedule = BatchSchedule(scan_shards(data.dir), config.batch_size, seed)
+    schedule = BatchSchedule(scan_shards(data.dir), config.local_batch_size * world_size, seed)
     server = ShardServer(schedule, data.seq_len, process_index=rank, process_count=world_size)
 
     harvester = Harvester(
@@ -111,7 +113,7 @@ def get_command(
         f"python -m param_decomp_lab.harvest.scripts.run_worker "
         f"--run_dir {run_dir} "
         f"--n_batches {config.n_batches} "
-        f"--batch_size {config.batch_size} "
+        f"--local_batch_size {config.local_batch_size} "
         f"--activation_threshold {_activation_threshold(config)} "
         f"--rank {rank} "
         f"--world_size {world_size} "
@@ -134,7 +136,10 @@ def main() -> None:
     ap.add_argument("--step", type=int, default=None, help="checkpoint step (default: latest)")
     ap.add_argument("--n_batches", type=int, required=True)
     ap.add_argument(
-        "--batch_size", type=int, default=HarvestConfig.model_fields["batch_size"].default
+        "--local_batch_size",
+        type=int,
+        default=HarvestConfig.model_fields["local_batch_size"].default,
+        help="sequences per forward on THIS worker (global batch = this x world_size)",
     )
     ap.add_argument(
         "--activation_threshold",
@@ -152,6 +157,16 @@ def main() -> None:
     args = ap.parse_args()
     assert (args.rank is None) == (args.world_size is None)
 
+    # Must be set before the jax backend initialises (first devices()/array op below):
+    # restoring a full 8B-run TrainState (~60GB checkpoint + restore staging + the frozen
+    # target) exceeds the default 0.75 preallocation pool on a single device.
+    os.environ.setdefault("XLA_PYTHON_CLIENT_MEM_FRACTION", "0.95")
+    if args.rank is not None:
+        assert jax.default_backend() == "gpu", (
+            f"sharded harvest worker on backend {jax.default_backend()!r} — a whole-array "
+            f"CPU harvest is ~100x slower than intended (CUDA jaxlib missing from the venv?)"
+        )
+
     run = open_jax_run(args.run_dir, args.step)
     subrun_id = args.subrun_id or "h-" + datetime.now().strftime("%Y%m%d_%H%M%S")
     config = HarvestConfig(
@@ -159,7 +174,7 @@ def main() -> None:
             wandb_path=run.run_id, activation_threshold=args.activation_threshold
         ),
         n_batches=args.n_batches,
-        batch_size=args.batch_size,
+        local_batch_size=args.local_batch_size,
         collect_component_cooccurrence=not args.no_cooccurrence,
     )
     output_dir = get_harvest_subrun_dir(run.run_id, subrun_id)


### PR DESCRIPTION
## What

Three fixes from the first attempt to harvest an 8B JAX run (p-289e3178, L18-MLP 200k) on the sharded SLURM path:

1. **`HarvestConfig.batch_size` → `local_batch_size`** (per-worker). The sharded launcher divided the global `batch_size` across the array (`ShardServer` `process_count=n_gpus`), so any production config quietly ran **every GPU at a local batch of 1** — e.g. `batch_size: 128` on 128 GPUs. Workers now always forward `local_batch_size` sequences per batch and the schedule's global batch derives as `local_batch_size × world_size`; total sequences = `n_batches × local_batch_size × world_size`. No back-compat alias — old configs fail loudly on the removed field.

2. **Fail-fast GPU assert for sharded workers.** A venv without CUDA jaxlib fell back to CPU silently; a 64-GPU array burned its allocation at ~100× slowdown with nothing in the logs but a jax warning. Sharded workers (`--rank` given) now assert `jax.default_backend() == "gpu"`. Single-process CPU spot-checks stay allowed.

3. **`XLA_PYTHON_CLIENT_MEM_FRACTION=0.95` default in the worker.** `open_jax_run` restores the full `TrainState` (fp32 masters + Adam + persistent-PGD sources — 60GB checkpoint for the L18 runs) plus the frozen 8B target onto one device; restore staging pushes the peak past the default 0.75 pool (`RESOURCE_EXHAUSTED` at ~135GB on a B200). Set before backend init, `setdefault` so callers can override.

A structural follow-up worth considering separately: `open_jax_run` could partially restore only `components` + `ci_fn` (orbax 0.12 `partial_restore`) — the optimizer states and adversary sources it materializes are dead weight for every consumer, and dropping them would halve harvest GPU pressure. Kept out of this PR to stay minimal.

## Testing
- `basedpyright param_decomp_lab/harvest/` clean; harvest test suite (62) passes.
- 1-GPU probe of the exact worker command on p-289e3178 confirmed the OOM and the 0.95 fix; overnight 128-GPU harvests of p-289e3178/p-fc8b6c7a run from this branch (results by morning).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVGsKRCYkqeeVhizuPnVuD