### PR TITLE
perf(compile): stacked V/U init — 13x faster jit_init_decomp_vu compile

### DIFF
--- a/param_decomp/components.py
+++ b/param_decomp/components.py
@@ -121,6 +121,49 @@ def init_decomp_vu(sites: tuple[SiteSpec, ...], key: Array) -> DecompVU:
     return DecompVU(vu=vu)
 
 
+VUShape = tuple[int, int, int]  # (d_in, d_out, C)
+
+
+def vu_shape_groups(sites: tuple[SiteSpec, ...]) -> dict[VUShape, tuple[SiteSpec, ...]]:
+    """Sites grouped by V/U shape, site order preserved within a group."""
+    groups: dict[VUShape, list[SiteSpec]] = {}
+    for spec in sites:
+        groups.setdefault((spec.d_in, spec.d_out, spec.C), []).append(spec)
+    return {shape: tuple(specs) for shape, specs in groups.items()}
+
+
+def init_decomp_vu_stacked(
+    sites: tuple[SiteSpec, ...], key: Array
+) -> dict[VUShape, tuple[Array, Array]]:
+    """`init_decomp_vu` computed as same-shape stacks: `{(d_in, d_out, C):
+    (V [n, d_in, C], U [n, C, d_out])}`, vmapped over the SAME per-site keys — so
+    `unstack_decomp_vu` recovers `init_decomp_vu`'s output BIT-IDENTICALLY (pinned by
+    `test_sharding`). Under jit the graph has 2×n_shapes sharded outputs instead of
+    2×n_sites, which cuts the production init compile ~10× (448 outputs → 14 at 32L)."""
+    keys = jax.random.split(key, 2 * len(sites))
+    site_index = {spec.name: idx for idx, spec in enumerate(sites)}
+    stacked: dict[VUShape, tuple[Array, Array]] = {}
+    for (d_in, d_out, c), specs in vu_shape_groups(sites).items():
+        idxs = jnp.array([site_index[spec.name] for spec in specs])
+        Vs = jax.vmap(lambda k, s=(d_in, c): jax.random.normal(k, s))(keys[2 * idxs])
+        Us = jax.vmap(lambda k, s=(c, d_out): jax.random.normal(k, s))(keys[2 * idxs + 1])
+        stacked[(d_in, d_out, c)] = (Vs * d_in**-0.5, Us * c**-0.5)
+    return stacked
+
+
+def unstack_decomp_vu(
+    sites: tuple[SiteSpec, ...], stacked: dict[VUShape, tuple[Array, Array]]
+) -> DecompVU:
+    """Slice `init_decomp_vu_stacked`'s per-shape stacks back into the per-site DecompVU."""
+    vu: dict[str, tuple[Array, Array]] = {}
+    for shape, specs in vu_shape_groups(sites).items():
+        Vs, Us = stacked[shape]
+        assert Vs.shape[0] == len(specs), (Vs.shape, len(specs))
+        for j, spec in enumerate(specs):
+            vu[spec.name] = (Vs[j], Us[j])
+    return DecompVU(vu={spec.name: vu[spec.name] for spec in sites})
+
+
 def site_out(
     x: Array,
     V: Array,

--- a/param_decomp/targets/llama8b_sharding.py
+++ b/param_decomp/targets/llama8b_sharding.py
@@ -51,7 +51,14 @@ from jaxtyping import Array, PRNGKeyArray
 
 from param_decomp.adversary import init_persistent_sources
 from param_decomp.ci_fn import CIFn, CIFnArch, build_ci_fn
-from param_decomp.components import DecompVU, SiteSpec, init_decomp_vu
+from param_decomp.components import (
+    DecompVU,
+    SiteSpec,
+    init_decomp_vu,
+    init_decomp_vu_stacked,
+    unstack_decomp_vu,
+    vu_shape_groups,
+)
 from param_decomp.configs import BSCScope, SCScope
 from param_decomp.sharding import hsdp_mesh, place_via_shardings
 from param_decomp.sharding import shard_batch as _generic_shard_batch
@@ -74,11 +81,27 @@ def place_target(tgt: LlamaDecomposedModel, mesh: Mesh) -> LlamaDecomposedModel:
 
 
 def init_decomp_vu_placed(sites: tuple[SiteSpec, ...], key: PRNGKeyArray, mesh: Mesh) -> DecompVU:
-    """Seeded per-site V/U init placed by `DecompVU.shardings` (pure HSDP: V d_in / U d_out
-    FSDP on `fsdp`, C replicated). Shardings computed on the abstract model, init under jit."""
-    init = partial(init_decomp_vu, sites)
-    out_shardings = eqx.filter_eval_shape(init, key).shardings(mesh)
-    return jax.jit(init, out_shardings=out_shardings)(key)
+    """Seeded per-site V/U init placed by `DecompVU.shardings`, bit-identical to
+    `init_decomp_vu` (pinned by `test_sharding`) but compiled in two cheap stages: the RNG
+    runs vmap-STACKED per V/U shape (2×n_shapes sharded outputs instead of 2×n_sites — the
+    SPMD/layout pass over a 448-output RNG graph was a multi-minute compile at 32L), then a
+    trivial slice jit fans the stacks out to the per-site layout. The stack axis is
+    unsharded (each trailing spec is the per-site spec behind a leading None); the stacked
+    input is donated so the transient stacked copy frees as the slices materialize."""
+    per_site_shardings = eqx.filter_eval_shape(partial(init_decomp_vu, sites), key).shardings(mesh)
+    stacked_shardings = {
+        shape: tuple(
+            NamedSharding(mesh, P(None, *per_site_shardings.vu[specs[0].name][i].spec))
+            for i in range(2)
+        )
+        for shape, specs in vu_shape_groups(sites).items()
+    }
+    stacked = jax.jit(partial(init_decomp_vu_stacked, sites), out_shardings=stacked_shardings)(key)
+    return jax.jit(
+        partial(unstack_decomp_vu, sites),
+        out_shardings=per_site_shardings,
+        donate_argnums=0,
+    )(stacked)
 
 
 def init_ci_fn_placed(

--- a/param_decomp/tests/test_sharding.py
+++ b/param_decomp/tests/test_sharding.py
@@ -101,8 +101,26 @@ def test_jitted_sharded_inits_match_eager_values():
         assert isinstance(V.sharding, NamedSharding) and isinstance(U.sharding, NamedSharding)
         assert V.sharding.spec == P(full, "tp"), (spec.name, V.sharding.spec)
         assert U.sharding.spec == P("tp", full), (spec.name, U.sharding.spec)
-    for got, want in zip(jax.tree.leaves(vu_placed), jax.tree.leaves(vu_eager), strict=True):
+    # The placed init runs vmap-stacked per shape group (compile-time optimization) and
+    # must be BIT-identical to the jitted per-site `init_decomp_vu` it replaced (vmap over
+    # the same per-site keys) — the trajectory anchor. The unjitted eager reference differs
+    # from EITHER jitted path by ~1 ULP (XLA fusion), so it only gets allclose.
+    from functools import partial
+
+    import equinox as eqx
+
+    per_site_shardings = eqx.filter_eval_shape(
+        partial(init_decomp_vu, sites), jax.random.PRNGKey(1)
+    ).shardings(mesh)
+    vu_jitted_per_site = jax.jit(partial(init_decomp_vu, sites), out_shardings=per_site_shardings)(
+        jax.random.PRNGKey(1)
+    )
+    for got, want in zip(
+        jax.tree.leaves(vu_placed), jax.tree.leaves(vu_jitted_per_site), strict=True
+    ):
         assert got.shape == want.shape and got.dtype == want.dtype
+        assert jnp.array_equal(jnp.asarray(got), jnp.asarray(want))
+    for got, want in zip(jax.tree.leaves(vu_placed), jax.tree.leaves(vu_eager), strict=True):
         assert jnp.allclose(jnp.asarray(got), want, rtol=1e-6, atol=0)
 
     # A declared ÷N shard dim that does NOT tile the device count is a loud crash inside


### PR DESCRIPTION
## Description

Targeted extraction of the V/U-init compile fix from #941 (bridge task `reduce-jax-compilation-time`), leaving the rest of that branch behind.

`init_decomp_vu_placed` compiled a single graph with 2×n_sites sharded outputs (448 at 32L); the SPMD partitioning/layout pass over that many distinct outputs was the 3m31s `jit_init_decomp_vu` compile on every new-config launch. It now compiles two cheap stages:

1. `init_decomp_vu_stacked` — RNG vmap-STACKED per V/U shape (2×n_shapes sharded outputs, 14 at 32L), sharded per-site behind a leading unsharded stack axis.
2. `unstack_decomp_vu` — a trivial slice jit (stacked input donated) fanning out to the per-site ZeRO-1 layout.

**Bit-identical to the previous jitted per-site init** (vmap over the same per-site keys); `test_sharding` now pins exact `array_equal` against the jitted per-site reference. (Found in passing: the unjitted eager `init_decomp_vu` differs from ANY jitted init by ~1 ULP of XLA fusion — pre-existing, previously hidden by the test's `allclose`.)

## Related Issue

Extracted from #941; measurements from bridge task `reduce-jax-compilation-time`.

## Motivation and Context

Every new-config launch of the 32L Llama-8B decomposition paid a 3m31s init compile before the train-step compile even started. **Measured on GPU at the full 224-site/32L shape set: 210.5s → 16.3s (12.9×).**

## How Has This Been Tested?

- `make check` clean; sharding tests pass at 1 and 4 simulated CPU devices (`pytest param_decomp/tests/test_sharding.py --runmultidevice`).
- Bit-identity of the new init vs the old jitted init pinned by test (exact `array_equal`, sharded + unsharded).
- GPU A/B at full production site count on the bridge branch (224 sites, 1 node, tp8): old 210.5s vs new 16.3s; probe runs there showed identical losses/step times.

## Does this PR introduce a breaking change?

No. Init values are bit-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E34cK5BaVr6ZFAwRidNp6n