### PR TITLE
refactor(pd-lm): job-side node workspaces, drop the submit-time shared-FS build

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,8 +106,8 @@ entry points, read `param_decomp/CLAUDE.md` and `SPEC.md`. In one breath:
   then calls the engine. Orbax sharded checkpoints; SIGTERM → save → SLURM requeue → resume.
 - **Launch from the lab side** via `pd-lm <config.yaml>` (login-node submission wrapper;
   CONFIG-DRIVEN via `runtime.dp`, no `--nodes` / `--local` flags). `dp = N` (multiple of 8)
-  → snapshots the tree to `refs/runs/snapshot/<id>` (hard-pushed to origin as the durable
-  provenance record), stages the run dir (`launch_config.yaml` + `.env`), and sbatches
+  → snapshots the tree to `refs/runs/snapshot/<id>` (pushed to origin best-effort, as a
+  provenance backup), stages the run dir (`launch_config.yaml` + `.env`), and sbatches
   `python -m param_decomp_lab.experiments.lm.run` across `N // 8` nodes — each node
   shallow-fetches the snapshot from the submitting checkout's shared-FS git dir into
   node-local `/tmp` and builds the driver-gated CUDA venv at job start; `dp = null` →

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,10 +106,11 @@ entry points, read `param_decomp/CLAUDE.md` and `SPEC.md`. In one breath:
   then calls the engine. Orbax sharded checkpoints; SIGTERM → save → SLURM requeue → resume.
 - **Launch from the lab side** via `pd-lm <config.yaml>` (login-node submission wrapper;
   CONFIG-DRIVEN via `runtime.dp`, no `--nodes` / `--local` flags). `dp = N` (multiple of 8)
-  → snapshots the tree to `refs/runs/snapshot/<id>`, pins the config as the run dir's
-  `launch_config.yaml`, and sbatches `python -m param_decomp_lab.experiments.lm.run`
-  across `N // 8` nodes — each node clones the snapshot into node-local `/tmp` and builds
-  the `[cuda]` venv at job start; `dp = null` → runs the trainer inline single-process.
+  → snapshots the tree to `refs/runs/snapshot/<id>` (pushed to origin, the ground truth
+  the nodes fetch from), stages the run dir (`launch_config.yaml` + `.env`), and sbatches
+  `python -m param_decomp_lab.experiments.lm.run` across `N // 8` nodes — each node
+  shallow-fetches the snapshot from origin into node-local `/tmp` and builds the `[cuda]`
+  venv at job start; `dp = null` → runs the trainer inline single-process.
   `lab → param_decomp` is a fine dependency; only `param_decomp → lab` is forbidden.
 
 ## Public API (consumer substrate)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,11 +106,12 @@ entry points, read `param_decomp/CLAUDE.md` and `SPEC.md`. In one breath:
   then calls the engine. Orbax sharded checkpoints; SIGTERM → save → SLURM requeue → resume.
 - **Launch from the lab side** via `pd-lm <config.yaml>` (login-node submission wrapper;
   CONFIG-DRIVEN via `runtime.dp`, no `--nodes` / `--local` flags). `dp = N` (multiple of 8)
-  → snapshots the tree to `refs/runs/snapshot/<id>` (pushed to origin, the ground truth
-  the nodes fetch from), stages the run dir (`launch_config.yaml` + `.env`), and sbatches
+  → snapshots the tree to `refs/runs/snapshot/<id>` (hard-pushed to origin as the durable
+  provenance record), stages the run dir (`launch_config.yaml` + `.env`), and sbatches
   `python -m param_decomp_lab.experiments.lm.run` across `N // 8` nodes — each node
-  shallow-fetches the snapshot from origin into node-local `/tmp` and builds the `[cuda]`
-  venv at job start; `dp = null` → runs the trainer inline single-process.
+  shallow-fetches the snapshot from the submitting checkout's shared-FS git dir into
+  node-local `/tmp` and builds the driver-gated CUDA venv at job start; `dp = null` →
+  runs the trainer inline single-process.
   `lab → param_decomp` is a fine dependency; only `param_decomp → lab` is forbidden.
 
 ## Public API (consumer substrate)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,11 +106,11 @@ entry points, read `param_decomp/CLAUDE.md` and `SPEC.md`. In one breath:
   then calls the engine. Orbax sharded checkpoints; SIGTERM → save → SLURM requeue → resume.
 - **Launch from the lab side** via `pd-lm <config.yaml>` (login-node submission wrapper;
   CONFIG-DRIVEN via `runtime.dp`, no `--nodes` / `--local` flags). `dp = N` (multiple of 8)
-  → snapshots the tree to an immutable shared-FS workspace, installs the `[cuda]` extra
-  there, sbatches `python -m param_decomp_lab.experiments.lm.run` across `N // 8` nodes;
-  `dp = null` → runs the trainer inline single-process. `lab → param_decomp` is a fine
-  dependency; only
-  `param_decomp → lab` is forbidden.
+  → snapshots the tree to `refs/runs/snapshot/<id>`, pins the config as the run dir's
+  `launch_config.yaml`, and sbatches `python -m param_decomp_lab.experiments.lm.run`
+  across `N // 8` nodes — each node clones the snapshot into node-local `/tmp` and builds
+  the `[cuda]` venv at job start; `dp = null` → runs the trainer inline single-process.
+  `lab → param_decomp` is a fine dependency; only `param_decomp → lab` is forbidden.
 
 ## Public API (consumer substrate)
 
@@ -245,9 +245,9 @@ via `pd-lm`. Slow/plot eval is in-loop only (no CLI).
 
 | Command | Entry point | Purpose |
 |---|---|---|
-| `python -m param_decomp_lab.experiments.lm.run` | `param_decomp_lab/experiments/lm/run.py` | The LM decomposition composition root (reads YAML, builds the target, calls the core engine; run inside a launch workspace) |
+| `python -m param_decomp_lab.experiments.lm.run` | `param_decomp_lab/experiments/lm/run.py` | The LM decomposition composition root (reads YAML, builds the target, calls the core engine; run inside a node workspace) |
 | `python -m pretrain.train` | `pretrain/train.py` | The core in-house target-LM pretrainer |
-| `pd-lm` | `experiments/lm/launch.py` | Launch a decomposition trainer run; config-driven via `runtime.dp` (`dp=N` → snapshot + workspace + sbatch across `N//8` nodes; `dp=null` → inline) |
+| `pd-lm` | `experiments/lm/launch.py` | Launch a decomposition trainer run; config-driven via `runtime.dp` (`dp=N` → snapshot + pinned launch config + sbatch across `N//8` nodes, per-node job-side venv; `dp=null` → inline) |
 | `pd-pretrain` | `experiments/lm/pretrain/launch.py` | Launch a pretrainer run; config-driven via `dp` (`dp=N` → sbatch; `dp=null` → inline) |
 | `pd-tms` / `pd-resid-mlp` | `experiments/{tms,resid_mlp}/run.py` | The CPU toy decomposition CLIs |
 | `pd-harvest` | `harvest/scripts/run_slurm_cli.py` | Submit harvest SLURM job |

--- a/param_decomp/CLAUDE.md
+++ b/param_decomp/CLAUDE.md
@@ -229,8 +229,8 @@ NOT changed C / sites / ci-fn arch). Add to the config:
 
 ```yaml
 resume_provenance:
-  # ABSOLUTE path — the trainer runs with cwd = <workspace> (the repo root), so a
-  # relative path would resolve under the workspace, not the output runs dir.
+  # ABSOLUTE path — the trainer runs with cwd = the node workspace (a repo checkout), so
+  # a relative path would resolve under the workspace, not the output runs dir.
   parent_run_dir: /mnt/data/artifacts/mechanisms/param-decomp/runs/p-bd3cd4d4
   parent_step: 175000
 ```
@@ -249,15 +249,16 @@ asserts matching sites (names + C) + ci-fn arch before the restore. Provenance f
 `runtime.dp`:
 - `dp = null` → run the trainer INLINE in the current process (single device, no SLURM, no
   workspace). For smoke / debug.
-- `dp = N` (a multiple of 8) → submit to SLURM across `nodes = N // 8` nodes,
-  `--ntasks-per-node=8`. Mints the `p-` run id, snapshots the tree to
-  `refs/runs/snapshot/<id>`, materializes an immutable shared-FS workspace (clone + the one
-  CUDA venv) at `$PARAM_DECOMP_OUT_DIR/workspaces/<id>`, stamps the id (+ out_dir / wandb
-  group / tags) into the workspace's single config yaml, and sbatches. The srun command is
-  bare `python -m param_decomp_lab.experiments.lm.run <config>` (no rank/topology flags).
+- `dp = N` (a multiple of 8) → submit to SLURM across `nodes = N // 8` nodes, one srun
+  task per node. Mints the `p-` run id, snapshots the tree to `refs/runs/snapshot/<id>`,
+  pins the config (wandb group / tags stamped) as
+  `$PARAM_DECOMP_OUT_DIR/runs/<id>/launch_config.yaml`, and sbatches. Each node builds its
+  own workspace at job start (clone the snapshot into node-local `/tmp` + the one CUDA
+  venv) and execs `python -m param_decomp_lab.experiments.lm.run <launch_config> --run-id
+  <id>` (no rank/topology flags).
 
-Requeues re-enter the workspace, never the live checkout. `--run_id` resubmits an existing
-workspace. Don't hand-write sbatch files.
+Requeues rebuild the node workspaces and re-read the pinned launch config, never the live
+checkout. `--run_id` resubmits an existing run. Don't hand-write sbatch files.
 
 `main` enables JAX's persistent compilation cache
 (`_enable_persistent_compilation_cache`) at `$PARAM_DECOMP_OUT_DIR/xla_compilation_cache`

--- a/param_decomp/CLAUDE.md
+++ b/param_decomp/CLAUDE.md
@@ -251,7 +251,7 @@ asserts matching sites (names + C) + ci-fn arch before the restore. Provenance f
   workspace). For smoke / debug.
 - `dp = N` (a multiple of 8) → submit to SLURM across `nodes = N // 8` nodes, one srun
   task per node. Mints the `p-` run id, snapshots the tree to `refs/runs/snapshot/<id>`
-  (hard-pushed to origin as the durable provenance record), stages
+  (pushed to origin best-effort, as a provenance backup), stages
   `$PARAM_DECOMP_OUT_DIR/runs/<id>/` with the pinned config (wandb group / tags stamped)
   + `.env`, and sbatches. Each node builds its own workspace at job start (shallow-fetch
   the snapshot from the submitting checkout's shared-FS git dir into node-local `/tmp` +

--- a/param_decomp/CLAUDE.md
+++ b/param_decomp/CLAUDE.md
@@ -251,10 +251,11 @@ asserts matching sites (names + C) + ci-fn arch before the restore. Provenance f
   workspace). For smoke / debug.
 - `dp = N` (a multiple of 8) → submit to SLURM across `nodes = N // 8` nodes, one srun
   task per node. Mints the `p-` run id, snapshots the tree to `refs/runs/snapshot/<id>`
-  (pushed to origin — the ground truth the nodes fetch from), stages
+  (hard-pushed to origin as the durable provenance record), stages
   `$PARAM_DECOMP_OUT_DIR/runs/<id>/` with the pinned config (wandb group / tags stamped)
   + `.env`, and sbatches. Each node builds its own workspace at job start (shallow-fetch
-  the snapshot from origin into node-local `/tmp` + the one CUDA venv) and execs
+  the snapshot from the submitting checkout's shared-FS git dir into node-local `/tmp` +
+  the driver-gated CUDA venv: >= r580 → `cuda13`, else `cuda`) and execs
   `python -m param_decomp_lab.experiments.lm.run <launch_config> --run-id <id>` (no
   rank/topology flags).
 

--- a/param_decomp/CLAUDE.md
+++ b/param_decomp/CLAUDE.md
@@ -250,12 +250,13 @@ asserts matching sites (names + C) + ci-fn arch before the restore. Provenance f
 - `dp = null` → run the trainer INLINE in the current process (single device, no SLURM, no
   workspace). For smoke / debug.
 - `dp = N` (a multiple of 8) → submit to SLURM across `nodes = N // 8` nodes, one srun
