### PR TITLE
fix(compile): pre-create the XLA cache dirs group-writable — first-creator ownership locked other users out

### DIFF
--- a/param_decomp/CLAUDE.md
+++ b/param_decomp/CLAUDE.md
@@ -300,6 +300,14 @@ write cache entries from the first process … contention for writes on some fil
 so all ranks read but only rank 0 writes — no shared-FS race. Requires the cache dir on a
 shared FS, which `$PARAM_DECOMP_OUT_DIR` already is.
 
+The cache dir is shared across USERS, and jax >= 0.10 auto-enables the XLA per-fusion
+autotune side cache under it — whose dirs XLA creates itself with hardcoded 0755
+(umask-independent), so whichever user ran first used to lock everyone else out
+(PERMISSION_DENIED at the first train step). Every jax entrypoint therefore pre-creates
+the cache tree group-writable via `compile_cache.ensure_group_writable_cache_dirs`
+before jax initializes the cache (trainer: rank 0 in the LM composition root;
+pretrainer: `_maybe_enable_compilation_cache`).
+
 ### Compile time (measured 2026-07-06 probe grid; full data in PR #956)
 
 - **Keep seeded inits few-outputs-under-jit**: a jit returning n_sites (hundreds of)

--- a/param_decomp/compile_cache.py
+++ b/param_decomp/compile_cache.py
@@ -1,0 +1,23 @@
+"""Shared-FS layout of the persistent XLA compilation cache."""
+
+import stat
+from pathlib import Path
+
+
+def ensure_group_writable_cache_dirs(cache_dir: Path) -> None:
+    """Pre-create the XLA cache dirs group-writable so first-creator identity stops mattering.
+
+    The cache dir is shared across users, but XLA itself creates the per-fusion autotune
+    subdir (auto-enabled alongside the persistent cache on jax >= 0.10, see
+    `jax_persistent_cache_enable_xla_caches`) and its `tmp/` with hardcoded 0755 —
+    umask-independent — so whichever user's run touched the cache first left everyone
+    else dying with PERMISSION_DENIED at the first train step. Creating the dirs here,
+    before jax initializes the cache, removes that dependence. Dirs that already have
+    group write are left alone; a group-unwritable dir owned by someone else makes the
+    chmod fail fast at startup instead of one compile (~25 min) later.
+    """
+    autotune_dir = cache_dir / "xla_gpu_per_fusion_autotune_cache_dir"
+    for d in (cache_dir, autotune_dir, autotune_dir / "tmp"):
+        d.mkdir(parents=True, exist_ok=True)
+        if d.stat().st_mode & stat.S_IWGRP == 0:
+            d.chmod(0o2775)

--- a/param_decomp/tests/test_compile_cache.py
+++ b/param_decomp/tests/test_compile_cache.py
@@ -1,0 +1,35 @@
+import stat
+from pathlib import Path
+
+from param_decomp.compile_cache import ensure_group_writable_cache_dirs
+
+
+def _mode(p: Path) -> int:
+    return stat.S_IMODE(p.stat().st_mode)
+
+
+def test_creates_cache_tree_group_writable(tmp_path: Path):
+    cache_dir = tmp_path / "xla_compilation_cache"
+    ensure_group_writable_cache_dirs(cache_dir)
+    autotune_dir = cache_dir / "xla_gpu_per_fusion_autotune_cache_dir"
+    for d in (cache_dir, autotune_dir, autotune_dir / "tmp"):
+        assert _mode(d) & stat.S_IWGRP
+
+
+def test_repairs_group_unwritable_dirs(tmp_path: Path):
+    cache_dir = tmp_path / "xla_compilation_cache"
+    autotune_dir = cache_dir / "xla_gpu_per_fusion_autotune_cache_dir"
+    autotune_dir.mkdir(parents=True)
+    autotune_dir.chmod(0o755)
+    (autotune_dir / "tmp").mkdir(mode=0o755)
+    ensure_group_writable_cache_dirs(cache_dir)
+    assert _mode(autotune_dir) & stat.S_IWGRP
+    assert _mode(autotune_dir / "tmp") & stat.S_IWGRP
+
+
+def test_leaves_already_writable_dirs_alone(tmp_path: Path):
+    cache_dir = tmp_path / "xla_compilation_cache"
+    ensure_group_writable_cache_dirs(cache_dir)
+    cache_dir.chmod(0o2770)
+    ensure_group_writable_cache_dirs(cache_dir)
+    assert _mode(cache_dir) == 0o2770

--- a/param_decomp_lab/experiments/lm/run.py
+++ b/param_decomp_lab/experiments/lm/run.py
@@ -61,6 +61,7 @@ from param_decomp.built_run import (
     EvalConfig,
     TargetSites,
 )
