### PR TITLE
tests: pin full-fp32 matmuls in the torch↔JAX goldens (GPU TF32 trap)

### DIFF
--- a/param_decomp/tests/equivalence/jax_equivalence.py
+++ b/param_decomp/tests/equivalence/jax_equivalence.py
@@ -210,7 +210,10 @@ def compute_jax_terms(f: dict[str, np.ndarray]) -> dict[str, float]:
 def main() -> None:
     f = dict(np.load(HERE / "fixtures.npz"))
     ref = json.loads((HERE / "torch_reference.json").read_text())
-    jaxv = compute_jax_terms(f)
+    # Same full-fp32 matmul pin as the pytest fixture: the GPU f32 default is TF32
+    # (~1e-3 rel), which swamps RTOL. No-op on CPU.
+    with jax.default_matmul_precision("highest"):
+        jaxv = compute_jax_terms(f)
     print(f"{'term':6} {'jax':>16} {'torch':>16} {'rel_err':>12}  ok")
     all_ok = True
     for term in ("faith", "imp", "stoch", "ppgd"):

--- a/param_decomp/tests/equivalence/test_equivalence.py
+++ b/param_decomp/tests/equivalence/test_equivalence.py
@@ -35,6 +35,7 @@ import inspect
 import json
 from pathlib import Path
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -48,6 +49,16 @@ from param_decomp.tests.equivalence.jax_equivalence import compute_jax_terms
 HERE = Path(__file__).resolve().parent
 RTOL = 2e-4
 ATOL = 1e-5
+
+
+@pytest.fixture(autouse=True)
+def full_fp32_matmuls():
+    """XLA's f32 matmul default on GPU tensor cores is TF32 (~1e-3 rel), which swamps
+    RTOL — unpinned GPU runs fail spuriously, or worse, teach us to read real torch↔JAX
+    divergence as precision noise. Pin full fp32 (a no-op on CPU CI, where "highest" is
+    already the default). Test-scope only: train numerics are bf16 by design."""
+    with jax.default_matmul_precision("highest"):
+        yield
 
 
 def _load_fixtures() -> dict[str, np.ndarray]:

--- a/param_decomp/tests/simple_mlp_equivalence/test_torch_equivalence.py
+++ b/param_decomp/tests/simple_mlp_equivalence/test_torch_equivalence.py
@@ -15,6 +15,7 @@ catches RoPE / GELU-flavor / GQA / norm-eps mismatches:
 import json
 from pathlib import Path
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -29,6 +30,15 @@ from param_decomp.targets.llama_simple_mlp import (
 
 FIXTURE_DIR = Path(__file__).parent
 REAL_CACHE_DIR = Path("/mnt/data/artifacts/mechanisms/param-decomp/pretrain_cache/spd-t-9d2b8f02")
+
+
+@pytest.fixture(autouse=True)
+def full_fp32_matmuls():
+    """XLA's f32 matmul default on GPU tensor cores is TF32 (~1e-3 rel), which swamps
+    the absolute tolerances below — the goldens are full-fp32 torch logits. No-op on
+    CPU CI, where "highest" is already the default. Test-scope only."""
+    with jax.default_matmul_precision("highest"):
+        yield
 
 
 def _max_abs_diff(a: Array, b: np.ndarray) -> float:

--- a/param_decomp/tests/stacked_parity/test_stacked_parity.py
+++ b/param_decomp/tests/stacked_parity/test_stacked_parity.py
@@ -22,6 +22,7 @@ git tag in a torch venv), out of scope for the API migration.
 from pathlib import Path
 
 import equinox as eqx
+import jax
 import jax.numpy as jnp
 import numpy as np
 import optax
@@ -61,6 +62,16 @@ from vendored_jax.llama import llama3_inv_freq
 FIXTURES = Path(__file__).resolve().parent / "stacked_fixtures.npz"
 RTOL = 1e-4
 ATOL = 1e-5
