### PR TITLE
perf(glu): emit residual taps from the clean-forward scan; one frozen forward per step

### DIFF
--- a/param_decomp/CLAUDE.md
+++ b/param_decomp/CLAUDE.md
@@ -25,8 +25,11 @@ never silently diverge. Cite IDs (`S14`, `N1`, …) in commit messages and revie
 ## Architecture in one breath
 
 `lm.py` defines `DecomposedModel` — a `@runtime_checkable Protocol`: ordered `sites` +
-`leading_axes` + the methods `clean_output`, `read_activations`, `masked_output`,
-`masked_site_outputs`, `weight_deltas`, and a `recon_loss_fn` (LM: `kl_per_position`). The
+`leading_axes` + the methods `clean_output`, `read_activations`,
+`clean_output_and_activations` (both from ONE frozen forward — the GLU target emits
+the taps as ys of its clean-forward `lax.scan`; what the train + fast-eval steps call),
+`masked_output`, `masked_site_outputs`, `weight_deltas`, and a `recon_loss_fn`
+(LM: `kl_per_position`). The
 concrete impl per target is an `eqx.Module` (`GLUDecomposedModel`,
 `SimpleMLPDecomposedModel`, `TMSDecomposedModel`, `ResidMLPDecomposedModel`) carrying its
 FROZEN target weights as ARRAY FIELDS; the TRAINABLE V/U (`vu: DecompVU`) stays an explicit

--- a/param_decomp/eval.py
+++ b/param_decomp/eval.py
@@ -179,8 +179,8 @@ def make_eval_step(
         key: PRNGKeyArray,
     ) -> dict[str, Array]:
         token_ids = batch_sharded(token_ids)
-        clean_output = batch_sharded(model.clean_output(token_ids))
-        taps = model.read_activations(token_ids, ci_fn.input_names)
+        clean_output, taps = model.clean_output_and_activations(token_ids, ci_fn.input_names)
+        clean_output = batch_sharded(clean_output)
 
         if n_valid_rows is None:
             row_mask = None

--- a/param_decomp/lm.py
+++ b/param_decomp/lm.py
@@ -105,6 +105,16 @@ class DecomposedModel(Protocol):
         interpreter; core just routes by key."""
         ...
 
+    def clean_output_and_activations(
+        self, inputs: Any, /, wanted: tuple[str, ...]
+    ) -> tuple[Any, dict[str, Float[Array, "*leading d_tap"]]]:
+        """`(clean_output(inputs), read_activations(inputs, wanted))` — SPEC S3+S4
+        unchanged, evaluated in ONE frozen forward where the target can (a scan target
+        emits the taps as ys of its clean-forward scan; XLA does not CSE the two passes
+        apart). Targets without that structure just call both. For the steps that need
+        both on the same batch (train, fast eval)."""
+        ...
+
     def prepare_compute_weights(self, vu: DecompVU) -> Any:
         """Build the per-step COMPUTE weights from the fp32 ÷N master `vu`, ONCE per step
         (SPEC unchanged — a read-only compute view). Mask-INDEPENDENT, so the result is shared

--- a/param_decomp/targets/glu_transformer.py
+++ b/param_decomp/targets/glu_transformer.py
@@ -366,6 +366,21 @@ def _tap_layer(key: str) -> int:
     return parse_site_name(key)[0]
 
 
