### PR TITLE
refactor(slurm): fetch snapshots from the git common dir, drop $HOME/param-decomp

### DIFF
--- a/param_decomp_lab/infra/slurm.py
+++ b/param_decomp_lab/infra/slurm.py
@@ -279,30 +279,50 @@ def _sbatch_header_array(config: SlurmArrayConfig, array_range: str) -> str:
     return "\n".join(lines)
 
 
+def _snapshot_source_repo() -> Path:
+    """The local git dir the SLURM job fetches the snapshot from: the submitting
+    checkout's COMMON git dir (the main checkout's ``.git``, even when submitting from a
+    worktree — worktrees share refs but the worktree itself may be gone before a requeue
+    re-fetches). Resolved at submit from ``REPO_ROOT`` (main-era semantics), so the job
+    never depends on GitHub reachability — ``create_git_snapshot``'s best-effort origin
+    push is a provenance backup, not the fetch source. Mirrors ``pd-lm``'s launcher
+    (`experiments/lm/launch.py::_snapshot_source_repo`)."""
+    result = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(result.stdout.strip())
+
+
 def generate_git_snapshot_setup(work_dir: str, snapshot_ref: str) -> str:
-    """Bash fragment to clone the repo, fetch `snapshot_ref`, check it out, and set up env.
+    """Bash fragment: shallow-fetch `snapshot_ref` from the submitting checkout's
+    shared-FS git dir into a node-local `work_dir`, check it out, copy the durable `.env`,
+    then build + activate the venv. `work_dir` is a bash expression and can include
+    `$SLURM_*` vars.
 
