### PR TITLE
fix(run): exit after profile.async_test — donation has consumed state

### DIFF
--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -625,8 +625,9 @@ class ProfileConfig(BaseConfig):
 
     `mem_profile` (static + runtime memory analysis, then exits), `time_steps` (per-step wall
     breakdown), `trace` (perfetto trace over `trace_start`..`trace_start+trace_steps`),
-    `profile_max_events` (raise the perfetto GPU-activity event cap), `async_test`,
-    `leaf_bench`, `no_checkpoint` (skip ALL saves — throwaway profiling only).
+    `profile_max_events` (raise the perfetto GPU-activity event cap), `async_test`
+    (dispatch-asynchrony probe, then exits), `leaf_bench`, `no_checkpoint` (skip ALL
+    saves — throwaway profiling only).
     """
 
     mem_profile: bool = False
@@ -644,6 +645,14 @@ class ProfileConfig(BaseConfig):
     async_test: bool = False
     leaf_bench: bool = False
     no_checkpoint: bool = False
+
+    @model_validator(mode="after")
+    def validate_exclusive_exiting_hooks(self) -> Self:
+        assert not (self.async_test and self.mem_profile), (
+            "async_test and mem_profile each consume `state` via step_fn donation and exit "
+            "before the loop — run them one at a time"
+        )
+        return self
 
 
 class LaunchEnv(BaseConfig):

--- a/param_decomp/run.py
+++ b/param_decomp/run.py
@@ -599,6 +599,7 @@ def run_decomposition_training(
                 f"sync/host-bound => each call big)",
                 flush=True,
             )
+        os._exit(0)  # profiling-only path; donation has consumed `state`, so don't enter the loop
 
     if profile.mem_profile:
         _gib = 1024**3

--- a/param_decomp/tests/test_config.py
+++ b/param_decomp/tests/test_config.py
@@ -16,6 +16,7 @@ from param_decomp.configs import (
     ImportanceMinimalityLossConfig,
     PDConfig,
     PersistentPGDReconLossConfig,
+    ProfileConfig,
 )
 from param_decomp.recon import (
     build_loss_terms,
@@ -87,6 +88,15 @@ def test_legacy_top_level_n_mask_samples_pushes_onto_stochastic_terms():
     by_type = {m.type: m for m in validated.loss_metrics}
     assert by_type["StochasticReconLoss"].n_mask_samples == 4  # pyright: ignore[reportAttributeAccessIssue]
     assert by_type["StochasticReconSubsetLoss"].n_mask_samples == 7  # pyright: ignore[reportAttributeAccessIssue]
+
+
+def test_profile_exiting_hooks_are_mutually_exclusive():
+    # Both hooks consume `state` via step_fn donation and os._exit(0) before the loop,
+    # so a config combining them would silently skip whichever runs second.
+    ProfileConfig(async_test=True)
+    ProfileConfig(mem_profile=True)
+    with pytest.raises(ValidationError, match="one at a time"):
+        ProfileConfig(async_test=True, mem_profile=True)
 
 
 def test_b128_config_converts():


### PR DESCRIPTION
## Description

`profile.async_test` (run.py) calls the donating `step_fn` (`donate="all-except-first"`) three times starting from `state` and never rebinds it — results land in locals while `state` keeps naming the donated (deleted) buffers. Control then falls through to the mem_profile path and the main training loop, which die with "Array has been deleted" the moment they touch `state`.

Two changes, mirroring how the mem_profile path already guards the identical situation:

- `os._exit(0)` at the end of the async_test block (same guard + comment as mem_profile's at the end of its block).
- A `ProfileConfig` validator refusing `async_test` + `mem_profile` in one config — each hook now exits before the loop, so combining them would silently skip whichever runs second. Refuse at config-parse time instead.

## Related Issue

Audit finding M2 from the 2026-07-10 JAX compile audit (latent correctness, profiling flag only). Refs against feature/jax @ eb786f7d9.

## Motivation and Context

async_test alone happened to work only because nothing after it ran; combined with a normal run or mem_profile it was a guaranteed crash. Precedent for loud donation guards: PR #932 (resume-oom donation fix).

## How Has This Been Tested?

- New `test_config.py::test_profile_exiting_hooks_are_mutually_exclusive` pins the validator (each flag alone validates; together refuses). `param_decomp/tests/test_config.py` passes (15/15).
- Pre-commit ruff + basedpyright clean.
- The exit guard itself is the same one-liner the mem_profile path has carried; not exercised on GPU (profiling-only path).

## Does this PR introduce a breaking change?

No. A config setting both `async_test: true` and `mem_profile: true` now refuses at validation — previously it would have crashed mid-run instead.

Crew-Address: task/fix-async-test-donated-state

🤖 Generated with [Claude Code](https://claude.com/claude-code)