+_TAP_CLASS_BY_KIND = {
+    "q": "h1", "k": "h1", "v": "h1", "o": "attn_y",
+    "gate": "mlp_in", "up": "mlp_in", "down": "down_in",
+}  # fmt: skip
+"""The block intermediate a site kind's tap reads — the activation entering that site's
+weight on the frozen path (`_clean_forward`'s per-class scan-ys stacks are keyed by
+these)."""
+
+
+def _tap_class(key: str) -> str:
+    if key.startswith("resid."):
+        return "resid"
+    return _TAP_CLASS_BY_KIND[parse_site_name(key)[1]]
+
+
 def _per_kind_dims(components: DecompVU) -> dict[str, tuple[int, int, int]]:
     """Per decomposed KIND, the `(d_in, C, d_out)` shared across its layers — asserting
     uniformity, the precondition for the layer-`lax.scan` masked forward (it stacks each
@@ -653,15 +668,9 @@ class GLUDecomposedModel(eqx.Module):
         stack so XLA compiles one block body instead of unrolling all 32 layers (the compile
         fix for the full model; the scan reassociates float ops vs an unrolled loop, within
         fp32 tolerance)."""
-
-        def block(x: Array, layer: GLULayer) -> tuple[Array, None]:
-            x = x + layer.attn(rms_norm(x, layer.ln1, self.eps), self.inv_freq)
-            x = x + _clean_mlp_out(layer, rms_norm(x, layer.ln2, self.eps))
-            return x, None
-
-        x, _ = jax.lax.scan(block, self.embed_tokens(inputs), self.stacked)
-        x = rms_norm(x, self.norm, self.eps)
-        return x @ self.lm_head.T
+        logits, _ = self._clean_forward(inputs, (), to_logits=True)
+        assert logits is not None
+        return logits
 
     def read_activations(
         self, inputs: Int[Array, "b t"], wanted: tuple[str, ...]
@@ -674,34 +683,68 @@ class GLUDecomposedModel(eqx.Module):
         that site's weight on the frozen path: `q/k/v_proj` ← post-LN1 residual, `o_proj` ←
         the attention output, `gate/up_proj` ← post-LN2 residual, `down_proj` ←
         `silu(gate)·up`). The residual is threaded identically to `clean_output`; the
-        per-site intermediates come from the same RMSNorm/attn/MLP math. Stops once the last
-        requested key's block is fully covered (no wasted block compute past it)."""
-        wanted_set = frozenset(wanted)
-        last = max(_tap_layer(key) for key in wanted)
-        taps: dict[str, Array] = {}
-        x = self.embed_tokens(inputs)
-        for layer in range(self.n_layer):
-            block = jax.tree.map(lambda a, li=layer: a[li], self.stacked)
-            if f"resid.{layer}" in wanted_set:
-                taps[f"resid.{layer}"] = x
-            attn = block.attn
-            h1 = rms_norm(x, block.ln1, self.eps)
-            attn_y = attn.core(h1 @ attn.wq.T, h1 @ attn.wk.T, h1 @ attn.wv.T, self.inv_freq)
-            post_attn = x + attn_y @ attn.wo.T
-            mlp_in = rms_norm(post_attn, block.ln2, self.eps)
-            down_in = jax.nn.silu(mlp_in @ block.Wg.T) * (mlp_in @ block.Wu.T)
-            for kind, site_input in (
-                ("q", h1), ("k", h1), ("v", h1), ("o", attn_y),
-                ("gate", mlp_in), ("up", mlp_in), ("down", down_in),
-            ):  # fmt: skip
-                name = site_name(layer, kind)
-                if name in wanted_set:
-                    taps[name] = site_input
-            x = post_attn + down_in @ block.Wd.T
-            if layer == last:
-                break
-        assert set(taps) == wanted_set, (sorted(taps), sorted(wanted))
+        per-site intermediates come from the same RMSNorm/attn/MLP math. The scan covers
+        only the blocks up to the last requested key's (no wasted block compute past it)."""
+        assert wanted, "read_activations with no wanted taps"
+        _, taps = self._clean_forward(inputs, wanted, to_logits=False)
         return taps
