### PR TITLE
refactor(infra): worktree-safe shallow snapshot fetch, drop $HOME/param-decomp

### DIFF
--- a/param_decomp_lab/experiments/lm/launch.py
+++ b/param_decomp_lab/experiments/lm/launch.py
@@ -35,7 +35,7 @@ from param_decomp.built_run import LAUNCH_CONFIG_FILENAME
 from param_decomp.configs import LaunchEnv
 from param_decomp.log import logger
 from param_decomp_lab.experiments.lm.config import LMExperimentConfig
-from param_decomp_lab.infra.git import create_git_snapshot
+from param_decomp_lab.infra.git import create_git_snapshot, snapshot_source_repo
 from param_decomp_lab.infra.run_files import generate_run_id
 from param_decomp_lab.infra.settings import PARAM_DECOMP_OUT_DIR, REPO_ROOT
 from param_decomp_lab.infra.slurm import SlurmConfig, generate_script, submit_slurm_job
@@ -73,21 +73,6 @@ def _render_rank_env(launch_env: LaunchEnv) -> str:
     exports = [f"export {k}={shlex.quote(v)}" for k, v in launch_env.as_env().items()]
     exports.append(_LD_LIBRARY_PATH_EXPORT)
     return "\n".join(exports)
-
-
-def _snapshot_source_repo() -> Path:
-    """The local git state the nodes fetch the snapshot from: the submitting checkout's
-    COMMON git dir (the main checkout's `.git`, even when submitting from a worktree —
-    worktrees share refs but may be deleted before a requeue re-fetches). Shared FS, so
-    neither submits nor requeues depend on GitHub reachability; the best-effort origin
-    push in `create_git_snapshot` is a provenance backup, not the job's fetch source."""
-    result = subprocess.run(
-        ["git", "-C", str(REPO_ROOT), "rev-parse", "--path-format=absolute", "--git-common-dir"],
-        capture_output=True,
-        text=True,
-        check=True,
-    )
-    return Path(result.stdout.strip())
 
 
 def _node_workspace_setup(run_id: str, snapshot_ref: str, source_repo: Path, run_dir: Path) -> str:
@@ -193,7 +178,7 @@ def main(
     assert dp % GPUS_PER_NODE == 0, f"runtime.dp={dp} must be a multiple of {GPUS_PER_NODE}"
     nodes = dp // GPUS_PER_NODE
 
-    source_repo = _snapshot_source_repo()
+    source_repo = snapshot_source_repo()
     if run_id is None:
         run_id = generate_run_id("param_decomp")
         snapshot_ref, commit_hash = create_git_snapshot(snapshot_id=run_id)

--- a/param_decomp_lab/infra/git.py
+++ b/param_decomp_lab/infra/git.py
@@ -35,6 +35,27 @@ def repo_is_clean() -> bool:
     return status == ""
 
 
+def snapshot_source_repo() -> Path:
+    """The local git dir a SLURM job fetches its snapshot from: the submitting checkout's
+    COMMON git dir (the main checkout's `.git`, even when submitting from a linked
+    worktree — worktrees share refs, but a linked worktree may be a node-local ephemeral
+    `/tmp/.../workspace-*` deleted before a requeue re-fetches). Resolved at submit via
+    `git rev-parse --path-format=absolute --git-common-dir`; on shared FS, so neither
+    submits nor requeues depend on GitHub reachability — the best-effort origin push in
+    `create_git_snapshot` is a provenance backup, not the job's fetch source.
+
+    Single source of truth for both launchers: the pd-lm trainer launch
+    (`experiments.lm.launch`) and the shared SLURM job fragment (`infra.slurm`).
+    """
+    result = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return Path(result.stdout.strip())
+
+
 def repo_current_commit_hash() -> str:
     """Return the current commit hash of the active HEAD."""
     commit_hash: str = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()

--- a/param_decomp_lab/infra/slurm.py
+++ b/param_decomp_lab/infra/slurm.py
@@ -15,6 +15,7 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
+from param_decomp_lab.infra.git import snapshot_source_repo
 from param_decomp_lab.infra.settings import REPO_ROOT, SBATCH_SCRIPTS_DIR, SLURM_LOGS_DIR
 
 # Bash expressions that uniquely identify a job invocation, used to name per-job /tmp
@@ -280,29 +281,33 @@ def _sbatch_header_array(config: SlurmArrayConfig, array_range: str) -> str:
 
 
 def generate_git_snapshot_setup(work_dir: str, snapshot_ref: str) -> str:
-    """Bash fragment to clone the repo, fetch `snapshot_ref`, check it out, and set up env.
+    """Bash fragment to fetch `snapshot_ref` into `work_dir`, check it out, set up env.
 
-    `git clone` only fetches `refs/heads/*` + tags, so custom namespaces like
-    `refs/runs/snapshot/*` need an explicit fetch. Also copies `.env` and activates the
-    venv. `work_dir` is a bash expression and can include `$SLURM_*` vars.
+    Shallow `git init` + `git fetch --depth 1` from the submitting checkout's common git
+    dir (shared FS, worktree-safe — see `git.snapshot_source_repo`), the same source the
+    pd-lm launcher fetches from. `file://` is required: git silently ignores `--depth` on
+    the bare-path local transport. `git clone` is avoided — it only fetches `refs/heads/*`
+    + tags, so custom namespaces like `refs/runs/snapshot/*` wouldn't come across anyway,
+    and a full clone of the worktree is needless when we want one commit.
 
-    Uses ``$HOME/param-decomp`` as the git source (resolved at shell-time on the
-    target node) rather than the Python-side ``REPO_ROOT``. This keeps the setup
-    portable: when this script is generated from inside another SLURM job
-    (e.g. async slow-eval submitted by training's ``sink.on_save``), ``REPO_ROOT``
-    would resolve to the submitting job's node-local ``/tmp/.../workspace-*`` —
-    which doesn't exist on the new job's nodes. ``$HOME/param-decomp`` always
-    points at the user's canonical shared-FS checkout.
+    `.env` (secrets, untracked, so no ref carries it) is copied from the durable main
+    checkout — the common git dir's parent worktree — NOT the possibly-ephemeral
+    submitting worktree (a node-local `/tmp` workspace when generated from inside another
+    SLURM job, e.g. async slow-eval submitted by training's `sink.on_save`).
+
+    `work_dir` is a bash expression and can include `$SLURM_*` vars.
     """
+    source_repo = snapshot_source_repo()
+    env_file = source_repo.parent / ".env"
     return f"""\
 WORK_DIR="{work_dir}"
 mkdir -p "$WORK_DIR"
 trap 'rm -rf "$WORK_DIR"' EXIT
-git clone "$HOME/param-decomp" "$WORK_DIR"
 cd "$WORK_DIR"
-[ -f "$HOME/param-decomp/.env" ] && cp "$HOME/param-decomp/.env" .env
-git fetch "$HOME/param-decomp" "{snapshot_ref}:{snapshot_ref}"
-git checkout "{snapshot_ref}"
+git init --quiet
+git fetch --quiet --depth 1 "file://{source_repo}" "{snapshot_ref}"
+git checkout --quiet FETCH_HEAD
+[ -f "{env_file}" ] && cp "{env_file}" .env
 deactivate 2>/dev/null || true
 unset VIRTUAL_ENV
 uv sync --all-packages --no-dev --link-mode copy -q

--- a/param_decomp_lab/tests/test_slurm.py
+++ b/param_decomp_lab/tests/test_slurm.py
@@ -1,0 +1,37 @@
+"""The SLURM job-script generator (`param_decomp_lab.infra.slurm`). Exercises the
+git-snapshot setup fragment: shallow worktree-safe fetch from the submitting checkout's
+common git dir, `.env` from the durable main checkout, no `git clone`."""
+
+from pathlib import Path
+
+import pytest
+
+from param_decomp_lab.infra import slurm
+
+
+def test_snapshot_setup_shallow_fetches_from_common_dir(monkeypatch: pytest.MonkeyPatch):
+    # submit resolves the common git dir (main checkout's `.git`, worktree-safe); shared
+    # helper `git.snapshot_source_repo`, imported into slurm's namespace
+    monkeypatch.setattr(slurm, "snapshot_source_repo", lambda: Path("/home/u/param-decomp/.git"))
+    fragment = slurm.generate_git_snapshot_setup(
+        "/tmp/$USER/param-decomp/workspace-harvest-$SLURM_JOB_ID",
+        "refs/runs/snapshot/p-abcd1234",
+    )
+    # snapshot comes from the shared-FS common git dir; file:// so --depth works (git
+    # ignores it on the bare-path local transport)
+    assert (
+        'git fetch --quiet --depth 1 "file:///home/u/param-decomp/.git" '
+        '"refs/runs/snapshot/p-abcd1234"'
+    ) in fragment
+    assert "git init --quiet" in fragment
+    assert "git checkout --quiet FETCH_HEAD" in fragment
+    # no full clone of the worktree, and no hardcoded $HOME/param-decomp
+    assert "git clone" not in fragment
+    assert "$HOME/param-decomp" not in fragment
+    # .env (untracked secrets) copied from the durable main checkout — the common git
+    # dir's parent worktree — not the possibly-ephemeral submitting worktree
+    assert '[ -f "/home/u/param-decomp/.env" ] && cp "/home/u/param-decomp/.env" .env' in fragment
+    # workspace is created, trapped for cleanup, and the venv is built + activated
+    assert "trap 'rm -rf \"$WORK_DIR\"' EXIT" in fragment
+    assert "uv sync --all-packages --no-dev --link-mode copy -q" in fragment
+    assert fragment.rstrip().endswith("source .venv/bin/activate")


### PR DESCRIPTION
## What

`generate_git_snapshot_setup` in `param_decomp_lab/infra/slurm.py` (harvest /
autointerp / investigate SLURM jobs) cloned `"$HOME/param-decomp"` and did a full
`git fetch <ref>:<ref>`. That `$HOME/param-decomp` hardcode is an unblessed hack from
commit `24190c261` (torch era), whose motivation — generating an sbatch from *inside* a
SLURM job (async slow-eval via `sink.on_save`), where `REPO_ROOT` points at a node-local
`/tmp/.../workspace-*` — is dead on `feature/jax`.

## Reconsidered in light of #960

#960 already **returned the pd-lm trainer launch to the same job-side setup pattern
these jobs never left**, and resolved the fetch source with
`git rev-parse --path-format=absolute --git-common-dir` (the main checkout's `.git` on
shared FS, worktree-safe). So rather than land a *second* copy of that helper, this PR
**promotes it to a single shared home** and points both launchers at it:

- **`infra/git.py`**: new `snapshot_source_repo()` — the one definition (it already hosts
  the other `REPO_ROOT`-based git utilities both launchers import).
- **`infra/slurm.py`**: `generate_git_snapshot_setup` now does `git init` +
  `git fetch --quiet --depth 1 "file://<common-dir>" <ref>` + `git checkout --quiet
  FETCH_HEAD`, replacing the `$HOME/param-decomp` clone + tag/head fetch. `file://` is
  required — git silently ignores `--depth` on the bare-path local transport. `.env`
  (untracked secrets) is copied from the **durable main checkout** (the common git dir's
  parent worktree), not the possibly-ephemeral submitting worktree.
- **`experiments/lm/launch.py`**: drops its private `_snapshot_source_repo` (added in
  #960), imports the shared one — net **−16 lines** there.

Result: one implementation of "where does a job fetch its snapshot from", used by both
the trainer launch and the shared SLURM fragment, instead of two.

## Testing

- New `param_decomp_lab/tests/test_slurm.py` asserts the fragment shape (shallow `file://`
  fetch from the common dir, `FETCH_HEAD` checkout, durable `.env`, no `git clone`, no
  `$HOME/param-decomp`).
- `pytest test_slurm.py test_launch.py` → 9 passed; `ruff check`/`format` clean;
  `basedpyright` 0 errors on all four touched files.
- Runtime sanity: `slurm.snapshot_source_repo is git.snapshot_source_repo` (single
  object), and rendering the fragment from inside a linked worktree resolves the common
  dir to the main checkout `/mnt/home/pd-user/param-decomp/.git` (worktree-safety).

Follow-up from #960. Board task `harvest-fragment-drop-home-checkout`.

Crew-Address: task/harvest-fragment-drop-home-checkout