-  task per node. Mints the `p-` run id, snapshots the tree to `refs/runs/snapshot/<id>`,
-  pins the config (wandb group / tags stamped) as
-  `$PARAM_DECOMP_OUT_DIR/runs/<id>/launch_config.yaml`, and sbatches. Each node builds its
-  own workspace at job start (clone the snapshot into node-local `/tmp` + the one CUDA
-  venv) and execs `python -m param_decomp_lab.experiments.lm.run <launch_config> --run-id
-  <id>` (no rank/topology flags).
+  task per node. Mints the `p-` run id, snapshots the tree to `refs/runs/snapshot/<id>`
+  (pushed to origin — the ground truth the nodes fetch from), stages
+  `$PARAM_DECOMP_OUT_DIR/runs/<id>/` with the pinned config (wandb group / tags stamped)
+  + `.env`, and sbatches. Each node builds its own workspace at job start (shallow-fetch
+  the snapshot from origin into node-local `/tmp` + the one CUDA venv) and execs
+  `python -m param_decomp_lab.experiments.lm.run <launch_config> --run-id <id>` (no
+  rank/topology flags).
 
 Requeues rebuild the node workspaces and re-read the pinned launch config, never the live
 checkout. `--run_id` resubmits an existing run. Don't hand-write sbatch files.

--- a/param_decomp_lab/experiments/CLAUDE.md
+++ b/param_decomp_lab/experiments/CLAUDE.md
@@ -56,7 +56,7 @@ core, in `param_decomp.configs`; the engine's `BuiltRun` bundle is core, in
 experiments/
 ├── utils.py                 # EXPERIMENT_CONFIG_FILENAME
 ├── lm/
-│   ├── launch.py        # pd-lm: snapshot + shared-FS workspace + sbatch
+│   ├── launch.py        # pd-lm: snapshot + pinned launch config + sbatch (per-node job-side venv)
 │   ├── data.py              # tokenize_and_concatenate (offline helper for prestage)
 │   └── prestage_tokenized.py  # HF text -> int32 parquet shards for the JAX trainer
 ├── tms/                     # pd-tms (CPU): model.py + run.py + configs/ + test_tms.py

--- a/param_decomp_lab/experiments/lm/launch.py
+++ b/param_decomp_lab/experiments/lm/launch.py
@@ -6,12 +6,13 @@ CONFIG-DRIVEN: the launch mode is a pure function of `runtime.dp` in the run con
 `nodes = dp // 8` nodes (8 GPUs each, one srun task per node claiming all 8 GPUs).
 
 The SLURM path mints the `p-<8hex>` run id, snapshots the working tree to
-`refs/runs/snapshot/<id>` (pushed to origin — the ground truth the nodes fetch from),
-stages the run dir with the pinned (group/tags-stamped) `launch_config.yaml` + `.env`
-(the copies the job — and every requeue — reads), and sbatches. Each node then builds its
-own workspace at job start: shallow-fetch the snapshot from origin into node-local
-`/tmp`, `uv sync --extra cuda`, exec the trainer. Nothing is built at submit time, no
-shared-FS workspace exists to leak or clean up, and no local checkout is read by the job.
+`refs/runs/snapshot/<id>` (hard-pushed to origin — the durable provenance record), stages
+the run dir with the pinned (group/tags-stamped) `launch_config.yaml` + `.env` (the
+copies the job — and every requeue — reads), and sbatches. Each node then builds its own
+workspace at job start: shallow-fetch the snapshot from the submitting checkout's
+shared-FS git dir into node-local `/tmp`, `uv sync` with the driver-gated CUDA extra,
+exec the trainer. Nothing is built at submit time and no shared-FS workspace exists to
+leak or clean up; requeues depend only on shared FS, never on GitHub reachability.
 
 The rank env (XLA flags, NCCL/host-memory knobs, `PD_*` profiling toggles) is rendered from
 the config's `runtime.launch_env` (single source of truth, defaults in `LaunchEnv`), plus
@@ -74,25 +75,30 @@ def _render_rank_env(launch_env: LaunchEnv) -> str:
     return "\n".join(exports)
 
 
-def _origin_url() -> str:
-    """Snapshot refs' ground truth is origin (`create_git_snapshot` fails the submit if
-    the push fails), so nodes fetch from there — no dependency on any local checkout."""
+def _snapshot_source_repo() -> Path:
+    """The local git state the nodes fetch the snapshot from: the submitting checkout's
+    COMMON git dir (the main checkout's `.git`, even when submitting from a worktree —
+    worktrees share refs but may be deleted before a requeue re-fetches). Shared FS, so
+    requeues never depend on GitHub reachability; origin (which `create_git_snapshot`
+    hard-pushes to) is the durable provenance record, not the job's fetch source."""
     result = subprocess.run(
-        ["git", "-C", str(REPO_ROOT), "remote", "get-url", "origin"],
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--path-format=absolute", "--git-common-dir"],
         capture_output=True,
         text=True,
         check=True,
     )
