### PR TITLE
perf(recon): prefix-shared masked forwards — one clean pass seeds every recon forward

### DIFF
--- a/param_decomp/CLAUDE.md
+++ b/param_decomp/CLAUDE.md
@@ -25,8 +25,18 @@ never silently diverge. Cite IDs (`S14`, `N1`, …) in commit messages and revie
 ## Architecture in one breath
 
 `lm.py` defines `DecomposedModel` — a `@runtime_checkable Protocol`: ordered `sites` +
-`leading_axes` + the methods `clean_output`, `read_activations`, `masked_output`,
-`masked_site_outputs`, `weight_deltas`, and a `recon_loss_fn` (LM: `kl_per_position`). The
+`leading_axes` + the methods `clean_output`, `clean_output_and_taps`, `read_activations`,
+`masked_output`, `masked_site_outputs`, `weight_deltas`, the forward-start constructors
+(`start_from_inputs` / `start_taps` / `masked_start`), and a `recon_loss_fn`
+(LM: `kl_per_position`). **Masked forwards take a FORWARD START, not the batch** (SPEC
+S18/D5, prefix sharing): the step's ONE clean pass (`clean_output_and_taps`, a segmented
+scan) emits the CI taps AND the residual boundaries every masked/ascent forward seeds from
+(`masked_start` → `(first_live_block, resid)`), so the frozen prefix below the earliest
+live site is never recomputed — the dominant per-step saving for partial (per-block)
+decompositions. Eval tiers start at the input edge via `start_from_inputs`. Toys' start IS
+their input (identity constructors). Gotcha: a start's static int must be destructured
+OUTSIDE any `jax.checkpoint` (`llama_simple_mlp.masked_output`), else it flattens into a
+tracer. The
 concrete impl per target is an `eqx.Module` (`LlamaDecomposedModel`,
 `SimpleMLPDecomposedModel`, `TMSDecomposedModel`, `ResidMLPDecomposedModel`) carrying its
 FROZEN target weights as ARRAY FIELDS; the TRAINABLE V/U (`vu: DecompVU`) stays an explicit

--- a/param_decomp/SPEC.md
+++ b/param_decomp/SPEC.md
@@ -47,6 +47,7 @@ and the tables (§2, §3, §6). Prose between them is orientation only. Notation
 | **PPGD warmup (`n_warmup`)** | supplemental source-ascent iterations inside each step | LR-schedule warmup; faithfulness warmup |
 | **LR warmup (`warmup_pct`)** | linear ramp 0 → start of a schedule's value | the above two |
 | **persistent** (PGD) | sources + their optimizer moments survive across training steps | re-initialized-per-step PGD (the eval-only `PGDReconLoss`) |