+
+    def clean_output_and_activations(
+        self, inputs: Int[Array, "b t"], wanted: tuple[str, ...]
+    ) -> tuple[Array, dict[str, Array]]:
+        logits, taps = self._clean_forward(inputs, wanted, to_logits=True)
+        assert logits is not None
+        return logits, taps
+
+    def _clean_forward(
+        self, inputs: Int[Array, "b t"], wanted: tuple[str, ...], *, to_logits: bool
+    ) -> tuple[Array | None, dict[str, Array]]:
+        """The frozen-path `lax.scan` behind `clean_output` / `read_activations` /
+        `clean_output_and_activations`. Taps ride out as scan ys — one stacked
+        `[tapped_depth, b, t, d]` array per block INTERMEDIATE `wanted` reads (see
+        `_tap_class`) — and the flat tap dict is indexed out of the stacks after the scan
+        (the `_run_masked_forward` per-kind-ys pattern; no per-layer `lax.cond`). Only the
+        block prefix up to the last tapped layer emits ys; the remaining depth (run only
+        when `to_logits`) scans the same body emitting nothing — so an unread intermediate
+        or an untapped layer stacks nothing."""
+
+        def block_body(emit: frozenset[str]):
+            def block(x: Array, layer: GLULayer) -> tuple[Array, dict[str, Array]]:
+                # `FrozenAttn.__call__` / `_clean_mlp_out` expanded — identical math
+                # (family behavior rides in `attn.core`'s `_prep_qk`), with the tap
+                # intermediates in scope.
+                attn = layer.attn
+                h1 = rms_norm(x, layer.ln1, self.eps)
+                attn_y = attn.core(h1 @ attn.wq.T, h1 @ attn.wk.T, h1 @ attn.wv.T, self.inv_freq)
+                post_attn = x + attn_y @ attn.wo.T
+                mlp_in = rms_norm(post_attn, layer.ln2, self.eps)
+                down_in = jax.nn.silu(mlp_in @ layer.Wg.T) * (mlp_in @ layer.Wu.T)
+                intermediates = {
+                    "resid": x, "h1": h1, "attn_y": attn_y,
+                    "mlp_in": mlp_in, "down_in": down_in,
+                }  # fmt: skip
+                return post_attn + down_in @ layer.Wd.T, {c: intermediates[c] for c in emit}
+
+            return block
+
+        def slice_layers(lo: int, hi: int) -> GLULayer:
+            return jax.tree.map(lambda a: a[lo:hi], self.stacked)
+
+        tapped_depth = 1 + max((_tap_layer(key) for key in wanted), default=-1)
+        x = self.embed_tokens(inputs)
+        stacks: dict[str, Array] = {}
+        if tapped_depth:
+            emit = frozenset(_tap_class(key) for key in wanted)
+            x, stacks = jax.lax.scan(block_body(emit), x, slice_layers(0, tapped_depth))
+        taps = {key: stacks[_tap_class(key)][_tap_layer(key)] for key in wanted}
+        if not to_logits:
+            return None, taps
+        if tapped_depth < self.n_layer:
+            x, _ = jax.lax.scan(
+                block_body(frozenset()), x, slice_layers(tapped_depth, self.n_layer)
+            )
+        x = rms_norm(x, self.norm, self.eps)
+        return x @ self.lm_head.T, taps
 
     def _run_masked_forward(
         self,

--- a/param_decomp/targets/llama_simple_mlp.py
+++ b/param_decomp/targets/llama_simple_mlp.py
@@ -375,6 +375,13 @@ class SimpleMLPDecomposedModel(eqx.Module):
         assert set(taps) == wanted_set, (sorted(taps), sorted(wanted))
         return taps
 
+    def clean_output_and_activations(
+        self, inputs: Int[Array, "b t"], wanted: tuple[str, ...]
+    ) -> tuple[Array, dict[str, Array]]:
+        # Two frozen passes: the blocks are an unstacked Python loop over few layers, so
+        # there is no scan to emit the taps from and no compile pressure to fuse.
+        return self.clean_output(inputs), self.read_activations(inputs, wanted)
+
     def _run_masked_forward(
         self,
         vu: DecompVU,

--- a/param_decomp/tests/test_attn_patterns_eval.py
+++ b/param_decomp/tests/test_attn_patterns_eval.py
@@ -216,6 +216,12 @@ class _PositionlessStub(eqx.Module):
         del resid, wanted
         raise AssertionError("positionless stub fn must not be called")
 
+    def clean_output_and_activations(
+        self, resid: Any, wanted: tuple[str, ...]
+    ) -> tuple[Any, dict[str, jax.Array]]:
+        del resid, wanted
+        raise AssertionError("positionless stub fn must not be called")
+
     def prepare_compute_weights(self, vu: Any) -> Any:
         return vu
 

--- a/param_decomp/tests/test_eval.py
+++ b/param_decomp/tests/test_eval.py
@@ -72,6 +72,12 @@ class _PositionlessStub(eqx.Module):
         del resid, wanted
         raise AssertionError("positionless stub fn must not be called")
 
+    def clean_output_and_activations(
+        self, resid: Any, wanted: tuple[str, ...]
+    ) -> tuple[Any, dict[str, jax.Array]]:
+        del resid, wanted
+        raise AssertionError("positionless stub fn must not be called")
+
     def prepare_compute_weights(self, vu: Any) -> Any:
         return vu
 

--- a/param_decomp/tests/test_generic_model_io.py
+++ b/param_decomp/tests/test_generic_model_io.py
@@ -95,6 +95,11 @@ class SyntheticDecomposedModel(eqx.Module):
         assert wanted == (SITE,), wanted
         return {SITE: self._residual(inputs)}
 
+    def clean_output_and_activations(
+        self, inputs: dict[str, Array], wanted: tuple[str, ...]
+    ) -> tuple[tuple[Array, Array], dict[str, Array]]:
+        return self.clean_output(inputs), self.read_activations(inputs, wanted)
+
     def prepare_compute_weights(self, vu: DecompVU) -> DecompVU:
         return vu
 

--- a/param_decomp/tests/test_llama8b.py
+++ b/param_decomp/tests/test_llama8b.py
@@ -325,6 +325,31 @@ def test_attention_sites_clean_and_masked_identity():
     assert deltas["layers.4.self_attn.v_proj"].shape == (kvd, cfg.n_embd)
 
 
+def test_clean_output_and_activations_shares_the_forward():
+    """The fused accessor must be exactly the two separate calls (SPEC S3+S4): taps
+    bit-equal to `read_activations`, and — when the taps reach the last block, every
+    production config — clean logits bit-equal to `clean_output` (one full-depth scan,
+    no tail; a mid-stack tap cutoff may recompile the tail within fp32 tolerance).
+    Also pins tap invariance to the `wanted` set (a tap can't depend on its neighbors)."""
+    cfg = _tiny_cfg()
+    sites = _mlp_sites(cfg, 3, 6, 8)
+    lm = _tiny_decomposed_lm(cfg, sites, jax.random.PRNGKey(0))
+    tokens = jax.random.randint(jax.random.PRNGKey(2), (2, 16), 0, cfg.vocab_size)
+
+    resid_taps = tuple(f"resid.{i}" for i in range(cfg.n_layer))
+    wanted = resid_taps + lm.site_names
+    logits, taps = lm.clean_output_and_activations(tokens, wanted)
+    assert jnp.array_equal(logits, lm.clean_output(tokens)), "fused clean logits drifted"
+    separate = lm.read_activations(tokens, wanted)
+    assert set(taps) == set(wanted)
+    for key in wanted:
+        assert jnp.array_equal(taps[key], separate[key]), key
+
+    subset = ("resid.0", "resid.5", site_name(4, "gate"))
+    for key, tap in lm.read_activations(tokens, subset).items():
+        assert jnp.array_equal(tap, separate[key]), key
+
+
 def test_o_site_masks_attention_output():
     cfg = _tiny_cfg()
     o_site = "layers.4.self_attn.o_proj"

--- a/param_decomp/train.py
+++ b/param_decomp/train.py
@@ -262,10 +262,9 @@ def make_train_step(
         imp_min_param = annealed_imp_min_param(step_f32, total_steps, imp_min)
 
         batch = batch_sharded(batch)
-        with jax.named_scope("pd_clean_fwd"):
-            clean_output = jax.lax.stop_gradient(batch_sharded(model.clean_output(batch)))
-        with jax.named_scope("pd_read_taps"):
-            taps = model.read_activations(batch, state.ci_fn.input_names)
+        with jax.named_scope("pd_clean_fwd_and_taps"):
+            clean_output, taps = model.clean_output_and_activations(batch, state.ci_fn.input_names)
+            clean_output = jax.lax.stop_gradient(batch_sharded(clean_output))
         # `leading` (batch, *positions) — the shape masks/sources/routes live in. Sourced
         # from a tap (always `[*leading, d_tap]`), not the opaque batch, so the engine never
         # assumes the batch's rank/feature dim.

--- a/param_decomp_lab/experiments/lm/load_run.py
+++ b/param_decomp_lab/experiments/lm/load_run.py
@@ -181,9 +181,11 @@ def open_jax_run(run_dir: Path, step: int | None = None) -> LoadedJaxRun:
         ci_fn: CIFn,
         token_ids: Int[Array, "B T"],
     ) -> tuple[dict[str, Array], dict[str, Array], Array]:
-        clean_output = model.clean_output(token_ids)
-        taps = model.read_activations(token_ids, ci_fn.input_names)
-        site_inputs = model.read_activations(token_ids, site_names)
+        clean_output, all_taps = model.clean_output_and_activations(
+            token_ids, ci_fn.input_names + site_names
+        )
+        taps = {k: all_taps[k] for k in ci_fn.input_names}
+        site_inputs = {k: all_taps[k] for k in site_names}
 
         components_bf16 = cast_floating(components, COMPUTE_DT)
         ci_fn_bf16 = cast_floating(ci_fn, COMPUTE_DT)

--- a/param_decomp_lab/experiments/resid_mlp/model.py
+++ b/param_decomp_lab/experiments/resid_mlp/model.py
@@ -390,6 +390,11 @@ class ResidMLPDecomposedModel(eqx.Module):
         inputs = site_inputs(self.target, resid)
         return {k: inputs[k] for k in wanted}
 
+    def clean_output_and_activations(
+        self, resid: Float[Array, "B d_embed"], wanted: tuple[str, ...]
+    ) -> tuple[Array, dict[str, Array]]:
+        return self.clean_output(resid), self.read_activations(resid, wanted)
+
     def prepare_compute_weights(self, vu: DecompVU) -> DecompVU:
         """Identity: ResidMLP weights are tiny + replicated, nothing to stack/gather/share."""
         return vu

--- a/param_decomp_lab/experiments/tms/model.py
+++ b/param_decomp_lab/experiments/tms/model.py
@@ -322,6 +322,11 @@ class TMSDecomposedModel(eqx.Module):
         inputs = site_inputs(self.target, resid)
         return {k: inputs[k] for k in wanted}
 
+    def clean_output_and_activations(
+        self, resid: Float[Array, "B n_features"], wanted: tuple[str, ...]
+    ) -> tuple[Array, dict[str, Array]]:
+        return self.clean_output(resid), self.read_activations(resid, wanted)
+
     def prepare_compute_weights(self, vu: DecompVU) -> DecompVU:
         """Identity: TMS weights are tiny + replicated, nothing to stack/gather/share."""
         return vu


### PR DESCRIPTION
## Description

Bridge task: **scan-read-activations-taps** (2026-07-10 JAX compile-hygiene audit finding).

`read_activations` was a Python `for layer in range(n_layer)` — the largest unrolled region left in the step HLO, inlined into the train step and all seven jitted eval/metric steps — and a duplicate of the scanned `clean_output` forward on the same batch two lines earlier in the train step (XLA won't CSE scan vs unroll). Authored against `llama8b.py`; after #987 the machinery lives in `targets/glu_transformer.py`, so the fix now covers **llama8b and qwen3** at once (rebased onto a2c297b43).

Now `clean_output` / `read_activations` / the new `clean_output_and_activations` all route through one private `_clean_forward` `lax.scan` (SPEC S3/S4 semantics unchanged):

- Taps ride out as **scan ys** — one stacked `[tapped_depth, b, t, d]` array per block intermediate (`resid` / post-LN1 / attn-out / post-LN2 / MLP-inner), indexed into the flat tap dict after the scan (the `_run_masked_forward` per-kind-ys pattern). No per-layer `lax.cond` (the scan-recon-chunks lesson). Family behavior (Qwen3 QK-norm) rides in `attn.core` exactly as the unrolled version had it.
- Only the block prefix up to the last tapped layer emits ys; the remainder scans the same body emitting nothing — the old early-`break` compute property, preserved statically.
- **`clean_output_and_activations`** (new `DecomposedModel` protocol method; trivial two-call impl on SimpleMLP/TMS/ResidMLP) serves the two steps that need clean logits AND taps on the same batch — train and fast eval — from ONE frozen forward. Harvest's `load_run` forward folds its three frozen passes (clean + CI taps + site inputs) into one fused call likewise.

Measured (32L/224-site structure at toy width, canonical 4-chunk recon, both arms one CPU node): HLO text 9.91→9.49 MB (−4%), CPU compile 54.2→49.9s. Per the 2026-06-30 review doc the step-time win is small (~0.3%: `read_activations` gathers no V/U and the step is gather-bound) — the payoff is HLO/compile across all eight jitted steps plus one whole frozen forward removed per train/eval step. A 4-node dp32 GPU `mem_profile` A/B (compile time + peak memory, per the task brief's memory caveat) is in flight; numbers land on the bridge thread and here.

## Related Issue

Bridge thread `scan-read-activations-taps`. Coordinated with `targets-refactor` (#966): agreed there that this PR's scan shape is what their remaining carve builds on.

## Motivation and Context

Compile hygiene: everything else on the layer axis is already `lax.scan`'d (`clean_output`, masked forwards, chunkwise CI fn). This removes the last per-layer unroll and a redundant frozen forward per jitted step.

## How Has This Been Tested?

- **Pinned pre-refactor CPU fixtures** (557 arrays: clean logits, taps for 4 `wanted` shapes, 3-step train trajectories in BOTH remat modes, eval-step metrics), re-pinned at the rebased base a2c297b43: `clean_output` logits **bit-identical**; taps vs the old *unrolled* forward within fp32 reassociation (≤1.7e-5 abs — the scan-vs-unroll class `clean_output`'s docstring already documents; same order as SPEC D4's accepted 2.2e-6), propagating to ≤3.9e-6 abs over the 3-step trajectory. Taps are now bit-identical to the residual the recon target actually threads (previously they came from a separately-compiled forward).
- **New test** `test_clean_output_and_activations_shares_the_forward`: fused accessor EXACTLY equals the separate methods (and taps are invariant to the `wanted` set); at full tapped depth (every production config) fused clean logits are bit-equal to `clean_output`.
- Full suite on a SLURM CPU node: pytest green at default devices and `--xla_force_host_platform_device_count=4`, basedpyright 0 errors, ruff clean (re-running post-rebase; will confirm on the thread).

## Does this PR introduce a breaking change?

`DecomposedModel` gains one protocol method (`clean_output_and_activations`); all in-repo targets + test stubs implement it. `read_activations` now asserts `wanted` is non-empty (previously crashed on `max()` of empty). No config or checkpoint format changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Crew-Address: task/scan-read-activations-taps