### PR TITLE
fix(slurm): raise nofile to the hard limit in generated sbatch scripts

### DIFF
--- a/param_decomp_lab/infra/slurm.py
+++ b/param_decomp_lab/infra/slurm.py
@@ -96,6 +96,10 @@ def generate_script(
 
 set -euo pipefail
 umask 002  # Ensure files are group-writable
+# NCCL cross-node bootstrap sockets exhaust the default 1024-fd soft limit at 4+ nodes
+# ("ncclOsSocketTryAccept: Accept failed: Too many open files"); srun propagates this shell's
+# limits to the ranks.
+ulimit -n "$(ulimit -Hn)"
 {env_exports}
 {setup}
 
@@ -158,6 +162,10 @@ esac
 
 set -euo pipefail
 umask 002  # Ensure files are group-writable
+# NCCL cross-node bootstrap sockets exhaust the default 1024-fd soft limit at 4+ nodes
+# ("ncclOsSocketTryAccept: Accept failed: Too many open files"); srun propagates this shell's
+# limits to the ranks.
+ulimit -n "$(ulimit -Hn)"
 {env_exports}
 {comment_section}
 {setup}


### PR DESCRIPTION
## Description
Add `ulimit -n "$(ulimit -Hn)"` to both generated-sbatch prologues in `infra/slurm.py`. srun propagates the batch shell's rlimits to the ranks.

## Motivation and Context
cw-east shells (login and compute) default to a 1024-fd soft limit (hard 1048576). At 4+ nodes, NCCL bootstrap exhausts it — `ncclOsSocketTryAccept: Accept failed: Too many open files` → `ncclGroupEnd() INTERNAL` on the first `jit_step`, all ranks die at the shutdown barrier. 1-node runs never hit it, which is why existing pile sweeps were unaffected.

## How Has This Been Tested?
A 4-node (dp=32) full32L run on cw-east B200 crashed reproducibly at the first `jit_step` without this (job 171652 pre-fix… job 171642), and ran to completion with it (jobs 171653/171656/171657, ~5.6s/step steady state).

## Does this PR introduce a breaking change?
No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FdeKYLCnk7E8BhKZoNvhAc