+
+
+@pytest.fixture(autouse=True)
+def full_fp32_matmuls():
+    """XLA's f32 matmul default on GPU tensor cores is TF32 (~1e-3 rel), which swamps
+    RTOL — the committed goldens were pinned with full-fp32 matmuls. No-op on CPU CI,
+    where "highest" is already the default. Test-scope only."""
+    with jax.default_matmul_precision("highest"):
+        yield
+
 
 STABLE_FIXTURE_METRIC_KEYS = (
     "total", "faith", "imp", "stoch", "ppgd", "p_imp", "src_lr",

--- a/vendored_jax/llama.py
+++ b/vendored_jax/llama.py
@@ -112,16 +112,20 @@ def repeat_kv(x: Float[Array, "b kvh t hd"], n_rep: int) -> Float[Array, "b h t 
     return x.reshape(b, kvh * n_rep, t, hd)
 
 
-def attn_implementation() -> Literal["cudnn", "xla"]:
-    """cuDNN flash attention on GPU; the XLA composite elsewhere (CPU tests)."""
-    return "cudnn" if jax.default_backend() == "gpu" else "xla"
+def attn_implementation(dtype: jnp.dtype) -> Literal["cudnn", "xla"]:
+    """cuDNN flash attention on GPU for the half dtypes it supports; the XLA composite
+    elsewhere. cuDNN rejects fp32, so the fp32 paths (CPU tests, the GPU-run
+    equivalence goldens) take the XLA composite."""
+    if jax.default_backend() == "gpu" and dtype in (jnp.bfloat16, jnp.float16):
+        return "cudnn"
+    return "xla"
 
 
 def causal_sdpa(q: Array, k: Array, v: Array) -> Array:
     # q,k,v: (B, H, T, hd); jax.nn.dot_product_attention takes (B, T, H, D).
     qt, kt, vt = (a.transpose(0, 2, 1, 3) for a in (q, k, v))
     out = jax.nn.dot_product_attention(
-        qt, kt, vt, is_causal=True, implementation=attn_implementation()
+        qt, kt, vt, is_causal=True, implementation=attn_implementation(q.dtype)
     )
     return out.transpose(0, 2, 1, 3)
 


### PR DESCRIPTION
## Description

Stacked on #936 (base is its branch; will retarget to `feature/jax` when it merges). Two changes:

1. **Pin `jax.default_matmul_precision("highest")` in every fp32-golden test harness** — `tests/equivalence`, `tests/stacked_parity`, and `tests/simple_mlp_equivalence` (same fp32-golden class, same trap), as an autouse fixture per module, plus the same pin in `jax_equivalence.py main()` (the CLI path). Test-scope only: train numerics stay bf16 by design, and the bf16 imp-min seam test is deliberately not pinned.
2. **`vendored_jax.llama.attn_implementation` now dispatches on dtype.** cuDNN flash attention rejects fp32, so the fp32 goldens previously could not run on GPU at all — every numeric test crashed with `NotImplementedError` on H100. bf16/fp16 keep cuDNN (production path unchanged); fp32 takes the XLA composite. Without this, the precision pin is unreachable on GPU.

## Related Issue

Compile-audit finding M6 (board task `pin-golden-matmul-precision`, promoted from the 2026-07-10 JAX compile audit).

## Motivation and Context

XLA's f32 matmul default on GPU tensor cores is TF32 (~1e-3 rel). The goldens are the only remaining torch↔JAX parity oracle (torch is retired at tag `torch-oracle`) and assert fp32 tolerances. CPU-only CI never sees the difference — "highest" is already the CPU default — but a GPU dev-box run does. #936 removes the `_PENDING_REGEN` xfail that currently masks this, so the pin should land with/right after it.

Measured on H100 against the committed goldens (per-term rel err, RTOL 2e-4):

| term | default (TF32) | pinned |
|---|---|---|
| faith | 1.8e-5 | 0 |
| imp | 0 | 0 |
| stoch | 4.1e-5 | 6.1e-8 |
| ppgd | **1.4e-4** | 8.0e-8 |

Unpinned, TF32 noise alone eats 70% of ppgd's tolerance budget — that's the "real port bug written off as TF32 noise" masquerade the audit flagged. Pinned, headroom is four orders of magnitude.

## How Has This Been Tested?

- CPU: all three suites — 17 passed, 1 xfailed (the still-pending trajectory golden), identical before/after (the pin is a CPU no-op).
- GPU (H100, 1×, via SLURM): before this PR — 11 of 18 tests fail (cuDNN fp32 crash); after — 17 passed, 1 xfailed, matching CPU exactly.
- `basedpyright` and `ruff` clean.

## Does this PR introduce a breaking change?

No. Production numerics untouched: the bf16 attention path still uses cuDNN; the dtype dispatch only enables the previously-crashing fp32 GPU path.

Crew-Address: task/pin-golden-matmul-precision

🤖 Generated with [Claude Code](https://claude.com/claude-code)