### PR TITLE
fix(pd-lm): SIGPIPE-proof the driver-version detection in the node-setup script

### DIFF
--- a/param_decomp_lab/experiments/lm/launch.py
+++ b/param_decomp_lab/experiments/lm/launch.py
@@ -100,7 +100,7 @@ git fetch --quiet --depth 1 "file://{source_repo}" "{snapshot_ref}"
 git checkout --quiet FETCH_HEAD
 cp "{run_dir}/.env" .env
 unset VIRTUAL_ENV
-DRIVER_MAJOR=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n 1 | cut -d. -f1)
+DRIVER_MAJOR=$(nvidia-smi --id=0 --query-gpu=driver_version --format=csv,noheader | cut -d. -f1)
 if [ "$DRIVER_MAJOR" -ge 580 ]; then CUDA_EXTRA=cuda13; else CUDA_EXTRA=cuda; fi
 echo "cuda extra: $CUDA_EXTRA (driver major $DRIVER_MAJOR)"
 uv sync --all-packages --no-dev --extra "$CUDA_EXTRA" --link-mode copy -q


### PR DESCRIPTION
## Description

The generated sbatch node-setup script detects the CUDA extra via
`nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -n 1 | cut -d. -f1`.
`nvidia-smi` writes one line per GPU; `head -n 1` closes the pipe after the first line, and under the script's `set -o pipefail` a late write from nvidia-smi becomes SIGPIPE → exit 141, killing the whole srun step before the workspace even builds. It's a per-node race — observed three times across 1- and 4-node submissions (jobs 1050555, 1050877's requeue, 1090526), and with N nodes per job the odds multiply.

Fix: query GPU 0 alone (`nvidia-smi --id=0 ...`) — `cut` consumes the full stream, no mid-stream pipe close, same `DRIVER_MAJOR`.

## Motivation and Context

Flaky launch failures burn queue time (an opportunistic 4-node allocation dies in 5s and goes back to the end of the line) and look like real breakage.

## How Has This Been Tested?

Patched the submitting checkout and resubmitted the same 4-node probes; generated scripts carry the new line. `nvidia-smi --id=0 --query-gpu=driver_version --format=csv,noheader` verified to emit exactly one line on an 8-GPU node.

## Does this PR introduce a breaking change?

No — submit-side script generation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Crew-Address: task/scan-read-activations-taps