### PR TITLE
config(pile_ppgd_bsc): imp-min eps 1e-12 -> 1e-6

### DIFF
--- a/param_decomp/configs/pile_ppgd_bsc.yaml
+++ b/param_decomp/configs/pile_ppgd_bsc.yaml
@@ -22,6 +22,9 @@ run_name: ai-jax-pile4l-ppgd-bsc
 #      address it).
 #   3. cadence.save_every: null -> 5000, keep_last null -> 2 (upstream saves
 #      nothing; the JAX leg checkpoints for requeue-resume + offline eval).
+#   4. ImportanceMinimalityLoss.eps: 1e-12 -> 1e-6, matching the L18-23 line. The
+#      imp-min gradient p(c+eps)^(p-1) is singular at c=0 for p<1, capped only by
+#      eps; at 1e-12 the cap is ~6e6 per dead component's CI late in the p-anneal.
 # Everything else (pd losses/optimizers/CI fn, 400k steps, batch 64, eval set) is
 # upstream-identical.
 cadence:
@@ -130,7 +133,7 @@ pd:
       coeff: 1.0e-04
       reference_token_count: 65536
     coeff: 0.0002
-    eps: 1.0e-12
+    eps: 1.0e-06
     pnorm:
       start_val: 2.0
       fn_type: linear


### PR DESCRIPTION
## Description
One-line change to the base pile-4L config (`param_decomp/configs/pile_ppgd_bsc.yaml`): `ImportanceMinimalityLoss.eps` 1e-12 → 1e-6, plus a note in the file's DOCUMENTED-EDITS-vs-upstream list.

## Motivation and Context
Requested by Oli on the board task [run-some-random-architecture-ideas]: the standard regime for architecture experiments is "jose-ish with 1 key change: imp min epsilon 1e-6 not 1e-12", so the base config should carry it.

Why it matters: the imp-min gradient `p(c+eps)^(p-1)` is singular at c=0 for p<1 and capped only by eps — at p=0.4 with eps=1e-12 the cap is ~6e6 per dead component's CI, the suspected driver of the endgame recon ramp seen in all arms of the imp-min Pareto sweep. 1e-6 is also what the L18-23 Llama-8B line already runs (explicit override in that config family).

Note: `llama8b_l18_C49k_200k.yaml`, `llama8b_l18_b128_cmp32.yaml`, and `pile_pgd1.yaml` still carry 1e-12 — left untouched, this PR scopes to the base config as asked.

## Related Issue
Board task `run-some-random-architecture-ideas` (bridge).

## How Has This Been Tested?
Config parses through the pydantic schema: `LMExperimentConfig(**yaml)` validates and reports `imp-min eps = 1e-06`.

## Does this PR introduce a breaking change?
No code change. Runs launched from this config after merge get eps=1e-6; resume of existing runs is unaffected (resume reads the run dir's pinned `launch_config.yaml`, never the live checkout).

Crew-Address: task/run-some-random-architecture-ideas

🤖 Generated with [Claude Code](https://claude.com/claude-code)