### PR TITLE
perf(slow-eval): build the hidden-acts eval steps once, not every slow cycle

### DIFF
--- a/param_decomp/slow_eval.py
+++ b/param_decomp/slow_eval.py
@@ -9,7 +9,8 @@ is a reduction over the per-site causal-importance arrays from a masked-free for
 a numpy/matplotlib plot. The forward + reduction is JAX; the plotting is framework-agnostic
 (it mirrors the torch `param_decomp_lab/eval_metrics/plotting.py` reductions on numpy
 arrays, no torch). `accumulate_site_reductions` / `render_slow_eval_figures` /
-`compute_hidden_acts_metrics` are the SHARED interface both callers use.
+`compute_hidden_acts_metrics` are the LM in-loop tier's interface (`run.py`); the toys
+use only the UV figure helpers (`render_uv_figure` / `plot_uv_matrices`).
 
 The slow tier runs IN-LOOP on `eval.slow_every` next to the fast pass (`run.py`,
 SPEC S28/S29), reusing the fast pass's eval batches and logging `slow_eval/*` on the live
@@ -73,10 +74,9 @@ from param_decomp.configs import (
     UVPlotsConfig,
 )
 from param_decomp.hidden_acts_eval import (
+    HiddenActsStep,
     accumulate_hidden_acts,
     hidden_acts_log_entries,
-    make_ci_hidden_acts_step,
-    make_stochastic_hidden_acts_step,
 )
 from param_decomp.jit_util import filter_jit
 from param_decomp.lm import DecomposedModel
@@ -797,23 +797,24 @@ def render_slow_eval_figures(
 
 
 def compute_hidden_acts_metrics(
+    ci_step: HiddenActsStep,
+    stoch_step: HiddenActsStep,
     model: DecomposedModel,
     state: Any,
     input_batches: list[Any],
-    n_mask_samples: int,
     base_key: Array,
-    compiler_options: dict[str, bool | int | str] | None = None,
 ) -> dict[str, float]:
     """Both hidden-acts recon eval metrics over the eval batches (`input_batches` holds
     the model's target-specific inputs — an LM's token ids), keyed by the torch
-    `<ClassName>[/<site>]` log keys. `state.components`/`state.ci_fn` are the restored
+    `<ClassName>[/<site>]` log keys. `ci_step` / `stoch_step` are the PREBUILT jitted
+    steps (`make_ci_hidden_acts_step` / `make_stochastic_hidden_acts_step`), built once
+    per run next to the other slow-eval steps — rebuilding them per call would retrace +
+    recompile every slow-eval cycle. `state.components`/`state.ci_fn` are the restored
     trajectory; `base_key` seeds the stochastic variant's per-batch draws."""
     ci_key, stoch_key = random.split(base_key)
-    ci_step = make_ci_hidden_acts_step(model, compiler_options)
     ci_reductions = accumulate_hidden_acts(
         ci_step, model, state.components, state.ci_fn, input_batches, ci_key
     )
-    stoch_step = make_stochastic_hidden_acts_step(model, n_mask_samples, compiler_options)
     stoch_reductions = accumulate_hidden_acts(
         stoch_step, model, state.components, state.ci_fn, input_batches, stoch_key
     )

--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -65,6 +65,10 @@ from param_decomp.configs import ResumeProvenance
 from param_decomp.data import BatchSchedule, ShardServer, scan_shards
 from param_decomp.eval import make_eval_step
 from param_decomp.hf_http import configure_hf_http_retries
+from param_decomp.hidden_acts_eval import (
+    make_ci_hidden_acts_step,
+    make_stochastic_hidden_acts_step,
+)
 from param_decomp.lm import DecomposedModel
 from param_decomp.log import setup_logger
 from param_decomp.run import (
@@ -394,7 +398,10 @@ def _make_lm_eval_fn(
     # drops the raw metric list). The launch config is pinned before train().
     run_eval_metrics = eval_metrics_from_run_dir(built.run.run_dir)
     perm_spec = resolve_permutation_metrics(lm.site_names, run_eval_metrics)
-    hidden_acts_n_mask_samples = stochastic_hidden_acts_n_mask_samples(run_eval_metrics)
+    ci_hidden_acts_step = make_ci_hidden_acts_step(lm, co)
+    stoch_hidden_acts_step = make_stochastic_hidden_acts_step(
+        lm, stochastic_hidden_acts_n_mask_samples(run_eval_metrics), co
+    )
     want_position_ci = perm_spec.any_plots or perm_spec.any_identity_error
     position_ci_step = make_position_ci_step(lm, co) if want_position_ci else None
 
@@ -449,8 +456,9 @@ def _make_lm_eval_fn(
             )
             hidden_acts_key = random.fold_in(run_key, 3 * pd.steps + eval_pass_index)
             hidden_acts = compute_hidden_acts_metrics(
-                lm, state, eval_batches, hidden_acts_n_mask_samples, hidden_acts_key, co
-            )
+                ci_hidden_acts_step, stoch_hidden_acts_step, lm, state, eval_batches,
+                hidden_acts_key,
+            )  # fmt: skip
             eval_record |= {f"eval/slow/loss/{k}": v for k, v in hidden_acts.items()}
             # The position-CI all-gather is ALSO collective (every rank joins it), gated on
             # the config naming a CI-heatmap / permutation / identity-error metric. The


### PR DESCRIPTION
## Description
`compute_hidden_acts_metrics` called `make_ci_hidden_acts_step` / `make_stochastic_hidden_acts_step` on every invocation. Each call returns a fresh `eqx.filter_jit` object, so every `slow_every` cycle paid a full retrace + XLA compile of both masked-forward steps — identical logic and shapes, only the jit object identity changed — for the entire life of a multi-day run.

This hoists the two builders to `_make_lm_eval_fn` (next to `make_slow_eval_step` / `make_position_ci_step`, matching the sibling calling convention in the `slow_due` block) and changes `compute_hidden_acts_metrics` to take the two prebuilt `HiddenActsStep`s. `compiler_options` still reaches the build site; `n_mask_samples` is resolved at build time via `stochastic_hidden_acts_n_mask_samples`. Slow-tier semantics unchanged (SPEC S28/S28a — same collective calls, same log keys, same RNG folds).

Also reconciles the stale `slow_eval.py` module-docstring claim that `compute_hidden_acts_metrics` is a shared interface "both callers use" — its only live caller is the LM in-loop tier.

## Related Issue
Bridge thread: **hoist-hidden-acts-eval-steps** (from the 2026-07-10 static JAX-compilation-hygiene audit of feature/jax @ eb786f7d9).

## Motivation and Context
Every compile after the first was pure waste; this was the sole violation of the codebase's own prebuilt-step convention in the slow-eval block. Slow-eval cycle wall time drops by two compiles.

## How Has This Been Tested?
- `make type` clean; `pytest param_decomp/tests/test_hidden_acts_eval.py param_decomp/tests/test_slow_eval.py` — 33 passed.
- Behavior verified directly: two consecutive `compute_hidden_acts_metrics` cycles under `jax_log_compiles` on the tiny-model fixture — first cycle compiles the steps, second cycle does **0** compiles (previously recompiled both every cycle).

## Does this PR introduce a breaking change?
No behavior change. Signature change to `compute_hidden_acts_metrics` (takes prebuilt steps instead of `n_mask_samples` + `compiler_options`); its only caller is updated in this PR.

Crew-Address: task/hoist-hidden-acts-eval-steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)