+from param_decomp.compile_cache import ensure_group_writable_cache_dirs
 from param_decomp.configs import ResumeProvenance
 from param_decomp.data import BatchSchedule, ShardServer, scan_shards
 from param_decomp.eval import make_eval_step
@@ -114,7 +115,10 @@ def _enable_persistent_compilation_cache(out_dir: Path) -> Path:
     ranks point at the same shared-FS path. Only process 0 writes (jax gates the write on
     `process_id == 0` to avoid shared-FS write contention); every rank reads. Must run
     after `init_distributed` (the rank gate reads the distributed state) and before the
-    first compile."""
+    first compile. jax >= 0.10 also auto-enables the XLA per-fusion autotune side cache
+    under this dir; rank 0 pre-creates its dirs group-writable
+    (`ensure_group_writable_cache_dirs`) because XLA would create them 0755, locking
+    every other user out of the shared cache."""
     cache_dir = out_dir.parent / "xla_compilation_cache"
     jax.config.update("jax_compilation_cache_dir", str(cache_dir))
     jax.config.update("jax_persistent_cache_min_compile_time_secs", 60.0)
@@ -560,7 +564,7 @@ def main(config: Path, run_id: str) -> None:
 
     is_main = jax.process_index() == 0
     if is_main:
-        cache_dir.mkdir(parents=True, exist_ok=True)
+        ensure_group_writable_cache_dirs(cache_dir)
         built.run.run_dir.mkdir(parents=True, exist_ok=True)
         setup_logger(built.run.run_dir / "logs.log")
         _pin_config_copy(built.run.run_dir, LAUNCH_CONFIG_FILENAME, config)

--- a/pretrain/train.py
+++ b/pretrain/train.py
@@ -37,6 +37,7 @@ from jax.typing import ArrayLike
 from jaxtyping import Array, Float, Int
 from orbax.checkpoint.type_handlers import ArrayHandler, register_type_handler
 
+from param_decomp.compile_cache import ensure_group_writable_cache_dirs
 from param_decomp.data import BatchSchedule, ShardServer, scan_shards
 from param_decomp.sharding import hsdp_mesh, init_distributed
 from pretrain.cache import (
@@ -396,6 +397,7 @@ def _maybe_enable_compilation_cache(cfg: PretrainConfig) -> None:
     if cfg.out_dir is None:
         return
     cache = cfg.out_dir.parent / "xla_compilation_cache"
+    ensure_group_writable_cache_dirs(cache)
     jax.config.update("jax_compilation_cache_dir", str(cache))
     jax.config.update("jax_persistent_cache_min_compile_time_secs", 60)
 


### PR DESCRIPTION
## Description
The shared `$PARAM_DECOMP_OUT_DIR/xla_compilation_cache` is multi-user, but jax >= 0.10 auto-enables the XLA per-fusion autotune side cache under it, and XLA creates `xla_gpu_per_fusion_autotune_cache_dir/` and its `tmp/` itself with hardcoded 0755 (umask-independent — that's why the *files* inside were 664 but the dirs weren't group-writable). Whichever user's run touched the cache first locked every other user out: their runs died with `PERMISSION_DENIED` writing `tmp_per_fusion_cache_*.textproto` at the first train step.

New `param_decomp/compile_cache.py::ensure_group_writable_cache_dirs` pre-creates the cache tree group-writable before jax initializes the cache; both jax entrypoints call it (LM trainer on rank 0, pretrainer in `_maybe_enable_compilation_cache`). Dirs that already have group write are untouched; a broken dir owned by someone else now fails fast at startup instead of one ~25-min compile later.

Note for #<jax-worker-persistent-cache>: `bridge/task-jax-worker-persistent-cache` introduces a `param_decomp/compile_cache.py` of its own (the one-policy-definition refactor). Same module name is deliberate — on merge, combine both functions in that module and call `ensure_group_writable_cache_dirs` from its `enable_persistent_compilation_cache`.

## Related Issue
Bridge task `xla-autotune-cache-group-unwritable` (run p-9e6a4af3 / job 1052115 was the observed casualty). The live shared dir was already healed by hand (swapped for a 2775 copy, 670 autotune entries preserved); this PR is the structural fix so first-creation never matters again.

## Motivation and Context
Any non-first user's `pd-lm` run was dead on arrival at the first train step.

## How Has This Been Tested?
- New `param_decomp/tests/test_compile_cache.py`: creates the tree group-writable, repairs a 0755 tree, leaves already-writable dirs untouched (3 passed).
- `make check` clean (ruff + basedpyright).
- Imported both entrypoints and ran the helper against the real healed production cache dir — verified it's a byte-for-byte no-op there.

## Does this PR introduce a breaking change?
No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Crew-Address: task/xla-autotune-cache-group-unwritable