-    return result.stdout.strip()
+    return Path(result.stdout.strip())
 
 
-def _node_workspace_setup(run_id: str, snapshot_ref: str, origin_url: str, run_dir: Path) -> str:
+def _node_workspace_setup(run_id: str, snapshot_ref: str, source_repo: Path, run_dir: Path) -> str:
     """The start of each node's srun task: sweep stale workspaces, shallow-fetch the
-    snapshot from origin into node-local /tmp, build the CUDA venv, activate. The `.env`
-    (secrets, not in git) comes from the run dir, where submit staged it. The task `exec`s
-    the trainer afterwards (bash is replaced, so no EXIT trap can run here) — normal-end
-    cleanup is the batch script's trap (`_node_workspace_cleanup_trap`), and the up-front
-    sweep self-heals leftovers from jobs that died before their trap fired.
+    snapshot from the shared-FS git dir into node-local /tmp, build the CUDA venv,
+    activate. (`file://` rather than the bare path — git silently ignores `--depth` on
+    the local transport.) The `.env` (secrets, not in git) comes from the run dir, where
+    submit staged it. The task `exec`s the trainer afterwards (bash is replaced, so no
+    EXIT trap can run here) — normal-end cleanup is the batch script's trap
+    (`_node_workspace_cleanup_trap`), and the up-front sweep self-heals leftovers from
+    jobs that died before their trap fired.
 
     The CUDA extra is driver-gated per node (buildable here, unlike at submit on a
     GPU-less login node): cuda13's runtime libs include the Blackwell-TMEM-fixed
@@ -105,7 +111,7 @@ rm -rf "{_NODE_WORKSPACES_DIR}"
 mkdir -p "$WORK_DIR"
 cd "$WORK_DIR"
 git init --quiet
-git fetch --quiet --depth 1 "{origin_url}" "{snapshot_ref}"
+git fetch --quiet --depth 1 "file://{source_repo}" "{snapshot_ref}"
 git checkout --quiet FETCH_HEAD
 cp "{run_dir}/.env" .env
 unset VIRTUAL_ENV
@@ -126,11 +132,11 @@ def _node_workspace_cleanup_trap(nodes: int) -> str:
 
 
 def _rank_command(
-    run_id: str, snapshot_ref: str, origin_url: str, run_dir: Path, rank_env: str
+    run_id: str, snapshot_ref: str, source_repo: Path, run_dir: Path, rank_env: str
 ) -> str:
     launch_config = run_dir / LAUNCH_CONFIG_FILENAME
     return (
-        f"{_node_workspace_setup(run_id, snapshot_ref, origin_url, run_dir)}\n{rank_env}\n"
+        f"{_node_workspace_setup(run_id, snapshot_ref, source_repo, run_dir)}\n{rank_env}\n"
         f"exec python -m param_decomp_lab.experiments.lm.run "
         f"{shlex.quote(str(launch_config))} --run-id {shlex.quote(run_id)}"
     )
@@ -187,7 +193,7 @@ def main(
     assert dp % GPUS_PER_NODE == 0, f"runtime.dp={dp} must be a multiple of {GPUS_PER_NODE}"
     nodes = dp // GPUS_PER_NODE
 
-    origin_url = _origin_url()
+    source_repo = _snapshot_source_repo()
     if run_id is None:
         run_id = generate_run_id("param_decomp")
         snapshot_ref, commit_hash = create_git_snapshot(snapshot_id=run_id)
@@ -196,7 +202,7 @@ def main(
         _stage_env_file(run_dir)
     else:
         snapshot_ref = f"refs/runs/snapshot/{run_id}"
-        _assert_snapshot_ref_on_origin(origin_url, snapshot_ref)
+        _assert_snapshot_ref_exists(source_repo, snapshot_ref)
         run_dir = PARAM_DECOMP_OUT_DIR / "runs" / run_id
         for staged in (LAUNCH_CONFIG_FILENAME, ".env"):
             assert (run_dir / staged).exists(), f"no {staged} to resubmit: {run_dir / staged}"
@@ -219,7 +225,7 @@ def main(
     # One task per node: `--nodes=N --ntasks=N` (N whole-node tasks) can't pack onto one
     # node, so the trainer's single process per node claims all local GPUs.
     srun = f"srun --nodes={nodes} --ntasks={nodes} {_SRUN_FLAGS}"
-    rank_command = _rank_command(run_id, snapshot_ref, origin_url, run_dir, rank_env)
+    rank_command = _rank_command(run_id, snapshot_ref, source_repo, run_dir, rank_env)
     command = f"{srun} bash -c {shlex.quote(rank_command)}"
     script = generate_script(slurm_config, command, setup=_node_workspace_cleanup_trap(nodes))
     result = submit_slurm_job(script, "pd-lm")
@@ -296,14 +302,15 @@ def _stage_env_file(run_dir: Path) -> None:
     shutil.copy(env_file, run_dir / ".env")
 
 
-def _assert_snapshot_ref_on_origin(origin_url: str, snapshot_ref: str) -> None:
-    """Guaranteed on a fresh submit (`create_git_snapshot` fails if the origin push
-    fails); load-bearing on `--run-id` resubmits."""
+def _assert_snapshot_ref_exists(source_repo: Path, snapshot_ref: str) -> None:
+    """Load-bearing on `--run-id` resubmits (a fresh submit just created the ref in a
+    checkout sharing `source_repo`'s refs)."""
     result = subprocess.run(
-        ["git", "ls-remote", "--exit-code", origin_url, snapshot_ref], capture_output=True
+        ["git", "-C", str(source_repo), "rev-parse", "--verify", "--quiet", snapshot_ref],
+        capture_output=True,
     )
     assert result.returncode == 0, (
-        f"{snapshot_ref} not on origin — nodes fetch the snapshot from there at job start"
+        f"{snapshot_ref} not in {source_repo} — nodes fetch the snapshot from there at job start"
     )
 
 

--- a/param_decomp_lab/experiments/lm/launch.py
+++ b/param_decomp_lab/experiments/lm/launch.py
@@ -92,7 +92,12 @@ def _node_workspace_setup(run_id: str, snapshot_ref: str, origin_url: str, run_d
     (secrets, not in git) comes from the run dir, where submit staged it. The task `exec`s
     the trainer afterwards (bash is replaced, so no EXIT trap can run here) — normal-end
     cleanup is the batch script's trap (`_node_workspace_cleanup_trap`), and the up-front
-    sweep self-heals leftovers from jobs that died before their trap fired."""
+    sweep self-heals leftovers from jobs that died before their trap fired.
+
+    The CUDA extra is driver-gated per node (buildable here, unlike at submit on a
+    GPU-less login node): cuda13's runtime libs include the Blackwell-TMEM-fixed
+    cuBLAS >= 13.2 (cuBLAS 12.9 warns of silent corruption on B200) but need driver
+    >= r580, below which (and-gmi's r570) the node falls back to cu12."""
     return f"""\
 set -euo pipefail
 WORK_DIR="{_NODE_WORKSPACES_DIR}/{run_id}"
@@ -104,7 +109,10 @@ git fetch --quiet --depth 1 "{origin_url}" "{snapshot_ref}"
 git checkout --quiet FETCH_HEAD
 cp "{run_dir}/.env" .env
 unset VIRTUAL_ENV
-uv sync --all-packages --no-dev --extra cuda --link-mode copy -q
+DRIVER_MAJOR=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n 1 | cut -d. -f1)
+if [ "$DRIVER_MAJOR" -ge 580 ]; then CUDA_EXTRA=cuda13; else CUDA_EXTRA=cuda; fi
+echo "cuda extra: $CUDA_EXTRA (driver major $DRIVER_MAJOR)"
+uv sync --all-packages --no-dev --extra "$CUDA_EXTRA" --link-mode copy -q
 source .venv/bin/activate"""
 
 

--- a/param_decomp_lab/experiments/lm/launch.py
+++ b/param_decomp_lab/experiments/lm/launch.py
@@ -6,7 +6,7 @@ CONFIG-DRIVEN: the launch mode is a pure function of `runtime.dp` in the run con
 `nodes = dp // 8` nodes (8 GPUs each, one srun task per node claiming all 8 GPUs).
 
 The SLURM path mints the `p-<8hex>` run id, snapshots the working tree to
-`refs/runs/snapshot/<id>` (hard-pushed to origin — the durable provenance record), stages
+`refs/runs/snapshot/<id>` (pushed to origin best-effort, as a provenance backup), stages
 the run dir with the pinned (group/tags-stamped) `launch_config.yaml` + `.env` (the
 copies the job — and every requeue — reads), and sbatches. Each node then builds its own
 workspace at job start: shallow-fetch the snapshot from the submitting checkout's
@@ -79,8 +79,8 @@ def _snapshot_source_repo() -> Path:
     """The local git state the nodes fetch the snapshot from: the submitting checkout's
     COMMON git dir (the main checkout's `.git`, even when submitting from a worktree —
     worktrees share refs but may be deleted before a requeue re-fetches). Shared FS, so
-    requeues never depend on GitHub reachability; origin (which `create_git_snapshot`
-    hard-pushes to) is the durable provenance record, not the job's fetch source."""
+    neither submits nor requeues depend on GitHub reachability; the best-effort origin
+    push in `create_git_snapshot` is a provenance backup, not the job's fetch source."""
     result = subprocess.run(
         ["git", "-C", str(REPO_ROOT), "rev-parse", "--path-format=absolute", "--git-common-dir"],
         capture_output=True,

--- a/param_decomp_lab/experiments/lm/launch.py
+++ b/param_decomp_lab/experiments/lm/launch.py
@@ -40,11 +40,6 @@ from param_decomp_lab.infra.wandb import get_wandb_entity
 
 GPUS_PER_NODE = 8
 
-# The job-side clone/fetch source. NOT the submitting checkout (`REPO_ROOT`): that may be
-# an ephemeral worktree a later requeue would no longer find. Worktrees share their main
-# checkout's refs, so a snapshot ref created in one is visible here.
-_HOME_CHECKOUT = Path.home() / "param-decomp"
-
 # Node-local. Trainer jobs hold whole nodes (8/8 GPUs), so no concurrent job shares a
 # node with one — the start-of-task sweep below cannot race another run's workspace.
 _NODE_WORKSPACES_DIR = "/tmp/$USER/param-decomp/node-workspaces"
@@ -77,7 +72,21 @@ def _render_rank_env(launch_env: LaunchEnv) -> str:
     return "\n".join(exports)
 
 
-def _node_workspace_setup(run_id: str, snapshot_ref: str) -> str:
+def _snapshot_source_repo() -> Path:
+    """The repo the job-side clone/fetch reads: the submitting checkout's COMMON git dir
+    (the main checkout's `.git`, even when submitting from a worktree). Worktrees share
+    their main checkout's refs but may themselves be deleted before a requeue re-clones,
+    so the ephemeral worktree path must not be the source."""
+    result = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def _node_workspace_setup(run_id: str, snapshot_ref: str, source_repo: Path) -> str:
     """The start of each node's srun task: sweep stale workspaces, clone the snapshot into
     node-local /tmp, build the CUDA venv, activate. The task `exec`s the trainer afterwards
     (bash is replaced, so no EXIT trap can run here) — normal-end cleanup is the batch
@@ -88,10 +97,10 @@ set -euo pipefail
 WORK_DIR="{_NODE_WORKSPACES_DIR}/{run_id}"
 rm -rf "{_NODE_WORKSPACES_DIR}"
 mkdir -p "$WORK_DIR"
-git clone --quiet "{_HOME_CHECKOUT}" "$WORK_DIR"
+git clone --quiet "{source_repo}" "$WORK_DIR"
 cd "$WORK_DIR"
-cp "{_HOME_CHECKOUT}/.env" .env
-git fetch --quiet "{_HOME_CHECKOUT}" "{snapshot_ref}:{snapshot_ref}"
+cp "{source_repo.parent}/.env" .env
+git fetch --quiet "{source_repo}" "{snapshot_ref}:{snapshot_ref}"
 git checkout --quiet "{snapshot_ref}"
 unset VIRTUAL_ENV
 uv sync --all-packages --no-dev --extra cuda --link-mode copy -q
@@ -107,9 +116,11 @@ def _node_workspace_cleanup_trap(nodes: int) -> str:
     )
 
 
-def _rank_command(run_id: str, snapshot_ref: str, launch_config: Path, rank_env: str) -> str:
+def _rank_command(
+    run_id: str, snapshot_ref: str, source_repo: Path, launch_config: Path, rank_env: str
+) -> str:
     return (
-        f"{_node_workspace_setup(run_id, snapshot_ref)}\n{rank_env}\n"
+        f"{_node_workspace_setup(run_id, snapshot_ref, source_repo)}\n{rank_env}\n"
         f"exec python -m param_decomp_lab.experiments.lm.run "
         f"{shlex.quote(str(launch_config))} --run-id {shlex.quote(run_id)}"
     )
@@ -166,20 +177,20 @@ def main(
     assert dp % GPUS_PER_NODE == 0, f"runtime.dp={dp} must be a multiple of {GPUS_PER_NODE}"
     nodes = dp // GPUS_PER_NODE
 
-    env_file = _HOME_CHECKOUT / ".env"
+    source_repo = _snapshot_source_repo()
+    env_file = source_repo.parent / ".env"
     assert env_file.exists(), f".env with wandb credentials required: {env_file}"
 
     if run_id is None:
         run_id = generate_run_id("param_decomp")
         snapshot_ref, commit_hash = create_git_snapshot(snapshot_id=run_id)
         logger.info(f"Created git snapshot: {snapshot_ref} ({commit_hash[:8]})")
-        _assert_snapshot_visible_from_home_checkout(snapshot_ref)
         launch_config = _write_launch_config(config, run_id, group, tag_list)
     else:
         snapshot_ref = f"refs/runs/snapshot/{run_id}"
-        _assert_snapshot_visible_from_home_checkout(snapshot_ref)
         launch_config = PARAM_DECOMP_OUT_DIR / "runs" / run_id / LAUNCH_CONFIG_FILENAME
         assert launch_config.exists(), f"no launch config to resubmit: {launch_config}"
+    _assert_snapshot_ref_exists(source_repo, snapshot_ref)
 
     wandb_url = _wandb_url(cfg, run_id)
     job_name = f"pd-{run_name}"
@@ -199,7 +210,7 @@ def main(
     # One task per node: `--nodes=N --ntasks=N` (N whole-node tasks) can't pack onto one
     # node, so the trainer's single process per node claims all local GPUs.
     srun = f"srun --nodes={nodes} --ntasks={nodes} {_SRUN_FLAGS}"
-    rank_command = _rank_command(run_id, snapshot_ref, launch_config, rank_env)
+    rank_command = _rank_command(run_id, snapshot_ref, source_repo, launch_config, rank_env)
     command = f"{srun} bash -c {shlex.quote(rank_command)}"
     script = generate_script(slurm_config, command, setup=_node_workspace_cleanup_trap(nodes))
     result = submit_slurm_job(script, "pd-lm")
@@ -267,17 +278,16 @@ def _write_launch_config(config: Path, run_id: str, group: str | None, tags: lis
     return launch_config
 
 
-def _assert_snapshot_visible_from_home_checkout(snapshot_ref: str) -> None:
-    """The job-side clone fetches the snapshot from `_HOME_CHECKOUT`, so the ref must be
-    visible there — true when submitting from that checkout or any of its worktrees
-    (shared refs), NOT from an unrelated clone."""
+def _assert_snapshot_ref_exists(source_repo: Path, snapshot_ref: str) -> None:
+    """Guaranteed by construction on a fresh submit (the snapshot was just created in a
+    checkout sharing `source_repo`'s refs); load-bearing on `--run-id` resubmits from a
+    different clone than the original submit's."""
     result = subprocess.run(
-        ["git", "-C", str(_HOME_CHECKOUT), "rev-parse", "--verify", "--quiet", snapshot_ref],
+        ["git", "-C", str(source_repo), "rev-parse", "--verify", "--quiet", snapshot_ref],
         capture_output=True,
     )
     assert result.returncode == 0, (
-        f"{snapshot_ref} not visible from {_HOME_CHECKOUT} — nodes clone the snapshot from "
-        f"there at job start; launch from that checkout or one of its worktrees"
+        f"{snapshot_ref} not in {source_repo} — nodes clone the snapshot from there at job start"
     )
 
 

--- a/param_decomp_lab/experiments/lm/launch.py
+++ b/param_decomp_lab/experiments/lm/launch.py
@@ -6,11 +6,12 @@ CONFIG-DRIVEN: the launch mode is a pure function of `runtime.dp` in the run con
 `nodes = dp // 8` nodes (8 GPUs each, one srun task per node claiming all 8 GPUs).
 
 The SLURM path mints the `p-<8hex>` run id, snapshots the working tree to
-`refs/runs/snapshot/<id>`, pins the (group/tags-stamped) config as the run dir's
-`launch_config.yaml` (the one copy the job — and every requeue — reads), and sbatches.
-Each node then builds its own workspace at job start: clone the snapshot into node-local
-`/tmp`, `uv sync --extra cuda`, exec the trainer. Nothing is built at submit time and no
-shared-FS workspace exists to leak or clean up.
+`refs/runs/snapshot/<id>` (pushed to origin — the ground truth the nodes fetch from),
+stages the run dir with the pinned (group/tags-stamped) `launch_config.yaml` + `.env`
+(the copies the job — and every requeue — reads), and sbatches. Each node then builds its
+own workspace at job start: shallow-fetch the snapshot from origin into node-local
+`/tmp`, `uv sync --extra cuda`, exec the trainer. Nothing is built at submit time, no
+shared-FS workspace exists to leak or clean up, and no local checkout is read by the job.
 
 The rank env (XLA flags, NCCL/host-memory knobs, `PD_*` profiling toggles) is rendered from
 the config's `runtime.launch_env` (single source of truth, defaults in `LaunchEnv`), plus
@@ -21,6 +22,7 @@ config edit, not a launcher edit.
 
 import os
 import shlex
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -72,36 +74,35 @@ def _render_rank_env(launch_env: LaunchEnv) -> str:
     return "\n".join(exports)
 
 
-def _snapshot_source_repo() -> Path:
-    """The repo the job-side clone/fetch reads: the submitting checkout's COMMON git dir
-    (the main checkout's `.git`, even when submitting from a worktree). Worktrees share
-    their main checkout's refs but may themselves be deleted before a requeue re-clones,
-    so the ephemeral worktree path must not be the source."""
+def _origin_url() -> str:
+    """Snapshot refs' ground truth is origin (`create_git_snapshot` fails the submit if
+    the push fails), so nodes fetch from there — no dependency on any local checkout."""
     result = subprocess.run(
-        ["git", "-C", str(REPO_ROOT), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        ["git", "-C", str(REPO_ROOT), "remote", "get-url", "origin"],
         capture_output=True,
         text=True,
         check=True,
     )
-    return Path(result.stdout.strip())
+    return result.stdout.strip()
 
 
-def _node_workspace_setup(run_id: str, snapshot_ref: str, source_repo: Path) -> str:
-    """The start of each node's srun task: sweep stale workspaces, clone the snapshot into
-    node-local /tmp, build the CUDA venv, activate. The task `exec`s the trainer afterwards
-    (bash is replaced, so no EXIT trap can run here) — normal-end cleanup is the batch
-    script's trap (`_node_workspace_cleanup_trap`), and the up-front sweep self-heals
-    leftovers from jobs that died before their trap fired."""
+def _node_workspace_setup(run_id: str, snapshot_ref: str, origin_url: str, run_dir: Path) -> str:
+    """The start of each node's srun task: sweep stale workspaces, shallow-fetch the
+    snapshot from origin into node-local /tmp, build the CUDA venv, activate. The `.env`
+    (secrets, not in git) comes from the run dir, where submit staged it. The task `exec`s
+    the trainer afterwards (bash is replaced, so no EXIT trap can run here) — normal-end
+    cleanup is the batch script's trap (`_node_workspace_cleanup_trap`), and the up-front
+    sweep self-heals leftovers from jobs that died before their trap fired."""
     return f"""\
 set -euo pipefail
 WORK_DIR="{_NODE_WORKSPACES_DIR}/{run_id}"
 rm -rf "{_NODE_WORKSPACES_DIR}"
 mkdir -p "$WORK_DIR"
-git clone --quiet "{source_repo}" "$WORK_DIR"
 cd "$WORK_DIR"
-cp "{source_repo.parent}/.env" .env
-git fetch --quiet "{source_repo}" "{snapshot_ref}:{snapshot_ref}"
-git checkout --quiet "{snapshot_ref}"
+git init --quiet
+git fetch --quiet --depth 1 "{origin_url}" "{snapshot_ref}"
+git checkout --quiet FETCH_HEAD
+cp "{run_dir}/.env" .env
 unset VIRTUAL_ENV
 uv sync --all-packages --no-dev --extra cuda --link-mode copy -q
 source .venv/bin/activate"""
@@ -117,10 +118,11 @@ def _node_workspace_cleanup_trap(nodes: int) -> str:
 
 
 def _rank_command(
-    run_id: str, snapshot_ref: str, source_repo: Path, launch_config: Path, rank_env: str
+    run_id: str, snapshot_ref: str, origin_url: str, run_dir: Path, rank_env: str
 ) -> str:
+    launch_config = run_dir / LAUNCH_CONFIG_FILENAME
     return (
-        f"{_node_workspace_setup(run_id, snapshot_ref, source_repo)}\n{rank_env}\n"
+        f"{_node_workspace_setup(run_id, snapshot_ref, origin_url, run_dir)}\n{rank_env}\n"
         f"exec python -m param_decomp_lab.experiments.lm.run "
         f"{shlex.quote(str(launch_config))} --run-id {shlex.quote(run_id)}"
     )
@@ -177,20 +179,19 @@ def main(
     assert dp % GPUS_PER_NODE == 0, f"runtime.dp={dp} must be a multiple of {GPUS_PER_NODE}"
     nodes = dp // GPUS_PER_NODE
 
-    source_repo = _snapshot_source_repo()
-    env_file = source_repo.parent / ".env"
-    assert env_file.exists(), f".env with wandb credentials required: {env_file}"
-
+    origin_url = _origin_url()
     if run_id is None:
         run_id = generate_run_id("param_decomp")
         snapshot_ref, commit_hash = create_git_snapshot(snapshot_id=run_id)
         logger.info(f"Created git snapshot: {snapshot_ref} ({commit_hash[:8]})")
-        launch_config = _write_launch_config(config, run_id, group, tag_list)
+        run_dir = _write_run_dir(config, run_id, group, tag_list)
+        _stage_env_file(run_dir)
     else:
         snapshot_ref = f"refs/runs/snapshot/{run_id}"
-        launch_config = PARAM_DECOMP_OUT_DIR / "runs" / run_id / LAUNCH_CONFIG_FILENAME
-        assert launch_config.exists(), f"no launch config to resubmit: {launch_config}"
-    _assert_snapshot_ref_exists(source_repo, snapshot_ref)
+        _assert_snapshot_ref_on_origin(origin_url, snapshot_ref)
+        run_dir = PARAM_DECOMP_OUT_DIR / "runs" / run_id
+        for staged in (LAUNCH_CONFIG_FILENAME, ".env"):
+            assert (run_dir / staged).exists(), f"no {staged} to resubmit: {run_dir / staged}"
 
     wandb_url = _wandb_url(cfg, run_id)
     job_name = f"pd-{run_name}"
@@ -210,7 +211,7 @@ def main(
     # One task per node: `--nodes=N --ntasks=N` (N whole-node tasks) can't pack onto one
     # node, so the trainer's single process per node claims all local GPUs.
     srun = f"srun --nodes={nodes} --ntasks={nodes} {_SRUN_FLAGS}"
-    rank_command = _rank_command(run_id, snapshot_ref, source_repo, launch_config, rank_env)
+    rank_command = _rank_command(run_id, snapshot_ref, origin_url, run_dir, rank_env)
     command = f"{srun} bash -c {shlex.quote(rank_command)}"
     script = generate_script(slurm_config, command, setup=_node_workspace_cleanup_trap(nodes))
     result = submit_slurm_job(script, "pd-lm")
@@ -223,7 +224,7 @@ def main(
         "Log file": result.log_pattern,
         "Script": str(result.script_path),
         "Snapshot": snapshot_ref,
-        "Launch config": str(launch_config),
+        "Launch config": str(run_dir / LAUNCH_CONFIG_FILENAME),
     }
     if wandb_url is not None:
         summary["WandB run URL"] = wandb_url
@@ -233,7 +234,7 @@ def main(
 def _run_local(config: Path, run_name: str, group: str | None, tags: list[str]) -> None:
     """Mint a run id, pin the launch config into the run dir, and run the trainer inline."""
     run_id = generate_run_id("param_decomp")
-    launch_config = _write_launch_config(config, run_id, group, tags)
+    launch_config = _write_run_dir(config, run_id, group, tags) / LAUNCH_CONFIG_FILENAME
     logger.section(f"pd-lm local: {run_name} ({run_id})")
     subprocess.run(
         [
@@ -266,8 +267,8 @@ def _validate_config(config_path: Path) -> tuple[LMExperimentConfig, str]:
     return cfg, cfg.run_name
 
 
-def _write_launch_config(config: Path, run_id: str, group: str | None, tags: list[str]) -> Path:
-    """Pin the run's config (with the wandb group/tags stamped in) as the run dir's
+def _write_run_dir(config: Path, run_id: str, group: str | None, tags: list[str]) -> Path:
+    """Mint the run dir and pin the config (wandb group/tags stamped in) as its
     `launch_config.yaml` — the one copy the job and every requeue read, and the same file
     the trainer pins (`run.py::_pin_config_copy` no-ops on it)."""
     run_dir = PARAM_DECOMP_OUT_DIR / "runs" / run_id
@@ -275,19 +276,26 @@ def _write_launch_config(config: Path, run_id: str, group: str | None, tags: lis
     launch_config = run_dir / LAUNCH_CONFIG_FILENAME
     launch_config.write_text(config.read_text())
     _stamp_config(launch_config, group, tags)
-    return launch_config
+    return run_dir
 
 
-def _assert_snapshot_ref_exists(source_repo: Path, snapshot_ref: str) -> None:
-    """Guaranteed by construction on a fresh submit (the snapshot was just created in a
-    checkout sharing `source_repo`'s refs); load-bearing on `--run-id` resubmits from a
-    different clone than the original submit's."""
+def _stage_env_file(run_dir: Path) -> None:
+    """Stage `.env` (secrets, not in git — they can't ride the snapshot) into the run dir
+    for the node setup to copy into its workspace. Mode-preserving copy (0o660 secrets
+    stay group-only under the runs dir's group-writable umask)."""
+    env_file = REPO_ROOT / ".env"
+    assert env_file.exists(), f".env with wandb credentials required: {env_file}"
+    shutil.copy(env_file, run_dir / ".env")
+
+
+def _assert_snapshot_ref_on_origin(origin_url: str, snapshot_ref: str) -> None:
+    """Guaranteed on a fresh submit (`create_git_snapshot` fails if the origin push
+    fails); load-bearing on `--run-id` resubmits."""
     result = subprocess.run(
-        ["git", "-C", str(source_repo), "rev-parse", "--verify", "--quiet", snapshot_ref],
-        capture_output=True,
+        ["git", "ls-remote", "--exit-code", origin_url, snapshot_ref], capture_output=True
     )
     assert result.returncode == 0, (
-        f"{snapshot_ref} not in {source_repo} — nodes clone the snapshot from there at job start"
+        f"{snapshot_ref} not on origin — nodes fetch the snapshot from there at job start"
     )
 
 

--- a/param_decomp_lab/experiments/lm/launch.py
+++ b/param_decomp_lab/experiments/lm/launch.py
@@ -2,20 +2,21 @@
 
 CONFIG-DRIVEN: the launch mode is a pure function of `runtime.dp` in the run config — no
 `--nodes` / `--local` flags. `dp is None` → run the trainer INLINE in the current process
-(single device, no SLURM, no workspace; smoke / debug). `dp is not None` → submit to SLURM
-across `nodes = dp // 8` nodes (8 GPUs each, one srun task per node claiming all 8 GPUs).
+(single device, no SLURM; smoke / debug). `dp is not None` → submit to SLURM across
+`nodes = dp // 8` nodes (8 GPUs each, one srun task per node claiming all 8 GPUs).
 
 The SLURM path mints the `p-<8hex>` run id, snapshots the working tree to
-`refs/runs/snapshot/<id>`, materializes the snapshot as a shared-FS workspace (clone + the
-one CUDA venv, built at submit time on the login node — all nodes share the one FS
-workspace, so in-job cloning would race), stamps the run id (+ out_dir / wandb group /
-tags) into the workspace's single config yaml, and sbatches. Requeues re-enter the same
-immutable workspace.
+`refs/runs/snapshot/<id>`, pins the (group/tags-stamped) config as the run dir's
+`launch_config.yaml` (the one copy the job — and every requeue — reads), and sbatches.
+Each node then builds its own workspace at job start: clone the snapshot into node-local
+`/tmp`, `uv sync --extra cuda`, exec the trainer. Nothing is built at submit time and no
+shared-FS workspace exists to leak or clean up.
 
 The rank env (XLA flags, NCCL/host-memory knobs, `PD_*` profiling toggles) is rendered from
-the config's `runtime.launch_env` (single source of truth, defaults in `LaunchEnv`), plus a
-submit-time-computed `LD_LIBRARY_PATH`. So a run's `launch_config.yaml` fully captures the
-environment it ran with, and A/B-ing a flag is a config edit, not a launcher edit.
+the config's `runtime.launch_env` (single source of truth, defaults in `LaunchEnv`), plus
+`LD_LIBRARY_PATH` computed in-job from the freshly-built venv. So a run's
+`launch_config.yaml` fully captures the environment it ran with, and A/B-ing a flag is a
+config edit, not a launcher edit.
 """
 
 import os
@@ -27,6 +28,7 @@ from pathlib import Path
 import fire
 import yaml
 
+from param_decomp.built_run import LAUNCH_CONFIG_FILENAME
 from param_decomp.configs import LaunchEnv
 from param_decomp.log import logger
 from param_decomp_lab.experiments.lm.config import LMExperimentConfig
@@ -37,14 +39,15 @@ from param_decomp_lab.infra.slurm import SlurmConfig, generate_script, submit_sl
 from param_decomp_lab.infra.wandb import get_wandb_entity
 
 GPUS_PER_NODE = 8
-WORKSPACES_DIR = PARAM_DECOMP_OUT_DIR / "workspaces"
 
-# uv hardlinks wheels from its cache into a venv when both share a filesystem, else
-# copies. The default cache (~/.cache/uv, home mount) and the workspaces (data mount) are
-# different PVCs, so every build copied multi-GB CUDA wheels; co-locating the cache here
-# makes it hardlink instead. Set per-build (below), not globally, so other cluster uv
-# usage keeps its default cache. uv falls back to copy if ever cross-FS — safe anywhere.
-UV_CACHE_DIR = PARAM_DECOMP_OUT_DIR / "uv_cache"
+# The job-side clone/fetch source. NOT the submitting checkout (`REPO_ROOT`): that may be
+# an ephemeral worktree a later requeue would no longer find. Worktrees share their main
+# checkout's refs, so a snapshot ref created in one is visible here.
+_HOME_CHECKOUT = Path.home() / "param-decomp"
+
+# Node-local. Trainer jobs hold whole nodes (8/8 GPUs), so no concurrent job shares a
+# node with one — the start-of-task sweep below cannot race another run's workspace.
+_NODE_WORKSPACES_DIR = "/tmp/$USER/param-decomp/node-workspaces"
 
 # ONE srun task per node (the torch torchrun model): each task runs the trainer once and
 # `sharding.init_distributed` claims all local GPUs for that one process. `--ntasks=N
@@ -56,8 +59,7 @@ _SRUN_FLAGS = "--kill-on-bad-exit=1 --ntasks-per-node=1"
 
 # jax[cuda12]'s version check dlopens cuSPARSE et al. by soname and on this cluster doesn't
 # find the pip-installed nvidia libs ("Unable to load cuSPARSE") — point the loader at the
-# venv's nvidia/*/lib dirs. Computed at submit time (machine-specific), so it stays here
-# rather than in the tracked `runtime.launch_env`.
+# venv's nvidia/*/lib dirs. Evaluated in-job, after the node's venv is built and activated.
 _LD_LIBRARY_PATH_EXPORT = (
     "export LD_LIBRARY_PATH=\"$(python -c 'import nvidia, os, glob; "
     'print(":".join(sorted(glob.glob(os.path.join(list(nvidia.__path__)[0], "*", "lib")))))\')'
@@ -67,7 +69,7 @@ _LD_LIBRARY_PATH_EXPORT = (
 
 def _render_rank_env(launch_env: LaunchEnv) -> str:
     """The bash `export` block for a rank, from the config's `runtime.launch_env` plus the
-    submit-time-computed `LD_LIBRARY_PATH`. The typed knobs are the single source of truth
+    in-job-computed `LD_LIBRARY_PATH`. The typed knobs are the single source of truth
     (defaults in `LaunchEnv`); shell-quote each value so spaces (e.g. multi-flag `XLA_FLAGS`)
     survive."""
     exports = [f"export {k}={shlex.quote(v)}" for k, v in launch_env.as_env().items()]
@@ -75,11 +77,41 @@ def _render_rank_env(launch_env: LaunchEnv) -> str:
     return "\n".join(exports)
 
 
-def _rank_command(config_rel: Path, run_id: str, rank_env: str) -> str:
+def _node_workspace_setup(run_id: str, snapshot_ref: str) -> str:
+    """The start of each node's srun task: sweep stale workspaces, clone the snapshot into
+    node-local /tmp, build the CUDA venv, activate. The task `exec`s the trainer afterwards
+    (bash is replaced, so no EXIT trap can run here) — normal-end cleanup is the batch
+    script's trap (`_node_workspace_cleanup_trap`), and the up-front sweep self-heals
+    leftovers from jobs that died before their trap fired."""
+    return f"""\
+set -euo pipefail
+WORK_DIR="{_NODE_WORKSPACES_DIR}/{run_id}"
+rm -rf "{_NODE_WORKSPACES_DIR}"
+mkdir -p "$WORK_DIR"
+git clone --quiet "{_HOME_CHECKOUT}" "$WORK_DIR"
+cd "$WORK_DIR"
+cp "{_HOME_CHECKOUT}/.env" .env
+git fetch --quiet "{_HOME_CHECKOUT}" "{snapshot_ref}:{snapshot_ref}"
+git checkout --quiet "{snapshot_ref}"
+unset VIRTUAL_ENV
+uv sync --all-packages --no-dev --extra cuda --link-mode copy -q
+source .venv/bin/activate"""
+
+
+def _node_workspace_cleanup_trap(nodes: int) -> str:
+    """Batch-script EXIT trap: sweep every node's /tmp workspace after the run. Best
+    effort — a hard kill skips it; the next job's start-of-task sweep is the backstop."""
     return (
-        f"source .venv/bin/activate\n{rank_env}\n"
+        f"trap 'srun --nodes={nodes} --ntasks={nodes} --ntasks-per-node=1 "
+        f'rm -rf "{_NODE_WORKSPACES_DIR}"\' EXIT'
+    )
+
+
+def _rank_command(run_id: str, snapshot_ref: str, launch_config: Path, rank_env: str) -> str:
+    return (
+        f"{_node_workspace_setup(run_id, snapshot_ref)}\n{rank_env}\n"
         f"exec python -m param_decomp_lab.experiments.lm.run "
-        f"{shlex.quote(str(config_rel))} --run-id {shlex.quote(run_id)}"
+        f"{shlex.quote(str(launch_config))} --run-id {shlex.quote(run_id)}"
     )
 
 
@@ -98,16 +130,16 @@ def main(
 
     Args:
         config_path: Single self-contained run yaml (the canonical schema + top-level
-            `run_name`), inside the repo. `runtime.dp` declares the world size: `None` →
-            run inline (single device); `N` (a multiple of 8) → submit across `N // 8`
-            nodes. The `run_id` is minted here and passed to the trainer as a `--run-id`
-            CLI arg (so it survives requeue); the run dir is
-            `PARAM_DECOMP_OUT_DIR/runs/<run_id>`.
+            `run_name`). `runtime.dp` declares the world size: `None` → run inline
+            (single device); `N` (a multiple of 8) → submit across `N // 8` nodes.
+            The `run_id` is minted here; the config is pinned as
+            `PARAM_DECOMP_OUT_DIR/runs/<run_id>/launch_config.yaml` and the job reads
+            THAT copy, so this file is free to change after submit.
         time: SLURM time limit.
         qos: SLURM QoS (e.g. `opportunistic`); None is the normal QoS.
-        run_id: Resubmit an existing launch — reuses its workspace (and identity)
-            instead of building a new one. `group`/`tags` are ignored on resubmit
-            (the original workspace config already carries them).
+        run_id: Resubmit an existing launch — reuses its pinned launch config (and
+            identity). `group`/`tags` are ignored on resubmit (the pinned config
+            already carries them).
         group: wandb UI group (no-op when the config omits `wandb:`).
         tags: Comma-separated wandb tags (no-op when `wandb:` is omitted).
         comment: SLURM `--comment`; defaults to the wandb run URL (or run id).
@@ -115,8 +147,9 @@ def main(
     The rank env (XLA flags, NCCL/host-memory knobs, profiling toggles) is config-driven
     via `runtime.launch_env` — set it in the YAML, not here (so `launch_config.yaml` records it).
     """
-    config_rel = _config_path_relative_to_repo(config_path)
-    cfg, run_name = _validate_config(REPO_ROOT / config_rel)
+    config = Path(config_path).resolve()
+    assert config.exists(), f"config not found: {config}"
+    cfg, run_name = _validate_config(config)
     # Python Fire parses a comma-separated `--tags a,b,c` into a tuple, but keeps a value with a
     # hyphen (e.g. `a,b,c-d`) as a string — normalize both (and the single-token case) to a list.
     if tags is None:
@@ -128,21 +161,25 @@ def main(
 
     dp = cfg.runtime.dp
     if dp is None:
-        _run_local(config_rel, run_name, group, tag_list)
+        _run_local(config, run_name, group, tag_list)
         return
     assert dp % GPUS_PER_NODE == 0, f"runtime.dp={dp} must be a multiple of {GPUS_PER_NODE}"
     nodes = dp // GPUS_PER_NODE
+
+    env_file = _HOME_CHECKOUT / ".env"
+    assert env_file.exists(), f".env with wandb credentials required: {env_file}"
 
     if run_id is None:
         run_id = generate_run_id("param_decomp")
         snapshot_ref, commit_hash = create_git_snapshot(snapshot_id=run_id)
         logger.info(f"Created git snapshot: {snapshot_ref} ({commit_hash[:8]})")
-        workspace = WORKSPACES_DIR / run_id
-        _build_workspace(workspace, snapshot_ref, config_rel, group, tag_list)
+        _assert_snapshot_visible_from_home_checkout(snapshot_ref)
+        launch_config = _write_launch_config(config, run_id, group, tag_list)
     else:
         snapshot_ref = f"refs/runs/snapshot/{run_id}"
-        workspace = WORKSPACES_DIR / run_id
-        assert workspace.exists(), f"no workspace to resubmit: {workspace}"
+        _assert_snapshot_visible_from_home_checkout(snapshot_ref)
+        launch_config = PARAM_DECOMP_OUT_DIR / "runs" / run_id / LAUNCH_CONFIG_FILENAME
+        assert launch_config.exists(), f"no launch config to resubmit: {launch_config}"
 
     wandb_url = _wandb_url(cfg, run_id)
     job_name = f"pd-{run_name}"
@@ -162,8 +199,9 @@ def main(
     # One task per node: `--nodes=N --ntasks=N` (N whole-node tasks) can't pack onto one
     # node, so the trainer's single process per node claims all local GPUs.
     srun = f"srun --nodes={nodes} --ntasks={nodes} {_SRUN_FLAGS}"
-    command = f"{srun} bash -c {shlex.quote(_rank_command(config_rel, run_id, rank_env))}"
-    script = generate_script(slurm_config, command, setup=f'cd "{workspace}"')
+    rank_command = _rank_command(run_id, snapshot_ref, launch_config, rank_env)
+    command = f"{srun} bash -c {shlex.quote(rank_command)}"
+    script = generate_script(slurm_config, command, setup=_node_workspace_cleanup_trap(nodes))
     result = submit_slurm_job(script, "pd-lm")
 
     logger.section("pd-lm job submitted!")
@@ -174,25 +212,24 @@ def main(
         "Log file": result.log_pattern,
         "Script": str(result.script_path),
         "Snapshot": snapshot_ref,
-        "Workspace": str(workspace),
+        "Launch config": str(launch_config),
     }
     if wandb_url is not None:
         summary["WandB run URL"] = wandb_url
     logger.values(summary)
 
 
-def _run_local(config_rel: Path, run_name: str, group: str | None, tags: list[str]) -> None:
-    """Mint a run id, stamp the live config in place, and run the trainer inline."""
+def _run_local(config: Path, run_name: str, group: str | None, tags: list[str]) -> None:
+    """Mint a run id, pin the launch config into the run dir, and run the trainer inline."""
     run_id = generate_run_id("param_decomp")
-    config = REPO_ROOT / config_rel
-    _stamp_config(config, group, tags)
+    launch_config = _write_launch_config(config, run_id, group, tags)
     logger.section(f"pd-lm local: {run_name} ({run_id})")
     subprocess.run(
         [
             sys.executable,
             "-m",
             "param_decomp_lab.experiments.lm.run",
-            str(config_rel),
+            str(launch_config),
             "--run-id",
             run_id,
         ],
@@ -200,15 +237,6 @@ def _run_local(config_rel: Path, run_name: str, group: str | None, tags: list[st
         check=True,
         env=os.environ.copy(),
     )
-
-
-def _config_path_relative_to_repo(config_path: str) -> Path:
-    path = Path(config_path).resolve()
-    assert path.exists(), f"config not found: {path}"
-    assert path.is_relative_to(REPO_ROOT), (
-        f"config must live inside the repo so the snapshot carries it: {path}"
-    )
-    return path.relative_to(REPO_ROOT)
 
 
 def _validate_config(config_path: Path) -> tuple[LMExperimentConfig, str]:
@@ -227,46 +255,34 @@ def _validate_config(config_path: Path) -> tuple[LMExperimentConfig, str]:
     return cfg, cfg.run_name
 
 
-def _build_workspace(
-    workspace: Path,
-    snapshot_ref: str,
-    config_rel: Path,
-    group: str | None,
-    tags: list[str],
-) -> None:
-    """Materialize the snapshot as an immutable shared-FS checkout with the one CUDA
-    venv, then stamp the wandb group/tags into the workspace's single config yaml. The run
-    id rides as a `--run-id` CLI arg on the trainer command, not in the config."""
-    assert not workspace.exists(), f"workspace already exists: {workspace}"
-    workspace.parent.mkdir(parents=True, exist_ok=True)
-    UV_CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    build_env = {**os.environ, "UV_CACHE_DIR": str(UV_CACHE_DIR)}
+def _write_launch_config(config: Path, run_id: str, group: str | None, tags: list[str]) -> Path:
+    """Pin the run's config (with the wandb group/tags stamped in) as the run dir's
+    `launch_config.yaml` — the one copy the job and every requeue read, and the same file
+    the trainer pins (`run.py::_pin_config_copy` no-ops on it)."""
+    run_dir = PARAM_DECOMP_OUT_DIR / "runs" / run_id
+    run_dir.mkdir(parents=True, exist_ok=False)
+    launch_config = run_dir / LAUNCH_CONFIG_FILENAME
+    launch_config.write_text(config.read_text())
+    _stamp_config(launch_config, group, tags)
+    return launch_config
 
-    def run(args: list[str], cwd: Path, env: dict[str, str] | None = None) -> None:
-        subprocess.run(args, cwd=cwd, check=True, env=env)
 
-    logger.info(f"Building workspace {workspace} ...")
-    run(["git", "clone", "--quiet", str(REPO_ROOT), str(workspace)], cwd=REPO_ROOT)
-    run(
-        ["git", "fetch", "--quiet", str(REPO_ROOT), f"{snapshot_ref}:{snapshot_ref}"], cwd=workspace
+def _assert_snapshot_visible_from_home_checkout(snapshot_ref: str) -> None:
+    """The job-side clone fetches the snapshot from `_HOME_CHECKOUT`, so the ref must be
+    visible there — true when submitting from that checkout or any of its worktrees
+    (shared refs), NOT from an unrelated clone."""
+    result = subprocess.run(
+        ["git", "-C", str(_HOME_CHECKOUT), "rev-parse", "--verify", "--quiet", snapshot_ref],
+        capture_output=True,
     )
-    run(["git", "checkout", "--quiet", snapshot_ref], cwd=workspace)
-    env_file = REPO_ROOT / ".env"
-    assert env_file.exists(), f".env with wandb credentials required: {env_file}"
-    (workspace / ".env").write_bytes(env_file.read_bytes())
-
-    logger.info("venv: uv sync --all-packages --no-dev --extra cuda (hardlink from uv_cache) ...")
-    run(
-        ["uv", "sync", "--all-packages", "--no-dev", "--extra", "cuda", "-q"],
-        cwd=workspace,
-        env=build_env,
+    assert result.returncode == 0, (
+        f"{snapshot_ref} not visible from {_HOME_CHECKOUT} — nodes clone the snapshot from "
+        f"there at job start; launch from that checkout or one of its worktrees"
     )
-
-    _stamp_config(workspace / config_rel, group, tags)
 
 
 def _stamp_config(config: Path, group: str | None, tags: list[str]) -> None:
-    """Stamp the wandb UI knobs onto the workspace's single config yaml's `wandb:` block
+    """Stamp the wandb UI knobs onto the pinned launch config's `wandb:` block
     (no-op when `wandb:` is omitted). The run id is NOT stamped — it is passed to the
     trainer as a `--run-id` CLI arg, and the run dir derives from it."""
     if group is None and not tags:

--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -2,7 +2,8 @@
 vendored target.
 
     python -m param_decomp_lab.experiments.lm.run <wrapper.yaml>   # normally via pd-lm,
-        # which stamps run_id into the workspace copy; re-running resumes in place
+        # which pins the config as runs/<id>/launch_config.yaml and passes --run-id;
+        # re-running resumes in place
 
 This is the LM I/O layer over the generic core engine
 (`param_decomp.run.run_decomposition_training`): read the run YAML, build the target, feed

--- a/param_decomp_lab/infra/git.py
+++ b/param_decomp_lab/infra/git.py
@@ -46,8 +46,8 @@ def create_git_snapshot(snapshot_id: str) -> tuple[str, str]:
 
     Creates a ref under `refs/runs/snapshot/<snapshot_id>` containing all current changes (staged
     and unstaged). Uses a temporary detached worktree to avoid affecting the current working
-    directory. Will push the snapshot ref to origin if possible, but will continue without error
-    if push permissions are lacking.
+    directory. Pushes the snapshot ref to origin and FAILS if the push fails: origin is the
+    ground truth for snapshot refs — SLURM jobs fetch them from origin at job start.
 
     The ref lives outside `refs/heads/*` and `refs/tags/*`, so it is invisible to a default
     `git fetch` — clients only pull it down if they ask for it explicitly. This keeps the set of
@@ -63,7 +63,7 @@ def create_git_snapshot(snapshot_id: str) -> tuple[str, str]:
         commit if changes existed, otherwise the base commit).
 
     Raises:
-        subprocess.CalledProcessError: If git commands fail (except for push)
+        subprocess.CalledProcessError: If git commands fail
     """
     snapshot_ref: str = f"refs/runs/snapshot/{snapshot_id}"
 
@@ -130,21 +130,19 @@ def create_git_snapshot(snapshot_id: str) -> tuple[str, str]:
                 capture_output=True,
             )
 
-            # Try push (non-fatal if fails)
-            try:
-                subprocess.run(
-                    ["git", "push", "origin", f"{snapshot_ref}:{snapshot_ref}"],
-                    cwd=REPO_ROOT,
-                    check=True,
-                    capture_output=True,
-                )
-                logger.info(f"Successfully pushed snapshot ref '{snapshot_ref}' to origin")
-            except subprocess.CalledProcessError as e:
-                logger.warning(
-                    f"Could not push snapshot ref '{snapshot_ref}' to origin. "
-                    f"The ref was created locally but won't be accessible to other users. "
-                    f"Error: {e.stderr.decode().strip() if e.stderr else 'Unknown error'}"
-                )
+            # Origin is the ground truth for snapshot refs — SLURM jobs fetch them from
+            # origin at job start, so a failed push must fail the submit.
+            push = subprocess.run(
+                ["git", "push", "origin", f"{snapshot_ref}:{snapshot_ref}"],
+                cwd=REPO_ROOT,
+                capture_output=True,
+                text=True,
+            )
+            assert push.returncode == 0, (
+                f"pushing {snapshot_ref} to origin failed (jobs fetch snapshots from origin): "
+                f"{push.stderr.strip()}"
+            )
+            logger.info(f"Pushed snapshot ref '{snapshot_ref}' to origin")
 
         finally:
             # Clean up worktree (the snapshot ref in the main repo remains)

--- a/param_decomp_lab/infra/git.py
+++ b/param_decomp_lab/infra/git.py
@@ -46,8 +46,8 @@ def create_git_snapshot(snapshot_id: str) -> tuple[str, str]:
 
     Creates a ref under `refs/runs/snapshot/<snapshot_id>` containing all current changes (staged
     and unstaged). Uses a temporary detached worktree to avoid affecting the current working
-    directory. Pushes the snapshot ref to origin and FAILS if the push fails: origin is the
-    ground truth for snapshot refs — SLURM jobs fetch them from origin at job start.
+    directory. Pushes the snapshot ref to origin as a best-effort provenance backup —
+    jobs fetch snapshots from the local shared-FS git dir, not origin.
 
     The ref lives outside `refs/heads/*` and `refs/tags/*`, so it is invisible to a default
     `git fetch` — clients only pull it down if they ask for it explicitly. This keeps the set of
@@ -130,19 +130,22 @@ def create_git_snapshot(snapshot_id: str) -> tuple[str, str]:
                 capture_output=True,
             )
 
-            # Origin is the ground truth for snapshot refs — SLURM jobs fetch them from
-            # origin at job start, so a failed push must fail the submit.
+            # Best-effort provenance backup — jobs fetch snapshots from the local shared-FS
+            # git dir, so a failed push shouldn't block the submit.
             push = subprocess.run(
                 ["git", "push", "origin", f"{snapshot_ref}:{snapshot_ref}"],
                 cwd=REPO_ROOT,
                 capture_output=True,
                 text=True,
             )
-            assert push.returncode == 0, (
-                f"pushing {snapshot_ref} to origin failed (jobs fetch snapshots from origin): "
-                f"{push.stderr.strip()}"
-            )
-            logger.info(f"Pushed snapshot ref '{snapshot_ref}' to origin")
+            if push.returncode == 0:
+                logger.info(f"Pushed snapshot ref '{snapshot_ref}' to origin")
+            else:
+                logger.warning(
+                    f"Could not push snapshot ref '{snapshot_ref}' to origin (continuing; "
+                    f"the ref exists locally and jobs fetch it from there): "
+                    f"{push.stderr.strip()}"
+                )
 
         finally:
             # Clean up worktree (the snapshot ref in the main repo remains)

--- a/param_decomp_lab/infra/slurm.py
+++ b/param_decomp_lab/infra/slurm.py
@@ -78,9 +78,9 @@ def generate_script(
 ) -> str:
     """Generate a single SLURM job script. `env` is exported at the start of the script.
 
-    `setup` overrides the default workspace/venv section — for launches whose
-    workspace is materialized at submit time (e.g. the JAX launcher) rather than
-    cloned inside the job.
+    `setup` overrides the default workspace/venv section — for launches that manage
+    their own workspaces (e.g. `pd-lm`, whose nodes each build one inside the srun
+    command and whose `setup` is just the cleanup trap).
     """
     header = _sbatch_header_singleton(config)
     if setup is None:

--- a/param_decomp_lab/tests/test_launch.py
+++ b/param_decomp_lab/tests/test_launch.py
@@ -68,7 +68,11 @@ def test_rank_command_builds_node_workspace_then_execs_trainer():
     # per-node job-side workspace: snapshot checkout + CUDA venv, then exec (no EXIT trap
     # — bash is replaced, cleanup is the batch script's trap)
     assert "git checkout --quiet FETCH_HEAD" in command
-    assert "uv sync --all-packages --no-dev --extra cuda" in command
+    # the CUDA extra is driver-gated on the node (cuda13 needs >= r580; cuBLAS TMEM fix)
+    assert 'if [ "$DRIVER_MAJOR" -ge 580 ]; then CUDA_EXTRA=cuda13; else CUDA_EXTRA=cuda; fi' in (
+        command
+    )
+    assert 'uv sync --all-packages --no-dev --extra "$CUDA_EXTRA"' in command
     assert "trap" not in command
     # venv activation precedes the rank env (LD_LIBRARY_PATH shells out to the venv python)
     assert command.index("source .venv/bin/activate") < command.index("export FOO=1")

--- a/param_decomp_lab/tests/test_launch.py
+++ b/param_decomp_lab/tests/test_launch.py
@@ -52,16 +52,22 @@ def test_rank_command_builds_node_workspace_then_execs_trainer():
     command = _rank_command(
         "p-abcd1234",
         "refs/runs/snapshot/p-abcd1234",
-        Path("/home/u/param-decomp/.git"),
-        Path("/out/runs/p-abcd1234/launch_config.yaml"),
+        "git@github.com:goodfire-ai/param-decomp.git",
+        Path("/out/runs/p-abcd1234"),
         rank_env="export FOO=1",
     )
-    # clones/fetches the durable common git dir; .env comes from its checkout root
-    assert 'git clone --quiet "/home/u/param-decomp/.git"' in command
-    assert 'cp "/home/u/param-decomp/.env" .env' in command
+    # the snapshot comes from origin (the refs' ground truth), never a local checkout;
+    # .env (secrets, not in git) comes from the run dir where submit staged it
+    fetch = (
+        'git fetch --quiet --depth 1 "git@github.com:goodfire-ai/param-decomp.git" '
+        '"refs/runs/snapshot/p-abcd1234"'
+    )
+    assert fetch in command
+    assert "git clone" not in command
+    assert 'cp "/out/runs/p-abcd1234/.env" .env' in command
     # per-node job-side workspace: snapshot checkout + CUDA venv, then exec (no EXIT trap
     # — bash is replaced, cleanup is the batch script's trap)
-    assert 'git checkout --quiet "refs/runs/snapshot/p-abcd1234"' in command
+    assert "git checkout --quiet FETCH_HEAD" in command
     assert "uv sync --all-packages --no-dev --extra cuda" in command
     assert "trap" not in command
     # venv activation precedes the rank env (LD_LIBRARY_PATH shells out to the venv python)

--- a/param_decomp_lab/tests/test_launch.py
+++ b/param_decomp_lab/tests/test_launch.py
@@ -48,13 +48,24 @@ _MINIMAL_LM = {
 }
 
 
-def test_rank_command_runs_trainer_as_module_with_run_id():
+def test_rank_command_builds_node_workspace_then_execs_trainer():
     command = _rank_command(
-        Path("param_decomp/configs/x.yaml"), "p-abcd1234", rank_env="export FOO=1"
+        "p-abcd1234",
+        "refs/runs/snapshot/p-abcd1234",
+        Path("/out/runs/p-abcd1234/launch_config.yaml"),
+        rank_env="export FOO=1",
     )
-    assert "exec python -m param_decomp_lab.experiments.lm.run" in command
-    assert "--run-id p-abcd1234" in command
-    assert "pd-train" not in command
+    # per-node job-side workspace: snapshot checkout + CUDA venv, then exec (no EXIT trap
+    # — bash is replaced, cleanup is the batch script's trap)
+    assert 'git checkout --quiet "refs/runs/snapshot/p-abcd1234"' in command
+    assert "uv sync --all-packages --no-dev --extra cuda" in command
+    assert "trap" not in command
+    # venv activation precedes the rank env (LD_LIBRARY_PATH shells out to the venv python)
+    assert command.index("source .venv/bin/activate") < command.index("export FOO=1")
+    assert command.endswith(
+        "exec python -m param_decomp_lab.experiments.lm.run "
+        "/out/runs/p-abcd1234/launch_config.yaml --run-id p-abcd1234"
+    )
 
 
 def test_validate_config_returns_run_name(tmp_path: Path):

--- a/param_decomp_lab/tests/test_launch.py
+++ b/param_decomp_lab/tests/test_launch.py
@@ -52,9 +52,13 @@ def test_rank_command_builds_node_workspace_then_execs_trainer():
     command = _rank_command(
         "p-abcd1234",
         "refs/runs/snapshot/p-abcd1234",
+        Path("/home/u/param-decomp/.git"),
         Path("/out/runs/p-abcd1234/launch_config.yaml"),
         rank_env="export FOO=1",
     )
+    # clones/fetches the durable common git dir; .env comes from its checkout root
+    assert 'git clone --quiet "/home/u/param-decomp/.git"' in command
+    assert 'cp "/home/u/param-decomp/.env" .env' in command
     # per-node job-side workspace: snapshot checkout + CUDA venv, then exec (no EXIT trap
     # — bash is replaced, cleanup is the batch script's trap)
     assert 'git checkout --quiet "refs/runs/snapshot/p-abcd1234"' in command

--- a/param_decomp_lab/tests/test_launch.py
+++ b/param_decomp_lab/tests/test_launch.py
@@ -52,14 +52,15 @@ def test_rank_command_builds_node_workspace_then_execs_trainer():
     command = _rank_command(
         "p-abcd1234",
         "refs/runs/snapshot/p-abcd1234",
-        "git@github.com:goodfire-ai/param-decomp.git",
+        Path("/home/u/param-decomp/.git"),
         Path("/out/runs/p-abcd1234"),
         rank_env="export FOO=1",
     )
-    # the snapshot comes from origin (the refs' ground truth), never a local checkout;
-    # .env (secrets, not in git) comes from the run dir where submit staged it
+    # the snapshot comes from the shared-FS common git dir (file:// so --depth works —
+    # git ignores it on the bare-path local transport); .env (secrets, not in git) comes
+    # from the run dir where submit staged it
     fetch = (
-        'git fetch --quiet --depth 1 "git@github.com:goodfire-ai/param-decomp.git" '
+        'git fetch --quiet --depth 1 "file:///home/u/param-decomp/.git" '
         '"refs/runs/snapshot/p-abcd1234"'
     )
     assert fetch in command

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,14 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-# CUDA jaxlib wheels for the cluster; the per-run snapshot venv the launcher builds
-# installs this extra. The dev venv (CPU box) takes the base CPU jax above.
+# CUDA jaxlib wheels for the cluster; pd-lm's job-side node workspaces install one of
+# these extras. The dev venv (CPU box) takes the base CPU jax above.
 cuda = ["jax[cuda12]==0.10.1"]
+# CUDA-13 wheel track: same jax, newer runtime libs. cuBLAS >= 13.2 fixes a Blackwell TMEM
+# double-free (silent-corruption hazard; cuBLAS 12.9 warns on B200). Needs driver >= r580,
+# so the node setup picks cuda13 vs cuda off the node's own driver (and-gmi's r570 falls
+# back to cu12).
+cuda13 = ["jax[cuda13]==0.10.1", "nvidia-cublas>=13.2.0.9"]
 
 [project.scripts]
 # No core console scripts: the trainers run as modules (`python -m param_decomp.run` /

--- a/uv.lock
+++ b/uv.lock
@@ -810,6 +810,10 @@ cuda12 = [
     { name = "jax-cuda12-plugin", extra = ["with-cuda"] },
     { name = "jaxlib" },
 ]
+cuda13 = [
+    { name = "jax-cuda13-plugin", extra = ["with-cuda"] },
+    { name = "jaxlib" },
+]
 
 [[package]]
 name = "jax-cuda12-pjrt"
@@ -848,6 +852,46 @@ with-cuda = [
     { name = "nvidia-nccl-cu12", marker = "sys_platform == 'linux'" },
     { name = "nvidia-nvjitlink-cu12", marker = "sys_platform == 'linux'" },
     { name = "nvidia-nvshmem-cu12", marker = "sys_platform == 'linux'" },
+]
+
+[[package]]
+name = "jax-cuda13-pjrt"
+version = "0.10.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/8e/57eebc0c4d6d63bad64f7443cbc96d3e3c5535fa4992af58568ad7388cbb/jax_cuda13_pjrt-0.10.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:7dd9f518876857e238a9a63abc185b277e9435470cc286b92209ef79d51d03cf", size = 113795506, upload-time = "2026-05-20T14:52:06.61Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/05adf1f245de3b37518ba1e7e668cdc38ec0291313ab63fc0768089f8baa/jax_cuda13_pjrt-0.10.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:af8042c7697fb6faa0cc4851d4f5e0504878ea1f6b6fc067255f449016336a6f", size = 119552553, upload-time = "2026-05-20T14:52:11.087Z" },
+]
+
+[[package]]
+name = "jax-cuda13-plugin"
+version = "0.10.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jax-cuda13-pjrt" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/cf/d6d807cbbb4e61103291a34856b32766b252c96a39897bf4e0143942f030/jax_cuda13_plugin-0.10.1-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:a31e7859ecebfa0680eca260ea64046d5c54c7596d734897526ebeb89d54e48b", size = 7255426, upload-time = "2026-05-20T14:52:21.663Z" },
+    { url = "https://files.pythonhosted.org/packages/80/80/ec043edee9db3debf5074fe5fd0431c6fea3f94d1b9a53458b35cd30544d/jax_cuda13_plugin-0.10.1-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:9070b1af00ebc7f5d6f20aafb789058f53812afd85e237dce0f1709a52cfd0f8", size = 7306050, upload-time = "2026-05-20T14:52:23.216Z" },
+    { url = "https://files.pythonhosted.org/packages/44/94/d480e1fb807cf67c3796200dca01cbe4c75dfa82ce64460b90c944e218cf/jax_cuda13_plugin-0.10.1-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:6baea37967bd9759f5bc014d8d6291782332478f746302f46fd08a9009a23304", size = 7268591, upload-time = "2026-05-20T14:52:24.77Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/7f/da438722130ca56ec5b15a3318c477418088aaa818480280816e6ce6259d/jax_cuda13_plugin-0.10.1-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:699a984d67b040f6dd26bae1b9326d748c62cafee769a9050085f953b42db0e5", size = 7316498, upload-time = "2026-05-20T14:52:26.47Z" },
+]
+
+[package.optional-dependencies]
+with-cuda = [
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvcc", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvvm" },
 ]
 
 [[package]]
@@ -1302,6 +1346,19 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cublas"
+version = "13.6.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-nvrtc" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/22/7c08d8e93f6a2e4879ac83c12696aecaf17a0fc2c9e8d204caceaa3b8426/nvidia_cublas-13.6.0.2-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:946f6a252b1cc72d8de912c75975fd6d8ba44f67d4e5044fe764ddb909f4a688", size = 518599300, upload-time = "2026-06-29T16:54:56.859Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/6c/173c7a3db77a6592210f73f194f0f8ed5e51b6ec61cfed7b1eee06ac5fd3/nvidia_cublas-13.6.0.2-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b82c80c886cea6da6e149a5c3bdba274f12b7e4ec4b00a050b916b0446fb4153", size = 410473152, upload-time = "2026-06-29T16:55:54.297Z" },
+    { url = "https://files.pythonhosted.org/packages/08/8f/890a96ea1ff615100296977cce23296052dcb8c114d4e451201ec39df9bf/nvidia_cublas-13.6.0.2-py3-none-win_amd64.whl", hash = "sha256:3b5bcd6bfb6f65010ebf195851bcb9b2aa34b9fe08479432002991c1fe84b67d", size = 394568225, upload-time = "2026-06-29T17:15:46.911Z" },
+]
+
+[[package]]
 name = "nvidia-cublas-cu12"
 version = "12.9.2.10"
 source = { registry = "https://pypi.org/simple" }
@@ -1314,12 +1371,39 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cuda-cccl"
+version = "13.3.3.4.1"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/bd/572971ffc14bd36676c821fc15d991b08fe6179cb09368250147475f954d/nvidia_cuda_cccl-13.3.3.4.1-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:067d19b4b3c9d0f2ebec9f29a311b2863db96bf98e058bbc331597d51ce818cf", size = 3454030, upload-time = "2026-06-29T16:41:49.092Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ab/049726d90147865a3ea53bae6cb7c35b98bf1fdf96cdb967101329625f83/nvidia_cuda_cccl-13.3.3.4.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:cc0adc188d570b09f4d606c7dc05a42aa3d8aa082e0d60f7bbfc5b6435f627c6", size = 3454034, upload-time = "2026-06-29T16:42:07.435Z" },
+]
+
+[[package]]
 name = "nvidia-cuda-cccl-cu12"
 version = "12.9.27"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/61/7e/82e49956b046bdc506c789235c587d9b3ef58b8bc1782258c1e247229647/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d7898b38aa68beaa234d48f0868273702342a196d6e2e9d0ef058dca2390ebea", size = 3152245, upload-time = "2025-05-01T19:32:04.802Z" },
     { url = "https://files.pythonhosted.org/packages/18/2a/d4cd8506d2044e082f8cd921be57392e6a9b5ccd3ffdf050362430a3d5d5/nvidia_cuda_cccl_cu12-12.9.27-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:37869e17ce2e1ecec6eddf1927cca0f8c34e64fd848d40453df559091e2d7117", size = 3152243, upload-time = "2025-05-01T19:32:13.955Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-crt"
+version = "13.3.73"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/41/2089e411507d66458d67208bdd1bc562d492bb6458c3d2aea4603072a219/nvidia_cuda_crt-13.3.73-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:60aacc0b5e1e8b40c62abe4d1ab16440add91b99bd2f17f62dd091586b73d166", size = 157353, upload-time = "2026-06-29T16:42:38.163Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/ce/16d76f4b5b3f7460f5ebd17516685495c149c66651ffdd381f90e4d4e65c/nvidia_cuda_crt-13.3.73-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:df14a17ae1c5c3171265411212246654d780f89344ea85344466c6b955247543", size = 157352, upload-time = "2026-06-29T16:43:09.209Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-cupti"
+version = "13.3.75"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/7b/d332e362c2c48929f913a5930a596c707c30632ae3248dd16be35f18fc11/nvidia_cuda_cupti-13.3.75-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:79f5a8c55378a998427d6974b1d85ec91ef684035d016b3fb3b85006914f94f0", size = 11824795, upload-time = "2026-06-29T16:46:00.894Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/68/ee003f64d79bd3cb95e243cfdc906bb0f1ae73b1aa2857baf1d7834dd1ee/nvidia_cuda_cupti-13.3.75-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:a969cc446c44db612e417bd0af722cfad9009c027dabd4ed255262c0e9a9a3d2", size = 12044533, upload-time = "2026-06-29T16:46:20.662Z" },
 ]
 
 [[package]]
@@ -1332,6 +1416,20 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cuda-nvcc"
+version = "13.3.73"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-crt", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvvm", marker = "sys_platform == 'linux'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/14/9f5cdc994d5431e2f08f62ffe34509e7feabd1f2e18517e2d7720c6ff0fd/nvidia_cuda_nvcc-13.3.73-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:70f250825355d2c3aa6c7a972a0ec00f020bad66d2679e527eb4336301c904aa", size = 39515578, upload-time = "2026-06-29T16:47:40.318Z" },
+    { url = "https://files.pythonhosted.org/packages/83/19/e46ef3597ba47a9f8a91ab24533db42a600b659fc418dbe4af0b630bcb41/nvidia_cuda_nvcc-13.3.73-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f483af83166c4fa356a21606076d553b0b4ceaebbd9912e537545080db695bdd", size = 44942138, upload-time = "2026-06-29T16:48:13.615Z" },
+]
+
+[[package]]
 name = "nvidia-cuda-nvcc-cu12"
 version = "12.9.86"
 source = { registry = "https://pypi.org/simple" }
@@ -1341,12 +1439,31 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.3.33"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8b/2c/86916c8a34dcdb0c3ddd1c0e30545041bd781184e437b9cb76fcda70560b/nvidia_cuda_nvrtc-13.3.33-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:82530788b8c6164a54d3fd9ae8bcca8893d397c4aeb998861982a03bbe41e204", size = 51110910, upload-time = "2026-05-26T16:38:16.116Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/b6/60a3641111d39ebfcfcd8b8bfd0290d7623c4b8b5f90952c2d84776f8ca4/nvidia_cuda_nvrtc-13.3.33-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7b05ecda494c6dabc44231a608b060a71008a730d9dfda932cc508e6d29159e0", size = 49260054, upload-time = "2026-05-26T16:37:51.177Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/42/edce72f2c5a0f587168109c867f25f4a9a6cd7289ecf0d68ed2b1070f273/nvidia_cuda_nvrtc-13.3.33-py3-none-win_amd64.whl", hash = "sha256:7d2af818851c0c224d5f92221e9226e51ee23c236df4b51f9194563979c888be", size = 45319163, upload-time = "2026-05-26T17:02:49.217Z" },
+]
+
+[[package]]
 name = "nvidia-cuda-nvrtc-cu12"
 version = "12.9.86"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b8/85/e4af82cc9202023862090bfca4ea827d533329e925c758f0cde964cb54b7/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:210cf05005a447e29214e9ce50851e83fc5f4358df8b453155d5e1918094dcb4", size = 89568129, upload-time = "2025-06-05T20:02:41.973Z" },
     { url = "https://files.pythonhosted.org/packages/64/eb/c2295044b8f3b3b08860e2f6a912b702fc92568a167259df5dddb78f325e/nvidia_cuda_nvrtc_cu12-12.9.86-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:096d4de6bda726415dfaf3198d4f5c522b8e70139c97feef5cd2ca6d4cd9cead", size = 44528905, upload-time = "2025-06-05T20:02:29.754Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.3.29"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5f/e5/c1a221c8e6fecd071b80ea44c20fc253ae24f56e15e3f77cfbc3fb76e724/nvidia_cuda_runtime-13.3.29-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:73291e19c9dd919c140c91bda2f80b0eca487da5ee30a086ef7bc4918ecb90ea", size = 2356574, upload-time = "2026-05-26T16:29:56.333Z" },
+    { url = "https://files.pythonhosted.org/packages/97/be/5699b6e642b372f7d24c59c2f41383e2696825e20bab85f7399c7c6a56f7/nvidia_cuda_runtime-13.3.29-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:e04420616e72f563167a7733272992d7e6df6dc5cb54b2f94f9f1520ea9e30c1", size = 2339786, upload-time = "2026-05-26T16:30:21.584Z" },
 ]
 
 [[package]]
@@ -1371,6 +1488,30 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.24.0.43"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/30/7c257e3d5cb4fecb147b93895c66e29c93f8e76d74b45bb418ff0587c4ec/nvidia_cudnn_cu13-9.24.0.43-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:a6812a554a1ff0413e9c52b84c26c050380649ab9615f9c16bded368ce9f421f", size = 650976863, upload-time = "2026-07-02T16:23:39.248Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ba/791cffd048fe5b044e620df55267e3e95c0e6e07d50b41e377c03dfc910f/nvidia_cudnn_cu13-9.24.0.43-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:71f181cd810e90f9b6023b01186fe82d13d65f0ec098581ee201d39fad769e4b", size = 553099438, upload-time = "2026-07-02T16:27:42.58Z" },
+]
+
+[[package]]
+name = "nvidia-cufft"
+version = "12.3.0.29"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/bc/543e6dfbcb659ed07a94a72d8925c8b5688dabc1f616ab2f6575483a3cb6/nvidia_cufft-12.3.0.29-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3c268ec73fdbfd22e42913dcef6e49e0c305ab09cd9848268a841cbe9f33f748", size = 184700143, upload-time = "2026-05-26T16:45:25.443Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/00/fab4a29fa1d7eb43bc6b94de4e86312c5e425d5582e58b9641300b9dffc7/nvidia_cufft-12.3.0.29-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:edb25c0626bd202ee5acc035b5dd361a3b89ed3b75a81a52df72c89150cb57c2", size = 184730406, upload-time = "2026-05-26T16:46:18.193Z" },
+]
+
+[[package]]
 name = "nvidia-cufft-cu12"
 version = "11.4.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1380,6 +1521,20 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9b/2b/76445b0af890da61b501fde30650a1a4bd910607261b209cccb5235d3daa/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:1a28c9b12260a1aa7a8fd12f5ebd82d027963d635ba82ff39a1acfa7c4c0fbcf", size = 200822453, upload-time = "2025-06-05T20:05:27.889Z" },
     { url = "https://files.pythonhosted.org/packages/95/f4/61e6996dd20481ee834f57a8e9dca28b1869366a135e0d42e2aa8493bdd4/nvidia_cufft_cu12-11.4.1.4-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c67884f2a7d276b4b80eb56a79322a95df592ae5e765cf1243693365ccab4e28", size = 200877592, upload-time = "2025-06-05T20:05:45.862Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.2.6.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/13/bd/61dcd7917f64c9e81a35f939f1bf4ab6535adf712192e915fb472e5bbf6c/nvidia_cusolver-12.2.6.9-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:658ce9e6ed8a321033419fe6e55faf0f245a15aa23669eda03d7f2dcce436d73", size = 267275679, upload-time = "2026-06-29T16:59:54.924Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3a/23e46a0919ba5ecf1a864400542a6c78d18c76893a0a77e1856e7033af31/nvidia_cusolver-12.2.6.9-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:e32cb40c8a4d3df475b556caaf6af5808ef064df7e291a049528a0d28017b674", size = 244667799, upload-time = "2026-06-29T17:00:42.543Z" },
 ]
 
 [[package]]
@@ -1394,6 +1549,18 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/03/99/686ff9bf3a82a531c62b1a5c614476e8dfa24a9d89067aeedf3592ee4538/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:62efa83e4ace59a4c734d052bb72158e888aa7b770e1a5f601682f16fe5b4fd2", size = 337869834, upload-time = "2025-06-05T20:06:53.125Z" },
     { url = "https://files.pythonhosted.org/packages/33/40/79b0c64d44d6c166c0964ec1d803d067f4a145cca23e23925fd351d0e642/nvidia_cusolver_cu12-11.7.5.82-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:15da72d1340d29b5b3cf3fd100e3cd53421dde36002eda6ed93811af63c40d88", size = 338117415, upload-time = "2025-06-05T20:07:16.809Z" },
+]
+
+[[package]]
+name = "nvidia-cusparse"
+version = "12.8.2.51"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ac/bc/925058f9343d93426864cbb113a3f5cf6db97a7d11642aaf4159b6f0c57a/nvidia_cusparse-12.8.2.51-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:00469fcf62c4d464a1225abd9b20864ecff35e3fbc9fb992572e83d358927755", size = 172868683, upload-time = "2026-06-29T17:01:23.244Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/dc/752e401a5d6fc5f1948cf190add5afc27e440e5ca08bc3fab66826c16213/nvidia_cusparse-12.8.2.51-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:65cbcc4e37a34fca4ee7df2fd57da103593842cda1bbb4a144664ecfe59873a5", size = 154538196, upload-time = "2026-06-29T17:02:06.078Z" },
 ]
 
 [[package]]
@@ -1418,6 +1585,24 @@ wheels = [
 ]
 
 [[package]]
+name = "nvidia-nccl-cu13"
+version = "2.30.7"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/21/a73174c6157101bdf1ffc22b517f76ff0082613989dd9bc8f43e8034caac/nvidia_nccl_cu13-2.30.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:ca786ffa5a647c75d4d1f5cc72a6c4f537947e2ba8823d7c8aaf768e7a7b9f77", size = 215983881, upload-time = "2026-06-09T03:23:15.633Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/34/c500f90c7ae641b8e0f98965b36b8a7ac79cc8b296e8d251fe3eb592ee54/nvidia_nccl_cu13-2.30.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:cefa7fdb9710efd0f39c5f1be1d61ff6fc9a996c451265bd7fbdcf9455ed4b50", size = 215965170, upload-time = "2026-06-09T03:23:39.73Z" },
+]
+
+[[package]]
+name = "nvidia-nvjitlink"
+version = "13.3.33"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/ee/580ca6f29dcab0221db8706badca1bbbb084f1975c4d4e83329c3a7e31f0/nvidia_nvjitlink-13.3.33-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:26a6de7fb4c8fdaa7703d3dad720d6d427ddfea5c48a528fd97c11733ad830e5", size = 40742423, upload-time = "2026-05-26T16:54:51.613Z" },
+    { url = "https://files.pythonhosted.org/packages/69/30/45414e35ff2eee7db3da037e5707037ccf9d2b5218ffbdb055ea4d5aa98a/nvidia_nvjitlink-13.3.33-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ce48b37dfeb3cb1eae4cf85adacb47d7a6539ea2272870c9a3628ce275c2037e", size = 39168635, upload-time = "2026-05-26T16:54:13.906Z" },
+]
+
+[[package]]
 name = "nvidia-nvjitlink-cu12"
 version = "12.9.86"
 source = { registry = "https://pypi.org/simple" }
@@ -1436,6 +1621,28 @@ dependencies = [
 wheels = [
     { url = "https://files.pythonhosted.org/packages/29/4f/2d705ab9a090fe946dc2be0a3c30f9241e99c49058d2f9c269459b445edc/nvidia_nvshmem_cu12-3.7.0-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:06426cd421093a63529d90a95e57ddf884c9ca43f93016d7a27b903f0a0acaed", size = 230116748, upload-time = "2026-06-11T12:40:27.683Z" },
     { url = "https://files.pythonhosted.org/packages/3e/85/1c12e849e4d50624e75496378a3fb168389f768d3ec7cb694fba873ff9a8/nvidia_nvshmem_cu12-3.7.0-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ca643cb87a214c0f7ad8396def747adcaa0c8dfb0cb7e5012338ac3b0d76404b", size = 230322323, upload-time = "2026-06-11T12:41:23.83Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu13"
+version = "3.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-cuda-cccl", marker = "sys_platform == 'linux'" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/472974dd368031048e23f00eb0761732b594622a66d7ddae592d9728ba6e/nvidia_nvshmem_cu13-3.7.1-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:23bd649aeb0518a380ed649bdbe090cbbac95aa24b8038890454dedd5cf51350", size = 135080181, upload-time = "2026-06-30T19:26:01.934Z" },
+    { url = "https://files.pythonhosted.org/packages/01/00/867006cd5626ed608fce8bf4227bfd3e1d25216abe1d110bb299fecf79b3/nvidia_nvshmem_cu13-3.7.1-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d0ac6c34d77d7528c72f0e50ed6a03a19670a8c6d0dc8c67a06f768502698f9a", size = 135321350, upload-time = "2026-06-30T19:27:03.57Z" },
+]
+
+[[package]]
+name = "nvidia-nvvm"
+version = "13.3.73"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/e7/ff646aa6015c7e6d12aad234e68925c87b6681d8d18c3ac40535994a3b0d/nvidia_nvvm-13.3.73-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:0e28e0858a3475e11ac67d35301cd5bf82666a1c0dc4ec4e80ceaf3a5fd1dea8", size = 69250424, upload-time = "2026-06-29T17:08:07.453Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/05/35754a7105563fd9b496e5ee8e1acd986aef8258760c3cbccf419aee861a/nvidia_nvvm-13.3.73-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:e2bcdd5783b5481445f1f0e7170cb836cc0d72999839ba850bbba6dc97b76bb8", size = 66984478, upload-time = "2026-06-29T17:07:43.765Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6b/d5756f485012b920475cbc01457c1b9a7d0485bfb04b92598c5e1ef3e9ab/nvidia_nvvm-13.3.73-py3-none-win_amd64.whl", hash = "sha256:b5c91dfa59ee4cee90b2dfb19c6203f31c914b9c9b5ca10726c2da7cf8ed401d", size = 59981103, upload-time = "2026-06-29T17:21:43.334Z" },
 ]
 
 [[package]]
@@ -1589,6 +1796,10 @@ dependencies = [
 cuda = [
     { name = "jax", extra = ["cuda12"] },
 ]
+cuda13 = [
+    { name = "jax", extra = ["cuda13"] },
+    { name = "nvidia-cublas" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -1612,9 +1823,11 @@ requires-dist = [
     { name = "equinox", specifier = "==0.13.8" },
     { name = "jax", specifier = "==0.10.1" },
     { name = "jax", extras = ["cuda12"], marker = "extra == 'cuda'", specifier = "==0.10.1" },
+    { name = "jax", extras = ["cuda13"], marker = "extra == 'cuda13'", specifier = "==0.10.1" },
     { name = "jaxtyping", specifier = "==0.3.10" },
     { name = "matplotlib", specifier = "==3.10.8" },
     { name = "numpy", specifier = "==2.4.6" },
+    { name = "nvidia-cublas", marker = "extra == 'cuda13'", specifier = ">=13.2.0.9" },
     { name = "optax", specifier = "==0.2.8" },
     { name = "orbax-checkpoint", specifier = "==0.12.0" },
     { name = "pillow", specifier = "==12.0.0" },
@@ -1624,7 +1837,7 @@ requires-dist = [
     { name = "safetensors", specifier = "==0.7.0" },
     { name = "wandb", specifier = "==0.21.0" },
 ]
-provides-extras = ["cuda"]
+provides-extras = ["cuda", "cuda13"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Description
Return `pd-lm` to the job-side workspace pattern main used (and harvest/autointerp still use): each node builds its workspace + venv in node-local `/tmp` at job start, instead of the submit-time shared-FS workspace the JAX launcher introduced. Three updates to the old pattern:

- Nodes shallow-fetch the snapshot from the submitting checkout's **common git dir** over shared FS (`file://` so `--depth 1` survives the local transport) — durable under worktree deletion, and requeues never depend on GitHub. The snapshot's origin push stays best-effort (a provenance backup, as on main), and is not the job's fetch source.
- The run config is pinned as `runs/<id>/launch_config.yaml` at submit (plus a staged `.env`), and the job reads that copy — so configs can live anywhere, and the inline path no longer mutates the user's config file.
- **Driver-gated cuda13** (subsumes #959): the venv now builds where the driver is observable, so each node picks `cuda13` vs `cuda` off its own driver major (>= 580 → cuda13, i.e. the Blackwell-TMEM-fixed cuBLAS >= 13.2; and-gmi's r570 falls back to cu12). #959's `--cuda-extra` flag existed only because the venv was built on a GPU-less login node.

The srun task still `exec`s the trainer (SIGTERM-save unchanged); `/tmp` cleanup = batch EXIT trap + start-of-task sweep. `pd-pretrain` keeps the submit-time build (8 tasks/node would race a per-node build).

## Motivation and Context
The submit-time build bought little over main's pattern while costing complexity (hardlink uv-cache machinery, workspace branching) and a multi-GB shared-FS workspace leaked per run. ~1–2 min job-start latency is a fine price. Discussion: Oli, 2026-07-07.

## How Has This Been Tested?
Four 1-node smokes (cw-east B200), run dirs deleted after:
- p-a5769c4b/171732 — build → saves → `scontrol requeue` mid-save → rebuild → resumed from 400 → COMPLETED.
- p-25ea5227/171743 — origin-fetch variant (later replaced by local fetch), COMPLETED with cleanup.
- p-f8f53746/172068 — driver-gated cuda13: node picked `cuda13` (driver 595), the cuBLAS TMEM warning present in the cu12 smokes is gone, COMPLETED.
- p-358e8f0c/172173 — final shape (local `file://` shallow fetch + cuda13 gate), COMPLETED.

`make check` clean, `uv lock --check` passes, launcher tests updated.

## Does this PR introduce a breaking change?
- Pre-PR runs can't `--run-id` resubmit (no pinned launch config); relaunch from their config instead.
- B200 runs on driver >= r580 clusters now get cu13 runtime libs by default (same jax/jaxlib pin; #959 measured bf16 throughput unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PvoYnzxByyYP4dmQtXWSmm

