### PR TITLE
feat(init): coupled component initialization (weight_init: kaiming | coupled)

### DIFF
--- a/param_decomp/components.py
+++ b/param_decomp/components.py
@@ -12,7 +12,7 @@ one target.
 from collections.abc import Iterator
 from dataclasses import dataclass
 from functools import cache
-from typing import ClassVar, Generic
+from typing import ClassVar, Generic, Literal
 
 import equinox as eqx
 import jax
@@ -71,6 +71,9 @@ def dequantize_fp8(q: Array, scale: Array) -> Array:
 
 
 VUShape = tuple[int, int, int]  # (d_in, d_out, C)
+
+# How `init_component_stacks` seeds V/U; the config schema (`PDConfig.weight_init`) reuses it.
+WeightInit = Literal["kaiming", "coupled"]
 
 # site name -> (shape group, slot on the group's stack axis); static, canonical site order
 SiteSlots = tuple[tuple[str, VUShape, int], ...]
@@ -150,7 +153,7 @@ class ComponentStacks(eqx.Module, Generic[VULeaf]):
         return lengths
 
 
-def init_stack_arrays(
+def _kaiming_stack_arrays(
     sites: tuple[SiteSpec, ...], key: Array
 ) -> dict[VUShape, tuple[Array, Array]]:
     """Seeded stack init: `{(d_in, d_out, C): (V [g, d_in, C], U [g, C, d_out])}`, vmapped
@@ -169,16 +172,16 @@ def init_stack_arrays(
     return stacked
 
 
-def init_coupled_component_stacks(
+def _coupled_stack_arrays(
     sites: tuple[SiteSpec, ...], target_weights: dict[str, Array], key: Array
-) -> ComponentStacks:
-    """Coupled init: unit-norm seed on the narrow side, wide side its raw W-image.
+) -> dict[VUShape, tuple[Array, Array]]:
+    """Coupled stack init: unit-norm seed on the narrow side, wide side its raw W-image.
 
     `d_in <= d_out`: `v_c ~ unit norm`, `U_c <- (W v_c)^T`; else `u_c ~ unit norm`,
     `V_c <- W^T u_c`. No C-dependent rescale — components sit at W's natural scale and
     the component sum equals W restricted to the seed span (`W V V^T` when V is seeded),
     the delta carrying the complement. One key per site, split in site order; vmapped
-    per shape group like `init_stack_arrays` so the compiled init doesn't scale with
+    per shape group like `_kaiming_stack_arrays` so the compiled init doesn't scale with
     site count."""
     keys = jax.random.split(key, len(sites))
     site_index = {spec.name: idx for idx, spec in enumerate(sites)}