-    `git clone` only fetches `refs/heads/*` + tags, so custom namespaces like
-    `refs/runs/snapshot/*` need an explicit fetch. Also copies `.env` and activates the
-    venv. `work_dir` is a bash expression and can include `$SLURM_*` vars.
-
-    Uses ``$HOME/param-decomp`` as the git source (resolved at shell-time on the
-    target node) rather than the Python-side ``REPO_ROOT``. This keeps the setup
-    portable: when this script is generated from inside another SLURM job
-    (e.g. async slow-eval submitted by training's ``sink.on_save``), ``REPO_ROOT``
-    would resolve to the submitting job's node-local ``/tmp/.../workspace-*`` —
-    which doesn't exist on the new job's nodes. ``$HOME/param-decomp`` always
-    points at the user's canonical shared-FS checkout.
+    The snapshot comes from the git COMMON dir resolved at submit (`_snapshot_source_repo`)
+    rather than a hard-coded ``$HOME/param-decomp`` or the Python-side ``REPO_ROOT``: shared
+    FS (no GitHub dependency), worktree-safe, and — because it's baked in at submit, not
+    resolved at shell-time — correct even when this script is generated from inside another
+    SLURM job (`REPO_ROOT` would then be the submitter's node-local `/tmp` workspace). The
+    `.env` (secrets, not in git) is copied from the durable main checkout that owns the
+    common dir, not the possibly-ephemeral submitting worktree. `file://` (not the bare
+    path) so git honours `--depth` — it silently ignores it on the bare-path local
+    transport. Mirrors ``pd-lm``'s `_node_workspace_setup`.
     """
+    source_repo = _snapshot_source_repo()
+    env_file = source_repo.parent / ".env"
     return f"""\
 WORK_DIR="{work_dir}"
 mkdir -p "$WORK_DIR"
 trap 'rm -rf "$WORK_DIR"' EXIT
-git clone "$HOME/param-decomp" "$WORK_DIR"
 cd "$WORK_DIR"
-[ -f "$HOME/param-decomp/.env" ] && cp "$HOME/param-decomp/.env" .env
-git fetch "$HOME/param-decomp" "{snapshot_ref}:{snapshot_ref}"
-git checkout "{snapshot_ref}"
+git init --quiet
+git fetch --quiet --depth 1 "file://{source_repo}" "{snapshot_ref}"
+git checkout --quiet FETCH_HEAD
+[ -f "{env_file}" ] && cp "{env_file}" .env
 deactivate 2>/dev/null || true
 unset VIRTUAL_ENV
 uv sync --all-packages --no-dev --link-mode copy -q

--- a/param_decomp_lab/tests/test_slurm.py
+++ b/param_decomp_lab/tests/test_slurm.py
@@ -1,0 +1,46 @@
+"""The SLURM snapshot-setup fragment (`harvest` / `autointerp` / `investigate` jobs).
+
+Mirrors the `pd-lm` node-workspace pattern: shallow-fetch the snapshot from the
+submitting checkout's shared-FS common git dir (no GitHub dependency, worktree-safe),
+copy the durable `.env`, build + activate the venv. Guards against the old
+`$HOME/param-decomp` shell-time clone.
+"""
+
+from pathlib import Path
+
+from param_decomp_lab.infra import slurm
+
+
+def test_git_snapshot_setup_fetches_from_common_dir(monkeypatch):
+    monkeypatch.setattr(slurm, "_snapshot_source_repo", lambda: Path("/home/u/param-decomp/.git"))
+    setup = slurm.generate_git_snapshot_setup(
+        "/tmp/$USER/param-decomp/workspace-harvest-$SLURM_JOB_ID",
+        "refs/runs/snapshot/h-20260708",
+    )
+    # snapshot comes from the shared-FS COMMON git dir via file:// so `--depth` is honoured
+    # (git silently ignores it on the bare-path local transport)
+    assert (
+        'git fetch --quiet --depth 1 "file:///home/u/param-decomp/.git" '
+        '"refs/runs/snapshot/h-20260708"'
+    ) in setup
+    assert "git checkout --quiet FETCH_HEAD" in setup
+    # the dead `$HOME/param-decomp` clone hack is gone
+    assert "git clone" not in setup
+    assert "$HOME/param-decomp" not in setup
+    # `.env` (secrets, not in git) comes from the durable main checkout that owns the
+    # common dir, not the possibly-ephemeral submitting worktree
+    assert '[ -f "/home/u/param-decomp/.env" ] && cp "/home/u/param-decomp/.env" .env' in setup
+    # venv build + activation
+    assert "uv sync --all-packages --no-dev --link-mode copy -q" in setup
+    assert setup.rstrip().endswith("source .venv/bin/activate")
+    # the node-local work dir is created and cleaned up
+    assert 'WORK_DIR="/tmp/$USER/param-decomp/workspace-harvest-$SLURM_JOB_ID"' in setup
+    assert "trap 'rm -rf \"$WORK_DIR\"' EXIT" in setup
+
+
+def test_snapshot_source_repo_resolves_common_git_dir():
+    # REPO_ROOT is a real checkout in the test env; the common dir is an absolute path
+    # ending in `.git` (or a linked-worktree's shared git dir).
+    source_repo = slurm._snapshot_source_repo()
+    assert source_repo.is_absolute()
+    assert source_repo.exists()


### PR DESCRIPTION
Follow-up from #960. `generate_git_snapshot_setup` in `param_decomp_lab/infra/slurm.py` (harvest / autointerp / investigate jobs) still cloned a hard-coded `$HOME/param-decomp` at shell-time — a hack from 24190c261 whose motivation (torch-era async slow-eval sbatching from *inside* a SLURM job, where `REPO_ROOT` resolved to the submitter's node-local `/tmp` workspace) is dead on `feature/jax`.

## What changed
Aligned it with pd-lm's node-workspace pattern (`experiments/lm/launch.py::_snapshot_source_repo` / `_node_workspace_setup`):

- Resolve the submitting checkout's **common git dir** at submit via `git rev-parse --path-format=absolute --git-common-dir` (new `_snapshot_source_repo` helper). Worktree-safe: a linked worktree shares the main checkout's `.git`, so a snapshot survives the worktree being deleted before a requeue re-fetches.
- In-job: `git init` + shallow `git fetch --depth 1 "file://<common dir>" <ref>` + `git checkout FETCH_HEAD`, replacing the `git clone`/`git fetch refs` pair. `file://` (not the bare path) so git honours `--depth` — it silently ignores it on the bare-path local transport.
- `.env` (secrets, not in git) now copied from the **durable main checkout** that owns the common dir, not the possibly-ephemeral submitting worktree.

Shared FS throughout, so neither submit nor requeue depends on GitHub reachability (the origin push in `create_git_snapshot` stays a best-effort provenance backup).

Only caller is `_workspace_setup` (via `SlurmConfig.snapshot_ref`); signature unchanged, so harvest/autointerp/investigate need no edits.

## Tests
Adds `param_decomp_lab/tests/test_slurm.py`: asserts the fragment fetches from the common dir via `file://` with `--depth 1`, checks out `FETCH_HEAD`, copies the durable `.env`, has no `git clone` / `$HOME/param-decomp`, and that `_snapshot_source_repo` resolves an absolute existing path. `ruff check` + `ruff format --check` clean.

Crew-Address: task/harvest-fragment-drop-home-checkout