### PR TITLE
fix(pd-lm): SIGPIPE race in node-setup driver check kills 16-node jobs

### DIFF
--- a/param_decomp_lab/experiments/lm/launch.py
+++ b/param_decomp_lab/experiments/lm/launch.py
@@ -100,7 +100,7 @@ git fetch --quiet --depth 1 "file://{source_repo}" "{snapshot_ref}"
 git checkout --quiet FETCH_HEAD
 cp "{run_dir}/.env" .env
 unset VIRTUAL_ENV
-DRIVER_MAJOR=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n 1 | cut -d. -f1)
+DRIVER_MAJOR=$(nvidia-smi --id=0 --query-gpu=driver_version --format=csv,noheader | cut -d. -f1)
 if [ "$DRIVER_MAJOR" -ge 580 ]; then CUDA_EXTRA=cuda13; else CUDA_EXTRA=cuda; fi
 echo "cuda extra: $CUDA_EXTRA (driver major $DRIVER_MAJOR)"
 uv sync --all-packages --no-dev --extra "$CUDA_EXTRA" --link-mode copy -q


### PR DESCRIPTION
The per-node workspace setup runs under `set -euo pipefail` and gated the CUDA extra on `nvidia-smi --query-gpu=driver_version ... | head -n 1 | cut ...`. On an 8-GPU node nvidia-smi prints 8 lines; `head -n 1` exits after the first, and when nvidia-smi loses the race it dies of SIGPIPE (exit 141) → pipefail fails the pipeline → `set -e` kills the srun task → SLURM cancels all 16 nodes seconds into the job.

Observed failures with this exact signature: jobs 172348 and 172349 (dan.braun, Jul 8) and 174502 and 174513 (pd-user, Jul 13) — roughly a coin flip per 16-node launch, always written off as "node flakiness, retry".

Fix: query only GPU 0 (`nvidia-smi --id=0`) — single output line, nothing truncates the pipe, no behavior change otherwise.

Verified: job 174520 (16 nodes, memprobe for run p-077fe120) launched with the patched setup script; all 16 nodes passed the driver check and the run completed.

Context: task:profile-llama-32b-cw-east-artifacts

Crew-Address: task/profile-llama-32b-cw-east-artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)