@@ -201,7 +204,7 @@ def init_coupled_component_stacks(
                 return w.T @ u.T, u
 
         stacked[(d_in, d_out, c)] = jax.vmap(seed_v)(ks, ws)
-    return ComponentStacks(stacks=stacked, site_slots=site_slots_for(sites))
+    return stacked
 
 
 def component_stacks_from_sites(vu: dict[str, tuple[Array, Array]]) -> ComponentStacks:
@@ -222,11 +225,25 @@ def component_stacks_from_sites(vu: dict[str, tuple[Array, Array]]) -> Component
     return ComponentStacks(stacks=stacks, site_slots=site_slots_for(sites))
 
 
-def init_component_stacks(sites: tuple[SiteSpec, ...], key: Array) -> ComponentStacks:
-    """Small random fp32 V ~ N(0, d_in^-0.5), U ~ N(0, C^-0.5) per site, built directly in
-    the stacked persistence layout; the weight-delta channel carries the faithfulness
-    residual at init (before faithfulness warmup)."""
-    return ComponentStacks(stacks=init_stack_arrays(sites, key), site_slots=site_slots_for(sites))
+def init_component_stacks(
+    sites: tuple[SiteSpec, ...],
+    key: Array,
+    weight_init: WeightInit = "kaiming",
+    target_weights: dict[str, Array] | None = None,
+) -> ComponentStacks:
+    """Seeded V/U masters in the stacked persistence layout, per `weight_init`:
+    'kaiming' — small random fp32 V ~ N(0, d_in^-0.5), U ~ N(0, C^-0.5), ignores W
+    (the weight-delta channel carries the faithfulness residual at init); 'coupled' —
+    `_coupled_stack_arrays`, seeded from `target_weights` (required there, refused
+    otherwise)."""
+    match weight_init:
+        case "kaiming":
+            assert target_weights is None, "kaiming init draws blind — no target_weights"
+            stacks = _kaiming_stack_arrays(sites, key)
+        case "coupled":
+            assert target_weights is not None, "coupled init seeds from W — pass target_weights"
+            stacks = _coupled_stack_arrays(sites, target_weights, key)
+    return ComponentStacks(stacks=stacks, site_slots=site_slots_for(sites))
 
 
 def site_out(

--- a/param_decomp/components.py
+++ b/param_decomp/components.py
@@ -169,6 +169,41 @@ def init_stack_arrays(
     return stacked
 
 
+def init_coupled_component_stacks(
+    sites: tuple[SiteSpec, ...], target_weights: dict[str, Array], key: Array
+) -> ComponentStacks:
+    """Coupled init: unit-norm seed on the narrow side, wide side its raw W-image.
+
+    `d_in <= d_out`: `v_c ~ unit norm`, `U_c <- (W v_c)^T`; else `u_c ~ unit norm`,
+    `V_c <- W^T u_c`. No C-dependent rescale — components sit at W's natural scale and
+    the component sum equals W restricted to the seed span (`W V V^T` when V is seeded),
+    the delta carrying the complement. One key per site, split in site order; vmapped
+    per shape group like `init_stack_arrays` so the compiled init doesn't scale with
+    site count."""
+    keys = jax.random.split(key, len(sites))
+    site_index = {spec.name: idx for idx, spec in enumerate(sites)}
+    stacked: dict[VUShape, tuple[Array, Array]] = {}
+    for (d_in, d_out, c), specs in vu_shape_groups(sites).items():
+        ws = jnp.stack([target_weights[spec.name] for spec in specs]).astype(jnp.float32)
+        assert ws.shape == (len(specs), d_out, d_in), (ws.shape, (d_in, d_out, c))
+        ks = keys[jnp.array([site_index[spec.name] for spec in specs])]
+        if d_in <= d_out:
+
+            def seed_v(k: Array, w: Array, s: tuple[int, int] = (d_in, c)) -> tuple[Array, Array]:
+                v = jax.random.normal(k, s)
+                v = v / jnp.linalg.norm(v, axis=0, keepdims=True)
+                return v, (w @ v).T
+        else:
+
+            def seed_v(k: Array, w: Array, s: tuple[int, int] = (c, d_out)) -> tuple[Array, Array]:
+                u = jax.random.normal(k, s)
+                u = u / jnp.linalg.norm(u, axis=1, keepdims=True)
+                return w.T @ u.T, u
+
+        stacked[(d_in, d_out, c)] = jax.vmap(seed_v)(ks, ws)
+    return ComponentStacks(stacks=stacked, site_slots=site_slots_for(sites))
+
+
 def component_stacks_from_sites(vu: dict[str, tuple[Array, Array]]) -> ComponentStacks:
     """Build the stacked `ComponentStacks` from a per-site `{name: (V, U)}` dict (site order =
     dict order). The explicit-arrays constructor for toys and tests; the trainer inits

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -1041,6 +1041,14 @@ class PDConfig(BaseConfig):
         default=0,
         description="Random seed for reproducibility, including LM dataset shuffling.",
     )
+    weight_init: Literal["kaiming", "coupled"] = Field(
+        default="kaiming",
+        description="How component V/U are initialized. 'kaiming': iid normal "
+        "(V ~ N(0, d_in^-0.5), U ~ N(0, C^-0.5)), ignores W. 'coupled': unit-norm seed on "
+        "the narrow side, wide side its raw W-image (U_c from (W v_c)^T when d_in <= d_out, "
+        "else V_c from W^T u_c) — W-natural scale, component sum ~ W on a rank-C random "
+        "subspace (the delta carries the complement).",
+    )
     loss_metrics: list[AnyLossMetricConfig] = Field(
         default_factory=list,
         description=(

--- a/param_decomp/configs.py
+++ b/param_decomp/configs.py
@@ -31,6 +31,7 @@ from pydantic import (
 )
 
 from param_decomp.base_config import BaseConfig, Probability
+from param_decomp.components import WeightInit
 from param_decomp.schedule import ScheduleConfig
 
 # ---------------------------------------------------------------------------
@@ -1041,7 +1042,7 @@ class PDConfig(BaseConfig):
         default=0,
         description="Random seed for reproducibility, including LM dataset shuffling.",
     )
-    weight_init: Literal["kaiming", "coupled"] = Field(
+    weight_init: WeightInit = Field(
         default="kaiming",
         description="How component V/U are initialized. 'kaiming': iid normal "
         "(V ~ N(0, d_in^-0.5), U ~ N(0, C^-0.5)), ignores W. 'coupled': unit-norm seed on "

--- a/param_decomp/model.py
+++ b/param_decomp/model.py
@@ -217,6 +217,10 @@ class DecomposedModel(Protocol):
         the recon grid, which stays KL-on-final-logits."""
         ...
 
+    def target_weight(self, name: str) -> Float[Array, "d_out d_in"]:
+        """The frozen target weight W for site `name`, in its stored dtype."""
+        ...
+
     def weight_deltas(self, vu: ComponentStacks) -> dict[str, Float[Array, "d_out d_in"]]:
         """fp32 `W − V@U` per site from the fp32 master `vu`."""
         ...

--- a/param_decomp/run.py
+++ b/param_decomp/run.py
@@ -516,7 +516,8 @@ def run_decomposition_training(
     rules = placement_rules
     if is_main:
         audit = component_stacks_audit(
-            eqx.filter_eval_shape(_partial(init_component_stacks, model.sites), init_key), rules
+            eqx.filter_eval_shape(_partial(init_component_stacks, model.sites), init_key),
+            rules,
         )
         print(
             rules.describe(

--- a/param_decomp/run_state.py
+++ b/param_decomp/run_state.py
@@ -20,7 +20,7 @@ from jaxtyping import Array, PRNGKeyArray
 
 from param_decomp.adversary import PersistentAdversary, init_sources_adam_state
 from param_decomp.ci_fn import ChunkwiseTransformerCIArch, CIFnArch
-from param_decomp.components import WeightInit, component_stacks_from_sites
+from param_decomp.components import WeightInit
 from param_decomp.configs import (
     AdamPGDConfig,
     AdamWOptimizerConfig,
@@ -175,11 +175,7 @@ def init_decomposition(
         case "kaiming":
             target_weights = None
         case "coupled":
-            # The protocol exposes W only through `weight_deltas`; on zero V/U the delta IS W.
-            zero_vu = component_stacks_from_sites(
-                {s.name: (jnp.zeros((s.d_in, s.C)), jnp.zeros((s.C, s.d_out))) for s in model.sites}
-            )
-            target_weights = model.weight_deltas(zero_vu)
+            target_weights = {name: model.target_weight(name) for name in model.site_names}
     # V/U placement derives from the rules table; the CI fn still declares its own
     # per-leaf shardings (the staged placement migration hasn't reached it).
     components = init_component_stacks_placed(

--- a/param_decomp/run_state.py
+++ b/param_decomp/run_state.py
@@ -8,7 +8,6 @@ optimizer-state structure.
 """
 
 from collections.abc import Callable
-from typing import Literal
 
 import equinox as eqx
 import jax
@@ -21,7 +20,7 @@ from jaxtyping import Array, PRNGKeyArray
 
 from param_decomp.adversary import PersistentAdversary, init_sources_adam_state
 from param_decomp.ci_fn import ChunkwiseTransformerCIArch, CIFnArch
-from param_decomp.components import component_stacks_from_sites
+from param_decomp.components import WeightInit, component_stacks_from_sites
 from param_decomp.configs import (
     AdamPGDConfig,
     AdamWOptimizerConfig,
@@ -42,7 +41,6 @@ from param_decomp.schedule import ScheduleConfig
 from param_decomp.targets.glu_transformer_sharding import (
     init_ci_fn_placed,
     init_component_stacks_placed,
-    init_coupled_component_stacks_placed,
     init_sources_sharded,
 )
 from param_decomp.train import Decomposition, TrainingItem, TrainState
@@ -166,26 +164,27 @@ def init_decomposition(
     init_key: PRNGKeyArray,
     mesh: Mesh,
     rules: PlacementRules,
-    weight_init: Literal["kaiming", "coupled"] = "kaiming",
+    weight_init: WeightInit = "kaiming",
 ) -> Decomposition:
     """The trained-product half of `init_train_state`, factored out so a consumer can
     `jax.eval_shape` it to recover the saved `decomposition` item's tree structure
     without building (or knowing about) the optimizers/adversaries (the `weight_init`
     default is safe there — both inits produce the same tree)."""
     ci_key = random.fold_in(init_key, 1)
-    # V/U placement derives from the rules table; the CI fn still declares its own
-    # per-leaf shardings (the staged placement migration hasn't reached it).
     match weight_init:
         case "kaiming":
-            components = init_component_stacks_placed(model.sites, init_key, rules)
+            target_weights = None
         case "coupled":
             # The protocol exposes W only through `weight_deltas`; on zero V/U the delta IS W.
             zero_vu = component_stacks_from_sites(
                 {s.name: (jnp.zeros((s.d_in, s.C)), jnp.zeros((s.C, s.d_out))) for s in model.sites}
             )
-            components = init_coupled_component_stacks_placed(
-                model.sites, model.weight_deltas(zero_vu), init_key, rules
-            )
+            target_weights = model.weight_deltas(zero_vu)
+    # V/U placement derives from the rules table; the CI fn still declares its own
+    # per-leaf shardings (the staged placement migration hasn't reached it).
+    components = init_component_stacks_placed(
+        model.sites, init_key, rules, weight_init, target_weights
+    )
     ci_fn = init_ci_fn_placed(ci_fn_arch, model.sites, ci_key, mesh)
     assert ci_fn.has_position_axis == model.has_position_axis, (
         f"CI fn has_position_axis={ci_fn.has_position_axis} but model declares "

--- a/param_decomp/run_state.py
+++ b/param_decomp/run_state.py
@@ -42,6 +42,7 @@ from param_decomp.schedule import ScheduleConfig
 from param_decomp.targets.glu_transformer_sharding import (
     init_ci_fn_placed,
     init_component_stacks_placed,
+    init_coupled_component_stacks_placed,
     init_sources_sharded,
 )
 from param_decomp.train import Decomposition, TrainingItem, TrainState
@@ -182,8 +183,8 @@ def init_decomposition(
             zero_vu = component_stacks_from_sites(
                 {s.name: (jnp.zeros((s.d_in, s.C)), jnp.zeros((s.C, s.d_out))) for s in model.sites}
             )
-            components = init_component_stacks_placed(
-                model.sites, init_key, rules, target_weights=model.weight_deltas(zero_vu)
+            components = init_coupled_component_stacks_placed(
+                model.sites, model.weight_deltas(zero_vu), init_key, rules
             )
     ci_fn = init_ci_fn_placed(ci_fn_arch, model.sites, ci_key, mesh)
     assert ci_fn.has_position_axis == model.has_position_axis, (

--- a/param_decomp/run_state.py
+++ b/param_decomp/run_state.py
@@ -8,6 +8,7 @@ optimizer-state structure.
 """
 
 from collections.abc import Callable
+from typing import Literal
 
 import equinox as eqx
 import jax
@@ -20,6 +21,7 @@ from jaxtyping import Array, PRNGKeyArray
 
 from param_decomp.adversary import PersistentAdversary, init_sources_adam_state
 from param_decomp.ci_fn import ChunkwiseTransformerCIArch, CIFnArch
+from param_decomp.components import component_stacks_from_sites
 from param_decomp.configs import (
     AdamPGDConfig,
     AdamWOptimizerConfig,
@@ -163,14 +165,26 @@ def init_decomposition(
     init_key: PRNGKeyArray,
     mesh: Mesh,
     rules: PlacementRules,
+    weight_init: Literal["kaiming", "coupled"] = "kaiming",
 ) -> Decomposition:
     """The trained-product half of `init_train_state`, factored out so a consumer can
     `jax.eval_shape` it to recover the saved `decomposition` item's tree structure
-    without building (or knowing about) the optimizers/adversaries."""
+    without building (or knowing about) the optimizers/adversaries (the `weight_init`
+    default is safe there — both inits produce the same tree)."""
     ci_key = random.fold_in(init_key, 1)
     # V/U placement derives from the rules table; the CI fn still declares its own
     # per-leaf shardings (the staged placement migration hasn't reached it).
-    components = init_component_stacks_placed(model.sites, init_key, rules)
+    match weight_init:
+        case "kaiming":
+            components = init_component_stacks_placed(model.sites, init_key, rules)
+        case "coupled":
+            # The protocol exposes W only through `weight_deltas`; on zero V/U the delta IS W.
+            zero_vu = component_stacks_from_sites(
+                {s.name: (jnp.zeros((s.d_in, s.C)), jnp.zeros((s.C, s.d_out))) for s in model.sites}
+            )
+            components = init_component_stacks_placed(
+                model.sites, init_key, rules, target_weights=model.weight_deltas(zero_vu)
+            )
     ci_fn = init_ci_fn_placed(ci_fn_arch, model.sites, ci_key, mesh)
     assert ci_fn.has_position_axis == model.has_position_axis, (
         f"CI fn has_position_axis={ci_fn.has_position_axis} but model declares "
@@ -195,7 +209,7 @@ def init_train_state(
     assert isinstance(positions, Positioned) == model.has_position_axis, (
         f"{positions} does not match the model's has_position_axis={model.has_position_axis}"
     )
-    decomposition = init_decomposition(model, ci_fn_arch, init_key, mesh, rules)
+    decomposition = init_decomposition(model, ci_fn_arch, init_key, mesh, rules, pd.weight_init)
     components, ci_fn = decomposition.components, decomposition.ci_fn
     losses = build_loss_terms(pd.loss_metrics, model.site_names)
     persistent = persistent_configs(losses.recon)

--- a/param_decomp/targets/glu_transformer.py
+++ b/param_decomp/targets/glu_transformer.py
@@ -1136,12 +1136,17 @@ class GLUDecomposedModel(eqx.Module):
         assert set(collect_activations) == set(live), (sorted(collect_activations), sorted(live))
         return collect_activations
 
+    def target_weight(self, name: str) -> Array:
+        """The frozen W for site `name` (stored dtype): the site's slice of the stacked
+        per-layer weights."""
+        layer, kind = parse_site_name(name)
+        return _frozen_site_weight(jax.tree.map(lambda a, li=layer: a[li], self.stacked), kind)
+
     def weight_deltas(self, vu: ComponentStacks) -> dict[str, Array]:
         """fp32 `W − V@U` per site from fp32 masters (faithfulness input)."""
         out: dict[str, Array] = {}
         for spec in self.sites:
-            layer, kind = parse_site_name(spec.name)
-            W = _frozen_site_weight(jax.tree.map(lambda a, li=layer: a[li], self.stacked), kind)
+            W = self.target_weight(spec.name)
             V, U = vu.site(spec.name)
             out[spec.name] = (
                 W.astype(jnp.float32) - (V.astype(jnp.float32) @ U.astype(jnp.float32)).T

--- a/param_decomp/targets/glu_transformer_sharding.py
+++ b/param_decomp/targets/glu_transformer_sharding.py
@@ -45,6 +45,7 @@ unsharded tree per process). A non-dividing declared shard axis is a loud crash 
 placement construction / inside `.shardings` (fail-fast), never a silent replicate.
 """
 
+from collections.abc import Callable
 from functools import partial
 
 import equinox as eqx
@@ -77,6 +78,7 @@ __all__ = [
     "hsdp_mesh",
     "place_target",
     "init_component_stacks_placed",
+    "init_coupled_component_stacks_placed",
     "init_ci_fn_placed",
     "init_sources_sharded",
     "shard_batch",
@@ -89,25 +91,37 @@ def place_target(tgt: GLUDecomposedModel, mesh: Mesh) -> GLUDecomposedModel:
     return place_via_shardings(tgt, tgt.shardings(mesh))
 
 
-def init_component_stacks_placed(
-    sites: tuple[SiteSpec, ...],
-    key: PRNGKeyArray,
+def _init_component_stacks_via(
+    init: "Callable[..., ComponentStacks]",
+    args: tuple[PRNGKeyArray | dict[str, Array], ...],
     rules: PlacementRules,
-    target_weights: dict[str, Array] | None = None,
 ) -> ComponentStacks:
-    """Seeded V/U init placed by `component_stacks_shardings(_, rules)` (the run's placement
-    policy), values bit-identical to the retired per-site init (pinned by `test_sharding`).
-    One jit, 2×n_shapes sharded outputs — the persistence layout IS the stacked layout, so
-    the old two-stage stack-then-unstack fan-out (and its transient extra copy) is gone.
-    `target_weights` selects the coupled init (`init_coupled_component_stacks`), riding as
-    jit ARGUMENTS (not closure constants) so the frozen W arrays are not baked into the
-    compiled init; None is the kaiming default."""
-    if target_weights is None:
-        init, args = partial(init_component_stacks, sites), (key,)
-    else:
-        init, args = partial(init_coupled_component_stacks, sites), (target_weights, key)
+    """Run a `ComponentStacks` init placed by `component_stacks_shardings(_, rules)` (the
+    run's placement policy). One jit, 2×n_shapes sharded outputs — the persistence layout
+    IS the stacked layout, so no host-side full tree ever exists; `args` ride as jit
+    ARGUMENTS (not closure constants) so nothing large is baked into the compiled init."""
     placement = component_stacks_shardings(eqx.filter_eval_shape(init, *args), rules)
     return jax.jit(init, out_shardings=placement)(*args)
+
+
+def init_component_stacks_placed(
+    sites: tuple[SiteSpec, ...], key: PRNGKeyArray, rules: PlacementRules
+) -> ComponentStacks:
+    """Placed kaiming V/U init, values bit-identical to the retired per-site init (pinned
+    by `test_sharding`)."""
+    return _init_component_stacks_via(partial(init_component_stacks, sites), (key,), rules)
+
+
+def init_coupled_component_stacks_placed(
+    sites: tuple[SiteSpec, ...],
+    target_weights: dict[str, Array],
+    key: PRNGKeyArray,
+    rules: PlacementRules,
+) -> ComponentStacks:
+    """Placed coupled V/U init (`init_coupled_component_stacks`)."""
+    return _init_component_stacks_via(
+        partial(init_coupled_component_stacks, sites), (target_weights, key), rules
+    )
 
 
 def init_ci_fn_placed(

--- a/param_decomp/targets/glu_transformer_sharding.py
+++ b/param_decomp/targets/glu_transformer_sharding.py
@@ -64,6 +64,7 @@ from param_decomp.components import (
     ComponentStacks,
     SiteSpec,
     init_component_stacks,
+    init_coupled_component_stacks,
 )
 from param_decomp.configs import SourceShape
 from param_decomp.model import PositionAxis, Positioned, Positionless
@@ -89,15 +90,24 @@ def place_target(tgt: GLUDecomposedModel, mesh: Mesh) -> GLUDecomposedModel:
 
 
 def init_component_stacks_placed(
-    sites: tuple[SiteSpec, ...], key: PRNGKeyArray, rules: PlacementRules
+    sites: tuple[SiteSpec, ...],
+    key: PRNGKeyArray,
+    rules: PlacementRules,
+    target_weights: dict[str, Array] | None = None,
 ) -> ComponentStacks:
     """Seeded V/U init placed by `component_stacks_shardings(_, rules)` (the run's placement
     policy), values bit-identical to the retired per-site init (pinned by `test_sharding`).
     One jit, 2×n_shapes sharded outputs — the persistence layout IS the stacked layout, so
-    the old two-stage stack-then-unstack fan-out (and its transient extra copy) is gone."""
-    abstract = eqx.filter_eval_shape(partial(init_component_stacks, sites), key)
-    placement = component_stacks_shardings(abstract, rules)
-    return jax.jit(partial(init_component_stacks, sites), out_shardings=placement)(key)
+    the old two-stage stack-then-unstack fan-out (and its transient extra copy) is gone.
+    `target_weights` selects the coupled init (`init_coupled_component_stacks`), riding as
+    jit ARGUMENTS (not closure constants) so the frozen W arrays are not baked into the
+    compiled init; None is the kaiming default."""
+    if target_weights is None:
+        init, args = partial(init_component_stacks, sites), (key,)
+    else:
+        init, args = partial(init_coupled_component_stacks, sites), (target_weights, key)
+    placement = component_stacks_shardings(eqx.filter_eval_shape(init, *args), rules)
+    return jax.jit(init, out_shardings=placement)(*args)
 
 
 def init_ci_fn_placed(

--- a/param_decomp/targets/glu_transformer_sharding.py
+++ b/param_decomp/targets/glu_transformer_sharding.py
@@ -45,7 +45,6 @@ unsharded tree per process). A non-dividing declared shard axis is a loud crash 
 placement construction / inside `.shardings` (fail-fast), never a silent replicate.
 """
 
-from collections.abc import Callable
 from functools import partial
 
 import equinox as eqx
@@ -64,8 +63,8 @@ from param_decomp.ci_fn import CIFn, CIFnArch, build_ci_fn
 from param_decomp.components import (
     ComponentStacks,
     SiteSpec,
+    WeightInit,
     init_component_stacks,
-    init_coupled_component_stacks,
 )
 from param_decomp.configs import SourceShape
 from param_decomp.model import PositionAxis, Positioned, Positionless
@@ -78,7 +77,6 @@ __all__ = [
     "hsdp_mesh",
     "place_target",
     "init_component_stacks_placed",
-    "init_coupled_component_stacks_placed",
     "init_ci_fn_placed",
     "init_sources_sharded",
     "shard_batch",
@@ -91,37 +89,24 @@ def place_target(tgt: GLUDecomposedModel, mesh: Mesh) -> GLUDecomposedModel:
     return place_via_shardings(tgt, tgt.shardings(mesh))
 
 
-def _init_component_stacks_via(
-    init: "Callable[..., ComponentStacks]",
-    args: tuple[PRNGKeyArray | dict[str, Array], ...],
-    rules: PlacementRules,
-) -> ComponentStacks:
-    """Run a `ComponentStacks` init placed by `component_stacks_shardings(_, rules)` (the
-    run's placement policy). One jit, 2×n_shapes sharded outputs — the persistence layout
-    IS the stacked layout, so no host-side full tree ever exists; `args` ride as jit
-    ARGUMENTS (not closure constants) so nothing large is baked into the compiled init."""
-    placement = component_stacks_shardings(eqx.filter_eval_shape(init, *args), rules)
-    return jax.jit(init, out_shardings=placement)(*args)
-
-
 def init_component_stacks_placed(
-    sites: tuple[SiteSpec, ...], key: PRNGKeyArray, rules: PlacementRules
-) -> ComponentStacks:
-    """Placed kaiming V/U init, values bit-identical to the retired per-site init (pinned
-    by `test_sharding`)."""
-    return _init_component_stacks_via(partial(init_component_stacks, sites), (key,), rules)
-
-
-def init_coupled_component_stacks_placed(
     sites: tuple[SiteSpec, ...],
-    target_weights: dict[str, Array],
     key: PRNGKeyArray,
     rules: PlacementRules,
+    weight_init: WeightInit = "kaiming",
+    target_weights: dict[str, Array] | None = None,
 ) -> ComponentStacks:
-    """Placed coupled V/U init (`init_coupled_component_stacks`)."""
-    return _init_component_stacks_via(
-        partial(init_coupled_component_stacks, sites), (target_weights, key), rules
+    """`init_component_stacks` placed by `component_stacks_shardings(_, rules)` (the run's
+    placement policy); kaiming values bit-identical to the retired per-site init (pinned
+    by `test_sharding`). One jit, 2×n_shapes sharded outputs — the persistence layout IS
+    the stacked layout, so no host-side full tree ever exists; `key`/`target_weights` ride
+    as jit ARGUMENTS (not closure constants) so the frozen W arrays are not baked into the
+    compiled init."""
+    init = partial(init_component_stacks, sites, weight_init=weight_init)
+    placement = component_stacks_shardings(
+        eqx.filter_eval_shape(init, key, target_weights=target_weights), rules
     )
+    return jax.jit(init, out_shardings=placement)(key, target_weights=target_weights)
 
 
 def init_ci_fn_placed(

--- a/param_decomp/targets/llama_simple_mlp.py
+++ b/param_decomp/targets/llama_simple_mlp.py
@@ -488,12 +488,16 @@ class SimpleMLPDecomposedModel(eqx.Module):
         assert set(collect) == set(live), (sorted(collect), sorted(live))
         return collect
 
+    def target_weight(self, name: str) -> Array:
+        """The frozen W for site `name`, in its stored dtype."""
+        layer_idx, kind = parse_site_name(name)
+        return _frozen_site_weight(self.layers[layer_idx], kind)
+
     def weight_deltas(self, vu: ComponentStacks) -> dict[str, Array]:
         """fp32 `W − V@U` per site from fp32 masters (faithfulness input)."""
         out: dict[str, Array] = {}
         for spec in self.sites:
-            layer_idx, kind = parse_site_name(spec.name)
-            W = _frozen_site_weight(self.layers[layer_idx], kind)
+            W = self.target_weight(spec.name)
             V, U = vu.site(spec.name)
             out[spec.name] = (
                 W.astype(jnp.float32) - (V.astype(jnp.float32) @ U.astype(jnp.float32)).T

--- a/param_decomp/tests/test_attn_patterns_eval.py
+++ b/param_decomp/tests/test_attn_patterns_eval.py
@@ -275,6 +275,10 @@ class _PositionlessStub(eqx.Module):
         del vu, resid, masks, delta_masks, routes, live, has_delta
         raise AssertionError("positionless stub fn must not be called")
 
+    def target_weight(self, name: str) -> jax.Array:
+        del name
+        raise AssertionError("positionless stub fn must not be called")
+
     def weight_deltas(self, vu: Any) -> dict[str, jax.Array]:
         del vu
         raise AssertionError("positionless stub fn must not be called")

--- a/param_decomp/tests/test_component_init.py
+++ b/param_decomp/tests/test_component_init.py
@@ -1,0 +1,78 @@
+"""Tests for the `coupled` component initialization (`init_coupled_component_stacks`)."""
+
+import jax
+import jax.numpy as jnp
+
+from param_decomp.components import SiteSpec, init_coupled_component_stacks
+
+
+def _random_weight(d_out: int, d_in: int) -> jax.Array:
+    return jax.random.normal(jax.random.PRNGKey(0), (d_out, d_in))
+
+
+def _component_sum(V: jax.Array, U: jax.Array) -> jax.Array:
+    return (V @ U).T
+
+
+def _col_space_residual(u: jax.Array, w: jax.Array) -> jax.Array:
+    q_out, _, _ = jnp.linalg.svd(w, full_matrices=False)
+    return u - (u @ q_out) @ q_out.T
+
+
+def _row_space_residual(v: jax.Array, w: jax.Array) -> jax.Array:
+    _, _, vh = jnp.linalg.svd(w, full_matrices=False)
+    q_in = vh.T
+    return v - q_in @ (q_in.T @ v)
+
+
+def _init_single(w: jax.Array, c: int, seed: int) -> tuple[jax.Array, jax.Array]:
+    d_out, d_in = w.shape
+    sites = (SiteSpec(name="m", d_in=d_in, d_out=d_out, C=c),)
+    vu = init_coupled_component_stacks(sites, {"m": w}, jax.random.PRNGKey(seed))
+    return vu.site("m")
+
+
+def test_coupled_seeds_are_unit_norm_and_derived_side_is_raw_w_image():
+    w = _random_weight(10, 6)  # d_in < d_out: V seeded, U derived
+    V, U = _init_single(w, c=8, seed=0)
+    assert jnp.allclose(jnp.linalg.norm(V, axis=0), jnp.ones(8), atol=1e-5)
+    assert jnp.allclose(U, (w @ V).T, atol=1e-6)
+    assert jnp.abs(_col_space_residual(U, w)).max() < 1e-5
+
+    w_t = w.T  # d_in > d_out: U seeded, V derived
+    V_t, U_t = _init_single(w_t, c=8, seed=0)
+    assert jnp.allclose(jnp.linalg.norm(U_t, axis=1), jnp.ones(8), atol=1e-5)
+    assert jnp.allclose(V_t, w_t.T @ U_t.T, atol=1e-6)
+    assert jnp.abs(_row_space_residual(V_t, w_t)).max() < 1e-5
+
+
+def test_coupled_sum_is_w_restricted_to_seed_span():
+    w = _random_weight(10, 6)
+    V, U = _init_single(w, c=4, seed=0)
+    # sum_c u_c v_c^T = W V V^T exactly.
+    assert jnp.allclose(_component_sum(V, U), w @ V @ V.T, atol=1e-5)
+
+
+def test_coupled_is_seed_deterministic():
+    w = _random_weight(10, 6)
+    V_a, U_a = _init_single(w, c=8, seed=7)
+    V_b, U_b = _init_single(w, c=8, seed=7)
+    assert jnp.array_equal(V_a, V_b) and jnp.array_equal(U_a, U_b)
+
+
+def test_coupled_stacked_sites_get_independent_draws_coupled_to_their_own_w():
+    # Two sites sharing one (d_in, d_out, C) shape group stack on one axis; each slice
+    # must be coupled to ITS OWN W with an independent seed draw.
+    key = jax.random.PRNGKey(3)
+    w_a = jax.random.normal(jax.random.fold_in(key, 0), (10, 6))
+    w_b = jax.random.normal(jax.random.fold_in(key, 1), (10, 6))
+    sites = (
+        SiteSpec(name="a", d_in=6, d_out=10, C=8),
+        SiteSpec(name="b", d_in=6, d_out=10, C=8),
+    )
+    vu = init_coupled_component_stacks(sites, {"a": w_a, "b": w_b}, jax.random.PRNGKey(0))
+    V_a, U_a = vu.site("a")
+    V_b, U_b = vu.site("b")
+    assert not jnp.allclose(V_a, V_b)
+    assert jnp.allclose(U_a, (w_a @ V_a).T, atol=1e-6)
+    assert jnp.allclose(U_b, (w_b @ V_b).T, atol=1e-6)

--- a/param_decomp/tests/test_component_init.py
+++ b/param_decomp/tests/test_component_init.py
@@ -1,9 +1,9 @@
-"""Tests for the `coupled` component initialization (`init_coupled_component_stacks`)."""
+"""Tests for the `coupled` mode of `init_component_stacks`."""
 
 import jax
 import jax.numpy as jnp
 
-from param_decomp.components import SiteSpec, init_coupled_component_stacks
+from param_decomp.components import SiteSpec, init_component_stacks
 
 
 def _random_weight(d_out: int, d_in: int) -> jax.Array:
@@ -28,7 +28,7 @@ def _row_space_residual(v: jax.Array, w: jax.Array) -> jax.Array:
 def _init_single(w: jax.Array, c: int, seed: int) -> tuple[jax.Array, jax.Array]:
     d_out, d_in = w.shape
     sites = (SiteSpec(name="m", d_in=d_in, d_out=d_out, C=c),)
-    vu = init_coupled_component_stacks(sites, {"m": w}, jax.random.PRNGKey(seed))
+    vu = init_component_stacks(sites, jax.random.PRNGKey(seed), "coupled", {"m": w})
     return vu.site("m")
 
 
@@ -70,7 +70,7 @@ def test_coupled_stacked_sites_get_independent_draws_coupled_to_their_own_w():
         SiteSpec(name="a", d_in=6, d_out=10, C=8),
         SiteSpec(name="b", d_in=6, d_out=10, C=8),
     )
-    vu = init_coupled_component_stacks(sites, {"a": w_a, "b": w_b}, jax.random.PRNGKey(0))
+    vu = init_component_stacks(sites, jax.random.PRNGKey(0), "coupled", {"a": w_a, "b": w_b})
     V_a, U_a = vu.site("a")
     V_b, U_b = vu.site("b")
     assert not jnp.allclose(V_a, V_b)

--- a/param_decomp/tests/test_component_init.py
+++ b/param_decomp/tests/test_component_init.py
@@ -10,10 +10,6 @@ def _random_weight(d_out: int, d_in: int) -> jax.Array:
     return jax.random.normal(jax.random.PRNGKey(0), (d_out, d_in))
 
 
-def _component_sum(V: jax.Array, U: jax.Array) -> jax.Array:
-    return (V @ U).T
-
-
 def _col_space_residual(u: jax.Array, w: jax.Array) -> jax.Array:
     q_out, _, _ = jnp.linalg.svd(w, full_matrices=False)
     return u - (u @ q_out) @ q_out.T
@@ -44,20 +40,6 @@ def test_coupled_seeds_are_unit_norm_and_derived_side_is_raw_w_image():
     assert jnp.allclose(jnp.linalg.norm(U_t, axis=1), jnp.ones(8), atol=1e-5)
     assert jnp.allclose(V_t, w_t.T @ U_t.T, atol=1e-6)
     assert jnp.abs(_row_space_residual(V_t, w_t)).max() < 1e-5
-
-
-def test_coupled_sum_is_w_restricted_to_seed_span():
-    w = _random_weight(10, 6)
-    V, U = _init_single(w, c=4, seed=0)
-    # sum_c u_c v_c^T = W V V^T exactly.
-    assert jnp.allclose(_component_sum(V, U), w @ V @ V.T, atol=1e-5)
-
-
-def test_coupled_is_seed_deterministic():
-    w = _random_weight(10, 6)
-    V_a, U_a = _init_single(w, c=8, seed=7)
-    V_b, U_b = _init_single(w, c=8, seed=7)
-    assert jnp.array_equal(V_a, V_b) and jnp.array_equal(U_a, U_b)
 
 
 def test_coupled_stacked_sites_get_independent_draws_coupled_to_their_own_w():

--- a/param_decomp/tests/test_eval.py
+++ b/param_decomp/tests/test_eval.py
@@ -131,6 +131,10 @@ class _PositionlessStub(eqx.Module):
         del vu, resid, masks, delta_masks, routes, live, has_delta
         raise AssertionError("positionless stub fn must not be called")
 
+    def target_weight(self, name: str) -> jax.Array:
+        del name
+        raise AssertionError("positionless stub fn must not be called")
+
     def weight_deltas(self, vu: Any) -> dict[str, jax.Array]:
         del vu
         raise AssertionError("positionless stub fn must not be called")

--- a/param_decomp/tests/test_generic_model_io.py
+++ b/param_decomp/tests/test_generic_model_io.py
@@ -166,6 +166,10 @@ class SyntheticDecomposedModel(eqx.Module):
             hidden = hidden + delta_masks[SITE][..., None] * (resid @ delta.T)
         return {SITE: hidden}
 
+    def target_weight(self, name: str) -> Array:
+        assert name == SITE, name
+        return self.W
+
     def weight_deltas(self, vu: ComponentStacks) -> dict[str, Array]:
         V, U = vu.site(SITE)
         return {

--- a/param_decomp_lab/experiments/resid_mlp/model.py
+++ b/param_decomp_lab/experiments/resid_mlp/model.py
@@ -457,6 +457,9 @@ class ResidMLPDecomposedModel(eqx.Module):
             self.target, prepared, resid, masks, delta_masks, routes, live, has_delta
         )
 
+    def target_weight(self, name: str) -> Array:
+        return _frozen_site_weight(self.target, name)
+
     def weight_deltas(self, vu: ComponentStacks) -> dict[str, Array]:
         return weight_deltas_fp32(self.target, vu, self.sites)
 

--- a/param_decomp_lab/experiments/tms/model.py
+++ b/param_decomp_lab/experiments/tms/model.py
@@ -389,6 +389,9 @@ class TMSDecomposedModel(eqx.Module):
             self.target, prepared, resid, masks, delta_masks, routes, live, has_delta
         )
 
+    def target_weight(self, name: str) -> Array:
+        return _frozen_site_weight(self.target, name)
+
     def weight_deltas(self, vu: ComponentStacks) -> dict[str, Array]:
         return weight_deltas_fp32(self.target, vu, self.sites)
 


### PR DESCRIPTION
## Summary

Adds the **coupled** component initialization to the JAX trainer as `pd.weight_init: kaiming | coupled` (kaiming stays the default).

With the "coupled" initialization scheme:
- For matrices with d_in ≤ d_out, the U vectors lie in the column space of the matrix. For matrices with d_in > d_out, the V vectors lie in the row space.
- The two vectors are coupled, such that one is the image of the other according to W

Concretely:
- If a matrix’s d_in ≤ d_out, draw V as random vectors normalized to unit norm, and set U = (W @ V)ᵀ 
- If d_in > d_out, draw unit-norm U and set V = (Wᵀ @ Uᵀ).

## Testing
This was tested on the targeted decomposition of Llama-8B L18 on arithmetic tasks, with 3 different random seeds per condition.
 
Black is normal kaiming init, red is the coupled init introduced in this PR. Green initializes the components within the row/column space of the matrices without coupling. It outperforms the baseline, but is not as good as the coupled init, so I didn’t include it in the PR.

<img width="2048" height="640" alt="image" src="https://github.com/user-attachments/assets/b9ab9bd1-57e7-456a-9f87-b3035648fc64" />

In practice this saves about 1000 steps on the arithmetic task, i.e. 5% of training.

Validation on Layer 17 for the same task (evals taken directly at init):
<img width="1904" height="711" alt="image" src="https://github.com/user-attachments/assets/60cf54d1-15a3-4431-8833-4fc0a5710684" />

Validation on a full-data decomposition: initialization + 100 steps of faithfulness warmup + 200 steps of training for the "Jose" decomposition (Pile llama 4L):
<img height="280" alt="image" src="https://github.com/user-attachments/assets/378c422f-a475-46b1-8c07-1e70610cc4db" />

<img height="280" alt="image" src="https://github.com/user-attachments/assets/c2cd6a26-c941-4d74-8550-98770849144b" /><img height="280" alt="image" src="https://github.com/user-attachments/assets/f1fa096a-e79a-42b5-a13c-0c63f29b6cd5" />

The coupled initialization is also in the right direction for full-data decomposition, but it’s less clear whether this changes anything in practice. On the other hand, it runs only once and has no practical cost, so it probably doesn’t hurt to use it.

Note that these tests where done using the old Pytorch implementation, which should behave the same as the Jax version.

For the new Jax implementation:
- New `param_decomp/tests/test_component_init.py`: the defining W-image property on both orientation branches (unit-norm seeds, span membership), and independent per-site draws within a stacked shape group.
- TMS 5-2 engine smokes run end-to-end for both `weight_init` modes (init → faith warmup → training → eval → checkpoint)