### PR TITLE
fix(slurm): scrub SLURM_*/SBATCH_* from the sbatch submission env

### DIFF
--- a/param_decomp_lab/infra/slurm.py
+++ b/param_decomp_lab/infra/slurm.py
@@ -349,16 +349,20 @@ def _case_block(commands: list[str]) -> str:
 def _submit_script(script_path: Path) -> str:
     """Submit script via sbatch and return job ID.
 
-    Submitting from INSIDE a SLURM allocation (agent sessions, dev pods) leaks the
-    caller's `SLURM_*` env into the new job — sbatch propagates it, and a mismatched
-    inherited `SLURM_CPUS_PER_TASK` makes the job's srun die instantly with
-    "cpus-per-task set by two different environment variables". Scrub `SLURM_*` (and
-    `SBATCH_*`) from the submission env so the new job's env comes only from its own
-    allocation.
+    Submitting from INSIDE a SLURM allocation (agent sessions, dev pods, tmux servers
+    created in an srun step) leaks the caller's step-scoped env into the new job —
+    sbatch propagates it, and the new job's srun reads it as directives. A mismatched
+    inherited `SLURM_CPUS_PER_TASK` kills the srun instantly ("cpus-per-task set by two
+    different environment variables"); an inherited `SLURM_CPU_BIND` silently pins every
+    rank to the ORIGINATING pod's few cores (the June 2026 fleet-wide ~3x slowdown).
+    Scrub `SLURM_*`/`SBATCH_*`/`PMIX_*` from the submission env so the new job's SLURM
+    state comes only from its own allocation.
 
     Raises RuntimeError if sbatch fails.
     """
-    clean_env = {k: v for k, v in os.environ.items() if not k.startswith(("SLURM_", "SBATCH_"))}
+    clean_env = {
+        k: v for k, v in os.environ.items() if not k.startswith(("SLURM_", "SBATCH_", "PMIX_"))
+    }
     result = subprocess.run(
         ["sbatch", str(script_path)], capture_output=True, text=True, check=False, env=clean_env
     )

--- a/param_decomp_lab/infra/slurm.py
+++ b/param_decomp_lab/infra/slurm.py
@@ -9,6 +9,7 @@ It handles:
 - Job submission with script renaming and log file creation
 """
 
+import os
 import subprocess
 import tempfile
 from dataclasses import dataclass
@@ -348,10 +349,18 @@ def _case_block(commands: list[str]) -> str:
 def _submit_script(script_path: Path) -> str:
     """Submit script via sbatch and return job ID.
 
+    Submitting from INSIDE a SLURM allocation (agent sessions, dev pods) leaks the
+    caller's `SLURM_*` env into the new job — sbatch propagates it, and a mismatched
+    inherited `SLURM_CPUS_PER_TASK` makes the job's srun die instantly with
+    "cpus-per-task set by two different environment variables". Scrub `SLURM_*` (and
+    `SBATCH_*`) from the submission env so the new job's env comes only from its own
+    allocation.
+
     Raises RuntimeError if sbatch fails.
     """
+    clean_env = {k: v for k, v in os.environ.items() if not k.startswith(("SLURM_", "SBATCH_"))}
     result = subprocess.run(
-        ["sbatch", str(script_path)], capture_output=True, text=True, check=False
+        ["sbatch", str(script_path)], capture_output=True, text=True, check=False, env=clean_env
     )
     if result.returncode != 0:
         raise RuntimeError(f"Failed to submit SLURM job: {result.stderr}")


### PR DESCRIPTION
## Description

`sbatch` propagates the submitting shell's env into the new job, and SLURM reads `SLURM_*` vars as directives — so submitting from inside an allocation (dev pod, launcher job, agent session, a tmux server created in an srun step) carries the *caller's* step/allocation state into the new job. Two observed failure modes of the same leak:

- **Loud:** an inherited `SLURM_CPUS_PER_TASK` conflicts with the new job's own allocation and its inner `srun` dies in ~2s with "cpus-per-task set by two different environment variables".
- **Silent (the expensive one):** an inherited `SLURM_CPU_BIND` pins every rank to the *originating* pod's few cores. This was the root cause of the [June 2026 fleet-wide ~3× slowdown](https://goodfire-ai.slack.com/archives/C09LRFRSVB5/p1781296924527189) — jobs sbatch'd from tmux windows (the tmux server was created inside an `srun --overlap` step) ran 8 ranks + dataloaders on 4 cores, cost days of debugging and nearly a vendor escalation before being root-caused on our side.

One line of substance in `infra/slurm.py::_submit_script`: the `sbatch` subprocess runs with `os.environ` minus `SLURM_*`/`SBATCH_*`/`PMIX_*`, so the new job's SLURM state comes only from its own allocation. Covers every `pd-*` submitter (they share `_submit_script`). The June incident's fix scrubbed one *source* (the tmux server env); this scrubs at the *sink*, so `pd-*` submissions are immune regardless of what launched them. `PMIX_*` is included to match what the June root-cause fix stripped.

Nothing the ranks rely on travels via inheritance: the run env is exported explicitly in the generated sbatch script from `runtime.launch_env` (the config-captured single source of truth); ambient inheritance of everything else (PATH, HOME, tokens) is untouched. One deliberate behavior change: exporting `SBATCH_*` option-vars (e.g. `SBATCH_PARTITION`) in your shell no longer steers `pd-*` submissions — submissions are config-driven by design.

Extracted from #941 (same base commit); #941/#954 dedupe on rebase once this merges.

## Related Issue

Extracted from #941. Sink-side counterpart of the June 2026 CPU-affinity incident ([Slack thread](https://goodfire-ai.slack.com/archives/C09LRFRSVB5/p1781296924527189)).

## Motivation and Context

Launching from anywhere other than a bare login shell currently fails in ~2s with a confusing srun error — and the same leak class already caused a silent fleet-wide 3× slowdown once.

## How Has This Been Tested?

All of this week's compile-probe launches (~15 `pd-lm` submissions, incl. an 8-node dp64 run) were submitted from inside 1-CPU launcher jobs on and-btdr with the `SLURM_*`/`SBATCH_*` scrub — every submission's inner srun started cleanly, which fails without it.

## Does this PR introduce a breaking change?

No (aside from the deliberate `SBATCH_*` note above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E34cK5BaVr6ZFAwRidNp6n