+| **forward start** | where a masked forward begins: a model-opaque value from `start_from_inputs` (the input edge) or `masked_start` (the clean forward's residual entering the earliest live block — prefix sharing, D5) | the recon target (`clean_output` is always the full frozen forward, S3) |
 
 ---
 
@@ -98,12 +99,19 @@ def site_out(x[.., d_in], s, mask[.., C]|ONES, delta_mask[..]|ONES, route[..]|AL
     y_dec  = ((x @ V_s) * mask) @ U_s  +  (x @ Δ_s) * delta_mask
     return where(route, y_dec, x @ W_s)                  # route=ALL ⇒ y_dec everywhere
 
-def masked_forward(batch, live_sites, masks, delta_masks, routes) -> logits[B,T,vocab]:
-    full forward (embed batch, all blocks, final norm, LM head);
+def masked_forward(start, live_sites, masks, delta_masks, routes) -> logits[B,T,vocab]:
+    forward from `start` — a FORWARD START `(k, resid entering block k)`, k ≤ the first
+    live block: `start_from_inputs(batch)` = embed (k=0); `masked_start(batch, taps, live)`
+    = the clean pass's `resid.{first live block}` tap (prefix sharing)              (S18, D5)
+    — through the remaining blocks, final norm, LM head;
     each site s ∈ live_sites computes site_out(x, s, masks[s], delta_masks[s], routes[s]);
     each site s ∉ live_sites computes x @ W_s            # frozen path, NOT y_dec(mask=1)   (S2)
 
-def clean_output(batch)   = masked_forward(batch, live_sites=∅)                             (S3)
+def clean_output(batch)   = clean_output_and_taps(batch, ())[0]                             (S3)
+def clean_output_and_taps(batch, wanted) -> (logits, {tap_key: [B,T,d_tap]})           (S3, S18)
+    # the step's ONE clean pass: the full frozen forward (embed batch, all blocks, final
+    # norm, LM head) emitting the wanted `resid.*` taps as boundary values of the SAME
+    # forward (a static scan split — carries bit-identical to the unsplit scan).
 def read_activations(batch, wanted: tuple[str,...]) -> {tap_key: [B,T,d_tap]}               (S4)
     # general clean-path activation accessor keyed by OPAQUE tap keys. `wanted` is the
     # CI fn's static `input_names`; the target is the sole key→activation interpreter.
@@ -180,9 +188,11 @@ def sources_update(sources, sources_grad, opt_state):
 
 ```
 def train_step(state, batch, step):                  # batch = fresh token batch            (S18)
-    cln      = sg[ clean_output(batch) ]                                                     (S3)
-    CI = ci(ci_fn, read_activations(batch, ci_fn.input_names))      # ONE conceptual CI eval/step;
+    cln, taps = clean_output_and_taps(batch, ci_fn.input_names ∪ start taps); cln = sg[cln] (S3)
+    CI = ci(ci_fn, taps[ci_fn.input_names])                         # ONE conceptual CI eval/step;
     ci_lower, ci_upper = CI.lower, CI.upper                         # recompute allowed (deterministic)
+    # every masked forward below runs from its entry's forward start — the clean pass's
+    # residual entering its earliest live block (`masked_start`)                    (S18, D5)
     # -- supplemental adversary ascents (components & CI detached) --
     set SRC_STEP lr = sched_src(step)                # stepped once per TRAINING step       (S13)
     repeat n_warmup:
@@ -287,7 +297,7 @@ faithfulness, sources/PPGD, the squashings (S5/S6), the imp-min reduction, the g
 | S15 | Every source update ends with `PROJ` (★ clamp to `[0,1]`). Init: ★ `sources ~ U[0,1]` i.i.d. |
 | S16 | Shared-scope sources are identical on every data-parallel replica at every step (identical init, identical updates from the global-batch gradient). `bsc` sources shard with the batch instead. (Implementation mapping in §8/§9.) |
 | S17 | `faithfulness_loss` is the global mean of squared delta entries over all sites' parameters (Σ‖Δ‖² / Σ numel), recomputed from live V/U each step. |
-| S18 | Each training step consumes a fresh token batch (a pure function of `(seed, step)` for O(1) resume); the model embeds it internally. **AMENDED 2026-06-24** (Oli-approved): removed the prefix harvest (residual-start) — there is no separate prefix forward; `clean_output` / `read_activations` / `masked_output` take the token batch directly. |
+| S18 | Each training step consumes a fresh token batch (a pure function of `(seed, step)` for O(1) resume); the model embeds it internally. **AMENDED 2026-06-24** (Oli-approved): removed the prefix harvest (residual-start) — there is no separate prefix forward; the clean path takes the token batch directly. **AMENDED 2026-07-09**: masked forwards take a FORWARD START instead of the token batch — `start_from_inputs(inputs)` (the input edge; eval tiers) or `masked_start(inputs, taps, live)` (the clean pass's `resid.{first live block}` boundary; every recon/ascent forward) — so the frozen prefix runs ONCE per step, inside `clean_output_and_taps`. The 2026-06-24 amendment's substance stands: the clean path (`clean_output` / `clean_output_and_taps` / `read_activations`) still takes the token batch and embeds internally, `clean_output` stays the whole-model frozen forward (S3), starts are model-opaque and built within the step graph (no engine `Prefix` / `first_layer` / harvest machinery, no tap ceiling). Equivalence contract: D5. |
 | S19 | Components gradients are global-norm-clipped at `0.01`, before the optimizer step. CI fn is unclipped (production). The clip coefficient uses torch's eps convention: `clip_coef = min(1, max_norm / (total_norm + 1e-6))` (`torch.nn.utils.clip_grad_norm_`). This `+1e-6` is canonical and matched JAX-side (#643); plain `optax.clip_by_global_norm` divides by `max(total_norm, max_norm)` with NO eps, which at `clip=0.01` (clip fires almost every step) gives a ~1e-4 relative component-grad difference each step — a real per-step deviation the JAX clip must avoid by reproducing the `+1e-6`. |
 | S20 | Both main optimizers are AdamW, `wd=0`, betas `(0.9, 0.999)`, eps `1e-8`; LR cosine to `0.1×` start, no warmup, stepped per training step. Cosine convention is canonical-torch: `progress = (step − warmup) / (decay_steps − 1)`, so LR reaches `0.1×` at `step = steps − 1` (`schedule.py`). This is matched JAX-side (#642); plain `optax.cosine_decay_schedule(lr, steps, alpha=0.1)` divides by `steps` and reaches `0.1×` one update LATER (at `count = steps`), a genuine formula divergence of ~O(1/steps) ≈ 2.5e-6/step at 400k that the JAX schedule must avoid by using the `decay_steps − 1` denominator. Both main LRs are evaluated by `scheduled_value_traced` honoring the full `ScheduleConfig`; the canonical cosine-to-0.1-no-warmup shape is pinned by the lab conversion gate (`assert_canonical_algorithm_config`). |
 | S21 | Faithfulness warmup (400 × AdamW lr `1e-3` on `faithfulness_loss` alone) precedes step 0; its optimizer is discarded. |
@@ -342,6 +352,7 @@ is global-batch math. This section is the whole answer to "now shard it":
 | D2 | Imp-min requires the exact global per-component sums *inside* the `log2` (S8) — the one term where mean-of-shard-results ≠ global result (Jensen). The reduction must also be autograd-aware so gradient reaches each shard's CI values. The eval-path imp-min reuses the one `importance_minimality_terms` impl (there is no separate non-autograd eval reduce as in torch), so the value is device-count invariant by D4; guarded directly at 1 vs N devices by `tests/test_imp_min_global_reduction.py`. |
 | D3 | Shared PPGD sources stay replica-identical per S16: identical init (broadcast or identical seeding), updates computed from the D1 gradient, identical optimizer steps. |
 | D4 | Validation property: with global batch + seed fixed, the metric trajectory is invariant to device count up to floating-point reassociation (cross-shard reduction order; observed rel ≤ ~1e-5 on the tiny-target harness, `experiments/invariance_check.py`). JAX's counter-based RNG makes even the stochastic draws identical across layouts. |
+| D5 | Prefix-start equivalence: with batch + seed fixed, a masked forward seeded from the clean pass's `resid.{k}` tap (k ≤ its first live block, `masked_start`) equals the input-edge (`start_from_inputs`) forward up to floating-point reassociation — a static scan split preserves the op sequence, so only XLA fusion differences remain. Guarded at fp32 by `tests/test_prefix_start.py` (deterministic + stochastic mask paths; the stochastic per-(layer,kind) keys fold over ABSOLUTE layer indices, so the draws are start-invariant). NOTE: a mid-run resume across the introduction of this seam is trajectory-continuous only up to reassociation (CI taps moved from the unrolled `read_activations` pass to the clean scan's boundary carries). |
 
 ---
 

--- a/param_decomp/arithmetic_eval.py
+++ b/param_decomp/arithmetic_eval.py
@@ -32,7 +32,7 @@ class ComponentActivationModel(DecomposedModel, Protocol):
     def masked_component_activations(
         self,
         prepared: Any,
-        inputs: Any,
+        start: Any,
         masks: dict[str, Array],
         delta_masks: dict[str, Array],
         routes: dict[str, Array] | None,
@@ -116,7 +116,7 @@ def make_arithmetic_grid_step(
         ones = {s: jnp.ones((*leading, site_component_counts[s]), COMPUTE_DT) for s in site_names}
         zeros_delta = {s: jnp.zeros(leading, COMPUTE_DT) for s in site_names}
         acts = model.masked_component_activations(
-            prepared, tokens, ones, zeros_delta, None, site_names, False
+            prepared, model.start_from_inputs(tokens), ones, zeros_delta, None, site_names, False
         )
         xv = {s: acts[s][:, answer_position, :].astype(jnp.float32) for s in site_names}
         valid = (jnp.arange(tokens.shape[0]) < n_valid_rows)[:, None]

--- a/param_decomp/attn_patterns_eval.py
+++ b/param_decomp/attn_patterns_eval.py
@@ -148,16 +148,16 @@ def _clean_patterns(
     pattern_fn: AttnPatternFn,
     layer_pairs: tuple[tuple[str, str], ...],
     prepared: Any,
-    tokens: Int[Array, "*leading"],
+    start: Any,
+    leading: tuple[int, ...],
     ci_lower: dict[str, Array],
 ) -> dict[str, Array]:
     """Per-layer target pattern from the clean (frozen `x @ W`) Q/K — `masked_site_outputs`
     with every site live but routed FALSE everywhere falls onto the frozen path (the same
     seam reuse `hidden_acts_eval` uses for its clean target)."""
     site_names = model.site_names
-    leading = tokens.shape
     clean_outputs = model.masked_site_outputs(
-        prepared, tokens,
+        prepared, start,
         {s: jnp.ones_like(ci_lower[s]) for s in site_names},
         {s: jnp.zeros(leading, COMPUTE_DT) for s in site_names},
         all_false_routes(site_names, leading), site_names, False,
@@ -206,18 +206,19 @@ def make_ci_attn_patterns_step(
         _key: PRNGKeyArray,
     ) -> tuple[dict[str, Array], dict[str, int]]:
         taps = model.read_activations(tokens, ci_fn.input_names)
+        start = model.start_from_inputs(tokens)
         components_bf16 = cast_floating(components, COMPUTE_DT)
         prepared = model.prepare_compute_weights(components_bf16)
         ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
         ci_lower = ci_fn_bf16(taps, remat=False).lower
 
-        target_patterns = _clean_patterns(
-            model, pattern_fn, layer_pairs, prepared, tokens, ci_lower
-        )
         leading = tokens.shape
+        target_patterns = _clean_patterns(
+            model, pattern_fn, layer_pairs, prepared, start, leading, ci_lower
+        )
         zeros_delta = {s: jnp.zeros(leading, COMPUTE_DT) for s in site_names}
         masked_outputs = model.masked_site_outputs(
-            prepared, tokens, ci_lower, zeros_delta, None, site_names, False
+            prepared, start, ci_lower, zeros_delta, None, site_names, False
         )
         sum_kl = _masked_patterns_kl(pattern_fn, layer_pairs, masked_outputs, target_patterns)
         n_distributions = {q: int(np.prod(target_patterns[q].shape[:3])) for q, _ in layer_pairs}
@@ -248,15 +249,16 @@ def make_stochastic_attn_patterns_step(
         key: PRNGKeyArray,
     ) -> tuple[dict[str, Array], dict[str, int]]:
         taps = model.read_activations(tokens, ci_fn.input_names)
+        start = model.start_from_inputs(tokens)
         components_bf16 = cast_floating(components, COMPUTE_DT)
         prepared = model.prepare_compute_weights(components_bf16)
         ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
         ci_lower = ci_fn_bf16(taps, remat=False).lower
 
-        target_patterns = _clean_patterns(
-            model, pattern_fn, layer_pairs, prepared, tokens, ci_lower
-        )
         leading = tokens.shape
+        target_patterns = _clean_patterns(
+            model, pattern_fn, layer_pairs, prepared, start, leading, ci_lower
+        )
 
         sum_kl = {q: jnp.zeros((), jnp.float32) for q, _ in layer_pairs}
         for draw_idx in range(n_mask_samples):
@@ -272,7 +274,7 @@ def make_stochastic_attn_patterns_step(
                     random.fold_in(delta_key, site_idx), leading, COMPUTE_DT
                 )
             masked_outputs = model.masked_site_outputs(
-                prepared, tokens, masks, delta_masks, None, site_names, True
+                prepared, start, masks, delta_masks, None, site_names, True
             )
             draw_kl = _masked_patterns_kl(pattern_fn, layer_pairs, masked_outputs, target_patterns)
             sum_kl = {q: sum_kl[q] + draw_kl[q] for q, _ in layer_pairs}

--- a/param_decomp/eval.py
+++ b/param_decomp/eval.py
@@ -162,12 +162,12 @@ def make_eval_step(
         )
 
     def masked_forward(
-        model: DecomposedModel, prepared: Any, tokens: Array, masks: dict[str, Array],
+        model: DecomposedModel, prepared: Any, start: Any, masks: dict[str, Array],
         delta_masks: dict[str, Array],
     ) -> Array:  # fmt: skip
         return batch_sharded(
             model.masked_output(
-                prepared, tokens, masks, delta_masks, None, site_names, True, remat=False
+                prepared, start, masks, delta_masks, None, site_names, True, remat=False
             )
         )
 
@@ -179,8 +179,9 @@ def make_eval_step(
         key: PRNGKeyArray,
     ) -> dict[str, Array]:
         token_ids = batch_sharded(token_ids)
-        clean_output = batch_sharded(model.clean_output(token_ids))
-        taps = model.read_activations(token_ids, ci_fn.input_names)
+        clean_output, taps = model.clean_output_and_taps(token_ids, ci_fn.input_names)
+        clean_output = batch_sharded(clean_output)
+        start = model.masked_start(token_ids, taps, site_names)
 
         if n_valid_rows is None:
             row_mask = None
@@ -252,7 +253,7 @@ def make_eval_step(
         kl: dict[str, Array] = {}
         ce: dict[str, Array] = {}
         for variant, (masks, delta_masks) in variant_masks.items():
-            variant_logits = masked_forward(model, prepared, token_ids, masks, delta_masks)
+            variant_logits = masked_forward(model, prepared, start, masks, delta_masks)
             kl[variant] = kl_metric(variant_logits)
             ce[variant] = ce_metric(variant_logits)
         target_ce = ce_metric(clean_output)
@@ -289,7 +290,7 @@ def make_eval_step(
                     ci_site = ci_lower[site]
                     masks[site] = ci_site + (1.0 - ci_site) * source[..., :-1]
                     delta_masks[site] = source[..., -1]
-                masked = masked_forward(model, prepared, token_ids, masks, delta_masks)
+                masked = masked_forward(model, prepared, start, masks, delta_masks)
                 return kl_metric(masked)
 
             def ascend(

--- a/param_decomp/experiments/invariance_check.py
+++ b/param_decomp/experiments/invariance_check.py
@@ -77,11 +77,11 @@ def _run(steps: int, sharded: bool) -> list[dict[str, float]]:
     src = init_persistent_sources(
         lm.site_names, tuple(s.C for s in lm.sites), (1, seq), jnp.float32, random.PRNGKey(3)
     )
-    resid = random.normal(random.PRNGKey(4), (gbatch, seq, cfg.n_embd)) * 0.5
+    tokens = random.randint(random.PRNGKey(4), (gbatch, seq), 0, cfg.vocab_size)
 
     mesh = hsdp_mesh() if sharded else None
     if mesh is not None:
-        resid = shard_batch(resid, mesh, batch_axis=0)
+        tokens = shard_batch(tokens, mesh, batch_axis=0)
 
     ppgd_cfg = PersistentPGDReconLossConfig(
         coeff=0.5,
@@ -131,7 +131,7 @@ def _run(steps: int, sharded: bool) -> list[dict[str, float]]:
 
     out = []
     for i in range(steps):
-        state, m = step(lm, state, resid, random.PRNGKey(100 + i))
+        state, m = step(lm, state, tokens, random.PRNGKey(100 + i))
         out.append({k: float(v) for k, v in m.items()})
     return out
 

--- a/param_decomp/hidden_acts_eval.py
+++ b/param_decomp/hidden_acts_eval.py
@@ -63,8 +63,9 @@ HiddenActsStep = Callable[
 """`(model, components, ci_fn, inputs, key) -> ({site: sum_mse}, {site: n_elements})`
 — one batch's per-site summed MSE (fp32) and element counts (the host folds these into
 `SiteMSEReduction`s). `inputs` is the model's target-specific input (an LM's `[batch, seq]`
-token ids), exactly as `read_activations` / `masked_site_outputs` take it. `key` is unused
-by the deterministic CI step. `model` (frozen-weight-bearing) is the jit ARG."""
+token ids), as `read_activations` takes it; the masked forwards run from
+`start_from_inputs(inputs)`. `key` is unused by the deterministic CI step. `model`
+(frozen-weight-bearing) is the jit ARG."""
 
 
 def _waist_leading(ci_lower: dict[str, Array], site_names: tuple[str, ...]) -> tuple[int, ...]:
@@ -88,6 +89,7 @@ def make_ci_hidden_acts_step(
         _key: PRNGKeyArray,
     ) -> tuple[dict[str, Array], dict[str, int]]:
         taps = model.read_activations(inputs, ci_fn.input_names)
+        start = model.start_from_inputs(inputs)
         components_bf16 = cast_floating(components, COMPUTE_DT)
         prepared = model.prepare_compute_weights(components_bf16)
         ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
@@ -96,12 +98,12 @@ def make_ci_hidden_acts_step(
         leading = _waist_leading(ci_lower, site_names)
         zeros_delta = {s: jnp.zeros(leading, COMPUTE_DT) for s in site_names}
         clean = model.masked_site_outputs(
-            prepared, inputs,
+            prepared, start,
             {s: jnp.ones_like(ci_lower[s]) for s in site_names}, zeros_delta,
             all_false_routes(site_names, leading), site_names, False,
         )  # fmt: skip
         masked = model.masked_site_outputs(
-            prepared, inputs, ci_lower, zeros_delta, None, site_names, False
+            prepared, start, ci_lower, zeros_delta, None, site_names, False
         )
         sum_mse = _per_site_sum_mse(masked, clean, site_names)
         n_elements = {s: clean[s].size for s in site_names}
@@ -129,6 +131,7 @@ def make_stochastic_hidden_acts_step(
         key: PRNGKeyArray,
     ) -> tuple[dict[str, Array], dict[str, int]]:
         taps = model.read_activations(inputs, ci_fn.input_names)
+        start = model.start_from_inputs(inputs)
         components_bf16 = cast_floating(components, COMPUTE_DT)
         prepared = model.prepare_compute_weights(components_bf16)
         ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)
@@ -136,7 +139,7 @@ def make_stochastic_hidden_acts_step(
 
         leading = _waist_leading(ci_lower, site_names)
         clean = model.masked_site_outputs(
-            prepared, inputs,
+            prepared, start,
             {s: jnp.ones_like(ci_lower[s]) for s in site_names},
             {s: jnp.zeros(leading, COMPUTE_DT) for s in site_names},
             all_false_routes(site_names, leading), site_names, False,
@@ -156,7 +159,7 @@ def make_stochastic_hidden_acts_step(
                     random.fold_in(delta_key, site_idx), leading, COMPUTE_DT
                 )
             masked = model.masked_site_outputs(
-                prepared, inputs, masks, delta_masks, None, site_names, True
+                prepared, start, masks, delta_masks, None, site_names, True
             )
             draw_sum = _per_site_sum_mse(masked, clean, site_names)
             sum_mse = {s: sum_mse[s] + draw_sum[s] for s in site_names}

--- a/param_decomp/lm.py
+++ b/param_decomp/lm.py
@@ -21,6 +21,14 @@ recon comparison (`recon_loss_fn`, `kl_per_position` for an LM).
 The frozen weights ride on the model `eqx.Module` and reach the jitted step as a pytree
 ARG (`eqx.filter_jit` traces the array leaves). Never close over the model in a jit: a
 frozen 8B target captured as a constant bakes multi-GB weights into the HLO.
+
+Masked forwards take a **forward start** (SPEC S18), not the raw input: a model-opaque
+value saying where the forward begins. `start_from_inputs(inputs)` starts at the input
+edge (an LM embeds; a toy's input already is the waist); `masked_start(inputs, taps,
+live)` starts at the deepest clean-forward residual boundary at or before the earliest
+live site, so a masked forward never recomputes the frozen prefix the clean forward
+already ran (prefix sharing, SPEC D5). The engine builds starts only through these two
+constructors — it never inspects one (the S4 opacity rule, applied to starts).
 """
 
 from typing import Any, Protocol, runtime_checkable
@@ -105,6 +113,42 @@ class DecomposedModel(Protocol):
         interpreter; core just routes by key."""
         ...
 
+    def clean_output_and_taps(
+        self, inputs: Any, /, wanted: tuple[str, ...]
+    ) -> tuple[Any, dict[str, Float[Array, "*leading d_tap"]]]:
+        """`(clean_output(inputs), read_activations(inputs, wanted))` from ONE frozen
+        forward — the step's single clean pass, feeding the recon target, the CI fn, and
+        the forward starts (SPEC S18/D5). A deep target emits the taps as boundary values
+        of the same forward instead of re-running the prefix per consumer."""
+        ...
+
+    def start_from_inputs(self, inputs: Any, /) -> Any:
+        """The forward start at the input edge (an LM embeds `inputs`; a toy's input
+        already is the waist). Off-hot-path consumers (eval tiers, harvest) use this;
+        the train step starts recon forwards from taps instead."""
+        ...
+
+    def start_taps(self, live: tuple[str, ...]) -> tuple[str, ...]:
+        """Tap names `masked_start` needs for a forward whose live sites are `live`
+        (an LM: the residual entering the earliest live block; a positionless target:
+        none). The engine unions these into `clean_output_and_taps`' `wanted`."""
+        ...
+
+    def masked_start(
+        self,
+        inputs: Any,
+        /,
+        taps: dict[str, Float[Array, "*leading d_tap"]],
+        live: tuple[str, ...],
+    ) -> Any:
+        """The forward start for a masked pass with live sites `live` — the deepest clean
+        boundary the target can seed from. An LM returns `(first_live_block,
+        taps[resid tap])`, skipping the frozen prefix the clean forward already computed
+        (equivalent to `start_from_inputs` up to float reassociation, SPEC D5); a
+        positionless target returns `inputs` unchanged. `taps` must cover
+        `start_taps(live)`."""
+        ...
+
     def prepare_compute_weights(self, vu: DecompVU) -> Any:
         """Build the per-step COMPUTE weights from the fp32 ÷N master `vu`, ONCE per step
         (SPEC unchanged — a read-only compute view). Mask-INDEPENDENT, so the result is shared
@@ -118,7 +162,7 @@ class DecomposedModel(Protocol):
     def masked_output(
         self,
         prepared: Any,
-        inputs: Any,
+        start: Any,
         /,
         masks: SiteMasks,
         delta_masks: SiteDeltaMasks,
@@ -129,7 +173,9 @@ class DecomposedModel(Protocol):
         remat: bool,
     ) -> Any:
         """The masked decomposed forward (SPEC §1.3, S2). `prepared` is the output of
-        `prepare_compute_weights` (the shared per-step compute weights). `live` (static under
+        `prepare_compute_weights` (the shared per-step compute weights). `start` is a forward
+        start from `start_from_inputs` / `masked_start` — where the forward begins; every
+        segment before it is the clean forward's job (SPEC S18/D5). `live` (static under
         jit) lists the sites running their decomposed forward; all other sites run the frozen
         `x @ W` path. `masks`/`delta_masks` may broadcast over the batch dim (the PPGD source
         case). `has_delta` (static) False skips the `x @ Δ` matmul for constant-source entries
@@ -150,7 +196,7 @@ class DecomposedModel(Protocol):
     def masked_output_stochastic(
         self,
         prepared: Any,
-        inputs: Any,
+        start: Any,
         /,
         ci_stacked: Any,
         draw_key: Array,
@@ -172,7 +218,7 @@ class DecomposedModel(Protocol):
     def masked_site_outputs(
         self,
         prepared: Any,
-        inputs: Any,
+        start: Any,
         /,
         masks: SiteMasks,
         delta_masks: SiteDeltaMasks,
@@ -215,7 +261,7 @@ def stochastic_site_masks(
 def run_stochastic_masked_output(
     model: "DecomposedModel",
     prepared: Any,
-    inputs: Any,
+    start: Any,
     ci_lower: dict[str, Array],
     draw_key: Array,
     routes: SiteRoutes,
@@ -229,7 +275,7 @@ def run_stochastic_masked_output(
     `masked_output`. Correct + uniform; only scan targets override for the memory win."""
     masks, delta_masks = stochastic_site_masks(ci_lower, live, draw_key, has_delta)
     return model.masked_output(
-        prepared, inputs, masks, delta_masks, routes, live, has_delta, remat=remat
+        prepared, start, masks, delta_masks, routes, live, has_delta, remat=remat
     )
 
 

--- a/param_decomp/targets/llama8b.py
+++ b/param_decomp/targets/llama8b.py
@@ -614,7 +614,7 @@ class LlamaDecomposedModel(eqx.Module):
     def masked_start(
         self, inputs: Int[Array, "b t"], taps: dict[str, Array], live: tuple[str, ...]
     ) -> tuple[int, Array]:
-        del inputs  # the tap seed replaces the input edge
+        del inputs
         (tap,) = self.start_taps(live)
         return _tap_layer(tap), taps[tap]
 

--- a/param_decomp/targets/llama8b.py
+++ b/param_decomp/targets/llama8b.py
@@ -507,9 +507,12 @@ class LlamaDecomposedModel(eqx.Module):
     separate lifecycle (own optimizer + checkpoint, C-sharded while these weights
     replicate), so it is NOT a field here.
 
-    Forward methods take token `inputs` and embed internally. Blocks with no decomposed
-    site run the plain frozen path — so a subset decomposition just leaves the rest
-    frozen.
+    The clean path takes token `inputs` and embeds internally; masked forwards take a
+    forward start `(start_block, resid)` — the residual entering `start_block`, from
+    `start_from_inputs` (block 0, the embed) or `start_from_taps` (a clean-forward
+    boundary at the earliest live block, so the frozen prefix is never recomputed —
+    SPEC S18/D5). Blocks with no decomposed site run the plain frozen path — so a
+    subset decomposition just leaves the rest frozen.
 
     `sites` / `leading_axes` are static config."""
 
@@ -561,20 +564,59 @@ class LlamaDecomposedModel(eqx.Module):
     def embed_tokens(self, tokens: Int[Array, "b t"]) -> Float[Array, "b t d"]:
         return self.embed[tokens]
 
+    def _slice_layers(self, lo: int, hi: int) -> LlamaLayer:
+        return jax.tree.map(lambda a: a[lo:hi], self.stacked)
+
     def clean_output(self, inputs: Int[Array, "b t"]) -> Array:
-        """The all-frozen forward — the recon target (SPEC S3). A `lax.scan` over the block
-        stack so XLA compiles one block body instead of unrolling all 32 layers (the compile
-        fix for the full model; the scan reassociates float ops vs an unrolled loop, within
-        fp32 tolerance)."""
+        """The all-frozen forward — the recon target (SPEC S3)."""
+        output, _ = self.clean_output_and_taps(inputs, ())
+        return output
+
+    def clean_output_and_taps(
+        self, inputs: Int[Array, "b t"], wanted: tuple[str, ...]
+    ) -> tuple[Array, dict[str, Array]]:
+        """The all-frozen forward (the recon target, SPEC S3) emitting `resid.{layer}` taps
+        as boundary values of the SAME forward (SPEC S18/D5) — the step's one clean pass. A
+        `lax.scan` over the block stack, split at the wanted tap layers: a static split
+        preserves the op sequence, so the output and taps are bit-identical to the unsplit
+        scan. Serves `resid.*` only — per-site matrix-input taps (harvest) live mid-block
+        and stay on `read_activations`."""
+        assert all(key.startswith("resid.") for key in wanted), (
+            f"clean_output_and_taps serves resid.* taps only, got {sorted(wanted)}"
+        )
+        boundaries = sorted({_tap_layer(key) for key in wanted})
+        assert all(0 <= b < self.n_layer for b in boundaries), (boundaries, self.n_layer)
 
         def block(x: Array, layer: LlamaLayer) -> tuple[Array, None]:
             x = x + layer.attn(rms_norm(x, layer.ln1, self.eps), self.inv_freq)
             x = x + _clean_mlp_out(layer, rms_norm(x, layer.ln2, self.eps))
             return x, None
 
-        x, _ = jax.lax.scan(block, self.embed_tokens(inputs), self.stacked)
+        x = self.embed_tokens(inputs)
+        taps: dict[str, Array] = {}
+        lo = 0
+        for boundary in boundaries:
+            if boundary > lo:
+                x, _ = jax.lax.scan(block, x, self._slice_layers(lo, boundary))
+                lo = boundary
+            taps[f"resid.{boundary}"] = x
+        x, _ = jax.lax.scan(block, x, self._slice_layers(lo, self.n_layer))
         x = rms_norm(x, self.norm, self.eps)
-        return x @ self.lm_head.T
+        return x @ self.lm_head.T, taps
+
+    def start_from_inputs(self, inputs: Int[Array, "b t"]) -> tuple[int, Array]:
+        return 0, self.embed_tokens(inputs)
+
+    def start_taps(self, live: tuple[str, ...]) -> tuple[str, ...]:
+        assert live, "a forward start needs at least one live site"
+        return (f"resid.{min(parse_site_name(site)[0] for site in live)}",)
+
+    def masked_start(
+        self, inputs: Int[Array, "b t"], taps: dict[str, Array], live: tuple[str, ...]
+    ) -> tuple[int, Array]:
+        del inputs  # the tap seed replaces the input edge
+        (tap,) = self.start_taps(live)
+        return _tap_layer(tap), taps[tap]
 
     def read_activations(
         self, inputs: Int[Array, "b t"], wanted: tuple[str, ...]
@@ -619,7 +661,7 @@ class LlamaDecomposedModel(eqx.Module):
     def _run_masked_forward(
         self,
         prepared: dict[str, dict[str, Array]],
-        inputs: Int[Array, "b t"],
+        start: tuple[int, Array],
         masks: dict[str, Array],
         delta_masks: dict[str, Array],
         routes: dict[str, Array] | None,
@@ -634,7 +676,10 @@ class LlamaDecomposedModel(eqx.Module):
         / `masked_site_outputs` / `masked_component_activations` (SPEC §1.3, S2). `live_set` is
         static at trace, so the forward runs as `[frozen prefix] → [live block] → [frozen suffix]`
         static sub-scans (no per-site `lax.cond`): only the live block carries + gathers V/U.
-        `live`/`has_delta` are static; a non-None `collect` gathers per-live-site decomposed
+        `start = (start_block, resid)` seeds the carry with the residual entering `start_block`
+        (static): the frozen prefix scan covers only `[start_block, first_live)` — empty when the
+        engine seeds at the first live block (SPEC S18/D5), the whole prefix for an input-edge
+        start. `live`/`has_delta` are static; a non-None `collect` gathers per-live-site decomposed
         OUTPUTS (`(x@V)*m@U + …`, SPEC S31), and a non-None `collect_activations` gathers
         per-live-site component ACTIVATIONS `x@V` (`[*leading, C]`, mask-independent — the
         pre-mask coefficient the arithmetic CI-grid eval visualizes). Assumes layer-aligned,
@@ -645,7 +690,7 @@ class LlamaDecomposedModel(eqx.Module):
         masks, so the ÷N→÷fsdp cross-node gather is not re-run here (SPEC unchanged; numerics
         identical — the reconstruction is mask-independent and the same for every forward)."""
         live_set = frozenset(live)
-        resid = self.embed_tokens(inputs)
+        start_block, resid = start
         leading = resid.shape[:-1]
         if stochastic is not None:
             ci_stacked, draw_key = stochastic
@@ -681,8 +726,11 @@ class LlamaDecomposedModel(eqx.Module):
             assert live_layers == list(range(first_live, last_live)), (
                 f"live layers must be contiguous, got {live_layers}"
             )
+            assert start_block <= first_live, (
+                f"start at block {start_block} is past the first live block {first_live}"
+            )
         else:
-            first_live = last_live = 0
+            first_live = last_live = start_block
 
         def decomp_site(x_in: Array, W: Array, e: dict[str, Array]) -> Array:
             v, u = e["V"], e["U"]
@@ -796,21 +844,18 @@ class LlamaDecomposedModel(eqx.Module):
                 jax.checkpoint(body, policy=policy), carry, xs, unroll=self.scan_unroll
             )
 
-        def slice_layers(lo: int, hi: int) -> LlamaLayer:
-            return jax.tree.map(lambda a: a[lo:hi], self.stacked)
-
         x = resid
         ys: tuple[dict[str, Array] | None, dict[str, Array] | None] | None = None
-        if first_live > 0:
-            x, _ = run_scan(frozen_block, x, slice_layers(0, first_live))
+        if first_live > start_block:
+            x, _ = run_scan(frozen_block, x, self._slice_layers(start_block, first_live))
         if last_live > first_live:
             pk_live = {
                 kind: {k: v[first_live:last_live] for k, v in e.items()}
                 for kind, e in per_kind.items()
             }
-            x, ys = run_scan(live_block, x, (slice_layers(first_live, last_live), pk_live))
+            x, ys = run_scan(live_block, x, (self._slice_layers(first_live, last_live), pk_live))
         if last_live < self.n_layer:
-            x, _ = run_scan(frozen_block, x, slice_layers(last_live, self.n_layer))
+            x, _ = run_scan(frozen_block, x, self._slice_layers(last_live, self.n_layer))
 
         x = rms_norm(x, self.norm, self.eps)
         logits = x @ self.lm_head.T
@@ -839,7 +884,7 @@ class LlamaDecomposedModel(eqx.Module):
     def masked_output(
         self,
         prepared: dict[str, dict[str, Array]],
-        inputs: Int[Array, "b t"],
+        start: tuple[int, Array],
         masks: dict[str, Array],
         delta_masks: dict[str, Array],
         routes: dict[str, Array] | None,
@@ -849,7 +894,7 @@ class LlamaDecomposedModel(eqx.Module):
         remat: bool,
     ) -> Array:
         return self._run_masked_forward(
-            prepared, inputs, masks, delta_masks, routes, live, has_delta, remat, None, None
+            prepared, start, masks, delta_masks, routes, live, has_delta, remat, None, None
         )
 
     def stack_ci(self, ci_lower: dict[str, Array]) -> dict[str, Array]:
@@ -861,7 +906,7 @@ class LlamaDecomposedModel(eqx.Module):
     def masked_output_stochastic(
         self,
         prepared: dict[str, dict[str, Array]],
-        inputs: Int[Array, "b t"],
+        start: tuple[int, Array],
         ci_stacked: dict[str, Array],
         draw_key: Array,
         routes: dict[str, Array] | None,
@@ -876,13 +921,13 @@ class LlamaDecomposedModel(eqx.Module):
         checkpointed block (faithful by checkpoint determinism). Same forward semantics as
         `masked_output` with stochastic sources — only the masks' liverange changes."""
         return self._run_masked_forward(
-            prepared, inputs, {}, {}, routes, live, has_delta, remat, None, (ci_stacked, draw_key)
+            prepared, start, {}, {}, routes, live, has_delta, remat, None, (ci_stacked, draw_key)
         )
 
     def masked_site_outputs(
         self,
         prepared: dict[str, dict[str, Array]],
-        inputs: Int[Array, "b t"],
+        start: tuple[int, Array],
         masks: dict[str, Array],
         delta_masks: dict[str, Array],
         routes: dict[str, Array] | None,
@@ -893,7 +938,7 @@ class LlamaDecomposedModel(eqx.Module):
         exact `masked_output` forward, discards the logits, returns the collected outputs."""
         collect: dict[str, Array] = {}
         self._run_masked_forward(
-            prepared, inputs, masks, delta_masks, routes, live, has_delta, False, collect, None
+            prepared, start, masks, delta_masks, routes, live, has_delta, False, collect, None
         )
         assert set(collect) == set(live), (sorted(collect), sorted(live))
         return collect
@@ -901,7 +946,7 @@ class LlamaDecomposedModel(eqx.Module):
     def masked_component_activations(
         self,
         prepared: dict[str, dict[str, Array]],
-        inputs: Int[Array, "b t"],
+        start: tuple[int, Array],
         masks: dict[str, Array],
         delta_masks: dict[str, Array],
         routes: dict[str, Array] | None,
@@ -916,7 +961,7 @@ class LlamaDecomposedModel(eqx.Module):
         LM-only, off the recon path."""
         collect_activations: dict[str, Array] = {}
         self._run_masked_forward(
-            prepared, inputs, masks, delta_masks, routes, live, has_delta, False, None,
+            prepared, start, masks, delta_masks, routes, live, has_delta, False, None,
             collect_activations=collect_activations,
         )  # fmt: skip
         assert set(collect_activations) == set(live), (sorted(collect_activations), sorted(live))

--- a/param_decomp/targets/llama_simple_mlp.py
+++ b/param_decomp/targets/llama_simple_mlp.py
@@ -285,8 +285,9 @@ class SimpleMLPDecomposedModel(eqx.Module):
     """The `LlamaSimpleMLP` `DecomposedModel` (the `lm.py` contract; SPEC §1).
 
     Carries the FROZEN full model (tied embedding, all blocks, final norm, lm_head) as array
-    fields — threaded into the jitted step as a pytree arg, weights traced not baked. Forward
-    methods take token `inputs` and embed internally; blocks with no decomposed site run the
+    fields — threaded into the jitted step as a pytree arg, weights traced not baked. The
+    clean path takes token `inputs` and embeds internally; masked forwards take a forward
+    start `(start_block, resid)` (SPEC S18/D5). Blocks with no decomposed site run the
     plain frozen block. The TRAINABLE V/U (`vu: DecompVU`) is an
     explicit method arg, NOT a field (separate lifecycle). `sites` / `leading_axes` / `n_ctx`
     / `eps` are static config."""
@@ -318,12 +319,43 @@ class SimpleMLPDecomposedModel(eqx.Module):
 
     def clean_output(self, inputs: Int[Array, "b t"]) -> Array:
         """The all-frozen forward — the recon target (SPEC S3)."""
+        output, _ = self.clean_output_and_taps(inputs, ())
+        return output
+
+    def clean_output_and_taps(
+        self, inputs: Int[Array, "b t"], wanted: tuple[str, ...]
+    ) -> tuple[Array, dict[str, Array]]:
+        """The all-frozen forward (SPEC S3) emitting `resid.{layer}` taps as boundary values
+        of the SAME pass (SPEC S18/D5). Serves `resid.*` only — per-site matrix-input taps
+        (harvest) live mid-block and stay on `read_activations`."""
+        assert all(key.startswith("resid.") for key in wanted), (
+            f"clean_output_and_taps serves resid.* taps only, got {sorted(wanted)}"
+        )
         assert inputs.shape[1] <= self.n_ctx, (inputs.shape, self.n_ctx)
+        wanted_set = frozenset(wanted)
+        taps: dict[str, Array] = {}
         x = self.embed_tokens(inputs)
-        for layer in self.layers:
+        for layer_idx, layer in enumerate(self.layers):
+            if f"resid.{layer_idx}" in wanted_set:
+                taps[f"resid.{layer_idx}"] = x
             x = _clean_block(layer, x, self.inv_freq, self.eps)
+        assert set(taps) == wanted_set, (sorted(taps), sorted(wanted))
         x = rms_norm(x, self.norm, self.eps)
-        return x @ self.lm_head.T
+        return x @ self.lm_head.T, taps
+
+    def start_from_inputs(self, inputs: Int[Array, "b t"]) -> tuple[int, Array]:
+        return 0, self.embed_tokens(inputs)
+
+    def start_taps(self, live: tuple[str, ...]) -> tuple[str, ...]:
+        assert live, "a forward start needs at least one live site"
+        return (f"resid.{min(_tap_layer(site) for site in live)}",)
+
+    def masked_start(
+        self, inputs: Int[Array, "b t"], taps: dict[str, Array], live: tuple[str, ...]
+    ) -> tuple[int, Array]:
+        del inputs  # the tap seed replaces the input edge
+        (tap,) = self.start_taps(live)
+        return _tap_layer(tap), taps[tap]
 
     def read_activations(
         self, inputs: Int[Array, "b t"], wanted: tuple[str, ...]
@@ -367,7 +399,8 @@ class SimpleMLPDecomposedModel(eqx.Module):
     def _run_masked_forward(
         self,
         vu: DecompVU,
-        inputs: Int[Array, "b t"],
+        x: Float[Array, "b t d"],
+        start_block: int,
         masks: dict[str, Array],
         delta_masks: dict[str, Array],
         routes: dict[str, Array] | None,
@@ -378,14 +411,21 @@ class SimpleMLPDecomposedModel(eqx.Module):
         """The masked decomposed forward shared by `masked_output` and
         `masked_site_outputs` (SPEC §4.1, S2): sites in `live` run their decomposed forward
         with `masks[s]` / `delta_masks[s]` / `routes[s]`; every other site — and every site
-        absent from the decomposition entirely — runs the frozen `x @ W` path. `live` and
-        `has_delta` are static under jit; `has_delta` False skips the `x @ Δ` matmul
-        (LOSS_PARITY_DESIGN §4b). A non-None `collect` gathers per-site decomposed
-        outputs."""
-        assert inputs.shape[1] <= self.n_ctx, (inputs.shape, self.n_ctx)
+        absent from the decomposition entirely — runs the frozen `x @ W` path. `x` is the
+        residual entering `start_block` (a forward start, destructured by the caller so the
+        static int never crosses a `jax.checkpoint`); layers before it are the clean
+        forward's job (SPEC S18/D5). `live` and `has_delta` are static under jit;
+        `has_delta` False skips the `x @ Δ` matmul (LOSS_PARITY_DESIGN §4b). A non-None
+        `collect` gathers per-site decomposed outputs."""
+        assert x.shape[1] <= self.n_ctx, (x.shape, self.n_ctx)
         live_set = frozenset(live)
-        x = self.embed_tokens(inputs)
-        for layer_idx, layer in enumerate(self.layers):
+        if live_set:
+            first_live = min(_tap_layer(site) for site in live)
+            assert start_block <= first_live, (
+                f"start at block {start_block} is past the first live block {first_live}"
+            )
+        for layer_idx in range(start_block, len(self.layers)):
+            layer = self.layers[layer_idx]
             live_kinds = {kind for kind in KIND_ORDER if site_name(layer_idx, kind) in live_set}
             attn = layer.attn
             site_args = (masks, delta_masks, routes, live_set, has_delta, collect)
@@ -425,7 +465,7 @@ class SimpleMLPDecomposedModel(eqx.Module):
     def masked_output(
         self,
         prepared: DecompVU,
-        inputs: Int[Array, "b t"],
+        start: tuple[int, Array],
         masks: dict[str, Array],
         delta_masks: dict[str, Array],
         routes: dict[str, Array] | None,
@@ -436,21 +476,24 @@ class SimpleMLPDecomposedModel(eqx.Module):
     ) -> Array:
         # This arch's forward is an unrolled Python loop (heterogeneous per-layer live sites),
         # not a scan, so its natural remat granularity is the whole forward: recompute it in
-        # the backward rather than store its activations. `live`/`has_delta` are closed over
-        # (static); the checkpoint sees only array/pytree leaves.
+        # the backward rather than store its activations. `live`/`has_delta`/`start_block` are
+        # closed over (static); the checkpoint sees only array/pytree leaves — the start is
+        # destructured HERE so its static int never flattens into a checkpoint tracer.
+        start_block, x0 = start
+
         def forward(
             vu: DecompVU,
-            inputs: Array,
+            x0: Array,
             masks: dict[str, Array],
             delta_masks: dict[str, Array],
             routes: dict[str, Array] | None,
         ) -> Array:
             return self._run_masked_forward(
-                vu, inputs, masks, delta_masks, routes, live, has_delta, None
+                vu, x0, start_block, masks, delta_masks, routes, live, has_delta, None
             )
 
         forward = jax.checkpoint(forward) if remat else forward
-        return forward(prepared, inputs, masks, delta_masks, routes)
+        return forward(prepared, x0, masks, delta_masks, routes)
 
     def stack_ci(self, ci_lower: dict[str, Array]) -> dict[str, Array]:
         return ci_lower  # unrolled-loop target: no scan to share a stack across; identity
@@ -458,7 +501,7 @@ class SimpleMLPDecomposedModel(eqx.Module):
     def masked_output_stochastic(
         self,
         prepared: DecompVU,
-        inputs: Int[Array, "b t"],
+        start: tuple[int, Array],
         ci_stacked: dict[str, Array],
         draw_key: Array,
         routes: dict[str, Array] | None,
@@ -468,13 +511,13 @@ class SimpleMLPDecomposedModel(eqx.Module):
         remat: bool,
     ) -> Array:
         return run_stochastic_masked_output(
-            self, prepared, inputs, ci_stacked, draw_key, routes, live, has_delta, remat=remat
+            self, prepared, start, ci_stacked, draw_key, routes, live, has_delta, remat=remat
         )
 
     def masked_site_outputs(
         self,
         prepared: DecompVU,
-        inputs: Int[Array, "b t"],
+        start: tuple[int, Array],
         masks: dict[str, Array],
         delta_masks: dict[str, Array],
         routes: dict[str, Array] | None,
@@ -483,9 +526,10 @@ class SimpleMLPDecomposedModel(eqx.Module):
     ) -> dict[str, Array]:
         """Per-`live`-site decomposed output of the masked forward (SPEC S31). Runs the
         exact `masked_output` forward, discards the logits, returns the collected outputs."""
+        start_block, x0 = start
         collect: dict[str, Array] = {}
         self._run_masked_forward(
-            prepared, inputs, masks, delta_masks, routes, live, has_delta, collect
+            prepared, x0, start_block, masks, delta_masks, routes, live, has_delta, collect
         )
         assert set(collect) == set(live), (sorted(collect), sorted(live))
         return collect

--- a/param_decomp/targets/llama_simple_mlp.py
+++ b/param_decomp/targets/llama_simple_mlp.py
@@ -353,7 +353,7 @@ class SimpleMLPDecomposedModel(eqx.Module):
     def masked_start(
         self, inputs: Int[Array, "b t"], taps: dict[str, Array], live: tuple[str, ...]
     ) -> tuple[int, Array]:
-        del inputs  # the tap seed replaces the input edge
+        del inputs
         (tap,) = self.start_taps(live)
         return _tap_layer(tap), taps[tap]
 

--- a/param_decomp/tests/equivalence/jax_equivalence.py
+++ b/param_decomp/tests/equivalence/jax_equivalence.py
@@ -143,6 +143,7 @@ def compute_jax_terms(f: dict[str, np.ndarray]) -> dict[str, float]:
     the pytest so there is one term-computation path."""
     lm, vu, n_layers = _build(f)
     resid = jnp.asarray(f["resid"], dtype=FP)
+    start = lm.start_from_inputs(resid)
 
     clean = jax.lax.stop_gradient(lm.clean_output(resid))
 
@@ -180,7 +181,7 @@ def compute_jax_terms(f: dict[str, np.ndarray]) -> dict[str, float]:
         routes = {site_name(i, k): jnp.asarray(f[f"route_chunk{i}_{k}"]) for k in MLP_KINDS}
         pred = lm.masked_output(
             lm.prepare_compute_weights(vu),
-            resid,
+            start,
             masks,
             delta_masks,
             routes,
@@ -196,7 +197,7 @@ def compute_jax_terms(f: dict[str, np.ndarray]) -> dict[str, float]:
     masks, delta_masks = source_masks(ci_lower, source, lm.site_names)
     pred = lm.masked_output(
         lm.prepare_compute_weights(vu),
-        resid,
+        start,
         masks,
         delta_masks,
         None,
@@ -274,8 +275,9 @@ def chunk_plan_static_gate_kl(f: dict[str, np.ndarray]) -> tuple[float, float]:
     delta_masks = {s: stoch_delta[s] for s in live}
 
     gate_pred = lm.masked_output(
-        lm.prepare_compute_weights(vu), resid, masks, delta_masks, None, live, True, remat=False
-    )
+        lm.prepare_compute_weights(vu), lm.start_from_inputs(resid), masks, delta_masks, None,
+        live, True, remat=False,
+    )  # fmt: skip
     ref_pred = _suffix_with_split_mlp(
         lm, vu, resid, live_layer, live_kinds, masks, delta_masks, n_layers
     )

--- a/param_decomp/tests/equivalence/test_equivalence.py
+++ b/param_decomp/tests/equivalence/test_equivalence.py
@@ -191,6 +191,7 @@ def test_sc_source_broadcasts_over_batch_in_masked_forward() -> None:
     f = _load_fixtures()
     lm, vu, n_layers = _build(f)
     resid = jnp.asarray(f["resid"], dtype=FP)
+    start = lm.start_from_inputs(resid)
     B, T = int(f["_scalar_B"]), int(f["_scalar_T"])
     vocab = int(f["_scalar_VOCAB"])
     assert B != T
@@ -212,7 +213,7 @@ def test_sc_source_broadcasts_over_batch_in_masked_forward() -> None:
 
     pred = lm.masked_output(
         lm.prepare_compute_weights(vu),
-        resid,
+        start,
         masks,
         delta_masks,
         None,
@@ -231,7 +232,7 @@ def test_sc_source_broadcasts_over_batch_in_masked_forward() -> None:
         bad_masks, bad_delta = source_masks(ci_lower, bt_transposed, lm.site_names)
         lm.masked_output(
             lm.prepare_compute_weights(vu),
-            resid,
+            start,
             bad_masks,
             bad_delta,
             None,

--- a/param_decomp/tests/stacked_parity/test_stacked_parity.py
+++ b/param_decomp/tests/stacked_parity/test_stacked_parity.py
@@ -166,17 +166,18 @@ def test_site_inputs_and_weight_deltas_match():
 @_PENDING_REGEN
 def test_masked_output_match():
     f, lm, vu, resid = _load()
+    start = lm.start_from_inputs(resid)
     masks = {s: jnp.asarray(f[f"mask::{s}"]) for s in lm.site_names}
     delta_masks = {s: jnp.asarray(f[f"delta_mask::{s}"]) for s in lm.site_names}
     masked_all = lm.masked_output(
-        vu, resid, masks, delta_masks, None, lm.site_names, True, remat=False
+        vu, start, masks, delta_masks, None, lm.site_names, True, remat=False
     )
     _assert_close(masked_all, f["out::masked_all"], "masked_output (all live)")
 
     chunk0 = lm.site_names[:3]
     routes0 = {s: jnp.asarray(f[f"route0::{s}"]) for s in chunk0}
     masked_subset = lm.masked_output(
-        vu, resid,
+        vu, start,
         {s: masks[s] for s in chunk0}, {s: delta_masks[s] for s in chunk0}, routes0, chunk0, True,
         remat=False,
     )  # fmt: skip
@@ -205,8 +206,9 @@ def test_chunk_plan_static_live_set_matches():
     delta_masks = {s: jnp.asarray(f[f"delta_mask::{s}"]) for s in chunk0}
     routes = {s: jnp.asarray(f[f"route0::{s}"]) for s in chunk0}
     masked = lm.masked_output(
-        vu, resid, masks, delta_masks, routes, plan[0].live_sites, plan[0].has_delta, remat=False
-    )
+        vu, lm.start_from_inputs(resid), masks, delta_masks, routes, plan[0].live_sites,
+        plan[0].has_delta, remat=False,
+    )  # fmt: skip
     _assert_close(masked, f["out::masked_subset"], "chunk-plan static-live-set forward")
 
 

--- a/param_decomp/tests/test_arithmetic_eval.py
+++ b/param_decomp/tests/test_arithmetic_eval.py
@@ -71,7 +71,9 @@ def test_grid_step_ci_xv_and_masked_max_match_hand_rolled():
     leading = tokens.shape
     ones = {s: jnp.ones((*leading, C), COMPUTE_DT) for s in names}
     zeros_delta = {s: jnp.zeros(leading, COMPUTE_DT) for s in names}
-    outputs = lm.masked_site_outputs(prepared, tokens, ones, zeros_delta, None, names, False)
+    outputs = lm.masked_site_outputs(
+        prepared, lm.start_from_inputs(tokens), ones, zeros_delta, None, names, False
+    )
     for site in names:
         ci = np.asarray(ci_grids[site])
         ci_exp = np.asarray(lower_leaky_hard_sigmoid(logits[site]))[:, ANSWER_POSITION, :]

--- a/param_decomp/tests/test_attn_patterns_eval.py
+++ b/param_decomp/tests/test_attn_patterns_eval.py
@@ -229,6 +229,22 @@ class _PositionlessStub(eqx.Module):
         del resid, wanted
         raise AssertionError("positionless stub fn must not be called")
 
+    def clean_output_and_taps(
+        self, resid: Any, wanted: tuple[str, ...]
+    ) -> tuple[Any, dict[str, jax.Array]]:
+        return self.clean_output(resid), self.read_activations(resid, wanted)
+
+    def start_from_inputs(self, resid: Any) -> Any:
+        return resid
+
+    def start_taps(self, live: tuple[str, ...]) -> tuple[str, ...]:
+        del live
+        return ()
+
+    def masked_start(self, resid: Any, taps: dict[str, Any], live: tuple[str, ...]) -> Any:
+        del taps, live
+        return resid
+
     def prepare_compute_weights(self, vu: Any) -> Any:
         return vu
 

--- a/param_decomp/tests/test_eval.py
+++ b/param_decomp/tests/test_eval.py
@@ -72,6 +72,22 @@ class _PositionlessStub(eqx.Module):
         del resid, wanted
         raise AssertionError("positionless stub fn must not be called")
 
+    def clean_output_and_taps(
+        self, resid: Any, wanted: tuple[str, ...]
+    ) -> tuple[Any, dict[str, jax.Array]]:
+        return self.clean_output(resid), self.read_activations(resid, wanted)
+
+    def start_from_inputs(self, resid: Any) -> Any:
+        return resid
+
+    def start_taps(self, live: tuple[str, ...]) -> tuple[str, ...]:
+        del live
+        return ()
+
+    def masked_start(self, resid: Any, taps: dict[str, Any], live: tuple[str, ...]) -> Any:
+        del taps, live
+        return resid
+
     def prepare_compute_weights(self, vu: Any) -> Any:
         return vu
 

--- a/param_decomp/tests/test_fresh_pgd_cscope_dp_invariance.py
+++ b/param_decomp/tests/test_fresh_pgd_cscope_dp_invariance.py
@@ -73,7 +73,7 @@ def _ascend_cscope_source(
         masks, delta_masks = source_masks(ci_lower, sources, lm.site_names)
         masked = lm.masked_output(
             lm.prepare_compute_weights(components),
-            residual,
+            lm.start_from_inputs(residual),
             masks,
             delta_masks,
             None,

--- a/param_decomp/tests/test_generic_model_io.py
+++ b/param_decomp/tests/test_generic_model_io.py
@@ -95,6 +95,24 @@ class SyntheticDecomposedModel(eqx.Module):
         assert wanted == (SITE,), wanted
         return {SITE: self._residual(inputs)}
 
+    def clean_output_and_taps(
+        self, inputs: dict[str, Array], wanted: tuple[str, ...]
+    ) -> tuple[tuple[Array, Array], dict[str, Array]]:
+        return self.clean_output(inputs), self.read_activations(inputs, wanted)
+
+    def start_from_inputs(self, inputs: dict[str, Array]) -> dict[str, Array]:
+        return inputs
+
+    def start_taps(self, live: tuple[str, ...]) -> tuple[str, ...]:
+        del live
+        return ()
+
+    def masked_start(
+        self, inputs: dict[str, Array], taps: dict[str, Array], live: tuple[str, ...]
+    ) -> dict[str, Array]:
+        del taps, live
+        return inputs
+
     def prepare_compute_weights(self, vu: DecompVU) -> DecompVU:
         return vu
 

--- a/param_decomp/tests/test_llama8b.py
+++ b/param_decomp/tests/test_llama8b.py
@@ -196,15 +196,16 @@ def test_masked_component_activations_pre_mask_and_matches_outputs():
     tokens = jax.random.randint(jax.random.PRNGKey(2), (b, t), 0, cfg.vocab_size)
     names = lm.site_names
     prepared = lm.prepare_compute_weights(vu)
+    start = lm.start_from_inputs(tokens)
     zeros_delta = {s: jnp.zeros((b, t)) for s in names}
     ones = {s: jnp.ones((b, t, C)) for s in names}
 
-    acts = lm.masked_component_activations(prepared, tokens, ones, zeros_delta, None, names, False)
+    acts = lm.masked_component_activations(prepared, start, ones, zeros_delta, None, names, False)
     # `acts[s]` is `x@V` BEFORE the per-component `*mask` (shape (b, t, C)). With all-ones
     # masks and no delta the site OUTPUT is exactly `(x@V) @ U`, so projecting the collected
     # activation through U reproduces `masked_site_outputs` — pinning that we collected the
     # pre-mask coefficient, not the post-mask/post-U output.
-    outputs = lm.masked_site_outputs(prepared, tokens, ones, zeros_delta, None, names, False)
+    outputs = lm.masked_site_outputs(prepared, start, ones, zeros_delta, None, names, False)
     for s in names:
         assert acts[s].shape == (b, t, C)
         assert jnp.all(jnp.isfinite(acts[s]))
@@ -225,11 +226,12 @@ def test_clean_path_and_masked_identity(first: int, last: int):
 
     clean = lm.clean_output(tokens)
     assert clean.shape == (b, t, cfg.vocab_size)
+    start = lm.start_from_inputs(tokens)
 
     # SPEC S2: a masked forward with NO live sites is the frozen path — bit-identical
     # to the clean target.
     none_masked = lm.masked_output(
-        lm.prepare_compute_weights(vu), tokens, {}, {}, None, (), True, remat=False
+        lm.prepare_compute_weights(vu), start, {}, {}, None, (), True, remat=False
     )
     assert jnp.array_equal(clean, none_masked), "live=() must be the exact frozen path"
 
@@ -240,7 +242,7 @@ def test_clean_path_and_masked_identity(first: int, last: int):
     ones_delta = {s: jnp.ones((b, t)) for s in names}
     full = lm.masked_output(
         lm.prepare_compute_weights(vu),
-        tokens,
+        start,
         ones_masks,
         ones_delta,
         None,
@@ -274,8 +276,9 @@ def test_attention_sites_clean_and_masked_identity():
         assert V.shape == (spec.d_in, spec.C) and U.shape == (spec.C, spec.d_out)
 
     clean = lm.clean_output(tokens)
+    start = lm.start_from_inputs(tokens)
     none_masked = lm.masked_output(
-        lm.prepare_compute_weights(vu), tokens, {}, {}, None, (), True, remat=False
+        lm.prepare_compute_weights(vu), start, {}, {}, None, (), True, remat=False
     )
     assert jnp.array_equal(clean, none_masked), "live=() must be the exact frozen path"
 
@@ -284,7 +287,7 @@ def test_attention_sites_clean_and_masked_identity():
     ones_delta = {s: jnp.ones((b, t)) for s in names}
     full = lm.masked_output(
         lm.prepare_compute_weights(vu),
-        tokens,
+        start,
         ones_masks,
         ones_delta,
         None,
@@ -305,7 +308,7 @@ def test_attention_sites_clean_and_masked_identity():
     zero_delta = {n: jnp.zeros((b, t)) for n in layer4}
     ablated = lm.masked_output(
         lm.prepare_compute_weights(vu),
-        tokens,
+        start,
         zero_mask,
         zero_delta,
         None,
@@ -339,7 +342,7 @@ def test_o_site_masks_attention_output():
     clean = lm.clean_output(tokens)
     ones = lm.masked_output(
         lm.prepare_compute_weights(vu),
-        tokens,
+        lm.start_from_inputs(tokens),
         {o_site: jnp.ones((b, t, 8))},
         {o_site: jnp.ones((b, t))},
         None,

--- a/param_decomp/tests/test_llama_simple_mlp.py
+++ b/param_decomp/tests/test_llama_simple_mlp.py
@@ -213,9 +213,10 @@ def test_clean_path_and_masked_identity():
 
     clean = lm.clean_output(tokens)
     assert clean.shape == (b, t, cfg.vocab_size)
+    start = lm.start_from_inputs(tokens)
 
     # SPEC S2: a masked forward with NO live sites is the frozen path — bit-identical.
-    none_masked = lm.masked_output(vu, tokens, {}, {}, None, (), True, remat=False)
+    none_masked = lm.masked_output(vu, start, {}, {}, None, (), True, remat=False)
     assert jnp.array_equal(clean, none_masked), "live=() must be the exact frozen path"
 
     # All-live, masks=1, delta=1, route-everywhere reconstructs the frozen path up to
@@ -223,7 +224,7 @@ def test_clean_path_and_masked_identity():
     names = lm.site_names
     ones_masks = {s.name: jnp.ones((b, t, s.C)) for s in lm.sites}
     ones_delta = {s: jnp.ones((b, t)) for s in names}
-    full = lm.masked_output(vu, tokens, ones_masks, ones_delta, None, names, True, remat=False)
+    full = lm.masked_output(vu, start, ones_masks, ones_delta, None, names, True, remat=False)
     assert jnp.allclose(clean, full, atol=1e-4), "mask=1 identity drifted"
 
     site_in = lm.read_activations(tokens, lm.site_names)
@@ -256,7 +257,7 @@ def test_zero_masking_one_site_changes_logits(ablated_site: str):
     clean = lm.clean_output(tokens)
     C = {s.name: s.C for s in _MIXED_SITE_CS}[ablated_site]
     ablated = lm.masked_output(
-        vu, tokens,
+        vu, lm.start_from_inputs(tokens),
         {ablated_site: jnp.zeros((b, t, C))}, {ablated_site: jnp.zeros((b, t))},
         None, (ablated_site,), True, remat=False,
     )  # fmt: skip
@@ -282,7 +283,7 @@ def test_masked_site_outputs_frozen_when_routed_false_or_unmasked():
     false_routes = {s: jnp.zeros((b, t), bool) for s in names}
 
     clean_outs = lm.masked_site_outputs(
-        vu, tokens, ones_masks, zeros_delta, false_routes, names, False
+        vu, lm.start_from_inputs(tokens), ones_masks, zeros_delta, false_routes, names, False
     )
     assert set(clean_outs) == set(names)
     # frozen `x @ W` per site, reconstructed independently from weight_deltas + V@U.
@@ -310,11 +311,12 @@ def test_masked_site_outputs_match_hand_computed_masked_linear(site_name_str: st
     tokens = jax.random.randint(jax.random.PRNGKey(2), (b, t), 0, cfg.vocab_size)
 
     x_in = lm.read_activations(tokens, (s,))[s]
+    start = lm.start_from_inputs(tokens)
     V, U = vu.site(s)
     mask = jax.random.uniform(jax.random.PRNGKey(7), (b, t, sites_cs[0].C))
 
     no_delta = lm.masked_site_outputs(
-        vu, tokens, {s: mask}, {s: jnp.zeros((b, t))}, None, names, False
+        vu, start, {s: mask}, {s: jnp.zeros((b, t))}, None, names, False
     )
     hand = ((x_in @ V) * mask) @ U
     assert jnp.allclose(no_delta[s], hand, atol=1e-4), s
@@ -322,7 +324,7 @@ def test_masked_site_outputs_match_hand_computed_masked_linear(site_name_str: st
     # delta path: + delta_mask · (x @ Δ), Δ = W − V@U == lm.weight_deltas (fp32 oracle)
     delta_in = lm.weight_deltas(vu)[s]
     delta_mask = jax.random.uniform(jax.random.PRNGKey(9), (b, t))
-    with_delta = lm.masked_site_outputs(vu, tokens, {s: mask}, {s: delta_mask}, None, names, True)
+    with_delta = lm.masked_site_outputs(vu, start, {s: mask}, {s: delta_mask}, None, names, True)
     hand_delta = delta_mask[..., None] * (x_in.astype(jnp.float32) @ delta_in.T)
     expected = hand.astype(jnp.float32) + hand_delta
     assert jnp.allclose(with_delta[s].astype(jnp.float32), expected, atol=1e-3), s
@@ -339,8 +341,8 @@ def test_o_site_masks_attention_output():
 
     clean = lm.clean_output(tokens)
     ones = lm.masked_output(
-        vu, tokens, {o_site: jnp.ones((b, t, 8))}, {o_site: jnp.ones((b, t))}, None,
-        (o_site,), True, remat=False,
+        vu, lm.start_from_inputs(tokens), {o_site: jnp.ones((b, t, 8))},
+        {o_site: jnp.ones((b, t))}, None, (o_site,), True, remat=False,
     )  # fmt: skip
     assert jnp.allclose(clean, ones, atol=1e-4)
     # o's clean site input is the pre-o_proj attention output, shape (b, t, qd)

--- a/param_decomp/tests/test_prefix_start.py
+++ b/param_decomp/tests/test_prefix_start.py
@@ -1,0 +1,125 @@
+"""Prefix-start equivalence (SPEC D5): a masked forward seeded from the clean pass's
+`resid.{first live block}` tap equals the input-edge (`start_from_inputs`) forward, on
+the deterministic AND stochastic mask paths, and `clean_output_and_taps` matches the
+separate clean/taps calls."""
+
+import jax
+import jax.numpy as jnp
+
+from param_decomp.components import init_decomp_vu
+from param_decomp.targets.llama_simple_mlp import site_specs
+from param_decomp.tests.test_llama8b import _mlp_sites, _tiny_cfg, _tiny_decomposed_lm
+from param_decomp.tests.test_llama_simple_mlp import (
+    _MIXED_SITE_CS,
+)
+from param_decomp.tests.test_llama_simple_mlp import (
+    _tiny_cfg as _tiny_simple_mlp_cfg,
+)
+from param_decomp.tests.test_llama_simple_mlp import (
+    _tiny_decomposed_model as _tiny_simple_mlp,
+)
+
+_ATOL = 1e-6  # fp32 CPU; the split scan preserves op order, only fusion may differ
+
+
+def _lm_and_masks(remat_key: int = 0):
+    cfg = _tiny_cfg()
+    key = jax.random.PRNGKey(remat_key)
+    lm_key, vu_key, tok_key, mask_key = jax.random.split(key, 4)
+    sites = _mlp_sites(cfg, 4, 5, 8)
+    lm = _tiny_decomposed_lm(cfg, sites, lm_key)
+    vu = init_decomp_vu(sites, vu_key)
+    prepared = lm.prepare_compute_weights(vu)
+    tokens = jax.random.randint(tok_key, (2, 16), 0, cfg.vocab_size)
+    names = lm.site_names
+    mask_keys = iter(jax.random.split(mask_key, 2 * len(names)))
+    masks = {s.name: jax.random.uniform(next(mask_keys), (2, 16, s.C), jnp.float32) for s in sites}
+    delta_masks = {s: jax.random.uniform(next(mask_keys), (2, 16), jnp.float32) for s in names}
+    return lm, prepared, tokens, names, masks, delta_masks
+
+
+def test_masked_output_tap_start_matches_input_start():
+    lm, prepared, tokens, names, masks, delta_masks = _lm_and_masks()
+    _, taps = lm.clean_output_and_taps(tokens, lm.start_taps(names))
+
+    from_inputs = lm.masked_output(
+        prepared, lm.start_from_inputs(tokens), masks, delta_masks, None, names, True,
+        remat=False,
+    )  # fmt: skip
+    from_tap = lm.masked_output(
+        prepared, lm.masked_start(tokens, taps, names), masks, delta_masks, None, names, True,
+        remat=False,
+    )  # fmt: skip
+    assert jnp.allclose(from_inputs, from_tap, atol=_ATOL), jnp.abs(from_inputs - from_tap).max()
+
+    from_tap_remat = lm.masked_output(
+        prepared, lm.masked_start(tokens, taps, names), masks, delta_masks, None, names, True,
+        remat=True,
+    )  # fmt: skip
+    assert jnp.allclose(from_inputs, from_tap_remat, atol=_ATOL)
+
+
+def test_stochastic_tap_start_matches_input_start():
+    """The stochastic per-(layer,kind) keys fold over ABSOLUTE layer indices, so the same
+    `draw_key` draws the same masks under either start (D5)."""
+    lm, prepared, tokens, names, _, _ = _lm_and_masks()
+    _, taps = lm.clean_output_and_taps(tokens, lm.start_taps(names))
+    ci_key, draw_key = jax.random.split(jax.random.PRNGKey(7))
+    ci_keys = iter(jax.random.split(ci_key, len(names)))
+    ci_lower = {
+        s.name: jax.random.uniform(next(ci_keys), (2, 16, s.C), jnp.float32) for s in lm.sites
+    }
+    ci_stacked = lm.stack_ci(ci_lower)
+
+    from_inputs = lm.masked_output_stochastic(
+        prepared, lm.start_from_inputs(tokens), ci_stacked, draw_key, None, names, True,
+        remat=False,
+    )  # fmt: skip
+    from_tap = lm.masked_output_stochastic(
+        prepared, lm.masked_start(tokens, taps, names), ci_stacked, draw_key, None, names, True,
+        remat=False,
+    )  # fmt: skip
+    assert jnp.allclose(from_inputs, from_tap, atol=_ATOL), jnp.abs(from_inputs - from_tap).max()
+
+
+def test_clean_output_and_taps_matches_separate_calls():
+    lm, _, tokens, names, _, _ = _lm_and_masks()
+    wanted = ("resid.2", *lm.start_taps(names))
+    output, taps = lm.clean_output_and_taps(tokens, wanted)
+    assert set(taps) == set(wanted)
+    assert jnp.allclose(output, lm.clean_output(tokens), atol=_ATOL)
+    # scan-emitted taps vs the unrolled `read_activations` loop: same math, different
+    # fusion — D4-level reassociation tolerance, not bit parity.
+    separate = lm.read_activations(tokens, wanted)
+    for tap in wanted:
+        assert jnp.allclose(taps[tap], separate[tap], rtol=1e-4, atol=1e-5), tap
+
+
+def test_simple_mlp_tap_start_matches_input_start():
+    """The unrolled-loop target, including remat=True — the start's static int must be
+    destructured OUTSIDE the `jax.checkpoint` (a tuple'd int would flatten to a tracer)."""
+    key = jax.random.PRNGKey(3)
+    lm_key, vu_key, tok_key, mask_key = jax.random.split(key, 4)
+    cfg = _tiny_simple_mlp_cfg()
+    sites = site_specs(cfg, _MIXED_SITE_CS)
+    lm = _tiny_simple_mlp(cfg, sites, lm_key)
+    names = lm.site_names
+    vu = init_decomp_vu(sites, vu_key)
+    tokens = jax.random.randint(tok_key, (2, 8), 0, cfg.vocab_size)
+    mask_keys = iter(jax.random.split(mask_key, 2 * len(names)))
+    masks = {s.name: jax.random.uniform(next(mask_keys), (2, 8, s.C), jnp.float32) for s in sites}
+    delta_masks = {s: jax.random.uniform(next(mask_keys), (2, 8), jnp.float32) for s in names}
+    _, taps = lm.clean_output_and_taps(tokens, lm.start_taps(names))
+
+    from_inputs = lm.masked_output(
+        vu, lm.start_from_inputs(tokens), masks, delta_masks, None, names, True, remat=False
+    )
+    for remat in (False, True):
+        from_tap = lm.masked_output(
+            vu, lm.masked_start(tokens, taps, names), masks, delta_masks, None, names, True,
+            remat=remat,
+        )  # fmt: skip
+        assert jnp.allclose(from_inputs, from_tap, atol=_ATOL), (
+            remat,
+            jnp.abs(from_inputs - from_tap).max(),
+        )

--- a/param_decomp/tests/test_prefix_start.py
+++ b/param_decomp/tests/test_prefix_start.py
@@ -22,9 +22,9 @@ from param_decomp.tests.test_llama_simple_mlp import (
 _ATOL = 1e-6  # fp32 CPU; the split scan preserves op order, only fusion may differ
 
 
-def _lm_and_masks(remat_key: int = 0):
+def _lm_and_masks():
     cfg = _tiny_cfg()
-    key = jax.random.PRNGKey(remat_key)
+    key = jax.random.PRNGKey(0)
     lm_key, vu_key, tok_key, mask_key = jax.random.split(key, 4)
     sites = _mlp_sites(cfg, 4, 5, 8)
     lm = _tiny_decomposed_lm(cfg, sites, lm_key)

--- a/param_decomp/tests/test_source_grad_mean.py
+++ b/param_decomp/tests/test_source_grad_mean.py
@@ -91,7 +91,7 @@ def _source_grad(sharded: bool) -> dict[str, jax.Array]:
         masks, delta_masks = source_masks(ci_lower, sources, lm.site_names)
         masked = lm.masked_output(
             lm.prepare_compute_weights(components_bf16),
-            resid,
+            lm.start_from_inputs(resid),
             masks,
             delta_masks,
             None,

--- a/param_decomp/train.py
+++ b/param_decomp/train.py
@@ -127,21 +127,21 @@ def make_train_step(
     recon_loss_fn = lm.recon_loss_fn  # static method: pure, holds no arrays — safe to close
     recon_terms = losses.recon
     # Static tap needs of the forward starts (SPEC S18/D5): each entry seeds its masked
-    # forwards at its earliest live block, the persistent warmups at the all-sites start.
+    # forwards at its earliest live block, the PPGD warmups at the all-sites start.
     # Unioned with the CI fn's `input_names` into the one clean pass's `wanted`.
     start_tap_names = tuple(
         dict.fromkeys(
-            tap
-            for term in recon_terms
-            for entry in term.plan
-            for tap in lm.start_taps(entry.live_sites)
+            (
+                *(
+                    t
+                    for term in recon_terms
+                    for e in term.plan
+                    for t in lm.start_taps(e.live_sites)
+                ),
+                *lm.start_taps(site_names),
+            )
         )
     )
-    uses_persistent = any(
-        isinstance(entry.sources, PersistentSources) for term in recon_terms for entry in term.plan
-    )
-    if uses_persistent:
-        start_tap_names = tuple(dict.fromkeys((*start_tap_names, *lm.start_taps(site_names))))
     faith_term = losses.faith
     imp_term = losses.imp
     faith_coeff = faith_term.coeff

--- a/param_decomp/train.py
+++ b/param_decomp/train.py
@@ -126,6 +126,22 @@ def make_train_step(
     sites = lm.sites
     recon_loss_fn = lm.recon_loss_fn  # static method: pure, holds no arrays — safe to close
     recon_terms = losses.recon
+    # Static tap needs of the forward starts (SPEC S18/D5): each entry seeds its masked
+    # forwards at its earliest live block, the persistent warmups at the all-sites start.
+    # Unioned with the CI fn's `input_names` into the one clean pass's `wanted`.
+    start_tap_names = tuple(
+        dict.fromkeys(
+            tap
+            for term in recon_terms
+            for entry in term.plan
+            for tap in lm.start_taps(entry.live_sites)
+        )
+    )
+    uses_persistent = any(
+        isinstance(entry.sources, PersistentSources) for term in recon_terms for entry in term.plan
+    )
+    if uses_persistent:
+        start_tap_names = tuple(dict.fromkeys((*start_tap_names, *lm.start_taps(site_names))))
     faith_term = losses.faith
     imp_term = losses.imp
     faith_coeff = faith_term.coeff
@@ -187,7 +203,7 @@ def make_train_step(
     def masked_forward(
         model: DecomposedModel,
         prepared: Any,
-        batch: Any,
+        start: Any,
         masks: dict[str, Float[Array, "*leading _"]],
         delta_masks: dict[str, Float[Array, "..."]],
         routes: dict[str, Bool[Array, "*leading"]] | None,
@@ -195,11 +211,12 @@ def make_train_step(
         has_delta: bool,
     ) -> Any:
         # `prepared` = `model.prepare_compute_weights(components_bf16)`, built ONCE per step and
-        # shared across all forwards (the ÷N→÷fsdp gather is not re-run per forward).
+        # shared across all forwards (the ÷N→÷fsdp gather is not re-run per forward). `start` is
+        # a forward start (`model.masked_start`), so the frozen prefix isn't re-run either.
         return batch_sharded(
             model.masked_output(
                 prepared,
-                batch,
+                start,
                 masks,
                 delta_masks,
                 routes,
@@ -228,20 +245,21 @@ def make_train_step(
         model: DecomposedModel,
         prepared: Any,
         ci_lower: dict[str, Array],
-        batch: Any,
+        start: Any,
         clean_output: Array,
         forward_fn: Any,
     ) -> Array:
         """Mean KL over the entry's draws with FIXED source values — the adversarial
         ascent objective (shared by fresh and persistent ascents, SPEC S12'). `prepared` is
-        the shared per-step compute weights (`prepare_compute_weights`)."""
+        the shared per-step compute weights (`prepare_compute_weights`); `start` the entry's
+        forward start."""
         masks, delta_masks = source_masks(ci_lower, sources, entry.live_sites)
         total = jnp.zeros((), jnp.float32)
         for routes in routes_per_draw:
             masked = forward_fn(
                 model,
                 prepared,
-                batch,
+                start,
                 masks,
                 delta_masks,
                 routes,
@@ -262,14 +280,19 @@ def make_train_step(
         imp_min_param = annealed_imp_min_param(step_f32, total_steps, imp_min)
 
         batch = batch_sharded(batch)
+        # ONE clean pass serves the recon target, the CI fn's taps, AND the forward starts
+        # (SPEC S18/D5) — the frozen prefix is never recomputed per consumer.
+        wanted_taps = tuple(dict.fromkeys((*state.ci_fn.input_names, *start_tap_names)))
         with jax.named_scope("pd_clean_fwd"):
-            clean_output = jax.lax.stop_gradient(batch_sharded(model.clean_output(batch)))
-        with jax.named_scope("pd_read_taps"):
-            taps = model.read_activations(batch, state.ci_fn.input_names)
+            clean_output, taps = model.clean_output_and_taps(batch, wanted_taps)
+            clean_output = jax.lax.stop_gradient(batch_sharded(clean_output))
+        # The MLP CI fns assert tap-set EQUALITY with their `input_names` — slice the
+        # start-widened tap dict back down for the CI call.
+        ci_taps = {name: taps[name] for name in state.ci_fn.input_names}
         # `leading` (batch, *positions) — the shape masks/sources/routes live in. Sourced
         # from a tap (always `[*leading, d_tap]`), not the opaque batch, so the engine never
         # assumes the batch's rank/feature dim.
-        leading = next(iter(taps.values())).shape[:-1]
+        leading = next(iter(ci_taps.values())).shape[:-1]
 
         # ── adversary ascents: params + CI detached (SPEC §4.5) ──
         prepared, recon_vjp = jax.vjp(
@@ -285,7 +308,9 @@ def make_train_step(
         # once inside the main backward.
         with jax.named_scope("pd_ci_fn_fwd"):
             ci, ci_vjp = eqx.filter_vjp(
-                lambda cf: ci_batch_sharded(cast_floating(cf, COMPUTE_DT)(taps, remat=remat_ci_fn)),
+                lambda cf: ci_batch_sharded(
+                    cast_floating(cf, COMPUTE_DT)(ci_taps, remat=remat_ci_fn)
+                ),
                 state.ci_fn,
             )
         ci_lower_detached = jax.lax.stop_gradient(ci).lower
@@ -297,7 +322,14 @@ def make_train_step(
         def warmup_scoring_loss(sources: dict[str, Array]) -> Array:
             masks, delta_masks = source_masks(ci_lower_detached, sources, site_names)
             masked = masked_forward(
-                model, prepared_ascend, batch, masks, delta_masks, None, site_names, True
+                model,
+                prepared_ascend,
+                model.masked_start(batch, taps, site_names),
+                masks,
+                delta_masks,
+                None,
+                site_names,
+                True,
             )
             return recon_loss_fn(masked, clean_output)
 
@@ -338,7 +370,7 @@ def make_train_step(
                         model,
                         prepared_ascend,
                         ci_lower_detached,
-                        batch,
+                        model.masked_start(batch, taps, entry.live_sites),
                         clean_output,
                         masked_forward,
                     )
@@ -404,7 +436,7 @@ def make_train_step(
                             return masked_forward(
                                 model,
                                 prepared,
-                                batch,
+                                model.masked_start(batch, taps, entry.live_sites),
                                 mds[0],
                                 mds[1],
                                 routes,
@@ -418,7 +450,7 @@ def make_train_step(
                                     masked = batch_sharded(
                                         model.masked_output_stochastic(
                                             prepared,
-                                            batch,
+                                            model.masked_start(batch, taps, entry.live_sites),
                                             ci_stacked,
                                             draw_key,
                                             routes,

--- a/param_decomp_lab/experiments/resid_mlp/model.py
+++ b/param_decomp_lab/experiments/resid_mlp/model.py
@@ -390,6 +390,27 @@ class ResidMLPDecomposedModel(eqx.Module):
         inputs = site_inputs(self.target, resid)
         return {k: inputs[k] for k in wanted}
 
+    def clean_output_and_taps(
+        self, resid: Float[Array, "B d_embed"], wanted: tuple[str, ...]
+    ) -> tuple[Array, dict[str, Array]]:
+        return self.clean_output(resid), self.read_activations(resid, wanted)
+
+    def start_from_inputs(self, resid: Float[Array, "B d_embed"]) -> Array:
+        return resid
+
+    def start_taps(self, live: tuple[str, ...]) -> tuple[str, ...]:
+        del live
+        return ()
+
+    def masked_start(
+        self,
+        resid: Float[Array, "B d_embed"],
+        taps: dict[str, Array],
+        live: tuple[str, ...],
+    ) -> Array:
+        del taps, live
+        return resid
+
     def prepare_compute_weights(self, vu: DecompVU) -> DecompVU:
         """Identity: ResidMLP weights are tiny + replicated, nothing to stack/gather/share."""
         return vu

--- a/param_decomp_lab/experiments/tms/model.py
+++ b/param_decomp_lab/experiments/tms/model.py
@@ -322,6 +322,27 @@ class TMSDecomposedModel(eqx.Module):
         inputs = site_inputs(self.target, resid)
         return {k: inputs[k] for k in wanted}
 
+    def clean_output_and_taps(
+        self, resid: Float[Array, "B n_features"], wanted: tuple[str, ...]
+    ) -> tuple[Array, dict[str, Array]]:
+        return self.clean_output(resid), self.read_activations(resid, wanted)
+
+    def start_from_inputs(self, resid: Float[Array, "B n_features"]) -> Array:
+        return resid
+
+    def start_taps(self, live: tuple[str, ...]) -> tuple[str, ...]:
+        del live
+        return ()
+
+    def masked_start(
+        self,
+        resid: Float[Array, "B n_features"],
+        taps: dict[str, Array],
+        live: tuple[str, ...],
+    ) -> Array:
+        del taps, live
+        return resid
+
     def prepare_compute_weights(self, vu: DecompVU) -> DecompVU:
         """Identity: TMS weights are tiny + replicated, nothing to stack/gather/share."""
         return vu


### PR DESCRIPTION
## Description

**Measured speedup (dp8 single-block smokes, B200, 300-step A/B at identical config + seed):**

| run | before | after | speedup | peak HBM |
|---|---|---|---|---|
| layer-18 block (all 7 matrices, doubled C) | 1.477 s/step | **1.18 s/step** | **1.25×** | 49.0 → 44.6 GB |
| layer-31 block | 1.186 s/step | **0.652 s/step** | **1.82×** | 43.7 → 42.1 GB |

The win scales with block depth (fleet average over 32 per-block runs ≈ 1.20×), and chunkwise multi-block runs get each chunk pass truncated at its own chunk start. Losses match the baseline runs to 4 significant figures in early steps; the layer-31 trajectory is identical through all 300 steps, layer-18 within 0.5% at step 300 (reassociation amplification, D5).

**Where the speedup comes from:** a step previously ran the frozen prefix of the target ~6× — once in `clean_output`, once in `read_activations`, and once inside *each* masked forward (2 PPGD warmup ascents + stochastic recon + PPGD main), which all re-embedded the batch and re-ran every block below the first live site. Now the step runs ONE clean pass (`clean_output_and_taps`, a segmented scan) that emits the recon target, the CI taps, and the residual boundaries; every masked/ascent forward starts from its entry's boundary (`masked_start` → `(first_live_block, resid)`), so the frozen prefix below the earliest live site is never recomputed. For a single-block-18 decomposition that deletes 4–5 × 18 frozen-block forwards per step.

Mechanically: the `DecomposedModel` masked family (`masked_output` / `masked_output_stochastic` / `masked_site_outputs` / `masked_component_activations`) takes a model-opaque **forward start** instead of the token batch, built via two constructors — `start_from_inputs` (input edge; eval tiers) and `masked_start` (tap-seeded; all recon/ascent forwards). The engine stays d-blind: starts are built and consumed target-side (the S4 opacity rule), `start_block` is static per recon-plan entry, and all-sites passes on a full-model run degrade gracefully to `start_block = 0`. All seven `DecomposedModel` impls migrated (toys: identity — their start IS their input). llama8b's already-segmented `[prefix][live][suffix]` scan just gets its prefix sliced `[start_block, first_live)`; `llama_simple_mlp` destructures the start's static int OUTSIDE its `jax.checkpoint` (tracer hazard, pinned by test).

This seam is also the substrate for later activation caching (`resid` from disk instead of the clean pass) and adjacent to block-local recon experiments.

## Related Issue

None — motivated by the per-block (two-stage) training investigation; step-cost model measured in wandb group `l18only` (runs 172591/172594-172596, A/B 172602/172603).

## Motivation and Context

Per-block VPD runs (the l18-style runs and the planned per-block stage-1 sweep) and mid-stack chunkwise runs (l18-26) spend a large share of each step recomputing a frozen prefix whose value the clean forward already produced.

**SPEC (needs @Oli sign-off per the one rule):** S18 amended — masked forwards take a forward start; the clean path still takes the token batch and embeds internally, `clean_output` stays the whole-model frozen forward (S3 untouched), and NONE of the removed residual-start engine machinery returns (no `Prefix` object, no `first_layer` offsets, no out-of-graph harvest, no tap ceiling — cf. the 2026-06-24 removal). New **D5**: tap-start ≡ input-start up to float reassociation. S2/S3/S10′/S24 untouched. Glossary + §4.1/§4.5 pseudocode updated.

One drive-by fix: `experiments/invariance_check.py` had been bitrotted since the 2026-06-24 token contract (fed a float residual batch into `embed[tokens]`) — now feeds tokens and passes.

## How Has This Been Tested?

- New `tests/test_prefix_start.py` (the D5 gate): tap-start vs input-start equivalence on the deterministic AND stochastic mask paths (stochastic RNG keys fold over absolute layer indices, so draws are start-invariant), both LM targets, remat on/off; `clean_output_and_taps` vs separate calls (clean bit-level, taps at D4 tolerance — scan vs unrolled loop).
- Full `param_decomp/tests/` + toy suites: 336 passed at default AND `--xla_force_host_platform_device_count=4` (skips/xfails pre-existing).
- `experiments/invariance_check.py` (D4): 3-step trajectory matches 1-layout vs 4-device GSPMD, reassociation-only.
- `make type` / `make check` clean.
- Live cluster A/B above (branch `perf/prefix-shared-recon-ab` = this + the smoke configs); losses vs baseline as described.

## Does this PR introduce a breaking change?

Yes, two contract-level notes:

- The masked-family signature changed everywhere (no legacy path): callers pass a forward start built by `start_from_inputs` / `masked_start`. All in-repo call sites are migrated; out-of-tree consumers of `masked_output` must wrap their batch in `model.start_from_inputs(batch)`.
- A mid-run resume across this change is trajectory-continuous only up to float reassociation (CI taps moved from the unrolled `read_activations` pass to the clean scan's boundary carries), and the persistent compile cache misses once (new HLO).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011F8uqqWqnkC48Y8G4QCKsk
